### PR TITLE
Allow empty groups for DNS setting

### DIFF
--- a/management/server/activity/codes.go
+++ b/management/server/activity/codes.go
@@ -97,9 +97,9 @@ const (
 	// GroupRemovedFromSetupKeyMessage is a human-readable text message of the GroupRemovedFromSetupKey activity
 	GroupRemovedFromSetupKeyMessage string = "Group removed from user setup key"
 	// GroupAddedToDisabledManagementGroupsMessage is a human-readable text message of the GroupAddedToDisabledManagementGroups activity
-	GroupAddedToDisabledManagementGroupsMessage
+	GroupAddedToDisabledManagementGroupsMessage string = "Group added to disabled management DNS setting"
 	// GroupRemovedFromDisabledManagementGroupsMessage is a human-readable text message of the GroupRemovedFromDisabledManagementGroups activity
-	GroupRemovedFromDisabledManagementGroupsMessage
+	GroupRemovedFromDisabledManagementGroupsMessage string = "Group removed from disabled management DNS setting"
 )
 
 // Activity that triggered an Event

--- a/management/server/dns.go
+++ b/management/server/dns.go
@@ -87,9 +87,11 @@ func (am *DefaultAccountManager) SaveDNSSettings(accountID string, userID string
 		return status.Errorf(status.InvalidArgument, "the dns settings provided are nil")
 	}
 
-	err = validateGroups(dnsSettingsToSave.DisabledManagementGroups, account.Groups)
-	if err != nil {
-		return err
+	if len(dnsSettingsToSave.DisabledManagementGroups) != 0 {
+		err = validateGroups(dnsSettingsToSave.DisabledManagementGroups, account.Groups)
+		if err != nil {
+			return err
+		}
 	}
 
 	oldSettings := &DNSSettings{}


### PR DESCRIPTION
## Describe your changes

We should allow passing empty group slice for DisabledManagementGroups to reset any setting.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
