### PR TITLE
Disable uninstall message when upgrade is silent

### DIFF
--- a/client/installer.nsis
+++ b/client/installer.nsis
@@ -101,6 +101,7 @@ done:
 Pop $2
 Exch $1
 FunctionEnd
+
 !macro GetAppFromCommand in out
 Push "${in}"
 Call GetAppFromCommand
@@ -117,7 +118,7 @@ Call GetAppFromCommand ; Remove quotes and parameters from UninstCommand
 Pop $0
 Pop $1
 GetFullPathName $2 "$0\.."
-ExecWait '"$0" $1 _?=$2'
+ExecWait '"$0" /S $1 _?=$2'
 Delete "$0" ; Extra cleanup because we used _?=
 RMDir "$2"
 Pop $2
@@ -126,30 +127,27 @@ Pop $0
 !macroend
 
 Function .onInit
-
-ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wiretrustee" "UninstallString"
-${If} $R0 != ""
-    MessageBox MB_YESNO|MB_ICONQUESTION "Wiretrustee is installed. We must remove it before installing Netbird. Procced?" IDNO noWTUninstOld
-    !insertmacro UninstallPreviousNSIS $R0 "/NoMsgBox"
-    noWTUninstOld:
-${EndIf}
-
+StrCpy $INSTDIR "${INSTALL_DIR}"
 ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\$(^NAME)" "UninstallString"
 ${If} $R0 != ""
-    MessageBox MB_YESNO|MB_ICONQUESTION "$(^NAME) is already installed. Do you want to remove the previous version?" IDNO noUninstOld
-    !insertmacro UninstallPreviousNSIS $R0 "/NoMsgBox"
-    noUninstOld:
+    # if silent install jump to uninstall step
+    IfSilent uninstall
+
+    MessageBox MB_YESNO|MB_ICONQUESTION "NetBird is already installed. We must remove it before installing upgrading NetBird. Proceed?" IDNO done IDYES uninstall
+
+    uninstall:
+      !insertmacro UninstallPreviousNSIS $R0 "/NoMsgBox"
+    done:
+
 ${EndIf}
 FunctionEnd
 ######################################################################
 Section -MainProgram
 	${INSTALL_TYPE}
-	SetOverwrite ifnewer
+	# SetOverwrite ifnewer
 	SetOutPath "$INSTDIR"
 	File /r "..\\dist\\netbird_windows_amd64\\"
-
 SectionEnd
-
 ######################################################################
 
 Section -Icons_Reg
@@ -172,24 +170,29 @@ SetShellVarContext current
 CreateShortCut "$SMPROGRAMS\${APP_NAME}.lnk" "$INSTDIR\${UI_APP_EXE}"
 CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${UI_APP_EXE}"
 SetShellVarContext all
+SectionEnd
 
+Section -Post
 ExecWait '"$INSTDIR\${MAIN_APP_EXE}" service install'
-Exec '"$INSTDIR\${MAIN_APP_EXE}" service start'
+ExecWait '"$INSTDIR\${MAIN_APP_EXE}" service start'
 # sleep a bit for visibility
 Sleep 1000
 SectionEnd
-
 ######################################################################
 
 Section Uninstall
 ${INSTALL_TYPE}
 
 ExecWait '"$INSTDIR\${MAIN_APP_EXE}" service stop'
-Exec '"$INSTDIR\${MAIN_APP_EXE}" service uninstall'
+ExecWait '"$INSTDIR\${MAIN_APP_EXE}" service uninstall'
+
 # kill ui client
 ExecWait `taskkill /im ${UI_APP_EXE}.exe`
+
 # wait the service uninstall take unblock the executable
 Sleep 3000
+Delete "$INSTDIR\${UI_APP_EXE}"
+Delete "$INSTDIR\${MAIN_APP_EXE}"
 RmDir /r "$INSTDIR"
 
 SetShellVarContext current


### PR DESCRIPTION
Disable uninstall message when an upgrade is silent. If the user clicks on yes, we also do the uninstall silently

Fix a problem with $INSTDIR pointing to subfolder

relates to #494 