### PR TITLE
Add incoming routing rules

### DIFF
--- a/client/internal/routemanager/firewall_linux.go
+++ b/client/internal/routemanager/firewall_linux.go
@@ -9,14 +9,16 @@ import (
 import "github.com/google/nftables"
 
 const (
-	ipv6Forwarding   = "netbird-rt-ipv6-forwarding"
-	ipv4Forwarding   = "netbird-rt-ipv4-forwarding"
-	ipv6Nat          = "netbird-rt-ipv6-nat"
-	ipv4Nat          = "netbird-rt-ipv4-nat"
-	natFormat        = "netbird-nat-%s"
-	forwardingFormat = "netbird-fwd-%s"
-	ipv6             = "ipv6"
-	ipv4             = "ipv4"
+	ipv6Forwarding     = "netbird-rt-ipv6-forwarding"
+	ipv4Forwarding     = "netbird-rt-ipv4-forwarding"
+	ipv6Nat            = "netbird-rt-ipv6-nat"
+	ipv4Nat            = "netbird-rt-ipv4-nat"
+	natFormat          = "netbird-nat-%s"
+	forwardingFormat   = "netbird-fwd-%s"
+	inNatFormat        = "netbird-nat-in-%s"
+	inForwardingFormat = "netbird-fwd-in-%s"
+	ipv6               = "ipv6"
+	ipv4               = "ipv4"
 )
 
 func genKey(format string, input string) string {
@@ -52,4 +54,16 @@ func NewFirewall(parentCTX context.Context) firewallManager {
 	}
 
 	return manager
+}
+
+func getInPair(pair routerPair) routerPair {
+	inPair := pair
+	inPair.source = pair.destination
+	inPair.destination = pair.source
+	return routerPair{
+		ID:          pair.ID,
+		source:      pair.destination,
+		destination: pair.source,
+		masquerade:  pair.masquerade,
+	}
 }

--- a/client/internal/routemanager/firewall_linux.go
+++ b/client/internal/routemanager/firewall_linux.go
@@ -57,11 +57,9 @@ func NewFirewall(parentCTX context.Context) firewallManager {
 }
 
 func getInPair(pair routerPair) routerPair {
-	inPair := pair
-	inPair.source = pair.destination
-	inPair.destination = pair.source
 	return routerPair{
-		ID:          pair.ID,
+		ID: pair.ID,
+		// invert source/destination
 		source:      pair.destination,
 		destination: pair.source,
 		masquerade:  pair.masquerade,

--- a/client/internal/routemanager/iptables_linux_test.go
+++ b/client/internal/routemanager/iptables_linux_test.go
@@ -186,7 +186,7 @@ func TestIptablesManager_InsertRoutingRules(t *testing.T) {
 				require.False(t, foundNat, "nat rule should not exist in the map")
 			}
 
-			inNatRuleKey := genKey(natFormat, testCase.inputPair.ID)
+			inNatRuleKey := genKey(inNatFormat, testCase.inputPair.ID)
 			inNatRule := genRuleSpec(routingFinalNatJump, inNatRuleKey, getInPair(testCase.inputPair).source, getInPair(testCase.inputPair).destination)
 
 			exists, err = iptablesClient.Exists(iptablesNatTable, iptablesRoutingNatChain, inNatRule...)

--- a/client/internal/routemanager/nftables_linux.go
+++ b/client/internal/routemanager/nftables_linux.go
@@ -247,48 +247,12 @@ func (n *nftablesManager) InsertRoutingRules(pair routerPair) error {
 	n.mux.Lock()
 	defer n.mux.Unlock()
 
-	prefix := netip.MustParsePrefix(pair.source)
-
-	sourceExp := generateCIDRMatcherExpressions("source", pair.source)
-	destExp := generateCIDRMatcherExpressions("destination", pair.destination)
-
-	forwardExp := append(sourceExp, append(destExp, exprCounterAccept...)...)
-	fwdKey := genKey(forwardingFormat, pair.ID)
-	if prefix.Addr().Unmap().Is4() {
-		n.rules[fwdKey] = n.conn.InsertRule(&nftables.Rule{
-			Table:    n.tableIPv4,
-			Chain:    n.chains[ipv4][nftablesRoutingForwardingChain],
-			Exprs:    forwardExp,
-			UserData: []byte(fwdKey),
-		})
-	} else {
-		n.rules[fwdKey] = n.conn.InsertRule(&nftables.Rule{
-			Table:    n.tableIPv6,
-			Chain:    n.chains[ipv6][nftablesRoutingForwardingChain],
-			Exprs:    forwardExp,
-			UserData: []byte(fwdKey),
-		})
-	}
+	n.insertRoutingRule(forwardingFormat, nftablesRoutingForwardingChain, pair, false)
+	n.insertRoutingRule(inForwardingFormat, nftablesRoutingForwardingChain, getInPair(pair), false)
 
 	if pair.masquerade {
-		natExp := append(sourceExp, append(destExp, &expr.Counter{}, &expr.Masq{})...)
-		natKey := genKey(natFormat, pair.ID)
-
-		if prefix.Addr().Unmap().Is4() {
-			n.rules[natKey] = n.conn.InsertRule(&nftables.Rule{
-				Table:    n.tableIPv4,
-				Chain:    n.chains[ipv4][nftablesRoutingNatChain],
-				Exprs:    natExp,
-				UserData: []byte(natKey),
-			})
-		} else {
-			n.rules[natKey] = n.conn.InsertRule(&nftables.Rule{
-				Table:    n.tableIPv6,
-				Chain:    n.chains[ipv6][nftablesRoutingNatChain],
-				Exprs:    natExp,
-				UserData: []byte(natKey),
-			})
-		}
+		n.insertRoutingRule(natFormat, nftablesRoutingNatChain, pair, true)
+		n.insertRoutingRule(inNatFormat, nftablesRoutingNatChain, getInPair(pair), true)
 	}
 
 	err := n.conn.Flush()
@@ -296,6 +260,40 @@ func (n *nftablesManager) InsertRoutingRules(pair routerPair) error {
 		return fmt.Errorf("nftables: unable to insert rules for %s: %v", pair.destination, err)
 	}
 	return nil
+}
+
+// insertRoutingRule inserts a nftable rule to the conn client flush queue
+func (n *nftablesManager) insertRoutingRule(format, chain string, pair routerPair, isNat bool) {
+
+	prefix := netip.MustParsePrefix(pair.source)
+
+	sourceExp := generateCIDRMatcherExpressions("source", pair.source)
+	destExp := generateCIDRMatcherExpressions("destination", pair.destination)
+
+	var expression []expr.Any
+	if isNat {
+		expression = append(sourceExp, append(destExp, &expr.Counter{}, &expr.Masq{})...)
+	} else {
+		expression = append(sourceExp, append(destExp, exprCounterAccept...)...)
+	}
+
+	ruleKey := genKey(format, pair.ID)
+
+	if prefix.Addr().Unmap().Is4() {
+		n.rules[ruleKey] = n.conn.InsertRule(&nftables.Rule{
+			Table:    n.tableIPv4,
+			Chain:    n.chains[ipv4][chain],
+			Exprs:    expression,
+			UserData: []byte(ruleKey),
+		})
+	} else {
+		n.rules[ruleKey] = n.conn.InsertRule(&nftables.Rule{
+			Table:    n.tableIPv6,
+			Chain:    n.chains[ipv6][chain],
+			Exprs:    expression,
+			UserData: []byte(ruleKey),
+		})
+	}
 }
 
 // RemoveRoutingRules removes a nftable rule pair from forwarding and nat chains
@@ -308,31 +306,54 @@ func (n *nftablesManager) RemoveRoutingRules(pair routerPair) error {
 		return err
 	}
 
-	fwdKey := genKey(forwardingFormat, pair.ID)
-	natKey := genKey(natFormat, pair.ID)
-	fwdRule, found := n.rules[fwdKey]
-	if found {
-		err = n.conn.DelRule(fwdRule)
-		if err != nil {
-			return fmt.Errorf("nftables: unable to remove forwarding rule for %s: %v", pair.destination, err)
-		}
-		log.Debugf("nftables: removing forwarding rule for %s", pair.destination)
-		delete(n.rules, fwdKey)
+	err = n.removeRoutingRule(forwardingFormat, pair)
+	if err != nil {
+		return err
 	}
-	natRule, found := n.rules[natKey]
-	if found {
-		err = n.conn.DelRule(natRule)
-		if err != nil {
-			return fmt.Errorf("nftables: unable to remove nat rule for %s: %v", pair.destination, err)
-		}
-		log.Debugf("nftables: removing nat rule for %s", pair.destination)
-		delete(n.rules, natKey)
+
+	err = n.removeRoutingRule(inForwardingFormat, getInPair(pair))
+	if err != nil {
+		return err
 	}
+
+	err = n.removeRoutingRule(natFormat, pair)
+	if err != nil {
+		return err
+	}
+
+	err = n.removeRoutingRule(inNatFormat, getInPair(pair))
+	if err != nil {
+		return err
+	}
+
 	err = n.conn.Flush()
 	if err != nil {
 		return fmt.Errorf("nftables: received error while applying rule removal for %s: %v", pair.destination, err)
 	}
 	log.Debugf("nftables: removed rules for %s", pair.destination)
+	return nil
+}
+
+// removeRoutingRule add a nftable rule to the removal queue and delete from rules map
+func (n *nftablesManager) removeRoutingRule(format string, pair routerPair) error {
+	ruleKey := genKey(format, pair.ID)
+
+	rule, found := n.rules[ruleKey]
+	if found {
+		ruleType := "forwarding"
+		if rule.Chain.Type == nftables.ChainTypeNAT {
+			ruleType = "nat"
+		}
+
+		err := n.conn.DelRule(rule)
+		if err != nil {
+			return fmt.Errorf("nftables: unable to remove %s rule for %s: %v", ruleType, pair.destination, err)
+		}
+
+		log.Debugf("nftables: removing %s rule for %s", ruleType, pair.destination)
+
+		delete(n.rules, ruleKey)
+	}
 	return nil
 }
 

--- a/client/internal/routemanager/nftables_linux.go
+++ b/client/internal/routemanager/nftables_linux.go
@@ -12,7 +12,6 @@ import (
 )
 import "github.com/google/nftables"
 
-//
 const (
 	nftablesTable                  = "netbird-rt"
 	nftablesRoutingForwardingChain = "netbird-rt-fwd"


### PR DESCRIPTION
add an income firewall rule for each routing pair the pair for the income rule has inverted source and destination

check if nftables rule exist before adding a new one

resolves #481 