### PR TITLE
 Coturn doesn't read the turnserver.conf when selfhosting netbird

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -58,6 +58,9 @@ services:
     #      - ./privkey.pem:/etc/coturn/private/privkey.pem:ro
     #      - ./cert.pem:/etc/coturn/certs/cert.pem:ro
     network_mode: host
+    command:
+      - -c /etc/turnserver.conf
+      
 volumes:
   $MGMT_VOLUMENAME:
   $SIGNAL_VOLUMENAME:


### PR DESCRIPTION
## Describe your changes
I added a `-c /etc/turnserver.conf` to the coturn command to specify the non-default config location, fixing #630

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/630

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
