### PR TITLE
Use latest tag for dashboard

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -2,7 +2,7 @@ version: "3"
 services:
   #UI dashboard
   dashboard:
-    image: wiretrustee/dashboard:main
+    image: wiretrustee/dashboard:latest
     restart: unless-stopped
     ports:
       - 80:80


### PR DESCRIPTION
Using the latest tag will align with the dashboard's new release cycle that relies on tags

