### PR TITLE
Make Signal Service listen on a standard 443/80 port instead of 10000

### DIFF
--- a/encryption/letsencrypt.go
+++ b/encryption/letsencrypt.go
@@ -18,7 +18,7 @@ func CreateCertManager(datadir string, letsencryptDomain string) (*autocert.Mana
 		}
 	}
 
-	log.Infof("running with Let's encrypt with domain %s. Cert will be stored in %s", letsencryptDomain, certDir)
+	log.Infof("running with LetsEncrypt (%s). Cert will be stored in %s", letsencryptDomain, certDir)
 
 	certManager := &autocert.Manager{
 		Prompt:     autocert.AcceptTOS,

--- a/encryption/letsencrypt.go
+++ b/encryption/letsencrypt.go
@@ -8,13 +8,13 @@ import (
 )
 
 // CreateCertManager wraps common logic of generating Let's encrypt certificate.
-func CreateCertManager(datadir string, letsencryptDomain string) *autocert.Manager {
+func CreateCertManager(datadir string, letsencryptDomain string) (*autocert.Manager, error) {
 	certDir := filepath.Join(datadir, "letsencrypt")
 
 	if _, err := os.Stat(certDir); os.IsNotExist(err) {
 		err = os.MkdirAll(certDir, os.ModeDir)
 		if err != nil {
-			log.Fatalf("failed creating Let's encrypt certdir: %s: %v", certDir, err)
+			return nil, err
 		}
 	}
 
@@ -26,5 +26,5 @@ func CreateCertManager(datadir string, letsencryptDomain string) *autocert.Manag
 		HostPolicy: autocert.HostWhitelist(letsencryptDomain),
 	}
 
-	return certManager
+	return certManager, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,9 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/xid v1.3.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
+	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.7.1
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
 )
 
@@ -97,7 +99,6 @@ require (
 	golang.org/x/image v0.0.0-20200430140353-33d19683fad8 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220513224357-95641704303c // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/text v0.3.8-0.20211105212822-18b340fc7af2 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect

--- a/go.sum
+++ b/go.sum
@@ -575,6 +575,8 @@ github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EE
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v1.13.0 h1:Dx1kYM01xsSqKPno3aqLnrwac2LetPvN23diwyr69Qs=
 github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
+github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
+github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -740,6 +742,7 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201201195509-5d6afe98e0b7/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201216054612-986b41b23924/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -25,7 +25,7 @@ services:
     volumes:
       - $SIGNAL_VOLUMENAME:/var/lib/netbird
     ports:
-      - 10000:10000
+      - 10000:80
   #     # port and command for Let's Encrypt validation
   #      - 443:443
   #    command: ["--letsencrypt-domain", "$NETBIRD_DOMAIN", "--log-file", "console"]

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -97,7 +97,10 @@ var (
 			var httpServer *http.Server
 			if config.HttpConfig.LetsEncryptDomain != "" {
 				// automatically generate a new certificate with Let's Encrypt
-				certManager := encryption.CreateCertManager(config.Datadir, config.HttpConfig.LetsEncryptDomain)
+				certManager, err := encryption.CreateCertManager(config.Datadir, config.HttpConfig.LetsEncryptDomain)
+				if err != nil {
+					log.Fatalf("failed creating Let's Encrypt cert manager: %v", err)
+				}
 				transportCredentials := credentials.NewTLS(certManager.TLSConfig())
 				opts = append(opts, grpc.Creds(transportCredentials))
 

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -46,6 +46,17 @@ var (
 		Timeout:               2 * time.Second,
 	}
 
+	// TLS enabled:
+	// 		- HTTP 80 for LetsEncrypt
+	//		- if --port not specified gRPC and HTTP servers on 443 (with multiplexing)
+	//		- if --port=X specified then run gRPC and HTTP servers on X (with multiplexing)
+	// 		- if --port=80 forbid this (throw error, otherwise we need to overcomplicate the logic with multiplexing)
+	// TLS disabled:
+	//		- if --port not specified gRPC and HTTP servers on 443 on 80 (with multiplexing)
+	//		- if --port=X specified then run gRPC and HTTP servers on 443 on X (with multiplexing)
+	// Always run gRPC on port 33073 regardless of TLS to be backward compatible
+	// Remove HTTP port 33071 from the configuration.
+
 	mgmtCmd = &cobra.Command{
 		Use:   "management",
 		Short: "start Netbird Management Server",

--- a/signal/client/grpc.go
+++ b/signal/client/grpc.go
@@ -75,6 +75,8 @@ func NewClient(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled boo
 		return nil, err
 	}
 
+	log.Debugf("connected to Signal Service: %v", conn.Target())
+
 	return &GrpcClient{
 		realClient: proto.NewSignalExchangeClient(conn),
 		ctx:        ctx,


### PR DESCRIPTION
Right now Signal Service runs the Let'sEncrypt manager on port 80
and a gRPC server on port 10000. There are two separate listeners.
This PR combines these listeners into one with a cmux lib.
The gRPC server runs on either 443 with TLS or 80 without TLS.
Let's Encrypt manager always runs on port 80.