### PR TITLE
Validate single account domain input

### DIFF
--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -22,9 +22,10 @@ var (
 	disableSingleAccMode bool
 
 	rootCmd = &cobra.Command{
-		Use:   "netbird-mgmt",
-		Short: "",
-		Long:  "",
+		Use:          "netbird-mgmt",
+		Short:        "",
+		Long:         "",
+		SilenceUsage: true,
 	}
 
 	// Execution control channel for stopCh signal

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -449,6 +449,9 @@ func BuildManager(store Store, peersUpdateManager *PeersUpdateManager, idpManage
 	// enable single account mode only if configured by user and number of existing accounts is not grater than 1
 	am.singleAccountMode = singleAccountModeDomain != "" && len(allAccounts) <= 1
 	if am.singleAccountMode {
+		if !isDomainValid(singleAccountModeDomain) {
+			return nil, status.Errorf(status.InvalidArgument, "invalid domain \"%s\" provided for single accound mode. Please review your input for --single-account-mode-domain", singleAccountModeDomain)
+		}
 		am.singleAccountModeDomain = singleAccountModeDomain
 		log.Infof("single account mode enabled, accounts number %d", len(allAccounts))
 	} else {


### PR DESCRIPTION
## Describe your changes

Fix a single account mode issue with invalid domains. 

Where retrieving an account with invalid domains caused users to join separate accounts

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
