### PR TITLE
Get windows version from registry

### DIFF
--- a/client/system/info_windows.go
+++ b/client/system/info_windows.go
@@ -1,40 +1,55 @@
 package system
 
 import (
-	"bytes"
 	"context"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows/registry"
 	"os"
-	"os/exec"
 	"runtime"
-	"strings"
 )
 
 // GetInfo retrieves and parses the system information
 func GetInfo(ctx context.Context) *Info {
-	cmd := exec.Command("cmd", "ver")
-	cmd.Stdin = strings.NewReader("some")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil {
-		panic(err)
-	}
-	osStr := strings.Replace(out.String(), "\n", "", -1)
-	osStr = strings.Replace(osStr, "\r\n", "", -1)
-	tmp1 := strings.Index(osStr, "[Version")
-	tmp2 := strings.Index(osStr, "]")
-	var ver string
-	if tmp1 == -1 || tmp2 == -1 {
-		ver = "unknown"
-	} else {
-		ver = osStr[tmp1+9 : tmp2]
-	}
+	ver := getOSVersion()
 	gio := &Info{Kernel: "windows", OSVersion: ver, Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	gio.WiretrusteeVersion = NetbirdVersion()
 	gio.UIVersion = extractUserAgent(ctx)
 
 	return gio
+}
+
+func getOSVersion() string {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		log.Error(err)
+		return "0.0.0.0"
+	}
+	defer func() {
+		deferErr := k.Close()
+		if deferErr != nil {
+			log.Error(deferErr)
+		}
+	}()
+	
+	major, _, err := k.GetIntegerValue("CurrentMajorVersionNumber")
+	if err != nil {
+		log.Error(err)
+	}
+	minor, _, err := k.GetIntegerValue("CurrentMinorVersionNumber")
+	if err != nil {
+		log.Error(err)
+	}
+	build, _, err := k.GetStringValue("CurrentBuildNumber")
+	if err != nil {
+		log.Error(err)
+	}
+	// Update Build Revision
+	ubr, _, err := k.GetIntegerValue("UBR")
+	if err != nil {
+		log.Error(err)
+	}
+	ver := fmt.Sprintf("%d.%d.%s.%d", major, minor, build, ubr)
+	return ver
 }


### PR DESCRIPTION
Avoid problems with localization by retrieving
version information from registry

Return a default 0.0.0.0 if operation fails