### PR TITLE
Use unix.Uname to get Darwin system info

### DIFF
--- a/client/system/info_darwin.go
+++ b/client/system/info_darwin.go
@@ -4,41 +4,25 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"golang.org/x/sys/unix"
 	"os"
-	"os/exec"
 	"runtime"
-	"strings"
-	"time"
 )
 
 // GetInfo retrieves and parses the system information
 func GetInfo(ctx context.Context) *Info {
-	out := _getInfo()
-	for strings.Contains(out, "broken pipe") {
-		out = _getInfo()
-		time.Sleep(500 * time.Millisecond)
+	utsname := unix.Utsname{}
+	err := unix.Uname(&utsname)
+	if err != nil {
+		fmt.Println("getInfo:", err)
 	}
-	osStr := strings.Replace(out, "\n", "", -1)
-	osStr = strings.Replace(osStr, "\r\n", "", -1)
-	osInfo := strings.Split(osStr, " ")
-	gio := &Info{Kernel: osInfo[0], OSVersion: osInfo[1], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
+	sysName := string(bytes.Split(utsname.Sysname[:], []byte{0})[0])
+	machine := string(bytes.Split(utsname.Machine[:], []byte{0})[0])
+	release := string(bytes.Split(utsname.Release[:], []byte{0})[0])
+	gio := &Info{Kernel: sysName, OSVersion: release, Core: release, Platform: machine, OS: sysName, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	gio.WiretrusteeVersion = NetbirdVersion()
 	gio.UIVersion = extractUserAgent(ctx)
 
 	return gio
-}
-
-func _getInfo() string {
-	cmd := exec.Command("uname", "-srm")
-	cmd.Stdin = strings.NewReader("some input")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil {
-		fmt.Println("getInfo:", err)
-	}
-	return out.String()
 }


### PR DESCRIPTION
This prevents the client from needing to use command line tools

relates to #403
