### PR TITLE
User custom loopback address

### DIFF
--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -257,7 +257,7 @@ func TestDNSServerStartStop(t *testing.T) {
 			d := net.Dialer{
 				Timeout: time.Second * 5,
 			}
-			addr := fmt.Sprintf("127.0.0.1:%d", port)
+			addr := fmt.Sprintf("%s:%d", dnsServer.runtimeIP, dnsServer.runtimePort)
 			conn, err := d.DialContext(ctx, network, addr)
 			if err != nil {
 				t.Log(err)
@@ -297,7 +297,7 @@ func getDefaultServerWithNoHostManager(ip string) *DefaultServer {
 	}
 
 	dnsServer := &dns.Server{
-		Addr:    fmt.Sprintf("%s:%d", ip, port),
+		Addr:    fmt.Sprintf("%s:%d", ip, defaultPort),
 		Net:     "udp",
 		Handler: mux,
 		UDPSize: 65535,
@@ -314,7 +314,7 @@ func getDefaultServerWithNoHostManager(ip string) *DefaultServer {
 		localResolver: &localResolver{
 			registeredMap: make(registrationMap),
 		},
-		runtimePort: port,
+		runtimePort: defaultPort,
 		runtimeIP:   listenIP,
 	}
 }

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -71,6 +71,10 @@ func TestEngine_SSH(t *testing.T) {
 		WgPort:       33100,
 	}, nbstatus.NewRecorder())
 
+	engine.dnsServer = &dns.MockServer{
+		UpdateDNSServerFunc: func(serial uint64, update nbdns.Config) error { return nil },
+	}
+
 	var sshKeysAdded []string
 	var sshPeersRemoved []string
 

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -389,6 +389,10 @@ func TestEngine_Sync(t *testing.T) {
 		WgPort:       33100,
 	}, nbstatus.NewRecorder())
 
+	engine.dnsServer = &dns.MockServer{
+		UpdateDNSServerFunc: func(serial uint64, update nbdns.Config) error { return nil },
+	}
+
 	defer func() {
 		err := engine.Stop()
 		if err != nil {


### PR DESCRIPTION
We will probe a set of addresses and ports to define the one available for our DNS service

if none is available, we return an error