### PR TITLE
Introduce larger retries for the agent

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -26,9 +26,9 @@ import (
 func RunClient(ctx context.Context, config *Config, statusRecorder *nbStatus.Status) error {
 	backOff := &backoff.ExponentialBackOff{
 		InitialInterval:     time.Second,
-		RandomizationFactor: backoff.DefaultRandomizationFactor,
-		Multiplier:          backoff.DefaultMultiplier,
-		MaxInterval:         5 * time.Minute,
+		RandomizationFactor: 1,
+		Multiplier:          1.7,
+		MaxInterval:         15 * time.Second,
 		MaxElapsedTime:      3 * 30 * 24 * time.Hour, // 3 months
 		Stop:                backoff.Stop,
 		Clock:               backoff.SystemClock,
@@ -43,7 +43,6 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *nbStatus.Sta
 	}()
 
 	wrapErr := state.Wrap
-	// validate our peer's Wireguard PRIVATE key
 	myPrivateKey, err := wgtypes.ParseKey(config.PrivateKey)
 	if err != nil {
 		log.Errorf("failed parsing Wireguard key %s: [%s]", config.PrivateKey, err.Error())

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -167,7 +167,7 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *nbStatus.Sta
 
 	err = backoff.Retry(operation, backOff)
 	if err != nil {
-		log.Errorf("exiting client retry loop due to unrecoverable error: %s", err)
+		log.Debugf("exiting client retry loop due to unrecoverable error: %s", err)
 		return err
 	}
 	return nil

--- a/client/main.go
+++ b/client/main.go
@@ -1,13 +1,42 @@
 package main
 
 import (
-	"os"
-
-	"github.com/netbirdio/netbird/client/cmd"
+	"context"
+	"fmt"
+	"github.com/cenkalti/backoff/v4"
+	log "github.com/sirupsen/logrus"
+	"time"
 )
 
 func main() {
-	if err := cmd.Execute(); err != nil {
-		os.Exit(1)
+
+	for i := 0; i < 5; i++ {
+		j := i
+		go func() {
+			try := 0
+			b := backoff.WithContext(&backoff.ExponentialBackOff{
+				InitialInterval:     800 * time.Millisecond,
+				RandomizationFactor: 1,
+				Multiplier:          1.7,
+				MaxInterval:         10 * time.Second,
+				MaxElapsedTime:      3 * 30 * 24 * time.Hour, // 3 months //todo make indefinite?
+				Stop:                backoff.Stop,
+				Clock:               backoff.SystemClock,
+			}, context.Background())
+			b.Reset()
+			backoff.RetryNotify(func() error {
+				return fmt.Errorf("error")
+			}, b, func(err error, duration time.Duration) {
+				log.Printf("routine %d -> try %d -> %v", j, try, duration)
+				try++
+				//fmt.Printf("%v;%v\n", time.Now().Format("2006-01-02 15:04:05"), duration.Seconds())
+			})
+		}()
 	}
+
+	select {}
+
+	/*if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}*/
 }

--- a/client/main.go
+++ b/client/main.go
@@ -1,42 +1,13 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"github.com/cenkalti/backoff/v4"
-	log "github.com/sirupsen/logrus"
-	"time"
+	"os"
+
+	"github.com/netbirdio/netbird/client/cmd"
 )
 
 func main() {
-
-	for i := 0; i < 5; i++ {
-		j := i
-		go func() {
-			try := 0
-			b := backoff.WithContext(&backoff.ExponentialBackOff{
-				InitialInterval:     800 * time.Millisecond,
-				RandomizationFactor: 1,
-				Multiplier:          1.7,
-				MaxInterval:         10 * time.Second,
-				MaxElapsedTime:      3 * 30 * 24 * time.Hour, // 3 months //todo make indefinite?
-				Stop:                backoff.Stop,
-				Clock:               backoff.SystemClock,
-			}, context.Background())
-			b.Reset()
-			backoff.RetryNotify(func() error {
-				return fmt.Errorf("error")
-			}, b, func(err error, duration time.Duration) {
-				log.Printf("routine %d -> try %d -> %v", j, try, duration)
-				try++
-				//fmt.Printf("%v;%v\n", time.Now().Format("2006-01-02 15:04:05"), duration.Seconds())
-			})
-		}()
-	}
-
-	select {}
-
-	/*if err := cmd.Execute(); err != nil {
+	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
-	}*/
+	}
 }

--- a/management/client/grpc.go
+++ b/management/client/grpc.go
@@ -138,7 +138,7 @@ func (c *GrpcClient) Sync(msgHandler func(msg *proto.SyncResponse) error) error 
 
 	err := backoff.Retry(operation, backOff)
 	if err != nil {
-		log.Warnf("exiting Management Service connection retry loop due to Permanent error: %s", err)
+		log.Warnf("exiting the Management service connection retry loop due to the unrecoverable error: %s", err)
 		return err
 	}
 

--- a/management/client/grpc.go
+++ b/management/client/grpc.go
@@ -37,7 +37,7 @@ func NewClient(ctx context.Context, addr string, ourPrivateKey wgtypes.Key, tlsE
 		transportOption = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
 	}
 
-	mgmCtx, cancel := context.WithTimeout(ctx, time.Second*3)
+	mgmCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	conn, err := grpc.DialContext(
 		mgmCtx,
@@ -74,8 +74,8 @@ func defaultBackoff(ctx context.Context) backoff.BackOff {
 		InitialInterval:     800 * time.Millisecond,
 		RandomizationFactor: backoff.DefaultRandomizationFactor,
 		Multiplier:          backoff.DefaultMultiplier,
-		MaxInterval:         10 * time.Second,
-		MaxElapsedTime:      12 * time.Hour, // stop after 12 hours of trying, the error will be propagated to the general retry of the client
+		MaxInterval:         5 * time.Minute,
+		MaxElapsedTime:      3 * 30 * 24 * time.Hour, // 3 months //todo make indefinite?
 		Stop:                backoff.Stop,
 		Clock:               backoff.SystemClock,
 	}, ctx)
@@ -95,11 +95,14 @@ func (c *GrpcClient) Sync(msgHandler func(msg *proto.SyncResponse) error) error 
 	operation := func() error {
 		log.Debugf("management connection state %v", c.conn.GetState())
 
-		if !c.ready() {
-			return fmt.Errorf("no connection to management")
+		connState := c.conn.GetState()
+		if connState == connectivity.Shutdown {
+			return backoff.Permanent(fmt.Errorf("connection to management has been shut down"))
+		} else if !(connState == connectivity.Ready || connState == connectivity.Idle) {
+			c.conn.WaitForStateChange(c.ctx, connState)
+			return fmt.Errorf("connection to management is not ready and in %s state", connState)
 		}
 
-		// todo we already have it since we did the Login, maybe cache it locally?
 		serverPubKey, err := c.GetServerPublicKey()
 		if err != nil {
 			log.Errorf("failed getting Management Service public key: %s", err)
@@ -109,6 +112,9 @@ func (c *GrpcClient) Sync(msgHandler func(msg *proto.SyncResponse) error) error 
 		stream, err := c.connectToStream(*serverPubKey)
 		if err != nil {
 			log.Errorf("failed to open Management Service stream: %s", err)
+			if s, ok := gstatus.FromError(err); ok && s.Code() == codes.PermissionDenied {
+				return backoff.Permanent(err) // unrecoverable error, propagate to the upper layer
+			}
 			return err
 		}
 
@@ -117,10 +123,9 @@ func (c *GrpcClient) Sync(msgHandler func(msg *proto.SyncResponse) error) error 
 		// blocking until error
 		err = c.receiveEvents(stream, *serverPubKey, msgHandler)
 		if err != nil {
-			if s, ok := gstatus.FromError(err); ok && (s.Code() == codes.InvalidArgument || s.Code() == codes.PermissionDenied) {
-				return backoff.Permanent(err)
+			if s, ok := gstatus.FromError(err); ok && s.Code() == codes.PermissionDenied {
+				return backoff.Permanent(err) // unrecoverable error, propagate to the upper layer
 			}
-			backOff.Reset()
 			return err
 		}
 
@@ -180,13 +185,13 @@ func (c *GrpcClient) receiveEvents(stream proto.ManagementService_SyncClient, se
 	}
 }
 
-// GetServerPublicKey returns server Wireguard public key (used later for encrypting messages sent to the server)
+// GetServerPublicKey returns server's WireGuard public key (used later for encrypting messages sent to the server)
 func (c *GrpcClient) GetServerPublicKey() (*wgtypes.Key, error) {
 	if !c.ready() {
 		return nil, fmt.Errorf("no connection to management")
 	}
 
-	mgmCtx, cancel := context.WithTimeout(c.ctx, time.Second*2)
+	mgmCtx, cancel := context.WithTimeout(c.ctx, 5*time.Second)
 	defer cancel()
 	resp, err := c.realClient.GetServerKey(mgmCtx, &proto.Empty{})
 	if err != nil {
@@ -210,7 +215,7 @@ func (c *GrpcClient) login(serverKey wgtypes.Key, req *proto.LoginRequest) (*pro
 		log.Errorf("failed to encrypt message: %s", err)
 		return nil, err
 	}
-	mgmCtx, cancel := context.WithTimeout(c.ctx, time.Second*2)
+	mgmCtx, cancel := context.WithTimeout(c.ctx, 5*time.Second)
 	defer cancel()
 	resp, err := c.realClient.Login(mgmCtx, &proto.EncryptedMessage{
 		WgPubKey: c.key.PublicKey().String(),

--- a/signal/client/grpc.go
+++ b/signal/client/grpc.go
@@ -145,7 +145,7 @@ func (c *GrpcClient) Receive(msgHandler func(msg *proto.Message) error) error {
 
 	err := backoff.Retry(operation, backOff)
 	if err != nil {
-		log.Errorf("exiting Signal Service connection retry loop due to unrecoverable error: %s", err)
+		log.Errorf("exiting the Signal service connection retry loop due to the unrecoverable error: %v", err)
 		return err
 	}
 
@@ -312,13 +312,13 @@ func (c *GrpcClient) receive(stream proto.SignalExchange_ConnectStreamClient,
 	for {
 		msg, err := stream.Recv()
 		if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
-			log.Warnf("stream canceled (usually indicates shutdown)")
+			log.Debugf("stream canceled (usually indicates shutdown)")
 			return err
 		} else if s.Code() == codes.Unavailable {
-			log.Warnf("Signal Service is unavailable")
+			log.Debugf("Signal Service is unavailable")
 			return err
 		} else if err == io.EOF {
-			log.Warnf("Signal Service stream closed by server")
+			log.Debugf("Signal Service stream closed by server")
 			return err
 		} else if err != nil {
 			return err


### PR DESCRIPTION
The Management client will try reconnecting in case
of network issues or non-permanent errors.
If the device was offboarded, then the client will stop retrying. 
