### PR TITLE
Use Peer.ID instead of Peer.Key as peer identifier

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -67,7 +67,7 @@ type AccountManager interface {
 	UpdateGroup(accountID string, groupID string, operations []GroupUpdateOperation) (*Group, error)
 	DeleteGroup(accountId, groupID string) error
 	ListGroups(accountId string) ([]*Group, error)
-	GroupAddPeer(accountId, groupID, peerKey string) error
+	GroupAddPeer(accountId, groupID, peerID string) error
 	GroupDeletePeer(accountId, groupID, peerKey string) error
 	GroupListPeers(accountId, groupID string) ([]*Peer, error)
 	GetRule(accountID, ruleID, userID string) (*Rule, error)
@@ -145,8 +145,8 @@ type UserInfo struct {
 
 // getRoutesToSync returns the enabled routes for the peer ID and the routes
 // from the ACL peers that have distribution groups associated with the peer ID
-func (a *Account) getRoutesToSync(peerID string, aclPeers []*Peer) []*route.Route {
-	routes, peerDisabledRoutes := a.getEnabledAndDisabledRoutesByPeer(peerID)
+func (a *Account) getRoutesToSync(peerID, peerKey string, aclPeers []*Peer) []*route.Route {
+	routes, peerDisabledRoutes := a.getEnabledAndDisabledRoutesByPeer(peerKey)
 	peerRoutesMembership := make(lookupMap)
 	for _, r := range append(routes, peerDisabledRoutes...) {
 		peerRoutesMembership[route.GetHAUniqueID(r)] = struct{}{}

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -196,11 +196,18 @@ func (a *Account) getEnabledAndDisabledRoutesByPeer(peerID string) ([]*route.Rou
 	var disabledRoutes []*route.Route
 	for _, r := range a.Routes {
 		if r.Peer == peerID {
-			if r.Enabled {
-				enabledRoutes = append(enabledRoutes, r)
+			peer := a.GetPeer(peerID)
+			if peer == nil {
+				log.Errorf("route %s has peer %s that doesn't exist under account %s", r.ID, peerID, a.Id)
 				continue
 			}
-			disabledRoutes = append(disabledRoutes, r)
+			raut := r.Copy()
+			raut.Peer = peer.Key
+			if r.Enabled {
+				enabledRoutes = append(enabledRoutes, raut)
+				continue
+			}
+			disabledRoutes = append(disabledRoutes, raut)
 		}
 	}
 	return enabledRoutes, disabledRoutes

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -59,8 +59,8 @@ type AccountManager interface {
 	GetNetworkMap(peerID string) (*NetworkMap, error)
 	GetPeerNetwork(peerID string) (*Network, error)
 	AddPeer(setupKey, userID string, peer *Peer) (*Peer, error)
-	UpdatePeerMeta(peerKey string, meta PeerSystemMeta) error
-	UpdatePeerSSHKey(peerKey string, sshKey string) error
+	UpdatePeerMeta(peerID string, meta PeerSystemMeta) error
+	UpdatePeerSSHKey(peerID string, sshKey string) error
 	GetUsersFromAccount(accountID, userID string) ([]*UserInfo, error)
 	GetGroup(accountId, groupID string) (*Group, error)
 	SaveGroup(accountID, userID string, group *Group) error

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -144,7 +144,8 @@ type UserInfo struct {
 }
 
 // getRoutesToSync returns the enabled routes for the peer ID and the routes
-// from the ACL peers that have distribution groups associated with the peer ID
+// from the ACL peers that have distribution groups associated with the peer ID.
+// Please mind, that the returned route.Route objects will contain Peer.Key instead of Peer.ID.
 func (a *Account) getRoutesToSync(peerID string, aclPeers []*Peer) []*route.Route {
 	routes, peerDisabledRoutes := a.getEnabledAndDisabledRoutesByPeer(peerID)
 	peerRoutesMembership := make(lookupMap)
@@ -190,12 +191,15 @@ func (a *Account) filterRoutesByGroups(routes []*route.Route, groupListMap looku
 	return filteredRoutes
 }
 
-// getEnabledAndDisabledRoutesByPeer returns the enabled and disabled lists of routes that belong to a peer
+// getEnabledAndDisabledRoutesByPeer returns the enabled and disabled lists of routes that belong to a peer.
+// Please mind, that the returned route.Route objects will contain Peer.Key instead of Peer.ID.
 func (a *Account) getEnabledAndDisabledRoutesByPeer(peerID string) ([]*route.Route, []*route.Route) {
 	var enabledRoutes []*route.Route
 	var disabledRoutes []*route.Route
 	for _, r := range a.Routes {
 		if r.Peer == peerID {
+			// We need to set Peer.Key instead of Peer.ID because this object will be sent to agents as part of a network map.
+			// Ideally we should have a separate field for that, but fine for now.
 			peer := a.GetPeer(peerID)
 			if peer == nil {
 				log.Errorf("route %s has peer %s that doesn't exist under account %s", r.ID, peerID, a.Id)

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -50,7 +50,7 @@ type AccountManager interface {
 	GetAccountFromToken(claims jwtclaims.AuthorizationClaims) (*Account, *User, error)
 	IsUserAdmin(claims jwtclaims.AuthorizationClaims) (bool, error)
 	AccountExists(accountId string) (*bool, error)
-	GetPeer(peerKey string) (*Peer, error)
+	GetPeerByKey(peerKey string) (*Peer, error)
 	GetPeers(accountID, userID string) ([]*Peer, error)
 	MarkPeerConnected(peerKey string, connected bool) error
 	DeletePeer(accountID, peerID, userID string) (*Peer, error)

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -493,8 +493,8 @@ func TestAccountManager_GetAccount(t *testing.T) {
 	}
 
 	for _, peer := range account.Peers {
-		if _, ok := getAccount.Peers[peer.Key]; !ok {
-			t.Errorf("expected account to have peer %s, not found", peer.Key)
+		if _, ok := getAccount.Peers[peer.ID]; !ok {
+			t.Errorf("expected account to have peer %s, not found", peer.ID)
 		}
 	}
 
@@ -717,13 +717,13 @@ func TestAccountManager_NetworkUpdates(t *testing.T) {
 		return
 	}
 
-	updMsg := manager.peersUpdateManager.CreateChannel(peer1.Key)
-	defer manager.peersUpdateManager.CloseChannel(peer1.Key)
+	updMsg := manager.peersUpdateManager.CreateChannel(peer1.ID)
+	defer manager.peersUpdateManager.CloseChannel(peer1.ID)
 
 	group := Group{
 		ID:    "group-id",
 		Name:  "GroupA",
-		Peers: []string{peer1.Key, peer2.Key, peer3.Key},
+		Peers: []string{peer1.ID, peer2.ID, peer3.ID},
 	}
 
 	rule := Rule{

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1001,7 +1001,7 @@ func TestAccountManager_UpdatePeerMeta(t *testing.T) {
 		OS:        "new-OS",
 		WtVersion: "new-WtVersion",
 	}
-	err = manager.UpdatePeerMeta(peer.Key, newMeta)
+	err = manager.UpdatePeerMeta(peer.ID, newMeta)
 	if err != nil {
 		t.Error(err)
 		return

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -580,7 +580,7 @@ func TestAccountManager_AddPeer(t *testing.T) {
 	assert.Equal(t, peer.Name, ev.Meta["name"])
 	assert.Equal(t, peer.FQDN(account.Domain), ev.Meta["fqdn"])
 	assert.Equal(t, setupKey.Id, ev.InitiatorID)
-	assert.Equal(t, peer.IP.String(), ev.TargetID)
+	assert.Equal(t, peer.ID, ev.TargetID)
 	assert.Equal(t, peer.IP.String(), fmt.Sprint(ev.Meta["ip"]))
 }
 
@@ -650,7 +650,7 @@ func TestAccountManager_AddPeerWithUserID(t *testing.T) {
 	assert.Equal(t, peer.Name, ev.Meta["name"])
 	assert.Equal(t, peer.FQDN(account.Domain), ev.Meta["fqdn"])
 	assert.Equal(t, userID, ev.InitiatorID)
-	assert.Equal(t, peer.IP.String(), ev.TargetID)
+	assert.Equal(t, peer.ID, ev.TargetID)
 	assert.Equal(t, peer.IP.String(), fmt.Sprint(ev.Meta["ip"]))
 }
 

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -810,7 +810,7 @@ func TestAccountManager_NetworkUpdates(t *testing.T) {
 			}
 		}()
 
-		if _, err := manager.DeletePeer(account.Id, peer3.Key, userID); err != nil {
+		if _, err := manager.DeletePeer(account.Id, peer3.ID, userID); err != nil {
 			t.Errorf("delete peer: %v", err)
 			return
 		}

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1188,7 +1188,7 @@ func TestAccount_GetRoutesToSync(t *testing.T) {
 		},
 	}
 
-	routes := account.getRoutesToSync("peer-2", []*Peer{{Key: "peer-1"}, {Key: "peer-3"}})
+	routes := account.getRoutesToSync("peer-2", "peer-2", []*Peer{{Key: "peer-1"}, {Key: "peer-3"}})
 
 	assert.Len(t, routes, 2)
 	routeIDs := make(map[string]struct{}, 2)
@@ -1198,7 +1198,7 @@ func TestAccount_GetRoutesToSync(t *testing.T) {
 	assert.Contains(t, routeIDs, "route-2")
 	assert.Contains(t, routeIDs, "route-3")
 
-	emptyRoutes := account.getRoutesToSync("peer-3", []*Peer{{Key: "peer-1"}, {Key: "peer-2"}})
+	emptyRoutes := account.getRoutesToSync("peer-3", "peer-3", []*Peer{{Key: "peer-1"}, {Key: "peer-2"}})
 
 	assert.Len(t, emptyRoutes, 0)
 }

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1007,7 +1007,7 @@ func TestAccountManager_UpdatePeerMeta(t *testing.T) {
 		return
 	}
 
-	p, err := manager.GetPeer(peer.Key)
+	p, err := manager.GetPeerByKey(peer.Key)
 	if err != nil {
 		return
 	}

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1188,7 +1188,7 @@ func TestAccount_GetRoutesToSync(t *testing.T) {
 		},
 	}
 
-	routes := account.getRoutesToSync("peer-2", "peer-2", []*Peer{{Key: "peer-1"}, {Key: "peer-3"}})
+	routes := account.getRoutesToSync("peer-2", []*Peer{{Key: "peer-1"}, {Key: "peer-3"}})
 
 	assert.Len(t, routes, 2)
 	routeIDs := make(map[string]struct{}, 2)
@@ -1198,7 +1198,7 @@ func TestAccount_GetRoutesToSync(t *testing.T) {
 	assert.Contains(t, routeIDs, "route-2")
 	assert.Contains(t, routeIDs, "route-3")
 
-	emptyRoutes := account.getRoutesToSync("peer-3", "peer-3", []*Peer{{Key: "peer-1"}, {Key: "peer-2"}})
+	emptyRoutes := account.getRoutesToSync("peer-3", []*Peer{{Key: "peer-1"}, {Key: "peer-2"}})
 
 	assert.Len(t, emptyRoutes, 0)
 }

--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -147,7 +147,17 @@ func TestGetNetworkMap_DNSConfigSync(t *testing.T) {
 		t.Error("failed to init testing account")
 	}
 
-	newAccountDNSConfig, err := am.GetNetworkMap(dnsPeer1Key)
+	peer1, err := account.FindPeerByPubKey(dnsPeer1Key)
+	if err != nil {
+		t.Error("failed to init testing account")
+	}
+
+	peer2, err := account.FindPeerByPubKey(dnsPeer2Key)
+	if err != nil {
+		t.Error("failed to init testing account")
+	}
+
+	newAccountDNSConfig, err := am.GetNetworkMap(peer1.ID)
 	require.NoError(t, err)
 	require.Len(t, newAccountDNSConfig.DNSConfig.CustomZones, 1, "default DNS config should have one custom zone for peers")
 	require.True(t, newAccountDNSConfig.DNSConfig.ServiceEnable, "default DNS config should have local DNS service enabled")
@@ -158,12 +168,12 @@ func TestGetNetworkMap_DNSConfigSync(t *testing.T) {
 	err = am.Store.SaveAccount(account)
 	require.NoError(t, err)
 
-	updatedAccountDNSConfig, err := am.GetNetworkMap(dnsPeer1Key)
+	updatedAccountDNSConfig, err := am.GetNetworkMap(peer1.ID)
 	require.NoError(t, err)
 	require.Len(t, updatedAccountDNSConfig.DNSConfig.CustomZones, 0, "updated DNS config should have no custom zone when peer belongs to a disabled group")
 	require.False(t, updatedAccountDNSConfig.DNSConfig.ServiceEnable, "updated DNS config should have local DNS service disabled when peer belongs to a disabled group")
 
-	peer2AccountDNSConfig, err := am.GetNetworkMap(dnsPeer2Key)
+	peer2AccountDNSConfig, err := am.GetNetworkMap(peer2.ID)
 	require.NoError(t, err)
 	require.Len(t, peer2AccountDNSConfig.DNSConfig.CustomZones, 1, "DNS config should have one custom zone for peers not in the disabled group")
 	require.True(t, peer2AccountDNSConfig.DNSConfig.ServiceEnable, "DNS config should have DNS service enabled for peers not in the disabled group")
@@ -234,9 +244,33 @@ func initTestDNSAccount(t *testing.T, am *DefaultAccountManager) (*Account, erro
 		return nil, err
 	}
 
+	_, err = am.AddPeer("", dnsAdminUserID, peer1)
+	if err != nil {
+		return nil, err
+	}
+	_, err = am.AddPeer("", dnsAdminUserID, peer2)
+	if err != nil {
+		return nil, err
+	}
+
+	account, err = am.Store.GetAccount(account.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	peer1, err = account.FindPeerByPubKey(peer1.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	peer2, err = account.FindPeerByPubKey(peer2.Key)
+	if err != nil {
+		return nil, err
+	}
+
 	newGroup1 := &Group{
 		ID:    dnsGroup1ID,
-		Peers: []string{peer1.Key},
+		Peers: []string{peer1.ID},
 		Name:  dnsGroup1ID,
 	}
 
@@ -253,14 +287,5 @@ func initTestDNSAccount(t *testing.T, am *DefaultAccountManager) (*Account, erro
 		return nil, err
 	}
 
-	_, err = am.AddPeer("", dnsAdminUserID, peer1)
-	if err != nil {
-		return nil, err
-	}
-	_, err = am.AddPeer("", dnsAdminUserID, peer2)
-	if err != nil {
-		return nil, err
-	}
-
-	return account, nil
+	return am.Store.GetAccount(account.Id)
 }

--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -263,7 +263,7 @@ func initTestDNSAccount(t *testing.T, am *DefaultAccountManager) (*Account, erro
 		return nil, err
 	}
 
-	peer2, err = account.FindPeerByPubKey(peer2.Key)
+	_, err = account.FindPeerByPubKey(peer2.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -383,7 +383,7 @@ func (s *FileStore) SaveInstallationID(ID string) error {
 
 // SavePeerStatus stores the PeerStatus in memory. It doesn't attempt to persist data to speed up things.
 // PeerStatus will be saved eventually when some other changes occur.
-func (s *FileStore) SavePeerStatus(accountID, peerKey string, peerStatus PeerStatus) error {
+func (s *FileStore) SavePeerStatus(accountID, peerID string, peerStatus PeerStatus) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
@@ -392,9 +392,9 @@ func (s *FileStore) SavePeerStatus(accountID, peerKey string, peerStatus PeerSta
 		return err
 	}
 
-	peer := account.Peers[peerKey]
+	peer := account.Peers[peerID]
 	if peer == nil {
-		return status.Errorf(status.NotFound, "peer %s not found", peerKey)
+		return status.Errorf(status.NotFound, "peer %s not found", peerID)
 	}
 
 	peer.Status = &peerStatus

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -146,6 +146,7 @@ func restore(file string) (*FileStore, error) {
 			for key, peer := range migrationPeers {
 				delete(account.Peers, key)
 				account.Peers[peer.ID] = peer
+				store.PeerID2AccountID[peer.ID] = accountID
 			}
 
 			// detect groups that have Peer.Key as a reference and replace it with ID.

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -294,7 +294,7 @@ func (s *FileStore) GetAccountByPeerID(peerID string) (*Account, error) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
-	accountID, accountIDFound := s.PeerKeyID2AccountID[peerID]
+	accountID, accountIDFound := s.PeerID2AccountID[peerID]
 	if !accountIDFound {
 		return nil, status.Errorf(status.NotFound, "provided peer ID doesn't exists %s", peerID)
 	}

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -244,6 +244,7 @@ func TestFileStore_SavePeerStatus(t *testing.T) {
 	// save new status of existing peer
 	account.Peers["testpeer"] = &Peer{
 		Key:      "peerkey",
+		ID:       "testpeer",
 		SetupKey: "peerkeysetupkey",
 		IP:       net.IP{127, 0, 0, 1},
 		Meta:     PeerSystemMeta{},

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -237,7 +237,7 @@ func (am *DefaultAccountManager) ListGroups(accountID string) ([]*Group, error) 
 }
 
 // GroupAddPeer appends peer to the group
-func (am *DefaultAccountManager) GroupAddPeer(accountID, groupID, peerKey string) error {
+func (am *DefaultAccountManager) GroupAddPeer(accountID, groupID, peerID string) error {
 
 	unlock := am.Store.AcquireAccountLock(accountID)
 	defer unlock()
@@ -254,13 +254,13 @@ func (am *DefaultAccountManager) GroupAddPeer(accountID, groupID, peerKey string
 
 	add := true
 	for _, itemID := range group.Peers {
-		if itemID == peerKey {
+		if itemID == peerID {
 			add = false
 			break
 		}
 	}
 	if add {
-		group.Peers = append(group.Peers, peerKey)
+		group.Peers = append(group.Peers, peerID)
 	}
 
 	account.Network.IncSerial()

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -111,7 +111,7 @@ func (am *DefaultAccountManager) SaveGroup(accountID, userID string, newGroup *G
 			log.Errorf("peer %s not found under account %s while saving group", p, accountID)
 			continue
 		}
-		am.storeEvent(userID, peer.IP.String(), accountID, activity.GroupAddedToPeer,
+		am.storeEvent(userID, peer.ID, accountID, activity.GroupAddedToPeer,
 			map[string]any{"group": newGroup.Name, "group_id": newGroup.ID, "peer_ip": peer.IP.String(),
 				"peer_fqdn": peer.FQDN(am.GetDNSDomain())})
 	}
@@ -122,7 +122,7 @@ func (am *DefaultAccountManager) SaveGroup(accountID, userID string, newGroup *G
 			log.Errorf("peer %s not found under account %s while saving group", p, accountID)
 			continue
 		}
-		am.storeEvent(userID, peer.IP.String(), accountID, activity.GroupRemovedFromPeer,
+		am.storeEvent(userID, peer.ID, accountID, activity.GroupRemovedFromPeer,
 			map[string]any{"group": newGroup.Name, "group_id": newGroup.ID, "peer_ip": peer.IP.String(),
 				"peer_fqdn": peer.FQDN(am.GetDNSDomain())})
 	}

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -88,6 +88,13 @@ func (am *DefaultAccountManager) SaveGroup(accountID, userID string, newGroup *G
 		return err
 	}
 
+	err = am.updateAccountPeers(account)
+	if err != nil {
+		return err
+	}
+
+	// the following snippet tracks the activity and stores the group events in the event store.
+	// It has to happen after all the operations have been successfully performed.
 	addedPeers := make([]string, 0)
 	removedPeers := make([]string, 0)
 	if exists {
@@ -120,7 +127,7 @@ func (am *DefaultAccountManager) SaveGroup(accountID, userID string, newGroup *G
 				"peer_fqdn": peer.FQDN(am.GetDNSDomain())})
 	}
 
-	return am.updateAccountPeers(account)
+	return nil
 }
 
 // difference returns the elements in `a` that aren't in `b`.

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -324,7 +324,7 @@ func (s *GRPCServer) Login(ctx context.Context, req *proto.EncryptedMessage) (*p
 		}
 	} else if loginReq.GetMeta() != nil {
 		// update peer's system meta data on Login
-		err = s.accountManager.UpdatePeerMeta(peerKey.String(), PeerSystemMeta{
+		err = s.accountManager.UpdatePeerMeta(peer.ID, PeerSystemMeta{
 			Hostname:  loginReq.GetMeta().GetHostname(),
 			GoOS:      loginReq.GetMeta().GetGoOS(),
 			Kernel:    loginReq.GetMeta().GetKernel(),
@@ -347,7 +347,7 @@ func (s *GRPCServer) Login(ctx context.Context, req *proto.EncryptedMessage) (*p
 	}
 
 	if len(sshKey) > 0 {
-		err = s.accountManager.UpdatePeerSSHKey(peerKey.String(), string(sshKey))
+		err = s.accountManager.UpdatePeerSSHKey(peer.ID, string(sshKey))
 		if err != nil {
 			return nil, err
 		}

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -111,7 +111,7 @@ func (s *GRPCServer) Sync(req *proto.EncryptedMessage, srv proto.ManagementServi
 		return status.Errorf(codes.InvalidArgument, "provided wgPubKey %s is invalid", peerKey.String())
 	}
 
-	peer, err := s.accountManager.GetPeer(peerKey.String())
+	peer, err := s.accountManager.GetPeerByKey(peerKey.String())
 	if err != nil {
 		p, _ := gPeer.FromContext(srv.Context())
 		msg := status.Errorf(codes.PermissionDenied, "provided peer with the key wgPubKey %s is not registered, remote addr is %s", peerKey.String(), p.Addr.String())
@@ -299,7 +299,7 @@ func (s *GRPCServer) Login(ctx context.Context, req *proto.EncryptedMessage) (*p
 		return nil, status.Errorf(codes.InvalidArgument, "invalid request message")
 	}
 
-	peer, err := s.accountManager.GetPeer(peerKey.String())
+	peer, err := s.accountManager.GetPeerByKey(peerKey.String())
 	if err != nil {
 		if errStatus, ok := internalStatus.FromError(err); ok && errStatus.Type() == internalStatus.NotFound {
 			// peer doesn't exist -> check if setup key was provided

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -141,7 +141,7 @@ func (s *GRPCServer) Sync(req *proto.EncryptedMessage, srv proto.ManagementServi
 	}
 
 	if s.config.TURNConfig.TimeBasedCredentials {
-		s.turnCredentialsManager.SetupRefresh(peerKey.String())
+		s.turnCredentialsManager.SetupRefresh(peer.ID)
 	}
 	// keep a connection to the peer and send updates when available
 	for {

--- a/management/server/http/groups.go
+++ b/management/server/http/groups.go
@@ -96,10 +96,16 @@ func (h *Groups) UpdateGroupHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var peers []string
+	if req.Peers == nil {
+		peers = make([]string, 0)
+	} else {
+		peers = *req.Peers
+	}
 	group := server.Group{
 		ID:    groupID,
 		Name:  *req.Name,
-		Peers: peerIPsToKeys(account, req.Peers),
+		Peers: peers,
 	}
 
 	if err := h.accountManager.SaveGroup(account.Id, user.Id, &group); err != nil {

--- a/management/server/http/groups_test.go
+++ b/management/server/http/groups_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 var TestPeers = map[string]*server.Peer{
-	"A": {Key: "A", IP: net.ParseIP("100.100.100.100")},
-	"B": {Key: "B", IP: net.ParseIP("200.200.200.200")},
+	"A": {Key: "A", ID: "peer-A-ID", IP: net.ParseIP("100.100.100.100")},
+	"B": {Key: "B", ID: "peer-B-ID", IP: net.ParseIP("200.200.200.200")},
 }
 
 func initGroupTestData(user *server.User, groups ...*server.Group) *Groups {
@@ -269,8 +269,8 @@ func TestWriteGroup(t *testing.T) {
 				Id:         "id-existed",
 				PeersCount: 2,
 				Peers: []api.PeerMinimum{
-					{Id: "100.100.100.100"},
-					{Id: "200.200.200.200"}},
+					{Id: "peer-A-ID"},
+					{Id: "peer-B-ID"}},
 			},
 		},
 	}

--- a/management/server/http/peers.go
+++ b/management/server/http/peers.go
@@ -27,7 +27,7 @@ func NewPeers(accountManager server.AccountManager, authAudience string) *Peers 
 	}
 }
 
-func (h *Peers) updatePeer(account *server.Account, user *server.User, peer *server.Peer, w http.ResponseWriter, r *http.Request) {
+func (h *Peers) updatePeer(account *server.Account, user *server.User, peerID string, w http.ResponseWriter, r *http.Request) {
 	req := &api.PutApiPeersIdJSONBody{}
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -35,8 +35,8 @@ func (h *Peers) updatePeer(account *server.Account, user *server.User, peer *ser
 		return
 	}
 
-	update := &server.Peer{Key: peer.Key, SSHEnabled: req.SshEnabled, Name: req.Name}
-	peer, err = h.accountManager.UpdatePeer(account.Id, user.Id, update)
+	update := &server.Peer{ID: peerID, SSHEnabled: req.SshEnabled, Name: req.Name}
+	peer, err := h.accountManager.UpdatePeer(account.Id, user.Id, update)
 	if err != nil {
 		util.WriteError(err, w)
 		return
@@ -45,8 +45,8 @@ func (h *Peers) updatePeer(account *server.Account, user *server.User, peer *ser
 	util.WriteJSONObject(w, toPeerResponse(peer, account, dnsDomain))
 }
 
-func (h *Peers) deletePeer(accountID, userID string, peer *server.Peer, w http.ResponseWriter, r *http.Request) {
-	_, err := h.accountManager.DeletePeer(accountID, peer.Key, userID)
+func (h *Peers) deletePeer(accountID, userID string, peerID string, w http.ResponseWriter) {
+	_, err := h.accountManager.DeletePeer(accountID, peerID, userID)
 	if err != nil {
 		util.WriteError(err, w)
 		return
@@ -62,15 +62,9 @@ func (h *Peers) HandlePeer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	vars := mux.Vars(r)
-	peerId := vars["id"] //effectively peer IP address
-	if len(peerId) == 0 {
+	peerID := vars["id"]
+	if len(peerID) == 0 {
 		util.WriteError(status.Errorf(status.InvalidArgument, "invalid peer ID"), w)
-		return
-	}
-
-	peer, err := h.accountManager.GetPeerByIP(account.Id, peerId)
-	if err != nil {
-		util.WriteError(err, w)
 		return
 	}
 
@@ -78,10 +72,10 @@ func (h *Peers) HandlePeer(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodDelete:
-		h.deletePeer(account.Id, user.Id, peer, w, r)
+		h.deletePeer(account.Id, user.Id, peerID, w)
 		return
 	case http.MethodPut:
-		h.updatePeer(account, user, peer, w, r)
+		h.updatePeer(account, user, peerID, w, r)
 		return
 	case http.MethodGet:
 		util.WriteJSONObject(w, toPeerResponse(peer, account, dnsDomain))
@@ -132,7 +126,7 @@ func toPeerResponse(peer *server.Peer, account *server.Account, dnsDomain string
 		}
 		groupsChecked[group.ID] = struct{}{}
 		for _, pk := range group.Peers {
-			if pk == peer.Key {
+			if pk == peer.ID {
 				info := api.GroupMinimum{
 					Id:         group.ID,
 					Name:       group.Name,
@@ -149,7 +143,7 @@ func toPeerResponse(peer *server.Peer, account *server.Account, dnsDomain string
 		fqdn = peer.DNSLabel
 	}
 	return &api.Peer{
-		Id:         peer.IP.String(),
+		Id:         peer.ID,
 		Name:       peer.Name,
 		Ip:         peer.IP.String(),
 		Connected:  peer.Status.Connected,

--- a/management/server/http/peers.go
+++ b/management/server/http/peers.go
@@ -68,8 +68,6 @@ func (h *Peers) HandlePeer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dnsDomain := h.accountManager.GetDNSDomain()
-
 	switch r.Method {
 	case http.MethodDelete:
 		h.deletePeer(account.Id, user.Id, peerID, w)
@@ -77,10 +75,6 @@ func (h *Peers) HandlePeer(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPut:
 		h.updatePeer(account, user, peerID, w, r)
 		return
-	case http.MethodGet:
-		util.WriteJSONObject(w, toPeerResponse(peer, account, dnsDomain))
-		return
-
 	default:
 		util.WriteError(status.Errorf(status.NotFound, "unknown METHOD"), w)
 	}

--- a/management/server/http/routes.go
+++ b/management/server/http/routes.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"encoding/json"
+	"github.com/google/martian/log"
 	"github.com/gorilla/mux"
 	"github.com/netbirdio/netbird/management/server"
 	"github.com/netbirdio/netbird/management/server/http/api"
@@ -367,11 +368,13 @@ func (h *Routes) GetRouteHandler(w http.ResponseWriter, r *http.Request) {
 func toRouteResponse(account *server.Account, serverRoute *route.Route) *api.Route {
 	var peerIP string
 	if serverRoute.Peer != "" {
-		peer, found := account.Peers[serverRoute.Peer]
-		if !found {
-			panic("peer ID not found")
+		peer, err := account.FindPeerByPubKey(serverRoute.Peer)
+		if err != nil {
+			log.Errorf("peer not found")
+		} else {
+			peerIP = peer.IP.String()
 		}
-		peerIP = peer.IP.String()
+
 	}
 
 	return &api.Route{

--- a/management/server/http/routes_test.go
+++ b/management/server/http/routes_test.go
@@ -24,8 +24,9 @@ import (
 const (
 	existingRouteID = "existingRouteID"
 	notFoundRouteID = "notFoundRouteID"
-	existingPeerID  = "100.64.0.100"
-	notFoundPeerID  = "100.64.0.200"
+	existingPeerIP  = "100.64.0.100"
+	existingPeerID  = "peer-id"
+	notFoundPeerID  = "nonExistingPeer"
 	existingPeerKey = "existingPeerKey"
 	testAccountID   = "test_id"
 	existingGroupID = "testGroup"
@@ -47,9 +48,10 @@ var testingAccount = &server.Account{
 	Id:     testAccountID,
 	Domain: "hotmail.com",
 	Peers: map[string]*server.Peer{
-		existingPeerKey: {
+		existingPeerID: {
 			Key: existingPeerKey,
-			IP:  netip.MustParseAddr(existingPeerID).AsSlice(),
+			IP:  netip.MustParseAddr(existingPeerIP).AsSlice(),
+			ID:  existingPeerID,
 		},
 	},
 	Users: map[string]*server.User{
@@ -66,18 +68,15 @@ func initRoutesTestData() *Routes {
 				}
 				return nil, status.Errorf(status.NotFound, "route with ID %s not found", routeID)
 			},
-			CreateRouteFunc: func(accountID string, network, peerIP, description, netID string, masquerade bool, metric int, groups []string, enabled bool, _ string) (*route.Route, error) {
-
-				peer := testingAccount.GetPeerByIP(peerIP)
-				if peer == nil {
-					return nil, status.Errorf(status.NotFound, "peer %s not found", peerIP)
+			CreateRouteFunc: func(accountID string, network, peerID, description, netID string, masquerade bool, metric int, groups []string, enabled bool, _ string) (*route.Route, error) {
+				if peerID == notFoundPeerID {
+					return nil, status.Errorf(status.InvalidArgument, "peer with ID %s not found", peerID)
 				}
-
 				networkType, p, _ := route.ParseNetwork(network)
 				return &route.Route{
 					ID:          existingRouteID,
 					NetID:       netID,
-					Peer:        peer.Key,
+					Peer:        peerID,
 					Network:     p,
 					NetworkType: networkType,
 					Description: description,
@@ -86,7 +85,10 @@ func initRoutesTestData() *Routes {
 					Groups:      groups,
 				}, nil
 			},
-			SaveRouteFunc: func(_, _ string, _ *route.Route) error {
+			SaveRouteFunc: func(_, _ string, r *route.Route) error {
+				if r.Peer == notFoundPeerID {
+					return status.Errorf(status.InvalidArgument, "peer with ID %s not found", r.Peer)
+				}
 				return nil
 			},
 			DeleteRouteFunc: func(_ string, routeID string, _ string) error {
@@ -119,6 +121,9 @@ func initRoutesTestData() *Routes {
 						routeToUpdate.NetID = operation.Values[0]
 					case server.UpdateRoutePeer:
 						routeToUpdate.Peer = operation.Values[0]
+						if routeToUpdate.Peer == notFoundPeerID {
+							return nil, status.Errorf(status.InvalidArgument, "peer with ID %s not found", routeToUpdate.Peer)
+						}
 					case server.UpdateRouteMetric:
 						routeToUpdate.Metric, _ = strconv.Atoi(operation.Values[0])
 					case server.UpdateRouteMasquerade:
@@ -166,7 +171,7 @@ func TestRoutesHandlers(t *testing.T) {
 			requestPath:    "/api/routes/" + existingRouteID,
 			expectedStatus: http.StatusOK,
 			expectedBody:   true,
-			expectedRoute:  toRouteResponse(testingAccount, baseExistingRoute),
+			expectedRoute:  toRouteResponse(baseExistingRoute),
 		},
 		{
 			name:           "Get Not Existing Route",
@@ -212,7 +217,7 @@ func TestRoutesHandlers(t *testing.T) {
 			requestType:    http.MethodPost,
 			requestPath:    "/api/routes",
 			requestBody:    bytes.NewBufferString(fmt.Sprintf("{\"Description\":\"Post\",\"Network\":\"192.168.0.0/16\",\"network_id\":\"awesomeNet\",\"Peer\":\"%s\",\"groups\":[\"%s\"]}", notFoundPeerID, existingGroupID)),
-			expectedStatus: http.StatusNotFound,
+			expectedStatus: http.StatusUnprocessableEntity,
 			expectedBody:   false,
 		},
 		{
@@ -263,7 +268,7 @@ func TestRoutesHandlers(t *testing.T) {
 			requestType:    http.MethodPut,
 			requestPath:    "/api/routes/" + existingRouteID,
 			requestBody:    bytes.NewBufferString(fmt.Sprintf("{\"Description\":\"Post\",\"Network\":\"192.168.0.0/16\",\"network_id\":\"awesomeNet\",\"Peer\":\"%s\",\"groups\":[\"%s\"]}", notFoundPeerID, existingGroupID)),
-			expectedStatus: http.StatusNotFound,
+			expectedStatus: http.StatusUnprocessableEntity,
 			expectedBody:   false,
 		},
 		{
@@ -326,7 +331,7 @@ func TestRoutesHandlers(t *testing.T) {
 			requestType:    http.MethodPatch,
 			requestPath:    "/api/routes/" + existingRouteID,
 			requestBody:    bytes.NewBufferString(fmt.Sprintf("[{\"op\":\"replace\",\"path\":\"peer\",\"value\":[\"%s\"]}]", notFoundPeerID)),
-			expectedStatus: http.StatusNotFound,
+			expectedStatus: http.StatusUnprocessableEntity,
 			expectedBody:   false,
 		},
 		{

--- a/management/server/metrics/selfhosted.go
+++ b/management/server/metrics/selfhosted.go
@@ -207,7 +207,7 @@ func (w *Worker) generateProperties() properties {
 				osUIClients[uiOSKey] = osUICount + 1
 			}
 
-			_, connected := connections[peer.Key]
+			_, connected := connections[peer.ID]
 			if connected || peer.Status.LastSeen.After(w.lastRun) {
 				activePeersLastDay++
 				osActiveKey := osKey + "_active"

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -331,9 +331,9 @@ func (am *MockAccountManager) UpdatePeer(accountID, userID string, peer *server.
 }
 
 // CreateRoute mock implementation of CreateRoute from server.AccountManager interface
-func (am *MockAccountManager) CreateRoute(accountID string, network, peerIP, description, netID string, masquerade bool, metric int, groups []string, enabled bool, userID string) (*route.Route, error) {
+func (am *MockAccountManager) CreateRoute(accountID string, network, peerID, description, netID string, masquerade bool, metric int, groups []string, enabled bool, userID string) (*route.Route, error) {
 	if am.CreateRouteFunc != nil {
-		return am.CreateRouteFunc(accountID, network, peerIP, description, netID, masquerade, metric, groups, enabled, userID)
+		return am.CreateRouteFunc(accountID, network, peerID, description, netID, masquerade, metric, groups, enabled, userID)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method CreateRoute is not implemented")
 }

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -42,8 +42,8 @@ type MockAccountManager struct {
 	DeleteRuleFunc                  func(accountID, ruleID, userID string) error
 	ListRulesFunc                   func(accountID, userID string) ([]*server.Rule, error)
 	GetUsersFromAccountFunc         func(accountID, userID string) ([]*server.UserInfo, error)
-	UpdatePeerMetaFunc              func(peerKey string, meta server.PeerSystemMeta) error
-	UpdatePeerSSHKeyFunc            func(peerKey string, sshKey string) error
+	UpdatePeerMetaFunc              func(peerID string, meta server.PeerSystemMeta) error
+	UpdatePeerSSHKeyFunc            func(peerID string, sshKey string) error
 	UpdatePeerFunc                  func(accountID, userID string, peer *server.Peer) (*server.Peer, error)
 	CreateRouteFunc                 func(accountID string, prefix, peer, description, netID string, masquerade bool, metric int, groups []string, enabled bool, userID string) (*route.Route, error)
 	GetRouteFunc                    func(accountID, routeID, userID string) (*route.Route, error)
@@ -299,9 +299,9 @@ func (am *MockAccountManager) ListRules(accountID, userID string) ([]*server.Rul
 }
 
 // UpdatePeerMeta mock implementation of UpdatePeerMeta from server.AccountManager interface
-func (am *MockAccountManager) UpdatePeerMeta(peerKey string, meta server.PeerSystemMeta) error {
+func (am *MockAccountManager) UpdatePeerMeta(peerID string, meta server.PeerSystemMeta) error {
 	if am.UpdatePeerMetaFunc != nil {
-		return am.UpdatePeerMetaFunc(peerKey, meta)
+		return am.UpdatePeerMetaFunc(peerID, meta)
 	}
 	return status.Errorf(codes.Unimplemented, "method UpdatePeerMetaFunc is not implemented")
 }
@@ -315,9 +315,9 @@ func (am *MockAccountManager) IsUserAdmin(claims jwtclaims.AuthorizationClaims) 
 }
 
 // UpdatePeerSSHKey mocks UpdatePeerSSHKey function of the account manager
-func (am *MockAccountManager) UpdatePeerSSHKey(peerKey string, sshKey string) error {
+func (am *MockAccountManager) UpdatePeerSSHKey(peerID string, sshKey string) error {
 	if am.UpdatePeerSSHKeyFunc != nil {
-		return am.UpdatePeerSSHKeyFunc(peerKey, sshKey)
+		return am.UpdatePeerSSHKeyFunc(peerID, sshKey)
 	}
 	return status.Errorf(codes.Unimplemented, "method UpdatePeerSSHKey is is not implemented")
 }

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -143,11 +143,11 @@ func (am *MockAccountManager) AccountExists(accountId string) (*bool, error) {
 }
 
 // GetPeer mock implementation of GetPeer from server.AccountManager interface
-func (am *MockAccountManager) GetPeer(peerKey string) (*server.Peer, error) {
+func (am *MockAccountManager) GetPeerByKey(peerKey string) (*server.Peer, error) {
 	if am.GetPeerFunc != nil {
 		return am.GetPeerFunc(peerKey)
 	}
-	return nil, status.Errorf(codes.Unimplemented, "method GetPeer is not implemented")
+	return nil, status.Errorf(codes.Unimplemented, "method GetPeerByKey is not implemented")
 }
 
 // MarkPeerConnected mock implementation of MarkPeerConnected from server.AccountManager interface

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -77,9 +77,9 @@ func (am *MockAccountManager) GetUsersFromAccount(accountID string, userID strin
 }
 
 // DeletePeer mock implementation of DeletePeer from server.AccountManager interface
-func (am *MockAccountManager) DeletePeer(accountID, peerKey, userID string) (*server.Peer, error) {
+func (am *MockAccountManager) DeletePeer(accountID, peerID, userID string) (*server.Peer, error) {
 	if am.DeletePeerFunc != nil {
-		return am.DeletePeerFunc(accountID, peerKey, userID)
+		return am.DeletePeerFunc(accountID, peerID, userID)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method DeletePeer is not implemented")
 }

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -101,7 +101,7 @@ func (p *PeerStatus) Copy() *PeerStatus {
 }
 
 // GetPeer looks up peer by its public WireGuard key
-func (am *DefaultAccountManager) GetPeer(peerPubKey string) (*Peer, error) {
+func (am *DefaultAccountManager) GetPeerByKey(peerPubKey string) (*Peer, error) {
 
 	account, err := am.Store.GetAccountByPeerPubKey(peerPubKey)
 	if err != nil {

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -225,7 +225,7 @@ func (am *DefaultAccountManager) UpdatePeer(accountID, userID string, update *Pe
 
 		peer.DNSLabel = newLabel
 
-		am.storeEvent(userID, peer.IP.String(), accountID, activity.PeerRenamed, peer.EventMeta(am.GetDNSDomain()))
+		am.storeEvent(userID, peer.ID, accountID, activity.PeerRenamed, peer.EventMeta(am.GetDNSDomain()))
 	}
 
 	account.UpdatePeer(peer)
@@ -289,7 +289,7 @@ func (am *DefaultAccountManager) DeletePeer(accountID, peerID, userID string) (*
 	}
 
 	am.peersUpdateManager.CloseChannel(peerID)
-	am.storeEvent(userID, peer.IP.String(), account.Id, activity.PeerRemovedByUser, peer.EventMeta(am.GetDNSDomain()))
+	am.storeEvent(userID, peer.ID, account.Id, activity.PeerRemovedByUser, peer.EventMeta(am.GetDNSDomain()))
 	return peer, nil
 }
 
@@ -483,7 +483,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 		return nil, err
 	}
 
-	opEvent.TargetID = newPeer.IP.String()
+	opEvent.TargetID = newPeer.ID
 	opEvent.Meta = newPeer.EventMeta(am.GetDNSDomain())
 	am.storeEvent(opEvent.InitiatorID, opEvent.TargetID, opEvent.AccountID, opEvent.Activity, opEvent.Meta)
 

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -327,7 +327,7 @@ func (am *DefaultAccountManager) GetNetworkMap(peerID string) (*NetworkMap, erro
 	}
 
 	aclPeers := account.getPeersByACL(peerID)
-	routesUpdate := account.getRoutesToSync(peerID, peer.Key, aclPeers)
+	routesUpdate := account.getRoutesToSync(peerID, aclPeers)
 
 	dnsManagementStatus := account.getPeerDNSManagementStatus(peerID)
 	dnsUpdate := nbdns.Config{

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -327,7 +327,7 @@ func (am *DefaultAccountManager) GetNetworkMap(peerID string) (*NetworkMap, erro
 	}
 
 	aclPeers := account.getPeersByACL(peerID)
-	routesUpdate := account.getRoutesToSync(peer.Key, aclPeers)
+	routesUpdate := account.getRoutesToSync(peerID, peer.Key, aclPeers)
 
 	dnsManagementStatus := account.getPeerDNSManagementStatus(peerID)
 	dnsUpdate := nbdns.Config{

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -327,6 +327,7 @@ func (am *DefaultAccountManager) GetNetworkMap(peerID string) (*NetworkMap, erro
 	}
 
 	aclPeers := account.getPeersByACL(peerID)
+	// Please mind, that the returned route.Route objects will contain Peer.Key instead of Peer.ID.
 	routesUpdate := account.getRoutesToSync(peerID, aclPeers)
 
 	dnsManagementStatus := account.getPeerDNSManagementStatus(peerID)

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -5,6 +5,7 @@ import (
 	nbdns "github.com/netbirdio/netbird/dns"
 	"github.com/netbirdio/netbird/management/server/activity"
 	"github.com/netbirdio/netbird/management/server/status"
+	"github.com/rs/xid"
 	"net"
 	"strings"
 	"time"
@@ -34,9 +35,11 @@ type PeerStatus struct {
 }
 
 // Peer represents a machine connected to the network.
-// The Peer is a Wireguard peer identified by a public key
+// The Peer is a WireGuard peer identified by a public key
 type Peer struct {
-	// Wireguard public key
+	// ID is an internal ID of the peer
+	ID string
+	// WireGuard public key
 	Key string
 	// A setup key this peer was registered with
 	SetupKey string
@@ -62,6 +65,7 @@ type Peer struct {
 // Copy copies Peer object
 func (p *Peer) Copy() *Peer {
 	return &Peer{
+		ID:         p.ID,
 		Key:        p.Key,
 		SetupKey:   p.SetupKey,
 		IP:         p.IP,
@@ -130,14 +134,14 @@ func (am *DefaultAccountManager) GetPeers(accountID, userID string) ([]*Peer, er
 		}
 		p := peer.Copy()
 		peers = append(peers, p)
-		peersMap[peer.Key] = p
+		peersMap[peer.ID] = p
 	}
 
 	// fetch all the peers that have access to the user's peers
 	for _, peer := range peers {
-		aclPeers := account.getPeersByACL(peer.Key)
+		aclPeers := account.getPeersByACL(peer.ID)
 		for _, p := range aclPeers {
-			peersMap[p.Key] = p
+			peersMap[p.ID] = p
 		}
 	}
 
@@ -195,10 +199,9 @@ func (am *DefaultAccountManager) UpdatePeer(accountID, userID string, update *Pe
 		return nil, err
 	}
 
-	//TODO Peer.ID migration: we will need to replace search by ID here
-	peer, err := account.FindPeerByPubKey(update.Key)
-	if err != nil {
-		return nil, err
+	peer := account.GetPeer(update.ID)
+	if peer == nil {
+		return nil, status.Errorf(status.NotFound, "peer %s not found", update.ID)
 	}
 
 	if peer.SSHEnabled != update.SSHEnabled {
@@ -241,7 +244,7 @@ func (am *DefaultAccountManager) UpdatePeer(accountID, userID string, update *Pe
 }
 
 // DeletePeer removes peer from the account by its IP
-func (am *DefaultAccountManager) DeletePeer(accountID, peerPubKey, userID string) (*Peer, error) {
+func (am *DefaultAccountManager) DeletePeer(accountID, peerID, userID string) (*Peer, error) {
 
 	unlock := am.Store.AcquireAccountLock(accountID)
 	defer unlock()
@@ -251,19 +254,19 @@ func (am *DefaultAccountManager) DeletePeer(accountID, peerPubKey, userID string
 		return nil, err
 	}
 
-	peer, err := account.FindPeerByPubKey(peerPubKey)
-	if err != nil {
-		return nil, err
+	peer := account.GetPeer(peerID)
+	if peer == nil {
+		return nil, status.Errorf(status.NotFound, "peer %s not found", peerID)
 	}
 
-	account.DeletePeer(peerPubKey)
+	account.DeletePeer(peerID)
 
 	err = am.Store.SaveAccount(account)
 	if err != nil {
 		return nil, err
 	}
 
-	err = am.peersUpdateManager.SendUpdate(peerPubKey,
+	err = am.peersUpdateManager.SendUpdate(peer.ID,
 		&UpdateMessage{
 			Update: &proto.SyncResponse{
 				// fill those field for backward compatibility
@@ -281,12 +284,11 @@ func (am *DefaultAccountManager) DeletePeer(accountID, peerPubKey, userID string
 		return nil, err
 	}
 
-	// TODO Peer.ID migration: we will need to replace search by Peer.ID here
 	if err := am.updateAccountPeers(account); err != nil {
 		return nil, err
 	}
 
-	am.peersUpdateManager.CloseChannel(peerPubKey)
+	am.peersUpdateManager.CloseChannel(peerID)
 	am.storeEvent(userID, peer.IP.String(), account.Id, activity.PeerRemovedByUser, peer.EventMeta(am.GetDNSDomain()))
 	return peer, nil
 }
@@ -312,9 +314,9 @@ func (am *DefaultAccountManager) GetPeerByIP(accountID string, peerIP string) (*
 }
 
 // GetNetworkMap returns Network map for a given peer (omits original peer from the Peers result)
-func (am *DefaultAccountManager) GetNetworkMap(peerPubKey string) (*NetworkMap, error) {
+func (am *DefaultAccountManager) GetNetworkMap(peerID string) (*NetworkMap, error) {
 
-	account, err := am.Store.GetAccountByPeerPubKey(peerPubKey)
+	account, err := am.Store.GetAccountByPeerID(peerID)
 	if err != nil {
 		return nil, err
 	}
@@ -346,9 +348,9 @@ func (am *DefaultAccountManager) GetNetworkMap(peerPubKey string) (*NetworkMap, 
 }
 
 // GetPeerNetwork returns the Network for a given peer
-func (am *DefaultAccountManager) GetPeerNetwork(peerPubKey string) (*Network, error) {
+func (am *DefaultAccountManager) GetPeerNetwork(peerID string) (*Network, error) {
 
-	account, err := am.Store.GetAccountByPeerPubKey(peerPubKey)
+	account, err := am.Store.GetAccountByPeerID(peerID)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +359,7 @@ func (am *DefaultAccountManager) GetPeerNetwork(peerPubKey string) (*Network, er
 }
 
 // AddPeer adds a new peer to the Store.
-// Each Account has a list of pre-authorised SetupKey and if no Account has a given key err wit ha code codes.Unauthenticated
+// Each Account has a list of pre-authorised SetupKey and if no Account has a given key err with a code codes.Unauthenticated
 // will be returned, meaning the key is invalid
 // If a User ID is provided, it means that we passed the authentication using JWT, then we look for account by User ID and register the peer
 // to it. We also add the User ID to the peer metadata to identify registrant.
@@ -428,6 +430,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 	}
 
 	newPeer := &Peer{
+		ID:         xid.New().String(),
 		Key:        peer.Key,
 		SetupKey:   upperKey,
 		IP:         nextIp,
@@ -445,7 +448,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 	if err != nil {
 		return nil, err
 	}
-	group.Peers = append(group.Peers, newPeer.Key)
+	group.Peers = append(group.Peers, newPeer.ID)
 
 	var groupsToAdd []string
 	if addedByUser {
@@ -463,12 +466,12 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 	if len(groupsToAdd) > 0 {
 		for _, s := range groupsToAdd {
 			if g, ok := account.Groups[s]; ok && g.Name != "All" {
-				g.Peers = append(g.Peers, newPeer.Key)
+				g.Peers = append(g.Peers, newPeer.ID)
 			}
 		}
 	}
 
-	account.Peers[newPeer.Key] = newPeer
+	account.Peers[newPeer.ID] = newPeer
 	account.Network.IncSerial()
 	err = am.Store.SaveAccount(account)
 	if err != nil {
@@ -558,9 +561,9 @@ func (am *DefaultAccountManager) UpdatePeerMeta(peerPubKey string, meta PeerSyst
 }
 
 // getPeersByACL returns all peers that given peer has access to.
-func (a *Account) getPeersByACL(peerPubKey string) []*Peer {
+func (a *Account) getPeersByACL(peerID string) []*Peer {
 	var peers []*Peer
-	srcRules, dstRules := a.GetPeerRules(peerPubKey)
+	srcRules, dstRules := a.GetPeerRules(peerID)
 
 	groups := map[string]*Group{}
 	for _, r := range srcRules {
@@ -603,8 +606,8 @@ func (a *Account) getPeersByACL(peerPubKey string) []*Peer {
 				continue
 			}
 			// exclude original peer
-			if _, ok := peersSet[peer.Key]; peer.Key != peerPubKey && !ok {
-				peersSet[peer.Key] = struct{}{}
+			if _, ok := peersSet[peer.ID]; peer.ID != peerID && !ok {
+				peersSet[peer.ID] = struct{}{}
 				peers = append(peers, peer.Copy())
 			}
 		}
@@ -619,13 +622,13 @@ func (am *DefaultAccountManager) updateAccountPeers(account *Account) error {
 	peers := account.GetPeers()
 
 	for _, peer := range peers {
-		remotePeerNetworkMap, err := am.GetNetworkMap(peer.Key)
+		remotePeerNetworkMap, err := am.GetNetworkMap(peer.ID)
 		if err != nil {
 			return err
 		}
 
 		update := toSyncResponse(nil, peer, nil, remotePeerNetworkMap, am.GetDNSDomain())
-		err = am.peersUpdateManager.SendUpdate(peer.Key, &UpdateMessage{Update: update})
+		err = am.peersUpdateManager.SendUpdate(peer.ID, &UpdateMessage{Update: update})
 		if err != nil {
 			return err
 		}

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -321,10 +321,15 @@ func (am *DefaultAccountManager) GetNetworkMap(peerID string) (*NetworkMap, erro
 		return nil, err
 	}
 
-	aclPeers := account.getPeersByACL(peerPubKey)
-	routesUpdate := account.getRoutesToSync(peerPubKey, aclPeers)
+	peer := account.GetPeer(peerID)
+	if peer == nil {
+		return nil, status.Errorf(status.NotFound, "peer with ID %s not found", peerID)
+	}
 
-	dnsManagementStatus := account.getPeerDNSManagementStatus(peerPubKey)
+	aclPeers := account.getPeersByACL(peerID)
+	routesUpdate := account.getRoutesToSync(peer.Key, aclPeers)
+
+	dnsManagementStatus := account.getPeerDNSManagementStatus(peerID)
 	dnsUpdate := nbdns.Config{
 		ServiceEnable: dnsManagementStatus,
 	}
@@ -336,7 +341,7 @@ func (am *DefaultAccountManager) GetNetworkMap(peerID string) (*NetworkMap, erro
 			zones = append(zones, peersCustomZone)
 		}
 		dnsUpdate.CustomZones = zones
-		dnsUpdate.NameServerGroups = getPeerNSGroups(account, peerPubKey)
+		dnsUpdate.NameServerGroups = getPeerNSGroups(account, peerID)
 	}
 
 	return &NetworkMap{

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -181,7 +181,7 @@ func (am *DefaultAccountManager) MarkPeerConnected(peerPubKey string, connected 
 	peer.Status = newStatus
 	account.UpdatePeer(peer)
 
-	err = am.Store.SavePeerStatus(account.Id, peerPubKey, *newStatus)
+	err = am.Store.SavePeerStatus(account.Id, peer.ID, *newStatus)
 	if err != nil {
 		return err
 	}

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -34,7 +34,7 @@ func TestAccountManager_GetNetworkMap(t *testing.T) {
 		return
 	}
 
-	_, err = manager.AddPeer(setupKey.Key, "", &Peer{
+	peer1, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey1.PublicKey().String(),
 		Meta: PeerSystemMeta{},
 		Name: "test-peer-2",
@@ -61,7 +61,7 @@ func TestAccountManager_GetNetworkMap(t *testing.T) {
 		return
 	}
 
-	networkMap, err := manager.GetNetworkMap(peerKey1.PublicKey().String())
+	networkMap, err := manager.GetNetworkMap(peer1.ID)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -107,7 +107,7 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 		return
 	}
 
-	_, err = manager.AddPeer(setupKey.Key, "", &Peer{
+	peer1, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey1.PublicKey().String(),
 		Meta: PeerSystemMeta{},
 		Name: "test-peer-2",
@@ -123,7 +123,7 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	_, err = manager.AddPeer(setupKey.Key, "", &Peer{
+	peer2, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey2.PublicKey().String(),
 		Meta: PeerSystemMeta{},
 		Name: "test-peer-2",
@@ -156,8 +156,8 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 	group1.Name = "src"
 	group2.Name = "dst"
 	rule.ID = xid.New().String()
-	group1.Peers = append(group1.Peers, peerKey1.PublicKey().String())
-	group2.Peers = append(group2.Peers, peerKey2.PublicKey().String())
+	group1.Peers = append(group1.Peers, peer1.ID)
+	group2.Peers = append(group2.Peers, peer2.ID)
 
 	err = manager.SaveGroup(account.Id, userID, &group1)
 	if err != nil {
@@ -180,7 +180,7 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 		return
 	}
 
-	networkMap1, err := manager.GetNetworkMap(peerKey1.PublicKey().String())
+	networkMap1, err := manager.GetNetworkMap(peer1.ID)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -203,7 +203,7 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 		)
 	}
 
-	networkMap2, err := manager.GetNetworkMap(peerKey2.PublicKey().String())
+	networkMap2, err := manager.GetNetworkMap(peer2.ID)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -228,7 +228,7 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 		return
 	}
 
-	networkMap1, err = manager.GetNetworkMap(peerKey1.PublicKey().String())
+	networkMap1, err = manager.GetNetworkMap(peer1.ID)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -243,7 +243,7 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 		return
 	}
 
-	networkMap2, err = manager.GetNetworkMap(peerKey2.PublicKey().String())
+	networkMap2, err = manager.GetNetworkMap(peer2.ID)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -281,7 +281,7 @@ func TestAccountManager_GetPeerNetwork(t *testing.T) {
 		return
 	}
 
-	_, err = manager.AddPeer(setupKey.Key, "", &Peer{
+	peer1, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey1.PublicKey().String(),
 		Meta: PeerSystemMeta{},
 		Name: "test-peer-2",
@@ -308,7 +308,7 @@ func TestAccountManager_GetPeerNetwork(t *testing.T) {
 		return
 	}
 
-	network, err := manager.GetPeerNetwork(peerKey1.PublicKey().String())
+	network, err := manager.GetPeerNetwork(peer1.ID)
 	if err != nil {
 		t.Fatal(err)
 		return

--- a/management/server/route.go
+++ b/management/server/route.go
@@ -91,9 +91,9 @@ func (am *DefaultAccountManager) GetRoute(accountID, routeID, userID string) (*r
 }
 
 // checkPrefixPeerExists checks the combination of prefix and peer id, if it exists returns an error, otherwise returns nil
-func (am *DefaultAccountManager) checkPrefixPeerExists(accountID, peer string, prefix netip.Prefix) error {
+func (am *DefaultAccountManager) checkPrefixPeerExists(accountID, peerID string, prefix netip.Prefix) error {
 
-	if peer == "" {
+	if peerID == "" {
 		return nil
 	}
 
@@ -111,7 +111,7 @@ func (am *DefaultAccountManager) checkPrefixPeerExists(accountID, peer string, p
 		return status.Errorf(status.InvalidArgument, "failed to parse prefix %s", prefix.String())
 	}
 	for _, prefixRoute := range routesWithPrefix {
-		if prefixRoute.Peer == peer {
+		if prefixRoute.Peer == peerID {
 			return status.Errorf(status.AlreadyExists, "failed a route with prefix %s and peer already exist", prefix.String())
 		}
 	}
@@ -119,7 +119,7 @@ func (am *DefaultAccountManager) checkPrefixPeerExists(accountID, peer string, p
 }
 
 // CreateRoute creates and saves a new route
-func (am *DefaultAccountManager) CreateRoute(accountID string, network, peerIP, description, netID string, masquerade bool, metric int, groups []string, enabled bool, userID string) (*route.Route, error) {
+func (am *DefaultAccountManager) CreateRoute(accountID string, network, peerID, description, netID string, masquerade bool, metric int, groups []string, enabled bool, userID string) (*route.Route, error) {
 	unlock := am.Store.AcquireAccountLock(accountID)
 	defer unlock()
 
@@ -128,13 +128,11 @@ func (am *DefaultAccountManager) CreateRoute(accountID string, network, peerIP, 
 		return nil, err
 	}
 
-	peerKey := ""
-	if peerIP != "" {
-		peer := account.GetPeerByIP(peerIP)
+	if peerID != "" {
+		peer := account.GetPeer(peerID)
 		if peer == nil {
-			return nil, status.Errorf(status.NotFound, "peer %s not found", peerIP)
+			return nil, status.Errorf(status.InvalidArgument, "peer with ID %s not found", peerID)
 		}
-		peerKey = peer.Key
 	}
 
 	var newRoute route.Route
@@ -142,7 +140,7 @@ func (am *DefaultAccountManager) CreateRoute(accountID string, network, peerIP, 
 	if err != nil {
 		return nil, status.Errorf(status.InvalidArgument, "failed to parse IP %s", network)
 	}
-	err = am.checkPrefixPeerExists(accountID, peerKey, newPrefix)
+	err = am.checkPrefixPeerExists(accountID, peerID, newPrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +158,7 @@ func (am *DefaultAccountManager) CreateRoute(accountID string, network, peerIP, 
 		return nil, err
 	}
 
-	newRoute.Peer = peerKey
+	newRoute.Peer = peerID
 	newRoute.ID = xid.New().String()
 	newRoute.Network = newPrefix
 	newRoute.NetworkType = prefixType
@@ -220,9 +218,9 @@ func (am *DefaultAccountManager) SaveRoute(accountID, userID string, routeToSave
 	}
 
 	if routeToSave.Peer != "" {
-		_, err = account.FindPeerByPubKey(routeToSave.Peer)
-		if err != nil {
-			return err
+		peer := account.GetPeer(routeToSave.Peer)
+		if peer == nil {
+			return status.Errorf(status.InvalidArgument, "peer with ID %s not found", routeToSave.Peer)
 		}
 	}
 
@@ -238,9 +236,14 @@ func (am *DefaultAccountManager) SaveRoute(accountID, userID string, routeToSave
 		return err
 	}
 
+	err = am.updateAccountPeers(account)
+	if err != nil {
+		return err
+	}
+
 	am.storeEvent(userID, routeToSave.ID, accountID, activity.RouteUpdated, routeToSave.EventMeta())
 
-	return am.updateAccountPeers(account)
+	return nil
 }
 
 // UpdateRoute updates existing route with set of operations
@@ -287,9 +290,9 @@ func (am *DefaultAccountManager) UpdateRoute(accountID, routeID string, operatio
 			newRoute.NetworkType = prefixType
 		case UpdateRoutePeer:
 			if operation.Values[0] != "" {
-				_, err = account.FindPeerByPubKey(operation.Values[0])
-				if err != nil {
-					return nil, err
+				peer := account.GetPeer(operation.Values[0])
+				if peer == nil {
+					return nil, status.Errorf(status.InvalidArgument, "peer with ID %s not found", operation.Values[0])
 				}
 			}
 

--- a/management/server/route.go
+++ b/management/server/route.go
@@ -220,9 +220,9 @@ func (am *DefaultAccountManager) SaveRoute(accountID, userID string, routeToSave
 	}
 
 	if routeToSave.Peer != "" {
-		_, peerExist := account.Peers[routeToSave.Peer]
-		if !peerExist {
-			return status.Errorf(status.InvalidArgument, "failed to find Peer %s", routeToSave.Peer)
+		_, err = account.FindPeerByPubKey(routeToSave.Peer)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -287,9 +287,9 @@ func (am *DefaultAccountManager) UpdateRoute(accountID, routeID string, operatio
 			newRoute.NetworkType = prefixType
 		case UpdateRoutePeer:
 			if operation.Values[0] != "" {
-				_, peerExist := account.Peers[operation.Values[0]]
-				if !peerExist {
-					return nil, status.Errorf(status.InvalidArgument, "failed to find Peer %s", operation.Values[0])
+				_, err = account.FindPeerByPubKey(operation.Values[0])
+				if err != nil {
+					return nil, err
 				}
 			}
 

--- a/management/server/route.go
+++ b/management/server/route.go
@@ -112,7 +112,7 @@ func (am *DefaultAccountManager) checkPrefixPeerExists(accountID, peerID string,
 	}
 	for _, prefixRoute := range routesWithPrefix {
 		if prefixRoute.Peer == peerID {
-			return status.Errorf(status.AlreadyExists, "failed a route with prefix %s and peer already exist", prefix.String())
+			return status.Errorf(status.AlreadyExists, "failed to add route with prefix %s - peer already has this route", prefix.String())
 		}
 	}
 	return nil

--- a/management/server/route_test.go
+++ b/management/server/route_test.go
@@ -874,13 +874,17 @@ func TestGetNetworkMap_RouteSync(t *testing.T) {
 	enabledRoute := createdRoute.Copy()
 	enabledRoute.Enabled = true
 
+	// network map contains route.Route objects that have Route.Peer field filled with Peer.Key instead of Peer.ID
+	expectedRoute := enabledRoute.Copy()
+	expectedRoute.Peer = peer1Key
+
 	err = am.SaveRoute(account.Id, userID, enabledRoute)
 	require.NoError(t, err)
 
 	peer1Routes, err := am.GetNetworkMap(peer1ID)
 	require.NoError(t, err)
 	require.Len(t, peer1Routes.Routes, 1, "we should receive one route for peer1")
-	require.True(t, enabledRoute.IsEqual(peer1Routes.Routes[0]), "received route should be equal")
+	require.True(t, expectedRoute.IsEqual(peer1Routes.Routes[0]), "received route should be equal")
 
 	peer2Routes, err := am.GetNetworkMap(peer2ID)
 	require.NoError(t, err)

--- a/management/server/route_test.go
+++ b/management/server/route_test.go
@@ -12,6 +12,8 @@ import (
 const (
 	peer1Key           = "BhRPtynAAYRDy08+q4HTMsos8fs4plTP4NOSh7C1ry8="
 	peer2Key           = "/yF0+vCfv+mRR5k0dca0TrGdO/oiNeAI58gToZm5NyI="
+	peer1ID            = "peer-1-id"
+	peer2ID            = "peer-2-id"
 	routeGroup1        = "routeGroup1"
 	routeGroup2        = "routeGroup2"
 	routeInvalidGroup1 = "routeInvalidGroup1"
@@ -43,7 +45,7 @@ func TestCreateRoute(t *testing.T) {
 			inputArgs: input{
 				network:     "192.168.0.0/16",
 				netID:       "happy",
-				peerKey:     peer1Key,
+				peerKey:     peer1ID,
 				description: "super",
 				masquerade:  false,
 				metric:      9999,
@@ -56,7 +58,7 @@ func TestCreateRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetworkType: route.IPv4Network,
 				NetID:       "happy",
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -69,7 +71,7 @@ func TestCreateRoute(t *testing.T) {
 			inputArgs: input{
 				network:     "192.168.0.0/34",
 				netID:       "happy",
-				peerKey:     peer1Key,
+				peerKey:     peer1ID,
 				description: "super",
 				masquerade:  false,
 				metric:      9999,
@@ -124,7 +126,7 @@ func TestCreateRoute(t *testing.T) {
 			name: "Large Metric Should Fail",
 			inputArgs: input{
 				network:     "192.168.0.0/16",
-				peerKey:     peer1Key,
+				peerKey:     peer1ID,
 				netID:       "happy",
 				description: "super",
 				masquerade:  false,
@@ -140,7 +142,7 @@ func TestCreateRoute(t *testing.T) {
 			inputArgs: input{
 				network:     "192.168.0.0/16",
 				netID:       "happy",
-				peerKey:     peer1Key,
+				peerKey:     peer1ID,
 				description: "super",
 				masquerade:  false,
 				metric:      0,
@@ -154,7 +156,7 @@ func TestCreateRoute(t *testing.T) {
 			name: "Large NetID Should Fail",
 			inputArgs: input{
 				network:     "192.168.0.0/16",
-				peerKey:     peer1Key,
+				peerKey:     peer1ID,
 				netID:       "12345678901234567890qwertyuiopqwertyuiop1",
 				description: "super",
 				masquerade:  false,
@@ -170,7 +172,7 @@ func TestCreateRoute(t *testing.T) {
 			inputArgs: input{
 				network:     "192.168.0.0/16",
 				netID:       "",
-				peerKey:     peer1Key,
+				peerKey:     peer1ID,
 				description: "",
 				masquerade:  false,
 				metric:      9999,
@@ -185,7 +187,7 @@ func TestCreateRoute(t *testing.T) {
 			inputArgs: input{
 				network:     "192.168.0.0/16",
 				netID:       "NewId",
-				peerKey:     peer1Key,
+				peerKey:     peer1ID,
 				description: "",
 				masquerade:  false,
 				metric:      9999,
@@ -200,7 +202,7 @@ func TestCreateRoute(t *testing.T) {
 			inputArgs: input{
 				network:     "192.168.0.0/16",
 				netID:       "NewId",
-				peerKey:     peer1Key,
+				peerKey:     peer1ID,
 				description: "",
 				masquerade:  false,
 				metric:      9999,
@@ -215,7 +217,7 @@ func TestCreateRoute(t *testing.T) {
 			inputArgs: input{
 				network:     "192.168.0.0/16",
 				netID:       "NewId",
-				peerKey:     peer1Key,
+				peerKey:     peer1ID,
 				description: "",
 				masquerade:  false,
 				metric:      9999,
@@ -238,18 +240,10 @@ func TestCreateRoute(t *testing.T) {
 				t.Error("failed to init testing account")
 			}
 
-			peerIP := "99.99.99.99"
-			peer, _ := account.FindPeerByPubKey(testCase.inputArgs.peerKey)
-			if testCase.inputArgs.peerKey == "" {
-				peerIP = ""
-			} else if peer != nil {
-				peerIP = peer.IP.String()
-			}
-
 			outRoute, err := am.CreateRoute(
 				account.Id,
 				testCase.inputArgs.network,
-				peerIP,
+				testCase.inputArgs.peerKey,
 				testCase.inputArgs.description,
 				testCase.inputArgs.netID,
 				testCase.inputArgs.masquerade,
@@ -278,7 +272,7 @@ func TestCreateRoute(t *testing.T) {
 
 func TestSaveRoute(t *testing.T) {
 
-	validPeer := peer2Key
+	validPeer := peer2ID
 	invalidPeer := "nonExisting"
 	validPrefix := netip.MustParsePrefix("192.168.0.0/24")
 	invalidPrefix, _ := netip.ParsePrefix("192.168.0.0/34")
@@ -306,7 +300,7 @@ func TestSaveRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       validNetID,
 				NetworkType: route.IPv4Network,
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -339,7 +333,7 @@ func TestSaveRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       validNetID,
 				NetworkType: route.IPv4Network,
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -356,7 +350,7 @@ func TestSaveRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       validNetID,
 				NetworkType: route.IPv4Network,
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -373,7 +367,7 @@ func TestSaveRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       validNetID,
 				NetworkType: route.IPv4Network,
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -390,7 +384,7 @@ func TestSaveRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       invalidNetID,
 				NetworkType: route.IPv4Network,
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -407,7 +401,7 @@ func TestSaveRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       validNetID,
 				NetworkType: route.IPv4Network,
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -424,7 +418,7 @@ func TestSaveRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       validNetID,
 				NetworkType: route.IPv4Network,
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -441,7 +435,7 @@ func TestSaveRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       validNetID,
 				NetworkType: route.IPv4Network,
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -458,7 +452,7 @@ func TestSaveRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       validNetID,
 				NetworkType: route.IPv4Network,
-				Peer:        peer1Key,
+				Peer:        peer1ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -495,7 +489,6 @@ func TestSaveRoute(t *testing.T) {
 				if testCase.newPeer != nil {
 					routeToSave.Peer = *testCase.newPeer
 				}
-
 				if testCase.newMetric != nil {
 					routeToSave.Metric = *testCase.newMetric
 				}
@@ -541,7 +534,7 @@ func TestUpdateRoute(t *testing.T) {
 		Network:     netip.MustParsePrefix("192.168.0.0/16"),
 		NetID:       "superRoute",
 		NetworkType: route.IPv4Network,
-		Peer:        peer1Key,
+		Peer:        peer1ID,
 		Description: "super",
 		Masquerade:  false,
 		Metric:      9999,
@@ -563,7 +556,7 @@ func TestUpdateRoute(t *testing.T) {
 			operations: []RouteUpdateOperation{
 				{
 					Type:   UpdateRoutePeer,
-					Values: []string{peer2Key},
+					Values: []string{peer2ID},
 				},
 			},
 			errFunc:      require.NoError,
@@ -573,7 +566,7 @@ func TestUpdateRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/16"),
 				NetID:       "superRoute",
 				NetworkType: route.IPv4Network,
-				Peer:        peer2Key,
+				Peer:        peer2ID,
 				Description: "super",
 				Masquerade:  false,
 				Metric:      9999,
@@ -595,7 +588,7 @@ func TestUpdateRoute(t *testing.T) {
 				},
 				{
 					Type:   UpdateRoutePeer,
-					Values: []string{peer2Key},
+					Values: []string{peer2ID},
 				},
 				{
 					Type:   UpdateRouteMetric,
@@ -625,7 +618,7 @@ func TestUpdateRoute(t *testing.T) {
 				Network:     netip.MustParsePrefix("192.168.0.0/24"),
 				NetID:       "megaRoute",
 				NetworkType: route.IPv4Network,
-				Peer:        peer2Key,
+				Peer:        peer2ID,
 				Description: "great",
 				Masquerade:  true,
 				Metric:      3030,
@@ -649,7 +642,7 @@ func TestUpdateRoute(t *testing.T) {
 			operations: []RouteUpdateOperation{
 				{
 					Type:   UpdateRoutePeer,
-					Values: []string{peer2Key, peer1Key},
+					Values: []string{peer2ID, peer1ID},
 				},
 			},
 			errFunc: require.Error,
@@ -847,7 +840,7 @@ func TestGetNetworkMap_RouteSync(t *testing.T) {
 		Network:     netip.MustParsePrefix("192.168.0.0/16"),
 		NetID:       "superNet",
 		NetworkType: route.IPv4Network,
-		Peer:        peer1Key,
+		Peer:        peer1ID,
 		Description: "super",
 		Masquerade:  false,
 		Metric:      9999,
@@ -865,20 +858,16 @@ func TestGetNetworkMap_RouteSync(t *testing.T) {
 		t.Error("failed to init testing account")
 	}
 
-	peer1, err := account.FindPeerByPubKey(peer1Key)
-	require.NoError(t, err)
-	peer2, err := account.FindPeerByPubKey(peer2Key)
-	require.NoError(t, err)
-	newAccountRoutes, err := am.GetNetworkMap(peer1.ID)
+	newAccountRoutes, err := am.GetNetworkMap(peer1ID)
 	require.NoError(t, err)
 	require.Len(t, newAccountRoutes.Routes, 0, "new accounts should have no routes")
 
-	createdRoute, err := am.CreateRoute(account.Id, baseRoute.Network.String(), peer1.IP.String(),
+	createdRoute, err := am.CreateRoute(account.Id, baseRoute.Network.String(), peer1ID,
 		baseRoute.Description, baseRoute.NetID, baseRoute.Masquerade, baseRoute.Metric, baseRoute.Groups, false,
 		userID)
 	require.NoError(t, err)
 
-	noDisabledRoutes, err := am.GetNetworkMap(peer1.ID)
+	noDisabledRoutes, err := am.GetNetworkMap(peer1ID)
 	require.NoError(t, err)
 	require.Len(t, noDisabledRoutes.Routes, 0, "no routes for disabled routes")
 
@@ -888,20 +877,19 @@ func TestGetNetworkMap_RouteSync(t *testing.T) {
 	err = am.SaveRoute(account.Id, userID, enabledRoute)
 	require.NoError(t, err)
 
-	peer1Routes, err := am.GetNetworkMap(peer1.ID)
+	peer1Routes, err := am.GetNetworkMap(peer1ID)
 	require.NoError(t, err)
 	require.Len(t, peer1Routes.Routes, 1, "we should receive one route for peer1")
 	require.True(t, enabledRoute.IsEqual(peer1Routes.Routes[0]), "received route should be equal")
 
-	peer2Routes, err := am.GetNetworkMap(peer2.ID)
+	peer2Routes, err := am.GetNetworkMap(peer2ID)
 	require.NoError(t, err)
 	require.Len(t, peer2Routes.Routes, 0, "no routes for peers not in the distribution group")
 
-	//account.Groups[routeGroup1].Peers = append(account.Groups[routeGroup1].Peers, peer2.ID)
-	err = am.GroupAddPeer(account.Id, routeGroup1, peer2.ID)
+	err = am.GroupAddPeer(account.Id, routeGroup1, peer2ID)
 	require.NoError(t, err)
 
-	peer2Routes, err = am.GetNetworkMap(peer2.ID)
+	peer2Routes, err = am.GetNetworkMap(peer2ID)
 	require.NoError(t, err)
 	require.Len(t, peer2Routes.Routes, 1, "we should receive one route")
 	require.True(t, peer1Routes.Routes[0].IsEqual(peer2Routes.Routes[0]), "routes should be the same for peers in the same group")
@@ -909,7 +897,7 @@ func TestGetNetworkMap_RouteSync(t *testing.T) {
 	newGroup := &Group{
 		ID:    xid.New().String(),
 		Name:  "peer1 group",
-		Peers: []string{peer1.ID},
+		Peers: []string{peer1ID},
 	}
 	err = am.SaveGroup(account.Id, userID, newGroup)
 	require.NoError(t, err)
@@ -930,18 +918,18 @@ func TestGetNetworkMap_RouteSync(t *testing.T) {
 	err = am.DeleteRule(account.Id, defaultRule.ID, userID)
 	require.NoError(t, err)
 
-	peer1GroupRoutes, err := am.GetNetworkMap(peer1.ID)
+	peer1GroupRoutes, err := am.GetNetworkMap(peer1ID)
 	require.NoError(t, err)
 	require.Len(t, peer1GroupRoutes.Routes, 1, "we should receive one route for peer1")
 
-	peer2GroupRoutes, err := am.GetNetworkMap(peer2.ID)
+	peer2GroupRoutes, err := am.GetNetworkMap(peer2ID)
 	require.NoError(t, err)
 	require.Len(t, peer2GroupRoutes.Routes, 0, "we should not receive routes for peer2")
 
 	err = am.DeleteRoute(account.Id, enabledRoute.ID, userID)
 	require.NoError(t, err)
 
-	peer1DeletedRoute, err := am.GetNetworkMap(peer1.ID)
+	peer1DeletedRoute, err := am.GetNetworkMap(peer1ID)
 	require.NoError(t, err)
 	require.Len(t, peer1DeletedRoute.Routes, 0, "we should receive one route for peer1")
 
@@ -968,9 +956,27 @@ func createRouterStore(t *testing.T) (Store, error) {
 
 func initTestRouteAccount(t *testing.T, am *DefaultAccountManager) (*Account, error) {
 
+	accountID := "testingAcc"
+	domain := "example.com"
+
+	account := newAccountWithId(accountID, userID, domain)
+	err := am.Store.SaveAccount(account)
+	if err != nil {
+		return nil, err
+	}
+
+	ips := account.getTakenIPs()
+	peer1IP, err := AllocatePeerIP(account.Network.Net, ips)
+	if err != nil {
+		return nil, err
+	}
+
 	peer1 := &Peer{
-		Key:  peer1Key,
-		Name: "test-host1@netbird.io",
+		IP:     peer1IP,
+		ID:     peer1ID,
+		Key:    peer1Key,
+		Name:   "test-host1@netbird.io",
+		UserID: userID,
 		Meta: PeerSystemMeta{
 			Hostname:  "test-host1@netbird.io",
 			GoOS:      "linux",
@@ -982,9 +988,20 @@ func initTestRouteAccount(t *testing.T, am *DefaultAccountManager) (*Account, er
 			UIVersion: "development",
 		},
 	}
+	account.Peers[peer1.ID] = peer1
+
+	ips = account.getTakenIPs()
+	peer2IP, err := AllocatePeerIP(account.Network.Net, ips)
+	if err != nil {
+		return nil, err
+	}
+
 	peer2 := &Peer{
-		Key:  peer2Key,
-		Name: "test-host2@netbird.io",
+		IP:     peer2IP,
+		ID:     peer2ID,
+		Key:    peer2Key,
+		Name:   "test-host2@netbird.io",
+		UserID: userID,
 		Meta: PeerSystemMeta{
 			Hostname:  "test-host2@netbird.io",
 			GoOS:      "linux",
@@ -996,24 +1013,13 @@ func initTestRouteAccount(t *testing.T, am *DefaultAccountManager) (*Account, er
 			UIVersion: "development",
 		},
 	}
+	account.Peers[peer2.ID] = peer2
 
-	accountID := "testingAcc"
-	domain := "example.com"
-
-	account := newAccountWithId(accountID, userID, domain)
-	err := am.Store.SaveAccount(account)
+	err = am.Store.SaveAccount(account)
 	if err != nil {
 		return nil, err
 	}
 
-	peer1, err = am.AddPeer("", userID, peer1)
-	if err != nil {
-		return nil, err
-	}
-	peer2, err = am.AddPeer("", userID, peer2)
-	if err != nil {
-		return nil, err
-	}
 	newGroup := &Group{
 		ID:    routeGroup1,
 		Name:  routeGroup1,

--- a/management/server/route_test.go
+++ b/management/server/route_test.go
@@ -1019,6 +1019,18 @@ func initTestRouteAccount(t *testing.T, am *DefaultAccountManager) (*Account, er
 	if err != nil {
 		return nil, err
 	}
+	groupAll, err := account.GetGroupAll()
+	if err != nil {
+		return nil, err
+	}
+	err = am.GroupAddPeer(accountID, groupAll.ID, peer1ID)
+	if err != nil {
+		return nil, err
+	}
+	err = am.GroupAddPeer(accountID, groupAll.ID, peer2ID)
+	if err != nil {
+		return nil, err
+	}
 
 	newGroup := &Group{
 		ID:    routeGroup1,

--- a/management/server/store.go
+++ b/management/server/store.go
@@ -15,7 +15,7 @@ type Store interface {
 	AcquireAccountLock(accountID string) func()
 	// AcquireGlobalLock should attempt to acquire a global lock and return a function that releases the lock
 	AcquireGlobalLock() func()
-	SavePeerStatus(accountID, peerKey string, status PeerStatus) error
+	SavePeerStatus(accountID, peerID string, status PeerStatus) error
 	// Close should close the store persisting all unsaved data.
 	Close() error
 }

--- a/management/server/store.go
+++ b/management/server/store.go
@@ -5,6 +5,7 @@ type Store interface {
 	GetAccount(accountID string) (*Account, error)
 	GetAccountByUser(userID string) (*Account, error)
 	GetAccountByPeerPubKey(peerKey string) (*Account, error)
+	GetAccountByPeerID(peerID string) (*Account, error)
 	GetAccountBySetupKey(setupKey string) (*Account, error) //todo use key hash later
 	GetAccountByPrivateDomain(domain string) (*Account, error)
 	SaveAccount(account *Account) error

--- a/route/route.go
+++ b/route/route.go
@@ -78,7 +78,7 @@ type Route struct {
 
 // EventMeta returns activity event meta related to the route
 func (r *Route) EventMeta() map[string]any {
-	return map[string]any{"name": r.NetID, "network_range": r.Network.String()}
+	return map[string]any{"name": r.NetID, "network_range": r.Network.String(), "peer_id": r.Peer}
 }
 
 // Copy copies a route object


### PR DESCRIPTION
## Describe your changes

Replace Peer.Key as internal identifier with a randomly generated Peer.ID in the Management service.
Every group now references peers by ID instead of a public key.
Every route now references peers by ID instead of a public key.
FileStore does store.json file migration on startup by generating Peer.ID and replacing
all Peer.Key identifier references .

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
