### PR TITLE
Refactor Management and Admin URL config

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -162,7 +162,7 @@ func foregroundGetTokenInfo(ctx context.Context, cmd *cobra.Command, config *int
 		} else if ok && s.Code() == codes.Unimplemented {
 			mgmtURL := managementURL
 			if mgmtURL == "" {
-				mgmtURL = internal.ManagementURLDefault().String()
+				mgmtURL = internal.DefaultManagementURL
 			}
 			return nil, fmt.Errorf("the management server, %s, does not support SSO providers, "+
 				"please update your servver or use Setup Keys to login", mgmtURL)

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -87,8 +87,8 @@ func init() {
 		defaultDaemonAddr = "tcp://127.0.0.1:41731"
 	}
 	rootCmd.PersistentFlags().StringVar(&daemonAddr, "daemon-addr", defaultDaemonAddr, "Daemon service address to serve CLI requests [unix|tcp]://[path|host:port]")
-	rootCmd.PersistentFlags().StringVarP(&managementURL, "management-url", "m", "", fmt.Sprintf("Management Service URL [http|https]://[host]:[port] (default \"%s\")", internal.ManagementURLDefault().String()))
-	rootCmd.PersistentFlags().StringVar(&adminURL, "admin-url", "https://app.netbird.io", "Admin Panel URL [http|https]://[host]:[port]")
+	rootCmd.PersistentFlags().StringVarP(&managementURL, "management-url", "m", "", fmt.Sprintf("Management Service URL [http|https]://[host]:[port] (default \"%s\")", internal.DefaultManagementURL))
+	rootCmd.PersistentFlags().StringVar(&adminURL, "admin-url", "", fmt.Sprintf("Admin Panel URL [http|https]://[host]:[port] (default \"%s\")", internal.DefaultAdminURL))
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", defaultConfigPath, "Netbird config file location")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "sets Netbird log level")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the the log will be output to stdout")

--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -54,7 +54,7 @@ func (p *program) Start(svc service.Service) error {
 			}
 		}
 
-		serverInstance := server.New(p.ctx, managementURL, adminURL, configPath, logFile)
+		serverInstance := server.New(p.ctx, configPath, logFile)
 		if err := serverInstance.Start(); err != nil {
 			log.Fatalf("failed to start daemon: %v", err)
 		}

--- a/client/cmd/testutil.go
+++ b/client/cmd/testutil.go
@@ -102,7 +102,8 @@ func startClientDaemon(
 	}
 	s := grpc.NewServer()
 
-	server := client.New(ctx, managementURL, adminURL, configPath, "")
+	server := client.New(ctx,
+		configPath, "")
 	if err := server.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -132,6 +132,7 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command) error {
 		SetupKey:            setupKey,
 		PreSharedKey:        preSharedKey,
 		ManagementUrl:       managementURL,
+		AdminURL:            adminURL,
 		NatExternalIPs:      natExternalIPs,
 		CleanNATExternalIPs: natExternalIPs != nil && len(natExternalIPs) == 0,
 		CustomDNSAddress:    customDNSAddressConverted,

--- a/client/internal/config_test.go
+++ b/client/internal/config_test.go
@@ -10,17 +10,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReadConfig(t *testing.T) {
-}
-
 func TestGetConfig(t *testing.T) {
+	// case 1: new default config has to be generated
+	config, err := GetConfig(ConfigInput{
+		ConfigPath: filepath.Join(t.TempDir(), "config.json"),
+	})
+
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, config.ManagementURL.String(), DefaultManagementURL)
+	assert.Equal(t, config.AdminURL.String(), DefaultAdminURL)
+
+	if err != nil {
+		return
+	}
 	managementURL := "https://test.management.url:33071"
-	adminURL := "https://app.admin.url"
+	adminURL := "https://app.admin.url:443"
 	path := filepath.Join(t.TempDir(), "config.json")
 	preSharedKey := "preSharedKey"
 
-	// case 1: new config has to be generated
-	config, err := GetConfig(ConfigInput{
+	// case 2: new config has to be generated
+	config, err = GetConfig(ConfigInput{
 		ManagementURL: managementURL,
 		AdminURL:      adminURL,
 		ConfigPath:    path,
@@ -37,7 +49,7 @@ func TestGetConfig(t *testing.T) {
 		t.Errorf("config file was expected to be created under path %s", path)
 	}
 
-	// case 2: existing config -> fetch it
+	// case 3: existing config -> fetch it
 	config, err = GetConfig(ConfigInput{
 		ManagementURL: managementURL,
 		AdminURL:      adminURL,
@@ -51,7 +63,7 @@ func TestGetConfig(t *testing.T) {
 	assert.Equal(t, config.ManagementURL.String(), managementURL)
 	assert.Equal(t, config.PreSharedKey, preSharedKey)
 
-	// case 3: existing config, but new managementURL has been provided -> update config
+	// case 4: existing config, but new managementURL has been provided -> update config
 	newManagementURL := "https://test.newManagement.url:33071"
 	config, err = GetConfig(ConfigInput{
 		ManagementURL: newManagementURL,

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -251,7 +251,12 @@ func loginToManagement(ctx context.Context, client mgm.Client, pubSSHKey []byte)
 // The check is performed only for the NetBird's managed version.
 func UpdateOldManagementPort(ctx context.Context, config *Config, configPath string) (*Config, error) {
 
-	if config.ManagementURL.Hostname() != ManagementURLDefault().Hostname() {
+	defaultManagementURL, err := ParseURL("Management URL", DefaultManagementURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.ManagementURL.Hostname() != defaultManagementURL.Hostname() {
 		// only do the check for the NetBird's managed version
 		return config, nil
 	}

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -45,13 +45,11 @@ type oauthAuthFlow struct {
 }
 
 // New server instance constructor.
-func New(ctx context.Context, managementURL, adminURL, configPath, logFile string) *Server {
+func New(ctx context.Context, configPath, logFile string) *Server {
 	return &Server{
 		rootCtx: ctx,
 		latestConfigInput: internal.ConfigInput{
-			ManagementURL: managementURL,
-			AdminURL:      adminURL,
-			ConfigPath:    configPath,
+			ConfigPath: configPath,
 		},
 		logFile: logFile,
 	}


### PR DESCRIPTION
## Describe your changes
We had an issue where the daemon service was overwriting the admin URL every time it was restarted. With the changes, we are making the default admin URL a concern of the config logic.

I've also reduced the number of input parameters for the New function in the daemon logic as it is only called after the service is installed, which kind brake the need for it to receive such inputs. 

Other changes:
- Avoid sending admin or management URLs on service start as it doesn't have an input
- Parse management and admin URL when needed
- Pass empty admin URL on commands to prevent default overwrite

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
