### PR TITLE
Involve foreground mode switch for up cmd

### DIFF
--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	daemonModeOff bool
-	upCmd         = &cobra.Command{
+	foregroundMode bool
+	upCmd          = &cobra.Command{
 		Use:   "up",
 		Short: "install, login and start Netbird client",
 		RunE:  upFunc,
@@ -23,7 +23,7 @@ var (
 )
 
 func init() {
-	upCmd.PersistentFlags().BoolVar(&daemonModeOff, "daemon-off", false, "start service in foreground")
+	upCmd.PersistentFlags().BoolVarP(&foregroundMode, "foreground-mode", "F", false, "start service in foreground")
 }
 
 func upFunc(cmd *cobra.Command, args []string) error {
@@ -38,13 +38,13 @@ func upFunc(cmd *cobra.Command, args []string) error {
 
 	ctx := internal.CtxInitState(cmd.Context())
 
-	if daemonModeOff {
-		return foregroundMode(ctx, cmd)
+	if foregroundMode {
+		return runInForegroundMode(ctx, cmd)
 	}
-	return daemonMode(ctx, cmd)
+	return runInDaemonMode(ctx, cmd)
 }
 
-func foregroundMode(ctx context.Context, cmd *cobra.Command) error {
+func runInForegroundMode(ctx context.Context, cmd *cobra.Command) error {
 	err := handleRebrand(cmd)
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func foregroundMode(ctx context.Context, cmd *cobra.Command) error {
 	return internal.RunClient(ctx, config, nbStatus.NewRecorder())
 }
 
-func daemonMode(ctx context.Context, cmd *cobra.Command) error {
+func runInDaemonMode(ctx context.Context, cmd *cobra.Command) error {
 
 	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -40,9 +40,8 @@ func upFunc(cmd *cobra.Command, args []string) error {
 
 	if daemonModeOff {
 		return foregroundMode(ctx, cmd)
-	} else {
-		return daemonMode(ctx, cmd)
 	}
+	return daemonMode(ctx, cmd)
 }
 
 func foregroundMode(ctx context.Context, cmd *cobra.Command) error {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -13,121 +13,138 @@ import (
 	gstatus "google.golang.org/grpc/status"
 )
 
-var upCmd = &cobra.Command{
-	Use:   "up",
-	Short: "install, login and start Netbird client",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		SetFlagsFromEnvVars()
+var (
+	daemonModeOff bool
+	upCmd         = &cobra.Command{
+		Use:   "up",
+		Short: "install, login and start Netbird client",
+		RunE:  upFunc,
+	}
+)
 
-		cmd.SetOut(cmd.OutOrStdout())
+func init() {
+	upCmd.PersistentFlags().BoolVar(&daemonModeOff, "daemon-off", false, "start service in foreground")
+}
 
-		err := util.InitLog(logLevel, "console")
+func upFunc(cmd *cobra.Command, args []string) error {
+	SetFlagsFromEnvVars()
+
+	cmd.SetOut(cmd.OutOrStdout())
+
+	err := util.InitLog(logLevel, "console")
+	if err != nil {
+		return fmt.Errorf("failed initializing log %v", err)
+	}
+
+	ctx := internal.CtxInitState(cmd.Context())
+
+	if daemonModeOff {
+		return foregroundMode(ctx, cmd)
+	} else {
+		return daemonMode(ctx, cmd)
+	}
+}
+
+func foregroundMode(ctx context.Context, cmd *cobra.Command) error {
+	err := handleRebrand(cmd)
+	if err != nil {
+		return err
+	}
+
+	config, err := internal.GetConfig(internal.ConfigInput{
+		ManagementURL: managementURL,
+		AdminURL:      adminURL,
+		ConfigPath:    configPath,
+		PreSharedKey:  &preSharedKey,
+	})
+	if err != nil {
+		return fmt.Errorf("get config file: %v", err)
+	}
+
+	config, _ = internal.UpdateOldManagementPort(ctx, config, configPath)
+
+	err = foregroundLogin(ctx, cmd, config, setupKey)
+	if err != nil {
+		return fmt.Errorf("foreground login failed: %v", err)
+	}
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	SetupCloseHandler(ctx, cancel)
+	return internal.RunClient(ctx, config, nbStatus.NewRecorder())
+}
+
+func daemonMode(ctx context.Context, cmd *cobra.Command) error {
+
+	conn, err := DialClientGRPCServer(ctx, daemonAddr)
+	if err != nil {
+		return fmt.Errorf("failed to connect to daemon error: %v\n"+
+			"If the daemon is not running please run: "+
+			"\nnetbird service install \nnetbird service start\n", err)
+	}
+	defer func() {
+		err := conn.Close()
 		if err != nil {
-			return fmt.Errorf("failed initializing log %v", err)
+			log.Warnf("failed closing dameon gRPC client connection %v", err)
+			return
 		}
+	}()
 
-		ctx := internal.CtxInitState(cmd.Context())
+	client := proto.NewDaemonServiceClient(conn)
 
-		// workaround to run without service
-		if logFile == "console" {
-			err = handleRebrand(cmd)
-			if err != nil {
-				return err
-			}
+	status, err := client.Status(ctx, &proto.StatusRequest{})
+	if err != nil {
+		return fmt.Errorf("unable to get daemon status: %v", err)
+	}
 
-			config, err := internal.GetConfig(internal.ConfigInput{
-				ManagementURL: managementURL,
-				AdminURL:      adminURL,
-				ConfigPath:    configPath,
-				PreSharedKey:  &preSharedKey,
-			})
-			if err != nil {
-				return fmt.Errorf("get config file: %v", err)
-			}
+	if status.Status == string(internal.StatusConnected) {
+		cmd.Println("Already connected")
+		return nil
+	}
 
-			config, _ = internal.UpdateOldManagementPort(ctx, config, configPath)
+	loginRequest := proto.LoginRequest{
+		SetupKey:      setupKey,
+		PreSharedKey:  preSharedKey,
+		ManagementUrl: managementURL,
+	}
 
-			err = foregroundLogin(ctx, cmd, config, setupKey)
-			if err != nil {
-				return fmt.Errorf("foreground login failed: %v", err)
-			}
+	var loginErr error
 
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithCancel(ctx)
-			SetupCloseHandler(ctx, cancel)
-			return internal.RunClient(ctx, config, nbStatus.NewRecorder())
-		}
+	var loginResp *proto.LoginResponse
 
-		conn, err := DialClientGRPCServer(ctx, daemonAddr)
-		if err != nil {
-			return fmt.Errorf("failed to connect to daemon error: %v\n"+
-				"If the daemon is not running please run: "+
-				"\nnetbird service install \nnetbird service start\n", err)
-		}
-		defer func() {
-			err := conn.Close()
-			if err != nil {
-				log.Warnf("failed closing dameon gRPC client connection %v", err)
-				return
-			}
-		}()
-
-		client := proto.NewDaemonServiceClient(conn)
-
-		status, err := client.Status(ctx, &proto.StatusRequest{})
-		if err != nil {
-			return fmt.Errorf("unable to get daemon status: %v", err)
-		}
-
-		if status.Status == string(internal.StatusConnected) {
-			cmd.Println("Already connected")
+	err = WithBackOff(func() error {
+		var backOffErr error
+		loginResp, backOffErr = client.Login(ctx, &loginRequest)
+		if s, ok := gstatus.FromError(backOffErr); ok && (s.Code() == codes.InvalidArgument ||
+			s.Code() == codes.PermissionDenied ||
+			s.Code() == codes.NotFound ||
+			s.Code() == codes.Unimplemented) {
+			loginErr = backOffErr
 			return nil
 		}
+		return backOffErr
+	})
+	if err != nil {
+		return fmt.Errorf("login backoff cycle failed: %v", err)
+	}
 
-		loginRequest := proto.LoginRequest{
-			SetupKey:      setupKey,
-			PreSharedKey:  preSharedKey,
-			ManagementUrl: managementURL,
-		}
+	if loginErr != nil {
+		return fmt.Errorf("login failed: %v", loginErr)
+	}
 
-		var loginErr error
+	if loginResp.NeedsSSOLogin {
 
-		var loginResp *proto.LoginResponse
+		openURL(cmd, loginResp.VerificationURIComplete)
 
-		err = WithBackOff(func() error {
-			var backOffErr error
-			loginResp, backOffErr = client.Login(ctx, &loginRequest)
-			if s, ok := gstatus.FromError(backOffErr); ok && (s.Code() == codes.InvalidArgument ||
-				s.Code() == codes.PermissionDenied ||
-				s.Code() == codes.NotFound ||
-				s.Code() == codes.Unimplemented) {
-				loginErr = backOffErr
-				return nil
-			}
-			return backOffErr
-		})
+		_, err = client.WaitSSOLogin(ctx, &proto.WaitSSOLoginRequest{UserCode: loginResp.UserCode})
 		if err != nil {
-			return fmt.Errorf("login backoff cycle failed: %v", err)
+			return fmt.Errorf("waiting sso login failed with: %v", err)
 		}
+	}
 
-		if loginErr != nil {
-			return fmt.Errorf("login failed: %v", loginErr)
-		}
-
-		if loginResp.NeedsSSOLogin {
-
-			openURL(cmd, loginResp.VerificationURIComplete)
-
-			_, err = client.WaitSSOLogin(ctx, &proto.WaitSSOLoginRequest{UserCode: loginResp.UserCode})
-			if err != nil {
-				return fmt.Errorf("waiting sso login failed with: %v", err)
-			}
-		}
-
-		if _, err := client.Up(ctx, &proto.UpRequest{}); err != nil {
-			return fmt.Errorf("call service up method: %v", err)
-		}
-		cmd.Println("Connected")
-		return nil
-	},
+	if _, err := client.Up(ctx, &proto.UpRequest{}); err != nil {
+		return fmt.Errorf("call service up method: %v", err)
+	}
+	cmd.Println("Connected")
+	return nil
 }


### PR DESCRIPTION
Add new --foreground-mode command line parameter
for 'up' cmd instead of existing log-file workaround

## Describe your changes

During debug the service, I am interested in output of the service. With this option it is easily configurable.
I tried to follow the current code style pattern, nevertheless I recommend to organize the content of the up.go into a new struct and register the upCmd into the cobra via a new function like this ```func registerUpCmd(rootCmd *cobra.Command)```. With it you can avoid global variables and ```init()``` functions.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
