### PR TITLE
Display peers of a user that it has access to

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -107,12 +107,30 @@ func (am *DefaultAccountManager) GetPeers(accountID, userID string) ([]*Peer, er
 	}
 
 	peers := make([]*Peer, 0, len(account.Peers))
+	peersMap := make(map[string]*Peer)
 	for _, peer := range account.Peers {
 		if !user.IsAdmin() && user.Id != peer.UserID {
 			// only display peers that belong to the current user if the current user is not an admin
 			continue
 		}
-		peers = append(peers, peer.Copy())
+		p := peer.Copy()
+		peers = append(peers, p)
+		peersMap[peer.Key] = p
+	}
+
+	// fetch all the peers that have access to the user's peers
+	for _, peer := range peers {
+		if _, ok := peersMap[peer.Key]; !ok {
+			aclPeers := am.getPeersByACL(account, peer.Key)
+			for _, p := range aclPeers {
+				peersMap[p.Key] = p
+			}
+		}
+	}
+
+	peers = make([]*Peer, 0, len(peersMap))
+	for _, peer := range peersMap {
+		peers = append(peers, peer)
 	}
 
 	return peers, nil

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -106,7 +106,7 @@ func (am *DefaultAccountManager) GetPeers(accountID, userID string) ([]*Peer, er
 		return nil, err
 	}
 
-	peers := make([]*Peer, 0, len(account.Peers))
+	peers := make([]*Peer, 0)
 	peersMap := make(map[string]*Peer)
 	for _, peer := range account.Peers {
 		if !user.IsAdmin() && user.Id != peer.UserID {
@@ -120,11 +120,9 @@ func (am *DefaultAccountManager) GetPeers(accountID, userID string) ([]*Peer, er
 
 	// fetch all the peers that have access to the user's peers
 	for _, peer := range peers {
-		if _, ok := peersMap[peer.Key]; !ok {
-			aclPeers := am.getPeersByACL(account, peer.Key)
-			for _, p := range aclPeers {
-				peersMap[p.Key] = p
-			}
+		aclPeers := am.getPeersByACL(account, peer.Key)
+		for _, p := range aclPeers {
+			peersMap[p.Key] = p
 		}
 	}
 


### PR DESCRIPTION
If a user has a non-admin role, display all peers
that user's peers have access to when calling
/peers endpoint of the HTTP API.