### PR TITLE
fix: return ctx error when UP command exists

### DIFF
--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -191,8 +191,12 @@ func runClient() error {
 		return err
 	}
 
-	log.Info("stopped Wiretrustee client")
-	cleanupCh <- struct{}{}
+	go func() {
+		cleanupCh <- struct{}{}
+	}()
 
-	return nil
+	log.Info("stopped Wiretrustee client")
+
+	return ctx.Err()
+
 }


### PR DESCRIPTION
The client app (UP command) won't restart in case the management server retry loop exists. 
This results in the service being in status RUNNING, but nothing happens in the app.