### PR TITLE
Fix interface ignore list

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -140,15 +140,11 @@ func RunClient(ctx context.Context, config *Config) error {
 
 // createEngineConfig converts configuration received from Management Service to EngineConfig
 func createEngineConfig(key wgtypes.Key, config *Config, peerConfig *mgmProto.PeerConfig) (*EngineConfig, error) {
-	iFaceBlackList := make(map[string]struct{})
-	for i := 0; i < len(config.IFaceBlackList); i += 2 {
-		iFaceBlackList[config.IFaceBlackList[i]] = struct{}{}
-	}
 
 	engineConf := &EngineConfig{
 		WgIfaceName:    config.WgIface,
 		WgAddr:         peerConfig.Address,
-		IFaceBlackList: iFaceBlackList,
+		IFaceBlackList: config.IFaceBlackList,
 		WgPrivateKey:   key,
 		WgPort:         iface.DefaultWgPort,
 	}

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -45,7 +45,7 @@ type EngineConfig struct {
 	WgPrivateKey wgtypes.Key
 
 	// IFaceBlackList is a list of network interfaces to ignore when discovering connection candidates (ICE related)
-	IFaceBlackList map[string]struct{}
+	IFaceBlackList []string
 
 	PreSharedKey *wgtypes.Key
 
@@ -592,11 +592,6 @@ func (e Engine) createPeerConn(pubKey string, allowedIPs string) (*peer.Conn, er
 	stunTurn = append(stunTurn, e.STUNs...)
 	stunTurn = append(stunTurn, e.TURNs...)
 
-	interfaceBlacklist := make([]string, 0, len(e.config.IFaceBlackList))
-	for k := range e.config.IFaceBlackList {
-		interfaceBlacklist = append(interfaceBlacklist, k)
-	}
-
 	proxyConfig := proxy.Config{
 		RemoteKey:    pubKey,
 		WgListenAddr: fmt.Sprintf("127.0.0.1:%d", e.config.WgPort),
@@ -611,7 +606,7 @@ func (e Engine) createPeerConn(pubKey string, allowedIPs string) (*peer.Conn, er
 		Key:                pubKey,
 		LocalKey:           e.config.WgPrivateKey.PublicKey().String(),
 		StunTurn:           stunTurn,
-		InterfaceBlackList: interfaceBlacklist,
+		InterfaceBlackList: e.config.IFaceBlackList,
 		Timeout:            timeout,
 		UDPMux:             e.udpMux,
 		UDPMuxSrflx:        e.udpMuxSrflx,

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -92,6 +92,7 @@ func interfaceFilter(blackList []string) func(string) bool {
 	return func(iFace string) bool {
 		for _, s := range blackList {
 			if strings.HasPrefix(iFace, s) {
+				log.Debugf("ignoring interface %s - it is not allowed", iFace)
 				return false
 			}
 		}


### PR DESCRIPTION
For some reason when reading a list of interfaces to ignore
from the config property `IFaceBlackList`, Engine was taking
only every other interface. Therefore, not all the interfaces
were ignored.
