### PR TITLE
correctly set the windows application icon on windows

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -62,12 +62,7 @@ func main() {
 	flag.Parse()
 
 	a := app.New()
-
-	if runtime.GOOS == "windows" {
-		a.SetIcon(fyne.NewStaticResource("netbird", iconDisconnectedICO))
-	} else {
-		a.SetIcon(fyne.NewStaticResource("netbird", iconDisconnectedPNG))
-	}
+	a.SetIcon(fyne.NewStaticResource("netbird", iconDisconnectedPNG))
 
 	client := newServiceClient(daemonAddr, a, showSettings)
 	if showSettings {


### PR DESCRIPTION
the icon format is not really supported, so this uses a png instead.

this closes https://github.com/netbirdio/netbird/issues/534.