### PR TITLE
Split goreleaser for UI and parallelized workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   SIGN_PIPE_VER: "v0.0.3"
+  GORELEASER_VER: "v1.6.3"
 
 jobs:
   release:
@@ -57,20 +58,11 @@ jobs:
           username: netbirdio
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -y -q libgtk-3-dev libappindicator3-dev libayatana-appindicator3-dev libgl1-mesa-dev xorg-dev gcc-mingw-w64-x86-64
-
-      - name: Install rsrc
-        run: go install github.com/akavel/rsrc@v0.10.2
-
-      - name: Generate windows rsrc
-        run: rsrc -arch amd64 -ico client/ui/netbird.ico -manifest client/ui/manifest.xml -o client/ui/resources_windows_amd64.syso
-
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v1.6.3
+          version: ${{ env.GORELEASER_VER }}
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,24 +70,63 @@ jobs:
           UPLOAD_DEBIAN_SECRET: ${{ secrets.PKG_UPLOAD_SECRET }}
           UPLOAD_YUM_SECRET: ${{ secrets.PKG_UPLOAD_SECRET }}
       -
-        name: Trigger Windows binaries sign pipeline
-        uses: benc-uk/workflow-dispatch@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          workflow: Sign windows bin and installer
-          repo: netbirdio/sign-pipelines
-          ref: ${{ env.SIGN_PIPE_VER }}
-          token: ${{ secrets.SIGN_GITHUB_TOKEN }}
-          inputs: '{ "tag": "${{ github.ref }}" }'
-      -
         name: upload non tags for debug purposes
         uses: actions/upload-artifact@v2
         with:
-          name: build
+          name: release
           path: dist/
           retention-days: 3
-          
+
   release_ui:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # It is required for GoReleaser to work properly
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Cache Go modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-ui-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-ui-go-
+
+      - name: Install modules
+        run: go mod tidy
+
+      - name: check git status
+        run: git --no-pager diff --exit-code
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -y -q libgtk-3-dev libappindicator3-dev libayatana-appindicator3-dev libgl1-mesa-dev xorg-dev gcc-mingw-w64-x86-64
+      - name: Install rsrc
+        run: go install github.com/akavel/rsrc@v0.10.2
+      - name: Generate windows rsrc
+        run: rsrc -arch amd64 -ico client/ui/netbird.ico -manifest client/ui/manifest.xml -o client/ui/resources_windows_amd64.syso
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: ${{ env.GORELEASER_VER }}
+          args: release --config .goreleaser_ui.yaml --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          UPLOAD_DEBIAN_SECRET: ${{ secrets.PKG_UPLOAD_SECRET }}
+          UPLOAD_YUM_SECRET: ${{ secrets.PKG_UPLOAD_SECRET }}
+      - name: upload non tags for debug purposes
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-ui
+          path: dist/
+          retention-days: 3
+
+  release_ui_darwin:
     runs-on: macos-latest
     steps:
       -
@@ -113,9 +144,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-ui-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-ui-go-
       -
         name: Install modules
         run: go mod tidy
@@ -124,26 +155,42 @@ jobs:
         id: goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v1.6.3
+          version: ${{ env.GORELEASER_VER }}
           args: release --config .goreleaser_ui_darwin.yaml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       -
-        name: Trigger Darwin App binaries sign pipeline
+        name: upload non tags for debug purposes
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-ui-darwin
+          path: dist/
+          retention-days: 3
+
+  trigger_windows_signer:
+    runs-on: ubuntu-latest
+    needs: [release,release_ui]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Trigger Windows binaries sign pipeline
         uses: benc-uk/workflow-dispatch@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          workflow: Sign windows bin and installer
+          repo: netbirdio/sign-pipelines
+          ref: ${{ env.SIGN_PIPE_VER }}
+          token: ${{ secrets.SIGN_GITHUB_TOKEN }}
+          inputs: '{ "tag": "${{ github.ref }}" }'
+
+  trigger_darwin_signer:
+    runs-on: ubuntu-latest
+    needs: release_ui_darwin
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Trigger Darwin App binaries sign pipeline
+        uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Sign darwin ui app with dispatch
           repo: netbirdio/sign-pipelines
           ref: ${{ env.SIGN_PIPE_VER }}
           token: ${{ secrets.SIGN_GITHUB_TOKEN }}
           inputs: '{ "tag": "${{ github.ref }}" }'
-
-      -
-        name: upload non tags for debug purposes
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-ui-darwin
-          path: dist/
-          retention-days: 3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,87 +58,11 @@ builds:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
     mod_timestamp: '{{ .CommitTimestamp }}'
 
-  - id: netbird-ui
-    dir: client/ui
-    binary: netbird-ui
-    env:
-      - CGO_ENABLED=1
-    goos:
-      - linux
-    goarch:
-      - amd64
-    ldflags:
-      - -s -w -X github.com/netbirdio/netbird/client/system.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
-    mod_timestamp: '{{ .CommitTimestamp }}'
-
-  - id: netbird-ui-windows
-    dir: client/ui
-    binary: netbird-ui
-    env:
-      - CGO_ENABLED=1
-      - CC=x86_64-w64-mingw32-gcc
-    goos:
-      - windows
-    goarch:
-      - amd64
-    ldflags:
-      - -s -w -X github.com/netbirdio/netbird/client/system.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
-      - -H windowsgui
-    mod_timestamp: '{{ .CommitTimestamp }}'
-
 archives:
   - builds:
       - netbird
-  - id: linux-arch
-    name_template: "{{ .ProjectName }}-ui-linux_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    builds:
-      - netbird-ui
-  - id: windows-arch
-    name_template: "{{ .ProjectName }}-ui-windows_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    builds:
-      - netbird-ui-windows
 
 nfpms:
-
-  - maintainer: Netbird <dev@netbird.io>
-    description: Netbird client UI.
-    homepage: https://netbird.io/
-    id: netbird-ui-deb
-    package_name: netbird-ui
-    builds:
-      - netbird-ui
-    formats:
-      - deb
-    contents:
-      - src: client/ui/netbird.desktop
-        dst: /usr/share/applications/netbird.desktop
-      - src: client/ui/disconnected.png
-        dst: /usr/share/pixmaps/netbird.png
-    dependencies:
-      - libayatana-appindicator3-1
-      - libgtk-3-dev
-      - libappindicator3-dev
-      - netbird
-
-  - maintainer: Netbird <dev@netbird.io>
-    description: Netbird client UI.
-    homepage: https://netbird.io/
-    id: netbird-ui-rpm
-    package_name: netbird-ui
-    builds:
-      - netbird-ui
-    formats:
-      - rpm
-    contents:
-      - src: client/ui/netbird.desktop
-        dst: /usr/share/applications/netbird.desktop
-      - src: client/ui/disconnected.png
-        dst: /usr/share/pixmaps/netbird.png
-    dependencies:
-      - libayatana-appindicator3-1
-      - libgtk-3-dev
-      - libappindicator3-dev
-      - netbird
 
   - maintainer: Netbird <dev@netbird.io>
     description: Netbird client.
@@ -431,7 +355,6 @@ uploads:
   - name: debian
     ids:
     - netbird-deb
-    - netbird-ui-deb
     mode: archive
     target: https://pkgs.wiretrustee.com/debian/pool/{{ .ArtifactName }};deb.distribution=stable;deb.component=main;deb.architecture={{ if .Arm }}armhf{{ else }}{{ .Arch }}{{ end }};deb.package=
     username: dev@wiretrustee.com
@@ -440,7 +363,6 @@ uploads:
   - name: yum
     ids:
       - netbird-rpm
-      - netbird-ui-rpm
     mode: archive
     target: https://pkgs.wiretrustee.com/yum/{{ .Arch }}{{ if .Arm }}{{ .Arm }}{{ end }}
     username: dev@wiretrustee.com

--- a/.goreleaser_ui.yaml
+++ b/.goreleaser_ui.yaml
@@ -1,0 +1,98 @@
+project_name: netbird-ui
+builds:
+  - id: netbird-ui
+    dir: client/ui
+    binary: netbird-ui
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w -X github.com/netbirdio/netbird/client/system.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
+  - id: netbird-ui-windows
+    dir: client/ui
+    binary: netbird-ui
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+    goos:
+      - windows
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w -X github.com/netbirdio/netbird/client/system.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+      - -H windowsgui
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
+archives:
+  - id: linux-arch
+    name_template: "{{ .ProjectName }}-linux_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    builds:
+      - netbird-ui
+  - id: windows-arch
+    name_template: "{{ .ProjectName }}-windows_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    builds:
+      - netbird-ui-windows
+
+nfpms:
+
+  - maintainer: Netbird <dev@netbird.io>
+    description: Netbird client UI.
+    homepage: https://netbird.io/
+    id: netbird-ui-deb
+    package_name: netbird-ui
+    builds:
+      - netbird-ui
+    formats:
+      - deb
+    contents:
+      - src: client/ui/netbird.desktop
+        dst: /usr/share/applications/netbird.desktop
+      - src: client/ui/disconnected.png
+        dst: /usr/share/pixmaps/netbird.png
+    dependencies:
+      - libayatana-appindicator3-1
+      - libgtk-3-dev
+      - libappindicator3-dev
+      - netbird
+
+  - maintainer: Netbird <dev@netbird.io>
+    description: Netbird client UI.
+    homepage: https://netbird.io/
+    id: netbird-ui-rpm
+    package_name: netbird-ui
+    builds:
+      - netbird-ui
+    formats:
+      - rpm
+    contents:
+      - src: client/ui/netbird.desktop
+        dst: /usr/share/applications/netbird.desktop
+      - src: client/ui/disconnected.png
+        dst: /usr/share/pixmaps/netbird.png
+    dependencies:
+      - libayatana-appindicator3-1
+      - libgtk-3-dev
+      - libappindicator3-dev
+      - netbird
+
+uploads:
+  - name: debian
+    ids:
+    - netbird-ui-deb
+    mode: archive
+    target: https://pkgs.wiretrustee.com/debian/pool/{{ .ArtifactName }};deb.distribution=stable;deb.component=main;deb.architecture={{ if .Arm }}armhf{{ else }}{{ .Arch }}{{ end }};deb.package=
+    username: dev@wiretrustee.com
+    method: PUT
+
+  - name: yum
+    ids:
+      - netbird-ui-rpm
+    mode: archive
+    target: https://pkgs.wiretrustee.com/yum/{{ .Arch }}{{ if .Arm }}{{ .Arm }}{{ end }}
+    username: dev@wiretrustee.com
+    method: PUT


### PR DESCRIPTION
decouple goreleaser ui might help us
parallelize workflow and run local tests

dividing the release workflow for each goreleaser
and making trigger sign a different job them
when small issues with sign happen