### PR TITLE
Fix Register/Deregister race on Signal

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -382,8 +382,6 @@ func signalCandidate(candidate ice.Candidate, myKey wgtypes.Key, remoteKey wgtyp
 		},
 	})
 	if err != nil {
-		log.Errorf("failed signaling candidate to the remote peer %s %s", remoteKey.String(), err)
-		// todo ??
 		return err
 	}
 
@@ -704,6 +702,7 @@ func (e Engine) peerExists(peerKey string) bool {
 }
 
 func (e Engine) createPeerConn(pubKey string, allowedIPs string) (*peer.Conn, error) {
+	log.Debugf("creating peer connection %s", pubKey)
 	var stunTurn []*ice.URL
 	stunTurn = append(stunTurn, e.STUNs...)
 	stunTurn = append(stunTurn, e.TURNs...)

--- a/signal/client/grpc.go
+++ b/signal/client/grpc.go
@@ -139,6 +139,7 @@ func (c *GrpcClient) Receive(msgHandler func(msg *proto.Message) error) error {
 			// we need this reset because after a successful connection and a consequent error, backoff lib doesn't
 			// reset times and next try will start with a long delay
 			backOff.Reset()
+			log.Warnf("disconnected from the Signal service but will retry silently. Reason: %v", err)
 			return err
 		}
 

--- a/signal/peer/peer.go
+++ b/signal/peer/peer.go
@@ -70,7 +70,6 @@ func (registry *Registry) Register(peer *Peer) {
 		log.Warnf("peer [%s] is already registered [new streamID %d, previous StreamID %d]. Will override stream.",
 			peer.Id, peer.StreamID, pp.StreamID)
 		registry.Peers.Store(peer.Id, peer)
-		return
 	}
 	log.Debugf("peer registered [%s]", peer.Id)
 	return

--- a/signal/peer/peer.go
+++ b/signal/peer/peer.go
@@ -86,8 +86,8 @@ func (registry *Registry) Deregister(peer *Peer) {
 		pp := p.(*Peer)
 		if peer.StreamID < pp.StreamID {
 			registry.Peers.Store(peer.Id, p)
-			log.Warnf("attempted to remove newer registered stream of a peer [%s] [newer streamID %d, previous StreamID %d]",
-				peer.Id, peer.StreamID, pp.StreamID)
+			log.Warnf("attempted to remove newer registered stream of a peer [%s] [newer streamID %d, previous StreamID %d]. Ignoring.",
+				peer.Id, pp.StreamID, peer.StreamID)
 			return
 		}
 	}

--- a/signal/peer/peer.go
+++ b/signal/peer/peer.go
@@ -67,7 +67,7 @@ func (registry *Registry) Register(peer *Peer) error {
 	p, loaded := registry.Peers.LoadOrStore(peer.Id, peer)
 	if loaded {
 		pp := p.(*Peer)
-		log.Warnf("peer [%s] is already registered [new streamID %d, previous StreamID %d]",
+		log.Warnf("peer [%s] is already registered [new streamID %d, previous StreamID %d]. Will override stream.",
 			peer.Id, peer.StreamID, pp.StreamID)
 		registry.Peers.Store(peer.Id, peer)
 		return nil

--- a/signal/peer/peer.go
+++ b/signal/peer/peer.go
@@ -59,7 +59,7 @@ func (registry *Registry) IsPeerRegistered(peerId string) bool {
 }
 
 // Register registers peer in the registry
-func (registry *Registry) Register(peer *Peer) error {
+func (registry *Registry) Register(peer *Peer) {
 	registry.regMutex.Lock()
 	defer registry.regMutex.Unlock()
 
@@ -70,10 +70,10 @@ func (registry *Registry) Register(peer *Peer) error {
 		log.Warnf("peer [%s] is already registered [new streamID %d, previous StreamID %d]. Will override stream.",
 			peer.Id, peer.StreamID, pp.StreamID)
 		registry.Peers.Store(peer.Id, peer)
-		return nil
+		return
 	}
 	log.Debugf("peer registered [%s]", peer.Id)
-	return nil
+	return
 }
 
 // Deregister Peer from the Registry (usually once it disconnects)

--- a/signal/peer/peer.go
+++ b/signal/peer/peer.go
@@ -4,12 +4,15 @@ import (
 	"github.com/netbirdio/netbird/signal/proto"
 	log "github.com/sirupsen/logrus"
 	"sync"
+	"time"
 )
 
 // Peer representation of a connected Peer
 type Peer struct {
 	// a unique id of the Peer (e.g. sha256 fingerprint of the Wireguard public key)
 	Id string
+
+	StreamID int64
 
 	//a gRpc connection stream to the Peer
 	Stream proto.SignalExchange_ConnectStreamServer
@@ -18,8 +21,9 @@ type Peer struct {
 // NewPeer creates a new instance of a connected Peer
 func NewPeer(id string, stream proto.SignalExchange_ConnectStreamServer) *Peer {
 	return &Peer{
-		Id:     id,
-		Stream: stream,
+		Id:       id,
+		Stream:   stream,
+		StreamID: time.Now().UnixMilli(),
 	}
 }
 
@@ -27,11 +31,15 @@ func NewPeer(id string, stream proto.SignalExchange_ConnectStreamServer) *Peer {
 type Registry struct {
 	// Peer.key -> Peer
 	Peers sync.Map
+	// regMutex ensures that registration and de-registrations are safe
+	regMutex sync.Mutex
 }
 
 // NewRegistry creates a new connected Peer registry
 func NewRegistry() *Registry {
-	return &Registry{}
+	return &Registry{
+		regMutex: sync.Mutex{},
+	}
 }
 
 // Get gets a peer from the registry
@@ -51,21 +59,37 @@ func (registry *Registry) IsPeerRegistered(peerId string) bool {
 }
 
 // Register registers peer in the registry
-func (registry *Registry) Register(peer *Peer) {
-	// can be that peer already exists but it is fine (e.g. reconnect)
-	// todo investigate what happens to the old peer (especially Peer.Stream) when we override it
-	registry.Peers.Store(peer.Id, peer)
-	log.Debugf("peer registered [%s]", peer.Id)
+func (registry *Registry) Register(peer *Peer) error {
+	registry.regMutex.Lock()
+	defer registry.regMutex.Unlock()
 
+	// can be that peer already exists, but it is fine (e.g. reconnect)
+	p, loaded := registry.Peers.LoadOrStore(peer.Id, peer)
+	if loaded {
+		pp := p.(*Peer)
+		log.Warnf("peer [%s] is already registered [new streamID %d, previous StreamID %d]",
+			peer.Id, peer.StreamID, pp.StreamID)
+		registry.Peers.Store(peer.Id, peer)
+		return nil
+	}
+	log.Debugf("peer registered [%s]", peer.Id)
+	return nil
 }
 
-// Deregister deregister Peer from the Registry (usually once it disconnects)
+// Deregister Peer from the Registry (usually once it disconnects)
 func (registry *Registry) Deregister(peer *Peer) {
-	_, loaded := registry.Peers.LoadAndDelete(peer.Id)
-	if loaded {
-		log.Debugf("peer deregistered [%s]", peer.Id)
-	} else {
-		log.Warnf("attempted to remove non-existent peer [%s]", peer.Id)
-	}
+	registry.regMutex.Lock()
+	defer registry.regMutex.Unlock()
 
+	p, loaded := registry.Peers.LoadAndDelete(peer.Id)
+	if loaded {
+		pp := p.(*Peer)
+		if peer.StreamID < pp.StreamID {
+			registry.Peers.Store(peer.Id, p)
+			log.Warnf("attempted to remove newer registered stream of a peer [%s] [newer streamID %d, previous StreamID %d]",
+				peer.Id, peer.StreamID, pp.StreamID)
+			return
+		}
+	}
+	log.Debugf("peer deregistered [%s]", peer.Id)
 }

--- a/signal/peer/peer.go
+++ b/signal/peer/peer.go
@@ -23,11 +23,11 @@ func NewPeer(id string, stream proto.SignalExchange_ConnectStreamServer) *Peer {
 	return &Peer{
 		Id:       id,
 		Stream:   stream,
-		StreamID: time.Now().UnixMilli(),
+		StreamID: time.Now().UnixNano(),
 	}
 }
 
-// Registry registry that holds all currently connected Peers
+// Registry that holds all currently connected Peers
 type Registry struct {
 	// Peer.key -> Peer
 	Peers sync.Map

--- a/signal/peer/peer.go
+++ b/signal/peer/peer.go
@@ -72,7 +72,6 @@ func (registry *Registry) Register(peer *Peer) {
 		registry.Peers.Store(peer.Id, peer)
 	}
 	log.Debugf("peer registered [%s]", peer.Id)
-	return
 }
 
 // Deregister Peer from the Registry (usually once it disconnects)

--- a/signal/peer/peer_test.go
+++ b/signal/peer/peer_test.go
@@ -1,8 +1,29 @@
 package peer
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
+
+func TestRegistry_ShouldNotDeregisterWhenHasNewerStreamRegistered(t *testing.T) {
+	r := NewRegistry()
+
+	peerID := "peer"
+
+	// when registry has a peer registered with the newest stream
+	peer1 := &Peer{Id: peerID, StreamID: 2, Stream: nil}
+	r.Register(peer1)
+
+	// and deregister with a peer with an older stream
+	peer2 := &Peer{Id: peerID, StreamID: 1, Stream: nil}
+	r.Deregister(peer2)
+
+	// then the newest stream should be left in the registry
+	registered, _ := r.Get(peer2.Id)
+
+	assert.NotNil(t, registered, "peer can't be nil")
+	assert.Equal(t, peer1, registered)
+}
 
 func TestRegistry_GetNonExistentPeer(t *testing.T) {
 	r := NewRegistry()

--- a/signal/peer/peer_test.go
+++ b/signal/peer/peer_test.go
@@ -22,8 +22,14 @@ func TestRegistry_Register(t *testing.T) {
 	r := NewRegistry()
 	peer1 := NewPeer("test_peer_1", nil)
 	peer2 := NewPeer("test_peer_2", nil)
-	r.Register(peer1)
-	r.Register(peer2)
+	err := r.Register(peer1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = r.Register(peer2)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if _, ok := r.Get("test_peer_1"); !ok {
 		t.Errorf("expected test_peer_1 not found in the registry")
@@ -38,8 +44,14 @@ func TestRegistry_Deregister(t *testing.T) {
 	r := NewRegistry()
 	peer1 := NewPeer("test_peer_1", nil)
 	peer2 := NewPeer("test_peer_2", nil)
-	r.Register(peer1)
-	r.Register(peer2)
+	err := r.Register(peer1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = r.Register(peer2)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	r.Deregister(peer1)
 

--- a/signal/peer/peer_test.go
+++ b/signal/peer/peer_test.go
@@ -3,6 +3,7 @@ package peer
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestRegistry_ShouldNotDeregisterWhenHasNewerStreamRegistered(t *testing.T) {
@@ -10,19 +11,22 @@ func TestRegistry_ShouldNotDeregisterWhenHasNewerStreamRegistered(t *testing.T) 
 
 	peerID := "peer"
 
-	// when registry has a peer registered with the newest stream
-	peer1 := &Peer{Id: peerID, StreamID: 2, Stream: nil}
-	r.Register(peer1)
+	olderPeer := NewPeer(peerID, nil)
+	r.Register(olderPeer)
+	time.Sleep(time.Nanosecond)
 
-	// and deregister with a peer with an older stream
-	peer2 := &Peer{Id: peerID, StreamID: 1, Stream: nil}
-	r.Deregister(peer2)
-
-	// then the newest stream should be left in the registry
-	registered, _ := r.Get(peer2.Id)
+	newerPeer := NewPeer(peerID, nil)
+	r.Register(newerPeer)
+	registered, _ := r.Get(olderPeer.Id)
 
 	assert.NotNil(t, registered, "peer can't be nil")
-	assert.Equal(t, peer1, registered)
+	assert.Equal(t, newerPeer, registered)
+
+	r.Deregister(olderPeer)
+	registered, _ = r.Get(olderPeer.Id)
+
+	assert.NotNil(t, registered, "peer can't be nil")
+	assert.Equal(t, newerPeer, registered)
 }
 
 func TestRegistry_GetNonExistentPeer(t *testing.T) {

--- a/signal/peer/peer_test.go
+++ b/signal/peer/peer_test.go
@@ -22,14 +22,8 @@ func TestRegistry_Register(t *testing.T) {
 	r := NewRegistry()
 	peer1 := NewPeer("test_peer_1", nil)
 	peer2 := NewPeer("test_peer_2", nil)
-	err := r.Register(peer1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = r.Register(peer2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	r.Register(peer1)
+	r.Register(peer2)
 
 	if _, ok := r.Get("test_peer_1"); !ok {
 		t.Errorf("expected test_peer_1 not found in the registry")
@@ -44,14 +38,8 @@ func TestRegistry_Deregister(t *testing.T) {
 	r := NewRegistry()
 	peer1 := NewPeer("test_peer_1", nil)
 	peer2 := NewPeer("test_peer_2", nil)
-	err := r.Register(peer1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = r.Register(peer2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	r.Register(peer1)
+	r.Register(peer2)
 
 	r.Deregister(peer1)
 

--- a/signal/server/signal.go
+++ b/signal/server/signal.go
@@ -101,10 +101,7 @@ func (s Server) connectPeer(stream proto.SignalExchange_ConnectStreamServer) (*p
 	if meta, hasMeta := metadata.FromIncomingContext(stream.Context()); hasMeta {
 		if id, found := meta[proto.HeaderId]; found {
 			p := peer.NewPeer(id[0], stream)
-			err := s.registry.Register(p)
-			if err != nil {
-				return nil, err
-			}
+			s.registry.Register(p)
 			return p, nil
 		} else {
 			return nil, status.Errorf(codes.FailedPrecondition, "missing connection header: "+proto.HeaderId)


### PR DESCRIPTION
This PR fixes a race condition that happens
when agents connect to a Signal stream, multiple 
times within a short amount of time. Common on 
slow and unstable internet connections.
Every time an agent establishes a new connection
to Signal, Signal creates a Stream and writes an entry 
to the registry of connected peers storing the stream.
Every time an agent disconnects, Signal removes the
stream from the registry. 
Due to unstable connections, the agent could detect 
a broken connection, and attempt to reconnect to Signal.
Signal will override the stream, but it might detect
the old broken connection later, causing peer deregistration.
It will deregister the peer leaving the client thinking 
it is still connected, rejecting any messages.