### PR TITLE
allow specifying --wg-iface and --wg-port

### DIFF
--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -85,6 +85,8 @@ var runCmd = &cobra.Command{
 	Short: "runs Netbird as service",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SetFlagsFromEnvVars(rootCmd)
+		SetFlagsFromEnvVars(serviceCmd)
+		SetFlagsFromEnvVars(cmd)
 
 		cmd.SetOut(cmd.OutOrStdout())
 
@@ -119,6 +121,8 @@ var startCmd = &cobra.Command{
 	Short: "starts Netbird service",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SetFlagsFromEnvVars(rootCmd)
+		SetFlagsFromEnvVars(serviceCmd)
+		SetFlagsFromEnvVars(cmd)
 
 		cmd.SetOut(cmd.OutOrStdout())
 
@@ -154,6 +158,8 @@ var stopCmd = &cobra.Command{
 	Short: "stops Netbird service",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SetFlagsFromEnvVars(rootCmd)
+		SetFlagsFromEnvVars(serviceCmd)
+		SetFlagsFromEnvVars(cmd)
 
 		cmd.SetOut(cmd.OutOrStdout())
 
@@ -187,6 +193,8 @@ var restartCmd = &cobra.Command{
 	Short: "restarts Netbird service",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SetFlagsFromEnvVars(rootCmd)
+		SetFlagsFromEnvVars(serviceCmd)
+		SetFlagsFromEnvVars(cmd)
 
 		cmd.SetOut(cmd.OutOrStdout())
 

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -84,6 +84,8 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command) error {
 		ConfigPath:       configPath,
 		NATExternalIPs:   natExternalIPs,
 		CustomDNSAddress: customDNSAddressConverted,
+		WgIface:          wgIface,
+		WgPort:           wgPort,
 	}
 	if preSharedKey != "" {
 		ic.PreSharedKey = &preSharedKey

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -48,7 +48,10 @@ var ErrResetConnection = fmt.Errorf("reset connection")
 
 // EngineConfig is a config for the Engine
 type EngineConfig struct {
-	WgPort      int
+	// WgPort is a port number Wireguard listens on
+	WgPort int
+
+	// WgIfaceName is a Wireguard interface name to use
 	WgIfaceName string
 
 	// WgAddr is a Wireguard local address (Netbird Network IP)


### PR DESCRIPTION
## Describe your changes

I am working on setting up multiple instances of Netbird on same machine, I need a way to tell the deamon to input different interfaces/ports to those without modifying files by hand.

I got it to work at https://github.com/nazarewk-iac/nix-configs/commit/aeefbf5c

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
