### PR TITLE
Use macOS v11 to build UI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           retention-days: 3
 
   release_ui_darwin:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       -
         name: Checkout


### PR DESCRIPTION
## Describe your changes
This allows us to run clients on older macOS versions

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
