### PR TITLE
Check and update Agent's Management URL if is legacy

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -43,6 +43,8 @@ var loginCmd = &cobra.Command{
 				return fmt.Errorf("get config file: %v", err)
 			}
 
+			config, _ = internal.CheckNewManagementPort(ctx, config, configPath)
+
 			err = foregroundLogin(ctx, cmd, config, setupKey)
 			if err != nil {
 				return fmt.Errorf("foreground login failed: %v", err)

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -43,7 +43,7 @@ var loginCmd = &cobra.Command{
 				return fmt.Errorf("get config file: %v", err)
 			}
 
-			config, _ = internal.CheckNewManagementPort(ctx, config, configPath)
+			config, _ = internal.UpdateOldManagementPort(ctx, config, configPath)
 
 			err = foregroundLogin(ctx, cmd, config, setupKey)
 			if err != nil {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -40,7 +40,7 @@ var upCmd = &cobra.Command{
 				return fmt.Errorf("get config file: %v", err)
 			}
 
-			config, _ = internal.CheckNewManagementPort(ctx, config, configPath)
+			config, _ = internal.UpdateOldManagementPort(ctx, config, configPath)
 
 			err = foregroundLogin(ctx, cmd, config, setupKey)
 			if err != nil {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -40,6 +40,8 @@ var upCmd = &cobra.Command{
 				return fmt.Errorf("get config file: %v", err)
 			}
 
+			config, _ = internal.CheckNewManagementPort(ctx, config, configPath)
+
 			err = foregroundLogin(ctx, cmd, config, setupKey)
 			if err != nil {
 				return fmt.Errorf("foreground login failed: %v", err)

--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -22,7 +22,7 @@ func ManagementURLDefault() *url.URL {
 }
 
 func init() {
-	managementURL, err := parseURL("Management URL", "https://api.wiretrustee.com:443")
+	managementURL, err := ParseURL("Management URL", "https://api.wiretrustee.com:443")
 	if err != nil {
 		panic(err)
 	}
@@ -51,7 +51,7 @@ func createNewConfig(managementURL, adminURL, configPath, preSharedKey string) (
 	}
 	config := &Config{SSHKey: string(pem), PrivateKey: wgKey, WgIface: iface.WgInterfaceDefault, IFaceBlackList: []string{}}
 	if managementURL != "" {
-		URL, err := parseURL("Management URL", managementURL)
+		URL, err := ParseURL("Management URL", managementURL)
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +65,7 @@ func createNewConfig(managementURL, adminURL, configPath, preSharedKey string) (
 	}
 
 	if adminURL != "" {
-		newURL, err := parseURL("Admin Panel URL", adminURL)
+		newURL, err := ParseURL("Admin Panel URL", adminURL)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +83,8 @@ func createNewConfig(managementURL, adminURL, configPath, preSharedKey string) (
 	return config, nil
 }
 
-func parseURL(serviceName, managementURL string) (*url.URL, error) {
+// ParseURL parses and validates management URL
+func ParseURL(serviceName, managementURL string) (*url.URL, error) {
 	parsedMgmtURL, err := url.ParseRequestURI(managementURL)
 	if err != nil {
 		log.Errorf("failed parsing management URL %s: [%s]", managementURL, err.Error())
@@ -115,7 +116,7 @@ func ReadConfig(managementURL, adminURL, configPath string, preSharedKey *string
 	if managementURL != "" && config.ManagementURL.String() != managementURL {
 		log.Infof("new Management URL provided, updated to %s (old value %s)",
 			managementURL, config.ManagementURL)
-		newURL, err := parseURL("Management URL", managementURL)
+		newURL, err := ParseURL("Management URL", managementURL)
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +127,7 @@ func ReadConfig(managementURL, adminURL, configPath string, preSharedKey *string
 	if adminURL != "" && (config.AdminURL == nil || config.AdminURL.String() != adminURL) {
 		log.Infof("new Admin Panel URL provided, updated to %s (old value %s)",
 			adminURL, config.AdminURL)
-		newURL, err := parseURL("Admin Panel URL", adminURL)
+		newURL, err := ParseURL("Admin Panel URL", adminURL)
 		if err != nil {
 			return nil, err
 		}

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -246,13 +246,18 @@ func connectToManagement(ctx context.Context, managementAddr string, ourPrivateK
 func CheckNewManagementPort(ctx context.Context, config *Config, configPath string) (*Config, error) {
 
 	if config.ManagementURL.Hostname() != ManagementURLDefault().Hostname() {
-		//only do the check for the NetBird managed version
+		// only do the check for the NetBird managed version
 		return config, nil
 	}
 
 	var mgmTlsEnabled bool
 	if config.ManagementURL.Scheme == "https" {
 		mgmTlsEnabled = true
+	}
+
+	if !mgmTlsEnabled {
+		// only do the check for HTTPs scheme (the hosted version of the Management service is always HTTPs)
+		return config, nil
 	}
 
 	if mgmTlsEnabled && config.ManagementURL.Port() == fmt.Sprintf("%d", mgmtcmd.ManagementLegacyPort) {

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -241,12 +241,13 @@ func connectToManagement(ctx context.Context, managementAddr string, ourPrivateK
 	return client, loginResp, nil
 }
 
-// CheckNewManagementPort checks whether client can switch to the new Management port 443.
+// UpdateOldManagementPort checks whether client can switch to the new Management port 443.
 // If it can switch, then it updates the config and returns a new one. Otherwise, it returns the provided config.
-func CheckNewManagementPort(ctx context.Context, config *Config, configPath string) (*Config, error) {
+// The check is performed only for the NetBird's managed version.
+func UpdateOldManagementPort(ctx context.Context, config *Config, configPath string) (*Config, error) {
 
 	if config.ManagementURL.Hostname() != ManagementURLDefault().Hostname() {
-		// only do the check for the NetBird managed version
+		// only do the check for the NetBird's managed version
 		return config, nil
 	}
 

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -282,15 +282,10 @@ func UpdateOldManagementPort(ctx context.Context, config *Config, configPath str
 			log.Infof("couldn't switch to the new Management %s", newURL.String())
 			return config, err
 		}
+		defer client.Close() //nolint
 
 		// gRPC check
 		_, err = client.GetServerPublicKey()
-		if err != nil {
-			log.Infof("couldn't switch to the new Management %s", newURL.String())
-			return nil, err
-		}
-
-		err = client.Close()
 		if err != nil {
 			log.Infof("couldn't switch to the new Management %s", newURL.String())
 			return nil, err

--- a/client/internal/login.go
+++ b/client/internal/login.go
@@ -49,6 +49,7 @@ func Login(ctx context.Context, config *Config, setupKey string, jwtToken string
 		log.Errorf("failed logging-in peer on Management Service : %v", err)
 		return err
 	}
+	log.Infof("peer has successfully logged-in to the Management service %s", config.ManagementURL.String())
 
 	err = mgmClient.Close()
 	if err != nil {
@@ -71,8 +72,6 @@ func loginPeer(ctx context.Context, serverPublicKey wgtypes.Key, client *mgm.Grp
 			return nil, err
 		}
 	}
-
-	log.Info("peer has successfully logged-in to Management Service")
 
 	return loginResp, nil
 }

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -92,7 +92,7 @@ func (s *Server) Start() error {
 	}
 
 	// if configuration exists, we just start connections.
-	config, _ = internal.CheckNewManagementPort(ctx, config, s.configPath)
+	config, _ = internal.UpdateOldManagementPort(ctx, config, s.configPath)
 
 	s.config = config
 
@@ -170,7 +170,7 @@ func (s *Server) Login(callerCtx context.Context, msg *proto.LoginRequest) (*pro
 	}
 
 	if msg.ManagementUrl == "" {
-		config, _ = internal.CheckNewManagementPort(ctx, config, s.configPath)
+		config, _ = internal.UpdateOldManagementPort(ctx, config, s.configPath)
 		s.config = config
 		s.managementURL = config.ManagementURL.String()
 	}

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -92,6 +92,7 @@ func (s *Server) Start() error {
 	}
 
 	// if configuration exists, we just start connections.
+	config, _ = internal.CheckNewManagementPort(ctx, config, s.configPath)
 
 	s.config = config
 
@@ -166,6 +167,12 @@ func (s *Server) Login(callerCtx context.Context, msg *proto.LoginRequest) (*pro
 	config, err := internal.GetConfig(managementURL, adminURL, s.configPath, msg.PreSharedKey)
 	if err != nil {
 		return nil, err
+	}
+
+	if msg.ManagementUrl == "" {
+		config, _ = internal.CheckNewManagementPort(ctx, config, s.configPath)
+		s.config = config
+		s.managementURL = config.ManagementURL.String()
 	}
 
 	s.mutex.Lock()


### PR DESCRIPTION
Relates to https://github.com/netbirdio/netbird/pull/400

All the existing agents by default connect to port 33073 of the
Management service. This value is also stored in the local config.
All the agents won't switch to the new port 443 
unless explicitly specified in the config.
We want the transition to be smooth for our users, therefore
this PR adds logic to check whether the old port 33073 can be 
changed to 443 and updates the config automatically.
