### PR TITLE
Check if peer name change before update labels

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -201,19 +201,20 @@ func (am *DefaultAccountManager) UpdatePeer(accountID string, update *Peer) (*Pe
 		return nil, err
 	}
 
-	if peer.Name != "" {
-		peer.Name = update.Name
-	}
 	peer.SSHEnabled = update.SSHEnabled
 
-	existingLabels := account.getPeerDNSLabels()
+	if peer.Name != update.Name {
+		peer.Name = update.Name
 
-	newLabel, err := getPeerHostLabel(peer.Name, existingLabels)
-	if err != nil {
-		return nil, err
+		existingLabels := account.getPeerDNSLabels()
+
+		newLabel, err := getPeerHostLabel(peer.Name, existingLabels)
+		if err != nil {
+			return nil, err
+		}
+
+		peer.DNSLabel = newLabel
 	}
-
-	peer.DNSLabel = newLabel
 
 	account.UpdatePeer(peer)
 


### PR DESCRIPTION
## Describe your changes
Before, we assumed that the name should be changed and tried to generate another peer label without considering if there was a change to the name actually made.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
