### PR TITLE
Enable HTTP/2 when loading TLS config from file

### DIFF
--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -319,6 +319,9 @@ func loadTLSConfig(certFile string, certKey string) (*tls.Config, error) {
 	config := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
 		ClientAuth:   tls.NoClientCert,
+		NextProtos: []string{
+			"h2", "http/1.1", // enable HTTP/2
+		},
 	}
 
 	return config, nil


### PR DESCRIPTION
When creating TLSConfig from provided certificate file, the HTTP/2 support is not enabled.
It works with Certmanager because it adds h2 support.
We can enable it the same way when creating TLSConfig from files:
```
NextProtos: []string{
  "h2", "http/1.1", // enable HTTP/2
  acme.ALPNProto, // enable tls-alpn ACME challenges
},
```  

Thanks to @kid-alan for pointing out the issue in https://github.com/netbirdio/netbird/issues/422