### PR TITLE
Install ca-certs in the Management docker image build

### DIFF
--- a/management/Dockerfile
+++ b/management/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+RUN apt update && apt install -y ca-certificates && rm -fr /var/cache/apt
 ENTRYPOINT [ "/go/bin/netbird-mgmt","management"]
 CMD ["--log-file", "console"]
 COPY netbird-mgmt /go/bin/netbird-mgmt


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
