### PR TITLE
Properly parse dns resolver address

### DIFF
--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -95,7 +95,10 @@ func (n *networkManagerDbusConfigurator) applyDNSConfig(config hostDNSConfig) er
 
 	connSettings.cleanDeprecatedSettings()
 
-	dnsIP := netip.MustParseAddr(config.serverIP)
+	dnsIP, err := netip.ParseAddr(config.serverIP)
+	if err != nil {
+		return fmt.Errorf("unable to parse ip address, error: %s", err)
+	}
 	convDNSIP := binary.LittleEndian.Uint32(dnsIP.AsSlice())
 	connSettings[networkManagerDbusIPv4Key][networkManagerDbusDNSKey] = dbus.MakeVariant([]uint32{convDNSIP})
 	var (

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -208,6 +208,12 @@ func TestUpdateDNSServer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer func() {
+				err = wgIface.Close()
+				if err != nil {
+					t.Log(err)
+				}
+			}()
 			dnsServer, err := NewDefaultServer(context.Background(), wgIface)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Prevent panic when the address is empty. Common with older managers, where the resolver is disabled by default as we receive an empty DNS config

## Describe your changes

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix

