### PR TITLE
Fix docker network interface filter

### DIFF
--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -80,7 +80,7 @@ func createNewConfig(managementURL, adminURL, configPath, preSharedKey string) (
 	}
 
 	config.IFaceBlackList = []string{iface.WgInterfaceDefault, "wt", "utun", "tun0", "zt", "ZeroTier", "utun", "wg", "ts",
-		"Tailscale", "tailscale", "docker", "vet"}
+		"Tailscale", "tailscale", "docker", "veth", "br-"}
 
 	err = util.WriteJson(configPath, config)
 	if err != nil {


### PR DESCRIPTION
docker network address are assigned on interfaces with name `br-${NETWORK_ID[:12]}`, docker also creates interfaces that start with `veth` but does not assign IPv4 address to them.
I didn't find any docker documentation backing this but this should be easy to verify.