### PR TITLE
Seticon only when status changes

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -324,12 +324,12 @@ func (s *serviceClient) updateStatus() error {
 			return err
 		}
 
-		if status.Status == string(internal.StatusConnected) {
+		if status.Status == string(internal.StatusConnected) && !s.mUp.Disabled() {
 			systray.SetIcon(s.icConnected)
 			s.mStatus.SetTitle("Connected")
 			s.mUp.Disable()
 			s.mDown.Enable()
-		} else {
+		} else if status.Status != string(internal.StatusConnected) && s.mUp.Disabled() {
 			systray.SetIcon(s.icDisconnected)
 			s.mStatus.SetTitle("Disconnected")
 			s.mDown.Disable()


### PR DESCRIPTION
This prevents a memory leak with the systray lib
when setting the icon every 2 seconds causes a large memory consumption

see https://github.com/getlantern/systray/issues/135