### PR TITLE
HA Network Routes: prevent routing directly-accessible networks through VPN interface

### DIFF
--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -3,12 +3,13 @@ package routemanager
 import (
 	"context"
 	"fmt"
+	"net/netip"
+
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/status"
 	"github.com/netbirdio/netbird/iface"
 	"github.com/netbirdio/netbird/route"
 	log "github.com/sirupsen/logrus"
-	"net/netip"
 )
 
 type routerPeerStatus struct {
@@ -52,7 +53,7 @@ func newClientNetworkWatcher(ctx context.Context, wgInterface *iface.WGIface, st
 	return client
 }
 
-func getClientNetworkID(input *route.Route) string {
+func getHANetworkID(input *route.Route) string {
 	return input.NetID + "-" + input.Network.String()
 }
 

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -151,21 +151,21 @@ func (m *DefaultManager) UpdateRoutes(updateSerial uint64, newRoutes []*route.Ro
 		ownNetworkIDs := make(map[string]bool)
 
 		for _, newRoute := range newRoutes {
-			if newRoute.Peer == m.pubKey {
-				ownNetworkIDs[getHANetworkID(newRoute)] = true
-			}
-		}
-
-		for _, newRoute := range newRoutes {
 			networkID := getHANetworkID(newRoute)
-			if ownNetworkIDs[networkID] {
+			if newRoute.Peer == m.pubKey {
+				ownNetworkIDs[networkID] = true
 				// only linux is supported for now
 				if runtime.GOOS != "linux" {
 					log.Warnf("received a route to manage, but agent doesn't support router mode on %s OS", runtime.GOOS)
 					continue
 				}
 				newServerRoutesMap[newRoute.ID] = newRoute
-			} else {
+			}
+		}
+
+		for _, newRoute := range newRoutes {
+			networkID := getHANetworkID(newRoute)
+			if !ownNetworkIDs[networkID] {
 				// if prefix is too small, lets assume is a possible default route which is not yet supported
 				// we skip this route management
 				if newRoute.Network.Bits() < 7 {

--- a/client/internal/routemanager/manager_test.go
+++ b/client/internal/routemanager/manager_test.go
@@ -383,7 +383,7 @@ func TestManagerUpdateRoutes(t *testing.T) {
 			},
 			inputSerial:                   1,
 			shouldCheckServerRoutes:       runtime.GOOS == "linux",
-			serverRoutesExpected:          3,
+			serverRoutesExpected:          2,
 			clientNetworkWatchersExpected: 1,
 		},
 	}


### PR DESCRIPTION
## Describe your changes

It prevents Server from adding rules to route directly accessible/own networks through VPN when the route is in HA mode (has more than 1 entry):

1. the code was checking membership against a single Network Route entry with equality operator on `Peer` attribute:
	1. there is 1 Route per Peer
	2. second (HA) Route entry did not pass the check because it was not the server
	3. rule for routing the traffic through VPN interface is created
	4. host X is routing through host Y
	5. host Y is routing through host X
	6. (i assume) we have a routing loop passing packets back and forth between HA hosts instead of going to the real network
2. The code fixes above issue by checking `NetID` instead of `Peer` values

see the linked issue for more details

## Issue ticket number and link

fixes: https://github.com/netbirdio/netbird/issues/598

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] Created tests that fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
