### PR TITLE
Simplify event storing with one generic method

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,6 @@
 - [ ] Is it a bug fix
 - [ ] Is a typo/documentation fix
 - [ ] Is a feature enhancement
+- [ ] It is a refactor
 - [ ] Created tests that fail without the change (if possible)
 - [ ] Extended the README / documentation, if necessary

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -673,16 +673,24 @@ func TestAccountManager_AddPeerWithUserID(t *testing.T) {
 		t.Errorf("expecting Network Serial=%d to be incremented by 1 and be equal to %d when adding new peer to account", serial, account.Network.CurrentSerial())
 	}
 
-	// check the corresponding events that should have been generated
-	events, err := manager.GetEvents(account.Id, userID)
-	if err != nil {
-		return
-	}
-
 	var ev *activity.Event
-	for _, event := range events {
-		if event.Activity == activity.PeerAddedByUser {
-			ev = event
+loop:
+	for {
+		select {
+		case <-time.After(time.Second):
+			t.Fatal("no PeerAddedWithSetupKey event was generated")
+			return
+		default:
+			events, err := manager.GetEvents(account.Id, userID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, event := range events {
+				if event.Activity == activity.PeerAddedByUser {
+					ev = event
+					break loop
+				}
+			}
 		}
 	}
 
@@ -930,16 +938,24 @@ func TestAccountManager_DeletePeer(t *testing.T) {
 		t.Errorf("expecting Network Serial=%d to be incremented and be equal to 2 after adding and deleteing a peer", account.Network.CurrentSerial())
 	}
 
-	// check the corresponding events that should have been generated
-	events, err := manager.GetEvents(account.Id, userID)
-	if err != nil {
-		return
-	}
-
 	var ev *activity.Event
-	for _, event := range events {
-		if event.Activity == activity.PeerRemovedByUser {
-			ev = event
+loop:
+	for {
+		select {
+		case <-time.After(time.Second):
+			t.Fatal("no PeerAddedWithSetupKey event was generated")
+			return
+		default:
+			events, err := manager.GetEvents(account.Id, userID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, event := range events {
+				if event.Activity == activity.PeerRemovedByUser {
+					ev = event
+					break loop
+				}
+			}
 		}
 	}
 

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -926,8 +926,6 @@ func getEvent(t *testing.T, accountID string, manager AccountManager, eventType 
 			}
 		}
 	}
-
-	return nil
 }
 
 func TestGetUsersFromAccount(t *testing.T) {

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -135,17 +135,7 @@ func TestAccountManager_GetOrCreateAccountByUser(t *testing.T) {
 	}
 
 	// check the corresponding events that should have been generated
-	events, err := manager.GetEvents(account.Id, userID)
-	if err != nil {
-		return
-	}
-
-	var ev *activity.Event
-	for _, event := range events {
-		if event.Activity == activity.AccountCreated {
-			ev = event
-		}
-	}
+	ev := getEvent(t, account.Id, manager, activity.AccountCreated)
 
 	assert.NotNil(t, ev)
 	assert.Equal(t, account.Id, ev.AccountID)

--- a/management/server/dns.go
+++ b/management/server/dns.go
@@ -106,21 +106,19 @@ func (am *DefaultAccountManager) SaveDNSSettings(accountID string, userID string
 		return err
 	}
 
-	go func() {
-		addedGroups := difference(dnsSettingsToSave.DisabledManagementGroups, oldSettings.DisabledManagementGroups)
-		for _, id := range addedGroups {
-			group := account.GetGroup(id)
-			meta := map[string]any{"group": group.Name, "group_id": group.ID}
-			am.storeEvent(userID, accountID, accountID, activity.GroupAddedToDisabledManagementGroups, meta)
-		}
+	addedGroups := difference(dnsSettingsToSave.DisabledManagementGroups, oldSettings.DisabledManagementGroups)
+	for _, id := range addedGroups {
+		group := account.GetGroup(id)
+		meta := map[string]any{"group": group.Name, "group_id": group.ID}
+		am.storeEvent(userID, accountID, accountID, activity.GroupAddedToDisabledManagementGroups, meta)
+	}
 
-		removedGroups := difference(oldSettings.DisabledManagementGroups, dnsSettingsToSave.DisabledManagementGroups)
-		for _, id := range removedGroups {
-			group := account.GetGroup(id)
-			meta := map[string]any{"group": group.Name, "group_id": group.ID}
-			am.storeEvent(userID, accountID, accountID, activity.GroupRemovedFromDisabledManagementGroups, meta)
-		}
-	}()
+	removedGroups := difference(oldSettings.DisabledManagementGroups, dnsSettingsToSave.DisabledManagementGroups)
+	for _, id := range removedGroups {
+		group := account.GetGroup(id)
+		meta := map[string]any{"group": group.Name, "group_id": group.ID}
+		am.storeEvent(userID, accountID, accountID, activity.GroupRemovedFromDisabledManagementGroups, meta)
+	}
 
 	return am.updateAccountPeers(account)
 }

--- a/management/server/event.go
+++ b/management/server/event.go
@@ -34,16 +34,22 @@ func (am *DefaultAccountManager) GetEvents(accountID, userID string) ([]*activit
 	return filtered, nil
 }
 
-func (am *DefaultAccountManager) storeEvent(initiatorID, targetID, accountID string, activityID activity.Activity, meta map[string]any) {
-	_, err := am.eventStore.Save(&activity.Event{
-		Timestamp:   time.Now(),
-		Activity:    activityID,
-		InitiatorID: initiatorID,
-		TargetID:    targetID,
-		AccountID:   accountID,
-		Meta:        meta,
-	})
-	if err != nil {
-		log.Errorf("received an error while storing an activity event, error: %s", err)
-	}
+func (am *DefaultAccountManager) storeEvent(initiatorID, targetID, accountID string, activityID activity.Activity,
+	meta map[string]any) {
+
+	go func() {
+		_, err := am.eventStore.Save(&activity.Event{
+			Timestamp:   time.Now(),
+			Activity:    activityID,
+			InitiatorID: initiatorID,
+			TargetID:    targetID,
+			AccountID:   accountID,
+			Meta:        meta,
+		})
+		if err != nil {
+			//todo add metric
+			log.Errorf("received an error while storing an activity event, error: %s", err)
+		}
+	}()
+
 }

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -278,18 +278,7 @@ func (am *DefaultAccountManager) DeletePeer(accountID, peerPubKey, userID string
 	}
 
 	am.peersUpdateManager.CloseChannel(peerPubKey)
-	event := &activity.Event{
-		Timestamp:   time.Now(),
-		AccountID:   account.Id,
-		InitiatorID: userID,
-		TargetID:    peer.IP.String(),
-		Activity:    activity.PeerRemovedByUser,
-		Meta:        peer.EventMeta(am.GetDNSDomain()),
-	}
-	_, err = am.eventStore.Save(event)
-	if err != nil {
-		return nil, err
-	}
+	am.storeEvent(userID, peer.IP.String(), account.Id, activity.PeerRemovedByUser, peer.EventMeta(am.GetDNSDomain()))
 	return peer, nil
 }
 
@@ -479,10 +468,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 
 	opEvent.TargetID = newPeer.IP.String()
 	opEvent.Meta = newPeer.EventMeta(am.GetDNSDomain())
-	_, err = am.eventStore.Save(opEvent)
-	if err != nil {
-		return nil, err
-	}
+	am.storeEvent(opEvent.InitiatorID, opEvent.TargetID, opEvent.AccountID, opEvent.Activity, opEvent.Meta)
 
 	return newPeer, nil
 }

--- a/management/server/rule.go
+++ b/management/server/rule.go
@@ -4,7 +4,6 @@ import (
 	"github.com/netbirdio/netbird/management/server/activity"
 	"github.com/netbirdio/netbird/management/server/status"
 	"strings"
-	"time"
 )
 
 // TrafficFlowType defines allowed direction of the traffic in the rule
@@ -144,19 +143,7 @@ func (am *DefaultAccountManager) SaveRule(accountID, userID string, rule *Rule) 
 	if exists {
 		action = activity.RuleUpdated
 	}
-
-	_, err = am.eventStore.Save(&activity.Event{
-		Timestamp:   time.Now(),
-		Activity:    action,
-		InitiatorID: userID,
-		TargetID:    rule.ID,
-		AccountID:   accountID,
-		Meta:        rule.EventMeta(),
-	})
-
-	if err != nil {
-		return err
-	}
+	am.storeEvent(userID, rule.ID, accountID, action, rule.EventMeta())
 
 	return am.updateAccountPeers(account)
 }
@@ -257,18 +244,7 @@ func (am *DefaultAccountManager) DeleteRule(accountID, ruleID, userID string) er
 		return err
 	}
 
-	_, err = am.eventStore.Save(&activity.Event{
-		Timestamp:   time.Now(),
-		Activity:    activity.RuleRemoved,
-		InitiatorID: userID,
-		TargetID:    ruleID,
-		AccountID:   accountID,
-		Meta:        rule.EventMeta(),
-	})
-
-	if err != nil {
-		return err
-	}
+	am.storeEvent(userID, rule.ID, accountID, activity.RuleRemoved, rule.EventMeta())
 
 	return am.updateAccountPeers(account)
 }

--- a/management/server/setupkey.go
+++ b/management/server/setupkey.go
@@ -226,7 +226,7 @@ func (am *DefaultAccountManager) CreateSetupKey(accountID string, keyName string
 		return nil, status.Errorf(status.Internal, "failed adding account key")
 	}
 
-	am.storeEvent(setupKey.Id, setupKey.Id, accountID, activity.SetupKeyCreated, setupKey.EventMeta())
+	am.storeEvent(userID, setupKey.Id, accountID, activity.SetupKeyCreated, setupKey.EventMeta())
 
 	for _, g := range setupKey.AutoGroups {
 		group := account.GetGroup(g)

--- a/management/server/setupkey.go
+++ b/management/server/setupkey.go
@@ -226,34 +226,13 @@ func (am *DefaultAccountManager) CreateSetupKey(accountID string, keyName string
 		return nil, status.Errorf(status.Internal, "failed adding account key")
 	}
 
-	_, err = am.eventStore.Save(&activity.Event{
-		Timestamp:   time.Now(),
-		Activity:    activity.SetupKeyCreated,
-		InitiatorID: userID,
-		TargetID:    setupKey.Id,
-		AccountID:   accountID,
-		Meta:        setupKey.EventMeta(),
-	})
-	if err != nil {
-		return nil, err
-	}
+	am.storeEvent(setupKey.Id, setupKey.Id, accountID, activity.SetupKeyCreated, setupKey.EventMeta())
 
 	for _, g := range setupKey.AutoGroups {
 		group := account.GetGroup(g)
 		if group != nil {
-			_, err := am.eventStore.Save(&activity.Event{
-				Timestamp:   time.Now(),
-				Activity:    activity.GroupAddedToSetupKey,
-				InitiatorID: userID,
-				TargetID:    setupKey.Id,
-				AccountID:   accountID,
-				Meta:        map[string]any{"group": group.Name, "group_id": group.ID, "setupkey": setupKey.Name},
-			})
-			if err != nil {
-				log.Errorf("failed saving setup key activity event %s: %v",
-					activity.GroupAddedToSetupKey.StringCode(), err)
-				continue
-			}
+			am.storeEvent(userID, setupKey.Id, accountID, activity.GroupAddedToSetupKey,
+				map[string]any{"group": group.Name, "group_id": group.ID, "setupkey": setupKey.Name})
 		} else {
 			log.Errorf("group %s not found while saving setup key activity event of account %s", g, account.Id)
 		}
@@ -304,17 +283,7 @@ func (am *DefaultAccountManager) SaveSetupKey(accountID string, keyToSave *Setup
 	}
 
 	if !oldKey.Revoked && newKey.Revoked {
-		_, err = am.eventStore.Save(&activity.Event{
-			Timestamp:   time.Now(),
-			Activity:    activity.SetupKeyRevoked,
-			InitiatorID: userID,
-			TargetID:    newKey.Id,
-			AccountID:   accountID,
-			Meta:        newKey.EventMeta(),
-		})
-		if err != nil {
-			return nil, err
-		}
+		am.storeEvent(userID, newKey.Id, accountID, activity.SetupKeyRevoked, newKey.EventMeta())
 	}
 
 	defer func() {
@@ -323,19 +292,8 @@ func (am *DefaultAccountManager) SaveSetupKey(accountID string, keyToSave *Setup
 		for _, g := range removedGroups {
 			group := account.GetGroup(g)
 			if group != nil {
-				_, err := am.eventStore.Save(&activity.Event{
-					Timestamp:   time.Now(),
-					Activity:    activity.GroupRemovedFromSetupKey,
-					InitiatorID: userID,
-					TargetID:    oldKey.Id,
-					AccountID:   accountID,
-					Meta:        map[string]any{"group": group.Name, "group_id": group.ID, "setupkey": newKey.Name},
-				})
-				if err != nil {
-					log.Errorf("failed saving setup key activity event %s: %v",
-						activity.GroupRemovedFromSetupKey.StringCode(), err)
-					continue
-				}
+				am.storeEvent(userID, oldKey.Id, accountID, activity.GroupRemovedFromSetupKey,
+					map[string]any{"group": group.Name, "group_id": group.ID, "setupkey": newKey.Name})
 			} else {
 				log.Errorf("group %s not found while saving setup key activity event of account %s", g, account.Id)
 			}
@@ -345,19 +303,8 @@ func (am *DefaultAccountManager) SaveSetupKey(accountID string, keyToSave *Setup
 		for _, g := range addedGroups {
 			group := account.GetGroup(g)
 			if group != nil {
-				_, err := am.eventStore.Save(&activity.Event{
-					Timestamp:   time.Now(),
-					Activity:    activity.GroupAddedToSetupKey,
-					InitiatorID: userID,
-					TargetID:    oldKey.Id,
-					AccountID:   accountID,
-					Meta:        map[string]any{"group": group.Name, "group_id": group.ID, "setupkey": newKey.Name},
-				})
-				if err != nil {
-					log.Errorf("failed saving setup key activity event %s: %v",
-						activity.GroupAddedToSetupKey.StringCode(), err)
-					continue
-				}
+				am.storeEvent(userID, oldKey.Id, accountID, activity.GroupAddedToSetupKey,
+					map[string]any{"group": group.Name, "group_id": group.ID, "setupkey": newKey.Name})
 			} else {
 				log.Errorf("group %s not found while saving setup key activity event of account %s", g, account.Id)
 			}

--- a/management/server/setupkey_test.go
+++ b/management/server/setupkey_test.go
@@ -56,17 +56,8 @@ func TestDefaultAccountManager_SaveSetupKey(t *testing.T) {
 	assertKey(t, newKey, newKeyName, revoked, "reusable", 0, key.CreatedAt, key.ExpiresAt,
 		key.Id, time.Now(), autoGroups)
 
-	events, err := manager.GetEvents(account.Id, userID)
-	if err != nil {
-		return
-	}
-
-	var ev *activity.Event
-	for _, event := range events {
-		if event.Activity == activity.SetupKeyRevoked {
-			ev = event
-		}
-	}
+	// check the corresponding events that should have been generated
+	ev := getEvent(t, account.Id, manager, activity.SetupKeyRevoked)
 
 	assert.NotNil(t, ev)
 	assert.Equal(t, account.Id, ev.AccountID)
@@ -160,17 +151,8 @@ func TestDefaultAccountManager_CreateSetupKey(t *testing.T) {
 				tCase.expectedCreatedAt, tCase.expectedExpiresAt, strconv.Itoa(int(Hash(key.Key))),
 				tCase.expectedUpdatedAt, tCase.expectedGroups)
 
-			events, err := manager.GetEvents(account.Id, userID)
-			if err != nil {
-				return
-			}
-
-			var ev *activity.Event
-			for _, event := range events {
-				if event.Activity == activity.SetupKeyCreated {
-					ev = event
-				}
-			}
+			// check the corresponding events that should have been generated
+			ev := getEvent(t, account.Id, manager, activity.SetupKeyCreated)
 
 			assert.NotNil(t, ev)
 			assert.Equal(t, account.Id, ev.AccountID)

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -8,7 +8,6 @@ import (
 	"github.com/netbirdio/netbird/management/server/status"
 	log "github.com/sirupsen/logrus"
 	"strings"
-	"time"
 )
 
 const (
@@ -178,18 +177,7 @@ func (am *DefaultAccountManager) CreateUser(accountID, userID string, invite *Us
 		return nil, err
 	}
 
-	event := &activity.Event{
-		Timestamp:   time.Now(),
-		Activity:    activity.UserInvited,
-		AccountID:   account.Id,
-		TargetID:    newUser.Id,
-		InitiatorID: userID,
-	}
-
-	_, err = am.eventStore.Save(event)
-	if err != nil {
-		return nil, err
-	}
+	am.storeEvent(userID, newUser.Id, accountID, activity.UserInvited, nil)
 
 	return newUser.toUserInfo(idpUser)
 
@@ -235,18 +223,7 @@ func (am *DefaultAccountManager) SaveUser(accountID, userID string, update *User
 
 	defer func() {
 		if oldUser.Role != newUser.Role {
-			_, err := am.eventStore.Save(&activity.Event{
-				Timestamp:   time.Now(),
-				Activity:    activity.UserRoleUpdated,
-				InitiatorID: userID,
-				TargetID:    oldUser.Id,
-				AccountID:   accountID,
-				Meta:        map[string]any{"role": newUser.Role},
-			})
-			if err != nil {
-				log.Errorf("failed saving user activity event %v", err)
-				return
-			}
+			am.storeEvent(userID, oldUser.Id, accountID, activity.UserRoleUpdated, map[string]any{"role": newUser.Role})
 		}
 
 		removedGroups := difference(oldUser.AutoGroups, update.AutoGroups)
@@ -254,19 +231,8 @@ func (am *DefaultAccountManager) SaveUser(accountID, userID string, update *User
 		for _, g := range removedGroups {
 			group := account.GetGroup(g)
 			if group != nil {
-				_, err := am.eventStore.Save(&activity.Event{
-					Timestamp:   time.Now(),
-					Activity:    activity.GroupRemovedFromUser,
-					InitiatorID: userID,
-					TargetID:    oldUser.Id,
-					AccountID:   accountID,
-					Meta:        map[string]any{"group": group.Name, "group_id": group.ID},
-				})
-				if err != nil {
-					log.Errorf("failed saving user activity event %s %v",
-						activity.GroupRemovedFromUser.StringCode(), err)
-					continue
-				}
+				am.storeEvent(userID, oldUser.Id, accountID, activity.UserRoleUpdated,
+					map[string]any{"group": group.Name, "group_id": group.ID})
 			} else {
 				log.Errorf("group %s not found while saving user activity event of account %s", g, account.Id)
 			}
@@ -276,19 +242,8 @@ func (am *DefaultAccountManager) SaveUser(accountID, userID string, update *User
 		for _, g := range addedGroups {
 			group := account.GetGroup(g)
 			if group != nil {
-				_, err := am.eventStore.Save(&activity.Event{
-					Timestamp:   time.Now(),
-					Activity:    activity.GroupAddedToUser,
-					InitiatorID: userID,
-					TargetID:    oldUser.Id,
-					AccountID:   accountID,
-					Meta:        map[string]any{"group": group.Name, "group_id": group.ID},
-				})
-				if err != nil {
-					log.Errorf("failed saving user activity event %s: %v",
-						activity.GroupAddedToUser.StringCode(), err)
-					continue
-				}
+				am.storeEvent(userID, oldUser.Id, accountID, activity.GroupAddedToUser,
+					map[string]any{"group": group.Name, "group_id": group.ID})
 			} else {
 				log.Errorf("group %s not found while saving user activity event of account %s", g, account.Id)
 			}

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -231,7 +231,7 @@ func (am *DefaultAccountManager) SaveUser(accountID, userID string, update *User
 		for _, g := range removedGroups {
 			group := account.GetGroup(g)
 			if group != nil {
-				am.storeEvent(userID, oldUser.Id, accountID, activity.UserRoleUpdated,
+				am.storeEvent(userID, oldUser.Id, accountID, activity.GroupRemovedFromUser,
 					map[string]any{"group": group.Name, "group_id": group.ID})
 			} else {
 				log.Errorf("group %s not found while saving user activity event of account %s", g, account.Id)


### PR DESCRIPTION
## Describe your changes
Use the generic `storeEvent()` funcion to store all activity events.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] It is a refactor
