### PR TITLE
Remove wiretrustee conflict checks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,11 +74,6 @@ nfpms:
     formats:
       - deb
 
-    replaces:
-      - wiretrustee
-    conflicts:
-      - wiretrustee
-
     scripts:
       postinstall: "release_files/post_install.sh"
       preremove: "release_files/pre_remove.sh"
@@ -92,12 +87,6 @@ nfpms:
       - netbird
     formats:
       - rpm
-
-    replaces:
-      - wiretrustee
-
-    conflicts:
-      - wiretrustee
 
     scripts:
       postinstall: "release_files/post_install.sh"
@@ -348,8 +337,6 @@ brews:
     license: "BSD3"
     test: |
       system "#{bin}/{{ .ProjectName	}} version"
-    conflicts:
-      - wiretrustee
 
 uploads:
   - name: debian


### PR DESCRIPTION
## Describe your changes
These checks were part of our rebranding, and since then almost all peers got updated to newer netbird versions. So we are good to remove these and deal with any conflicts individually. 


## Issue ticket number and link
Relates to #613

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
