### PR TITLE
Send netmask from account network

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -49,6 +49,7 @@ type AccountManager interface {
 	DeletePeer(accountId string, peerKey string) (*Peer, error)
 	GetPeerByIP(accountId string, peerIP string) (*Peer, error)
 	GetNetworkMap(peerKey string) (*NetworkMap, error)
+	GetPeerNetwork(peerKey string) (*Network, error)
 	AddPeer(setupKey string, userId string, peer *Peer) (*Peer, error)
 	UpdatePeerMeta(peerKey string, meta PeerSystemMeta) error
 	UpdatePeerSSHKey(peerKey string, sshKey string) error

--- a/management/server/management_test.go
+++ b/management/server/management_test.go
@@ -435,7 +435,7 @@ var _ = Describe("Management service", func() {
 			_, secondLoginNetwork, err := net.ParseCIDR(secondLogin.GetPeerConfig().GetAddress())
 			Expect(err).NotTo(HaveOccurred())
 
-			Equal(secondLoginNetwork.String()).Match(firstLoginNetwork.String())
+			Expect(secondLoginNetwork.String()).To(BeEquivalentTo(firstLoginNetwork.String()))
 		})
 	})
 })

--- a/management/server/management_test.go
+++ b/management/server/management_test.go
@@ -422,6 +422,22 @@ var _ = Describe("Management service", func() {
 			close(ipChannel)
 		})
 	})
+
+	Context("after login two peers", func() {
+		Specify("then they receive the same network", func() {
+			key, _ := wgtypes.GenerateKey()
+			firstLogin := loginPeerWithValidSetupKey(serverPubKey, key, client)
+			key, _ = wgtypes.GenerateKey()
+			secondLogin := loginPeerWithValidSetupKey(serverPubKey, key, client)
+
+			_, firstLoginNetwork, err := net.ParseCIDR(firstLogin.GetPeerConfig().GetAddress())
+			Expect(err).NotTo(HaveOccurred())
+			_, secondLoginNetwork, err := net.ParseCIDR(secondLogin.GetPeerConfig().GetAddress())
+			Expect(err).NotTo(HaveOccurred())
+
+			Equal(secondLoginNetwork.String()).Match(firstLoginNetwork.String())
+		})
+	})
 })
 
 func loginPeerWithValidSetupKey(serverPubKey wgtypes.Key, key wgtypes.Key, client mgmtProto.ManagementServiceClient) *mgmtProto.LoginResponse {

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -25,6 +25,7 @@ type MockAccountManager struct {
 	DeletePeerFunc                        func(accountId string, peerKey string) (*server.Peer, error)
 	GetPeerByIPFunc                       func(accountId string, peerIP string) (*server.Peer, error)
 	GetNetworkMapFunc                     func(peerKey string) (*server.NetworkMap, error)
+	GetPeerNetworkFunc                    func(peerKey string) (*server.Network, error)
 	AddPeerFunc                           func(setupKey string, userId string, peer *server.Peer) (*server.Peer, error)
 	GetGroupFunc                          func(accountID, groupID string) (*server.Group, error)
 	SaveGroupFunc                         func(accountID string, group *server.Group) error
@@ -202,6 +203,14 @@ func (am *MockAccountManager) GetNetworkMap(peerKey string) (*server.NetworkMap,
 		return am.GetNetworkMapFunc(peerKey)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method GetNetworkMap is not implemented")
+}
+
+// GetPeerNetwork mock implementation of GetPeerNetwork from server.AccountManager interface
+func (am *MockAccountManager) GetPeerNetwork(peerKey string) (*server.Network, error) {
+	if am.GetPeerNetworkFunc != nil {
+		return am.GetPeerNetworkFunc(peerKey)
+	}
+	return nil, status.Errorf(codes.Unimplemented, "method GetPeerNetwork is not implemented")
 }
 
 // AddPeer mock implementation of AddPeer from server.AccountManager interface

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -253,3 +253,69 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 		t.Errorf("expecting Account NetworkMap to have 0 peers, got %v", len(networkMap2.Peers))
 	}
 }
+
+func TestAccountManager_GetPeerNetwork(t *testing.T) {
+	manager, err := createManager(t)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	expectedId := "test_account"
+	userId := "account_creator"
+	account, err := createAccount(manager, expectedId, userId, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var setupKey *SetupKey
+	for _, key := range account.SetupKeys {
+		if key.Type == SetupKeyReusable {
+			setupKey = key
+		}
+	}
+
+	peerKey1, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	_, err = manager.AddPeer(setupKey.Key, "", &Peer{
+		Key:  peerKey1.PublicKey().String(),
+		Meta: PeerSystemMeta{},
+		Name: "test-peer-2",
+	})
+
+	if err != nil {
+		t.Errorf("expecting peer to be added, got failure %v", err)
+		return
+	}
+
+	peerKey2, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	_, err = manager.AddPeer(setupKey.Key, "", &Peer{
+		Key:  peerKey2.PublicKey().String(),
+		Meta: PeerSystemMeta{},
+		Name: "test-peer-2",
+	})
+
+	if err != nil {
+		t.Errorf("expecting peer to be added, got failure %v", err)
+		return
+	}
+
+	network, err := manager.GetPeerNetwork(peerKey1.PublicKey().String())
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if account.Network.Id != network.Id {
+		t.Errorf("expecting Account Networks ID to be equal, got %s expected %s", network.Id, account.Network.Id)
+	}
+
+}


### PR DESCRIPTION
Added the GetPeerNetwork method to account manager

Pass a copy of the network to the toPeerConfig function
to retrieve the netmask from the network instead of constant

updated methods and added test