### PR TITLE
Fix UP calls when state is idle

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -265,12 +265,10 @@ func (s *serviceClient) menuUpClick() error {
 		return err
 	}
 
-	if status.Status == string(internal.StatusNeedsLogin) || status.Status == string(internal.StatusLoginFailed) {
-		err = s.login()
-		if err != nil {
-			log.Errorf("get service status: %v", err)
-			return err
-		}
+	err = s.login()
+	if err != nil {
+		log.Errorf("get service status: %v", err)
+		return err
 	}
 
 	status, err = conn.Status(s.ctx, &proto.StatusRequest{})


### PR DESCRIPTION
When we want to login we can call server.Login
It already checks the login status of the peer