### PR TITLE
Enable IPv6 address discovery

### DIFF
--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -3,6 +3,9 @@ package internal
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
+
 	"github.com/netbirdio/netbird/client/ssh"
 	"github.com/netbirdio/netbird/iface"
 	mgm "github.com/netbirdio/netbird/management/client"
@@ -11,8 +14,6 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"net/url"
-	"os"
 )
 
 var managementURLDefault *url.URL
@@ -32,13 +33,14 @@ func init() {
 // Config Configuration type
 type Config struct {
 	// Wireguard private key of local peer
-	PrivateKey     string
-	PreSharedKey   string
-	ManagementURL  *url.URL
-	AdminURL       *url.URL
-	WgIface        string
-	WgPort         int
-	IFaceBlackList []string
+	PrivateKey           string
+	PreSharedKey         string
+	ManagementURL        *url.URL
+	AdminURL             *url.URL
+	WgIface              string
+	WgPort               int
+	IFaceBlackList       []string
+	DisableIPv6Discovery bool
 	// SSHKey is a private SSH key in a PEM format
 	SSHKey string
 }
@@ -51,11 +53,12 @@ func createNewConfig(managementURL, adminURL, configPath, preSharedKey string) (
 		return nil, err
 	}
 	config := &Config{
-		SSHKey:         string(pem),
-		PrivateKey:     wgKey,
-		WgIface:        iface.WgInterfaceDefault,
-		WgPort:         iface.DefaultWgPort,
-		IFaceBlackList: []string{},
+		SSHKey:               string(pem),
+		PrivateKey:           wgKey,
+		WgIface:              iface.WgInterfaceDefault,
+		WgPort:               iface.DefaultWgPort,
+		IFaceBlackList:       []string{},
+		DisableIPv6Discovery: false,
 	}
 	if managementURL != "" {
 		URL, err := ParseURL("Management URL", managementURL)

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -3,10 +3,11 @@ package internal
 import (
 	"context"
 	"fmt"
-	"github.com/netbirdio/netbird/client/ssh"
-	nbStatus "github.com/netbirdio/netbird/client/status"
 	"strings"
 	"time"
+
+	"github.com/netbirdio/netbird/client/ssh"
+	nbStatus "github.com/netbirdio/netbird/client/status"
 
 	"github.com/netbirdio/netbird/client/system"
 
@@ -184,12 +185,13 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *nbStatus.Sta
 func createEngineConfig(key wgtypes.Key, config *Config, peerConfig *mgmProto.PeerConfig) (*EngineConfig, error) {
 
 	engineConf := &EngineConfig{
-		WgIfaceName:    config.WgIface,
-		WgAddr:         peerConfig.Address,
-		IFaceBlackList: config.IFaceBlackList,
-		WgPrivateKey:   key,
-		WgPort:         config.WgPort,
-		SSHKey:         []byte(config.SSHKey),
+		WgIfaceName:          config.WgIface,
+		WgAddr:               peerConfig.Address,
+		IFaceBlackList:       config.IFaceBlackList,
+		DisableIPv6Discovery: config.DisableIPv6Discovery,
+		WgPrivateKey:         key,
+		WgPort:               config.WgPort,
+		SSHKey:               []byte(config.SSHKey),
 	}
 
 	if config.PreSharedKey != "" {

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -7,11 +7,6 @@ import (
 	"sync"
 	"time"
 
-	nbStatus "github.com/netbirdio/netbird/client/status"
-	"github.com/netbirdio/netbird/client/system"
-	"github.com/netbirdio/netbird/iface"
-	"golang.zx2c4.com/wireguard/wgctrl"
-
 	"github.com/netbirdio/netbird/client/internal/proxy"
 	nbStatus "github.com/netbirdio/netbird/client/status"
 	"github.com/netbirdio/netbird/client/system"
@@ -160,7 +155,7 @@ func (conn *Conn) reCreateAgent() error {
 		InterfaceFilter:  interfaceFilter(conn.config.InterfaceBlackList),
 		UDPMux:           conn.config.UDPMux,
 		UDPMuxSrflx:      conn.config.UDPMuxSrflx,
-    NAT1To1IPs:       conn.config.NATExternalIPs,
+		NAT1To1IPs:       conn.config.NATExternalIPs,
 	}
 
 	if conn.config.DisableIPv6Discovery {


### PR DESCRIPTION
- Enabled IPv6 address discovery, this allows clients to establish connection directly via IPv6 when available.
- Added a new config option `DisableIPv6Discovery` to revert the behavior back to IPv4 only. Default value is `false`, so existing config will default to using IPv6 when possible without user manually changing the config file.

Tested between my Windows 10 PC and a Raspberry Pi, using the hosted management and signal server (https://app.netbird.io/)

Closes #577

-----

Some notes:

Link-local IPv6 addresses (e.g. `fe80:*`) are filtered out, unlike IPv4 address (e.g. `10.0.4.3` is not filtered out).
I don't have a Unique local address so I don't know if that's also being filtered out. 

`ice.Candidate` with IPv6 host are formatted similar to `fe80::1:51820`, this only affects the log output, might be a good idea to submit a fix upstream later.

Filtered log from testing:

<details>


Public keys are replaced with `<WG_PUBLIC_KEY_1>` `<WG_PUBLIC_KEY_2>`
IPv4 Addresses are replaced with `999.999.999.999`
IPv6 Addresses are masked with `xxxx`

```
conn.go:559 OnRemoteOffer from peer <WG_PUBLIC_KEY_1> on status Disconnected
conn.go:565 OnRemoteOffer skipping message from peer <WG_PUBLIC_KEY_1> on status Disconnected because is not ready
conn.go:190 trying to connect to peer <WG_PUBLIC_KEY_1>
conn.go:221 connection offer sent to peer <WG_PUBLIC_KEY_1>, waiting for the confirmation
conn.go:574 OnRemoteAnswer from peer <WG_PUBLIC_KEY_1> on status Disconnected
conn.go:242 received connection confirmation from peer <WG_PUBLIC_KEY_1> running version development and with remote WireGuard listen port 51820
conn.go:476 peer <WG_PUBLIC_KEY_1> ICE ConnectionState has changed to Checking
conn.go:121 ignoring interface wt0 - it is not allowed
conn.go:459 discovered local candidate udp4 host 192.168.1.8:42332
conn.go:459 discovered local candidate udp6 host xxxx:xxx:xxxx:xxxx::a000:42332
conn.go:459 discovered local candidate udp6 host xxxx:xxx:xxxx:xxxx:xxxx:xxxx:xxxx:c1ae:42332
conn.go:121 ignoring interface wt0 - it is not allowed
conn.go:459 discovered local candidate udp4 srflx 999.999.999.999:27835 related :::57778
conn.go:588 OnRemoteCandidate from peer <WG_PUBLIC_KEY_1> -> udp6 host xxxx:xxx:xxxx:xxxx::a001:51423
conn.go:588 OnRemoteCandidate from peer <WG_PUBLIC_KEY_1> -> udp6 host xxxx:xxx:xxxx:xxxx:xxxx:xxxx:xxxx:ffe0:51423
noproxy.go:37 using NoProxy while connecting to peer <WG_PUBLIC_KEY_1>
conn.go:476 peer <WG_PUBLIC_KEY_1> ICE ConnectionState has changed to Connected
conn.go:470 selected candidate pair [local <-> remote] -> [udp6 host xxxx:xxx:xxxx:xxxx::a000:42332 <-> udp6 host xxxx:xxx:xxxx:xxxx::a001:51423], peer <WG_PUBLIC_KEY_1>
configuration.go:94 updating interface wt0 peer <WG_PUBLIC_KEY_1>: endpoint [xxxx:xxx:xxxx:xxxx::a001]:51820
configuration.go:35 got Wireguard device wt0
conn.go:295 directly connected to peer <WG_PUBLIC_KEY_1> [laddr <-> raddr] [xxxx:xxx:xxxx:xxxx::a000:51820 <-> xxxx:xxx:xxxx:xxxx::a001:51820]
conn.go:588 OnRemoteCandidate from peer <WG_PUBLIC_KEY_1> -> udp4 host 172.28.64.1:51423
conn.go:459 discovered local candidate udp4 relay 54.255.13.85:46396 related 0.0.0.0:50789
conn.go:588 OnRemoteCandidate from peer <WG_PUBLIC_KEY_1> -> udp4 host 192.168.1.6:51423
conn.go:459 discovered local candidate udp4 relay 54.255.13.85:40497 related 192.168.1.8:60472
conn.go:588 OnRemoteCandidate from peer <WG_PUBLIC_KEY_1> -> udp4 srflx 999.999.999.999:27806 related :::51424
conn.go:588 OnRemoteCandidate from peer <WG_PUBLIC_KEY_1> -> udp4 relay 18.198.13.240:40266 related 0.0.0.0:59880
conn.go:588 OnRemoteCandidate from peer <WG_PUBLIC_KEY_1> -> udp4 relay 18.198.13.240:34423 related 192.168.1.6:63150
conn.go:459 discovered local candidate udp4 relay 52.16.140.95:64436 related 192.168.1.8:37008
conn.go:588 OnRemoteCandidate from peer <WG_PUBLIC_KEY_1> -> udp4 relay 52.16.140.95:30546 related 192.168.1.6:63149
```

```
root@raspberrypi:~# wg
interface: wt0
  public key: <WG_PUBLIC_KEY_2>
  private key: (hidden)
  listening port: 51820

peer: <WG_PUBLIC_KEY_1>
  endpoint: [xxxx:xxx:xxxx:xxxx::a001]:51820
  allowed ips: 100.999.999.999/32
  latest handshake: 2 minutes, 49 seconds ago
  transfer: 2.47 KiB received, 1.44 KiB sent
  persistent keepalive: every 25 seconds
```

</details>