### PR TITLE
Fix TURN credentials renewal

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -679,7 +679,7 @@ func (e *Engine) connWorker(conn *peer.Conn, peerKey string) {
 		// we might have received new STUN and TURN servers meanwhile, so update them
 		e.syncMsgMux.Lock()
 		conf := conn.GetConf()
-		conf.StunTurn = append(e.STUNs, e.STUNs...)
+		conf.StunTurn = append(e.STUNs, e.TURNs...)
 		conn.UpdateConf(conf)
 		e.syncMsgMux.Unlock()
 

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -75,6 +75,11 @@ func (conn *Conn) GetConf() ConnConfig {
 	return conn.config
 }
 
+// UpdateConf updates the connection config
+func (conn *Conn) UpdateConf(conf ConnConfig) {
+	conn.config = conf
+}
+
 // NewConn creates a new not opened Conn to the remote peer.
 // To establish a connection run Conn.Open
 func NewConn(config ConnConfig, statusRecorder *nbStatus.Status) (*Conn, error) {
@@ -415,7 +420,7 @@ func (conn *Conn) SetSignalCandidate(handler func(candidate ice.Candidate) error
 // and then signals them to the remote peer
 func (conn *Conn) onICECandidate(candidate ice.Candidate) {
 	if candidate != nil {
-		// log.Debugf("discovered local candidate %s", candidate.String())
+		log.Debugf("discovered local candidate %s", candidate.String())
 		go func() {
 			err := conn.signalCandidate(candidate)
 			if err != nil {

--- a/signal/client/grpc.go
+++ b/signal/client/grpc.go
@@ -58,7 +58,7 @@ func NewClient(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled boo
 		transportOption = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
 	}
 
-	sigCtx, cancel := context.WithTimeout(ctx, time.Second*3)
+	sigCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	conn, err := grpc.DialContext(
 		sigCtx,


### PR DESCRIPTION
Whenever a peer connection is restarted a new TURN
and STUN configs won't be applied. 
This leads to connection drops and agents won't 
reestablish a connection if TURN was the only
way.  The PR fixes this. 