### PR TITLE
Handle peer deletion and state update

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -177,6 +177,9 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *nbStatus.Sta
 	err = backoff.Retry(operation, backOff)
 	if err != nil {
 		log.Debugf("exiting client retry loop due to unrecoverable error: %s", err)
+		if s, ok := gstatus.FromError(err); ok && (s.Code() == codes.PermissionDenied) {
+			state.Set(StatusNeedsLogin)
+		}
 		return err
 	}
 	return nil

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -335,7 +335,7 @@ func (s *Server) WaitSSOLogin(callerCtx context.Context, msg *proto.WaitSSOLogin
 }
 
 // Up starts engine work in the daemon.
-func (s *Server) Up(callerCtx context.Context, msg *proto.UpRequest) (*proto.UpResponse, error) {
+func (s *Server) Up(callerCtx context.Context, _ *proto.UpRequest) (*proto.UpResponse, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -375,7 +375,7 @@ func (s *Server) Up(callerCtx context.Context, msg *proto.UpRequest) (*proto.UpR
 
 	go func() {
 		if err := internal.RunClient(ctx, s.config, s.statusRecorder); err != nil {
-			log.Errorf("run client connection: %v", state.Wrap(err))
+			log.Errorf("run client connection: %v", err)
 			return
 		}
 	}()
@@ -384,7 +384,7 @@ func (s *Server) Up(callerCtx context.Context, msg *proto.UpRequest) (*proto.UpR
 }
 
 // Down engine work in the daemon.
-func (s *Server) Down(ctx context.Context, msg *proto.DownRequest) (*proto.DownResponse, error) {
+func (s *Server) Down(_ context.Context, _ *proto.DownRequest) (*proto.DownResponse, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -392,6 +392,8 @@ func (s *Server) Down(ctx context.Context, msg *proto.DownRequest) (*proto.DownR
 		return nil, fmt.Errorf("service is not up")
 	}
 	s.actCancel()
+	state := internal.CtxGetState(s.rootCtx)
+	state.Set(internal.StatusIdle)
 
 	return &proto.DownResponse{}, nil
 }
@@ -425,7 +427,7 @@ func (s *Server) Status(
 }
 
 // GetConfig of the daemon.
-func (s *Server) GetConfig(ctx context.Context, msg *proto.GetConfigRequest) (*proto.GetConfigResponse, error) {
+func (s *Server) GetConfig(_ context.Context, _ *proto.GetConfigRequest) (*proto.GetConfigResponse, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 


### PR DESCRIPTION
## Describe your changes
If peer is deleted in the console,
we set its state as needs login

On Down command, we clean any previous state errors. This prevents the need for a daemon restart

Removed state error wrapping when engine exits. The log is enough for this case.

## Issue ticket number and link
Relates to #462
### Checklist
- [x] Is it a bug fix
