### PR TITLE
Create account in 1 place

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -620,23 +620,6 @@ func (am *DefaultAccountManager) AccountExists(accountId string) (*bool, error) 
 	return &res, nil
 }
 
-// AddAccount generates a new Account with a provided accountId and userId, saves to the Store
-func (am *DefaultAccountManager) AddAccount(accountId, userId, domain string) (*Account, error) {
-	am.mux.Lock()
-	defer am.mux.Unlock()
-
-	return am.createAccount(accountId, userId, domain)
-}
-
-func (am *DefaultAccountManager) createAccount(accountId, userId, domain string) (*Account, error) {
-	account := newAccountWithId(accountId, userId, domain)
-	err := am.Store.SaveAccount(account)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed creating account")
-	}
-	return account, nil
-}
-
 // addAllGroup to account object if it doesn't exists
 func addAllGroup(account *Account) {
 	if len(account.Groups) == 0 {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -44,7 +44,6 @@ type AccountManager interface {
 	GetAccountWithAuthorizationClaims(claims jwtclaims.AuthorizationClaims) (*Account, error)
 	IsUserAdmin(claims jwtclaims.AuthorizationClaims) (bool, error)
 	AccountExists(accountId string) (*bool, error)
-	AddAccount(accountId, userId, domain string) (*Account, error)
 	GetPeer(peerKey string) (*Peer, error)
 	MarkPeerConnected(peerKey string, connected bool) error
 	RenamePeer(accountId string, peerKey string, newName string) (*Peer, error)

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -267,7 +267,7 @@ func TestAccountManager_AddAccount(t *testing.T) {
 	expectedPeersSize := 0
 	expectedSetupKeysSize := 2
 
-	account, err := manager.AddAccount(expectedId, userId, "")
+	account, err := createAccount(manager, expectedId, userId, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,6 +320,15 @@ func TestAccountManager_GetAccountByUserOrAccountId(t *testing.T) {
 	}
 }
 
+func createAccount(am *DefaultAccountManager, accountId, userId, domain string) (*Account, error) {
+	account := newAccountWithId(accountId, userId, domain)
+	err := am.Store.SaveAccount(account)
+	if err != nil {
+		return nil, err
+	}
+	return account, nil
+}
+
 func TestAccountManager_AccountExists(t *testing.T) {
 	manager, err := createManager(t)
 	if err != nil {
@@ -329,7 +338,7 @@ func TestAccountManager_AccountExists(t *testing.T) {
 
 	expectedId := "test_account"
 	userId := "account_creator"
-	_, err = manager.AddAccount(expectedId, userId, "")
+	_, err = createAccount(manager, expectedId, userId, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +362,7 @@ func TestAccountManager_GetAccount(t *testing.T) {
 
 	expectedId := "test_account"
 	userId := "account_creator"
-	account, err := manager.AddAccount(expectedId, userId, "")
+	account, err := createAccount(manager, expectedId, userId, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -389,7 +398,7 @@ func TestAccountManager_AddPeer(t *testing.T) {
 		return
 	}
 
-	account, err := manager.AddAccount("test_account", "account_creator", "")
+	account, err := createAccount(manager, "test_account", "account_creator", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -521,7 +530,7 @@ func TestAccountManager_NetworkUpdates(t *testing.T) {
 		return
 	}
 
-	account, err := manager.AddAccount("test_account", "account_creator", "")
+	account, err := createAccount(manager, "test_account", "account_creator", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -704,7 +713,7 @@ func TestAccountManager_DeletePeer(t *testing.T) {
 		return
 	}
 
-	account, err := manager.AddAccount("test_account", "account_creator", "")
+	account, err := createAccount(manager, "test_account", "account_creator", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -757,7 +766,7 @@ func TestGetUsersFromAccount(t *testing.T) {
 	users := map[string]*User{"1": {Id: "1", Role: "admin"}, "2": {Id: "2", Role: "user"}, "3": {Id: "3", Role: "user"}}
 	accountId := "test_account_id"
 
-	account, err := manager.AddAccount(accountId, users["1"].Id, "")
+	account, err := createAccount(manager, accountId, users["1"].Id, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -788,7 +797,7 @@ func TestAccountManager_UpdatePeerMeta(t *testing.T) {
 		return
 	}
 
-	account, err := manager.AddAccount("test_account", "account_creator", "")
+	account, err := createAccount(manager, "test_account", "account_creator", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -20,10 +20,6 @@ func TestNewAccount(t *testing.T) {
 
 	account := NewAccount(userId, domain)
 
-	if account == nil {
-		t.Errorf("expected non-nil Account structure when calling NewAccount")
-	}
-
 	if len(account.Peers) != expectedPeersSize {
 		t.Errorf("expected account to have len(Peers) = %v, got %v", expectedPeersSize, len(account.Peers))
 	}

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -320,8 +320,8 @@ func TestAccountManager_GetAccountByUserOrAccountId(t *testing.T) {
 	}
 }
 
-func createAccount(am *DefaultAccountManager, accountId, userId, domain string) (*Account, error) {
-	account := newAccountWithId(accountId, userId, domain)
+func createAccount(am *DefaultAccountManager, accountID, userID, domain string) (*Account, error) {
+	account := newAccountWithId(accountID, userID, domain)
 	err := am.Store.SaveAccount(account)
 	if err != nil {
 		return nil, err

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -34,7 +34,6 @@ func TestSaveAccount(t *testing.T) {
 	store := newStore(t)
 
 	account := NewAccount("testuser", "")
-	account.Users["testuser"] = NewAdminUser("testuser")
 	setupKey := GenerateDefaultSetupKey()
 	account.SetupKeys[setupKey.Key] = setupKey
 	account.Peers["testpeer"] = &Peer{
@@ -74,7 +73,6 @@ func TestStore(t *testing.T) {
 	store := newStore(t)
 
 	account := NewAccount("testuser", "")
-	account.Users["testuser"] = NewAdminUser("testuser")
 	account.Peers["testpeer"] = &Peer{
 		Key:      "peerkey",
 		SetupKey: "peerkeysetupkey",

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -19,7 +19,6 @@ type MockAccountManager struct {
 	GetAccountWithAuthorizationClaimsFunc func(claims jwtclaims.AuthorizationClaims) (*server.Account, error)
 	IsUserAdminFunc                       func(claims jwtclaims.AuthorizationClaims) (bool, error)
 	AccountExistsFunc                     func(accountId string) (*bool, error)
-	AddAccountFunc                        func(accountId, userId, domain string) (*server.Account, error)
 	GetPeerFunc                           func(peerKey string) (*server.Peer, error)
 	MarkPeerConnectedFunc                 func(peerKey string, connected bool) error
 	RenamePeerFunc                        func(accountId string, peerKey string, newName string) (*server.Peer, error)
@@ -137,15 +136,6 @@ func (am *MockAccountManager) AccountExists(accountId string) (*bool, error) {
 		return am.AccountExistsFunc(accountId)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method AccountExists not implemented")
-}
-
-func (am *MockAccountManager) AddAccount(
-	accountId, userId, domain string,
-) (*server.Account, error) {
-	if am.AddAccountFunc != nil {
-		return am.AddAccountFunc(accountId, userId, domain)
-	}
-	return nil, status.Errorf(codes.Unimplemented, "method AddAccount not implemented")
 }
 
 func (am *MockAccountManager) GetPeer(peerKey string) (*server.Peer, error) {

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -16,7 +16,7 @@ func TestAccountManager_GetNetworkMap(t *testing.T) {
 
 	expectedId := "test_account"
 	userId := "account_creator"
-	account, err := manager.AddAccount(expectedId, userId, "")
+	account, err := createAccount(manager, expectedId, userId, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 
 	expectedId := "test_account"
 	userId := "account_creator"
-	account, err := manager.AddAccount(expectedId, userId, "")
+	account, err := createAccount(manager, expectedId, userId, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -60,8 +60,6 @@ func (am *DefaultAccountManager) GetOrCreateAccountByUser(userId, domain string)
 	if err != nil {
 		if s, ok := status.FromError(err); ok && s.Code() == codes.NotFound {
 			account = NewAccount(userId, lowerDomain)
-			account.Users[userId] = NewAdminUser(userId)
-			am.addAllGroup(account)
 			err = am.Store.SaveAccount(account)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed creating account")


### PR DESCRIPTION
There are a few places where account is created.
When we create a new account, there should be 
some defaults set. E.g. created by and group ALL.
It makes sense to add it in one place to avoid inconsistencies.