### PR TITLE
Fix nameserver peer conn check

### DIFF
--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -3,8 +3,9 @@ package dns
 import (
 	"bytes"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -14,6 +15,7 @@ const (
 		"\n# If needed you can restore the original file by copying back %s\n\nnameserver %s\n" +
 		fileGeneratedResolvConfSearchBeginContent + "%s\n"
 )
+
 const (
 	fileDefaultResolvConfBackupLocation = defaultResolvConfPath + ".original.netbird"
 	fileMaxLineCharsLimit               = 256
@@ -66,7 +68,7 @@ func (f *fileConfigurator) applyDNSConfig(config hostDNSConfig) error {
 	var searchDomains string
 	appendedDomains := 0
 	for _, dConf := range config.domains {
-		if dConf.matchOnly {
+		if dConf.matchOnly || dConf.disabled {
 			continue
 		}
 		if appendedDomains >= fileMaxNumberOfSearchDomains {

--- a/client/internal/dns/host.go
+++ b/client/internal/dns/host.go
@@ -56,6 +56,9 @@ func dnsConfigToHostDNSConfig(dnsConfig nbdns.Config, ip string, port int) hostD
 		serverPort: port,
 	}
 	for _, nsConfig := range dnsConfig.NameServerGroups {
+		if len(nsConfig.NameServers) == 0 {
+			continue
+		}
 		if nsConfig.Primary {
 			config.routeAll = true
 		}

--- a/client/internal/dns/host.go
+++ b/client/internal/dns/host.go
@@ -2,8 +2,9 @@ package dns
 
 import (
 	"fmt"
-	nbdns "github.com/netbirdio/netbird/dns"
 	"strings"
+
+	nbdns "github.com/netbirdio/netbird/dns"
 )
 
 type hostManager interface {
@@ -19,6 +20,7 @@ type hostDNSConfig struct {
 }
 
 type domainConfig struct {
+	disabled  bool
 	domain    string
 	matchOnly bool
 }

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -4,11 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/netbirdio/netbird/iface"
-	log "github.com/sirupsen/logrus"
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/netbirdio/netbird/iface"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -61,6 +62,9 @@ func (s *systemConfigurator) applyDNSConfig(config hostDNSConfig) error {
 	)
 
 	for _, dConf := range config.domains {
+		if dConf.disabled {
+			continue
+		}
 		if dConf.matchOnly {
 			matchDomains = append(matchDomains, dConf.domain)
 			continue

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -2,10 +2,11 @@ package dns
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/netbirdio/netbird/iface"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/registry"
-	"strings"
 )
 
 const (
@@ -63,6 +64,9 @@ func (r *registryConfigurator) applyDNSConfig(config hostDNSConfig) error {
 	)
 
 	for _, dConf := range config.domains {
+		if dConf.disabled {
+			continue
+		}
 		if !dConf.matchOnly {
 			searchDomains = append(searchDomains, dConf.domain)
 		}

--- a/client/internal/dns/mock_test.go
+++ b/client/internal/dns/mock_test.go
@@ -23,12 +23,3 @@ func (rw *mockResponseWriter) Close() error              { return nil }
 func (rw *mockResponseWriter) TsigStatus() error         { return nil }
 func (rw *mockResponseWriter) TsigTimersOnly(bool)       {}
 func (rw *mockResponseWriter) Hijack()                   {}
-
-
-type mockResolver struct {
-  ServeDNSFunc func(w dns.ResponseWriter, r *dns.Msg)
-}
-
-func (rl *mockResolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
-  rl.ServeDNSFunc(w, r) 
-}

--- a/client/internal/dns/mock_test.go
+++ b/client/internal/dns/mock_test.go
@@ -1,8 +1,9 @@
 package dns
 
 import (
-	"github.com/miekg/dns"
 	"net"
+
+	"github.com/miekg/dns"
 )
 
 type mockResponseWriter struct {
@@ -23,16 +24,3 @@ func (rw *mockResponseWriter) Close() error              { return nil }
 func (rw *mockResponseWriter) TsigStatus() error         { return nil }
 func (rw *mockResponseWriter) TsigTimersOnly(bool)       {}
 func (rw *mockResponseWriter) Hijack()                   {}
-
-type mockHostManager struct {
-	applyDNSConfigFunc func(config hostDNSConfig) error
-	restoreHostDNSFunc func() error
-}
-
-func (hm *mockHostManager) applyDNSConfig(config hostDNSConfig) error {
-	return hm.applyDNSConfigFunc(config)
-}
-
-func (hm *mockHostManager) restoreHostDNS() error {
-	return hm.restoreHostDNSFunc()
-}

--- a/client/internal/dns/mock_test.go
+++ b/client/internal/dns/mock_test.go
@@ -23,3 +23,16 @@ func (rw *mockResponseWriter) Close() error              { return nil }
 func (rw *mockResponseWriter) TsigStatus() error         { return nil }
 func (rw *mockResponseWriter) TsigTimersOnly(bool)       {}
 func (rw *mockResponseWriter) Hijack()                   {}
+
+type mockHostManager struct {
+	applyDNSConfigFunc func(config hostDNSConfig) error
+	restoreHostDNSFunc func() error
+}
+
+func (hm *mockHostManager) applyDNSConfig(config hostDNSConfig) error {
+	return hm.applyDNSConfigFunc(config)
+}
+
+func (hm *mockHostManager) restoreHostDNS() error {
+	return hm.restoreHostDNSFunc()
+}

--- a/client/internal/dns/mock_test.go
+++ b/client/internal/dns/mock_test.go
@@ -23,3 +23,12 @@ func (rw *mockResponseWriter) Close() error              { return nil }
 func (rw *mockResponseWriter) TsigStatus() error         { return nil }
 func (rw *mockResponseWriter) TsigTimersOnly(bool)       {}
 func (rw *mockResponseWriter) Hijack()                   {}
+
+
+type mockResolver struct {
+  ServeDNSFunc func(w dns.ResponseWriter, r *dns.Msg)
+}
+
+func (rl *mockResolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
+  rl.ServeDNSFunc(w, r) 
+}

--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"net/netip"
+	"regexp"
+	"time"
+
 	"github.com/godbus/dbus/v5"
 	"github.com/hashicorp/go-version"
 	"github.com/miekg/dns"
 	"github.com/netbirdio/netbird/iface"
 	log "github.com/sirupsen/logrus"
-	"net/netip"
-	"regexp"
-	"time"
 )
 
 const (
@@ -106,6 +107,9 @@ func (n *networkManagerDbusConfigurator) applyDNSConfig(config hostDNSConfig) er
 		matchDomains  []string
 	)
 	for _, dConf := range config.domains {
+		if dConf.disabled {
+			continue
+		}
 		if dConf.matchOnly {
 			matchDomains = append(matchDomains, "~."+dns.Fqdn(dConf.domain))
 			continue

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -2,10 +2,11 @@ package dns
 
 import (
 	"fmt"
-	"github.com/netbirdio/netbird/iface"
-	log "github.com/sirupsen/logrus"
 	"os/exec"
 	"strings"
+
+	"github.com/netbirdio/netbird/iface"
+	log "github.com/sirupsen/logrus"
 )
 
 const resolvconfCommand = "resolvconf"
@@ -33,7 +34,7 @@ func (r *resolvconf) applyDNSConfig(config hostDNSConfig) error {
 	var searchDomains string
 	appendedDomains := 0
 	for _, dConf := range config.domains {
-		if dConf.matchOnly {
+		if dConf.matchOnly || dConf.disabled {
 			continue
 		}
 

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -211,6 +211,7 @@ func (s *DefaultServer) UpdateDNSServer(serial uint64, update nbdns.Config) erro
 			ZeroNil:         true,
 			IgnoreZeroValue: true,
 			SlicesAsSets:    true,
+			UseStringer:     true,
 		})
 		if err != nil {
 			log.Errorf("unable to hash the dns configuration update, got error: %s", err)

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -429,6 +429,10 @@ func (s *DefaultServer) upstreamCallbacks(
 		for _, domain := range nsGroup.Domains {
 			removeIndex[domain] = -1
 		}
+		if nsGroup.Primary {
+			removeIndex[nbdns.RootZone] = -1
+			s.currentConfig.routeAll = false
+		}
 
 		for i, item := range s.currentConfig.domains {
 			if _, found := removeIndex[item.domain]; found {
@@ -436,10 +440,6 @@ func (s *DefaultServer) upstreamCallbacks(
 				s.deregisterMux(item.domain)
 				removeIndex[item.domain] = i
 			}
-		}
-
-		if nsGroup.Primary {
-			s.currentConfig.routeAll = false
 		}
 		if err := s.hostManager.applyDNSConfig(s.currentConfig); err != nil {
 			l.WithError(err).Error("temporary deactivate nameservers group, DNS update apply")

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -293,6 +293,7 @@ func (s *DefaultServer) buildUpstreamHandlerUpdate(nameServerGroups []*nbdns.Nam
 			parentCTX:       s.ctx,
 			upstreamClient:  &dns.Client{},
 			upstreamTimeout: defaultUpstreamTimeout,
+      fallback: s.localResolver,
 		}
 		for _, ns := range nsGroup.NameServers {
 			if ns.NSType != nbdns.UDPNameServerType {

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -293,7 +293,6 @@ func (s *DefaultServer) buildUpstreamHandlerUpdate(nameServerGroups []*nbdns.Nam
 			parentCTX:       s.ctx,
 			upstreamClient:  &dns.Client{},
 			upstreamTimeout: defaultUpstreamTimeout,
-      fallback: s.localResolver,
 		}
 		for _, ns := range nsGroup.NameServers {
 			if ns.NSType != nbdns.UDPNameServerType {
@@ -329,6 +328,16 @@ func (s *DefaultServer) buildUpstreamHandlerUpdate(nameServerGroups []*nbdns.Nam
 				domain:  domain,
 				handler: handler,
 			})
+		}
+		handler.deactivateHook = func() {
+			for _, pattern := range muxUpdates {
+				s.deregisterMux(pattern.domain)
+			}
+		}
+		handler.reactivateHook = func() {
+			for _, pattern := range muxUpdates {
+				s.registerMux(pattern.domain, pattern.handler)
+			}
 		}
 	}
 	return muxUpdates, nil

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -423,7 +423,7 @@ func (s *DefaultServer) upstreamCallbacks(
 		defer s.mux.Unlock()
 
 		l := log.WithField("nameservers", nsGroup.NameServers)
-		l.Info("temporary deactivate nameservers group")
+		l.Info("temporary deactivate nameservers group due timeout")
 
 		removeIndex = make(map[string]int)
 		for _, domain := range nsGroup.Domains {
@@ -442,7 +442,7 @@ func (s *DefaultServer) upstreamCallbacks(
 			}
 		}
 		if err := s.hostManager.applyDNSConfig(s.currentConfig); err != nil {
-			l.WithError(err).Error("temporary deactivate nameservers group, DNS update apply")
+			l.WithError(err).Error("fail to apply nameserver deactivation on the host")
 		}
 	}
 	reactivate = func() {

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -300,11 +300,7 @@ func (s *DefaultServer) buildUpstreamHandlerUpdate(nameServerGroups []*nbdns.Nam
 		if len(nsGroup.NameServers) == 0 {
 			return nil, fmt.Errorf("received a nameserver group with empty nameserver list")
 		}
-		handler := &upstreamResolver{
-			parentCTX:       s.ctx,
-			upstreamClient:  &dns.Client{},
-			upstreamTimeout: defaultUpstreamTimeout,
-		}
+		handler := newUpstreamResolver(s.ctx)
 		for _, ns := range nsGroup.NameServers {
 			if ns.NSType != nbdns.UDPNameServerType {
 				log.Warnf("skiping nameserver %s with type %s, this peer supports only %s",
@@ -415,7 +411,7 @@ func (s *DefaultServer) upstreamDeactivateCallback(index int) func() {
 		var excludeNameservers string
 		for i, group := range s.currentConfig.NameServerGroups {
 			if i == index {
-        excludeNameservers = fmt.Sprintf("%v", group.NameServers)
+				excludeNameservers = fmt.Sprintf("%v", group.NameServers)
 				continue
 			}
 			update.NameServerGroups = append(update.NameServerGroups, group)
@@ -437,7 +433,7 @@ func (s *DefaultServer) upstreamReactivateCallback(index int) func() {
 		var excludeNameservers string
 		for i, group := range s.currentConfig.NameServerGroups {
 			if i == index {
-        excludeNameservers = fmt.Sprintf("%v", group.NameServers)
+				excludeNameservers = fmt.Sprintf("%v", group.NameServers)
 				break
 			}
 		}

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -343,9 +343,9 @@ func TestDNSServerUpstreamDeactivateCallback(t *testing.T) {
 		hostManager: hostManager,
 		currentConfig: hostDNSConfig{
 			domains: []domainConfig{
-				{"domain0", false},
-				{"domain1", false},
-				{"domain2", false},
+				{false, "domain0", false},
+				{false, "domain1", false},
+				{false, "domain2", false},
 			},
 		},
 	}
@@ -354,6 +354,9 @@ func TestDNSServerUpstreamDeactivateCallback(t *testing.T) {
 	hostManager.applyDNSConfigFunc = func(config hostDNSConfig) error {
 		domains := []string{}
 		for _, item := range config.domains {
+			if item.disabled {
+				continue
+			}
 			domains = append(domains, item.domain)
 		}
 		domainsUpdate = strings.Join(domains, ",")
@@ -371,6 +374,9 @@ func TestDNSServerUpstreamDeactivateCallback(t *testing.T) {
 	expected := "domain0,domain2"
 	domains := []string{}
 	for _, item := range server.currentConfig.domains {
+		if item.disabled {
+			continue
+		}
 		domains = append(domains, item.domain)
 	}
 	got := strings.Join(domains, ",")
@@ -379,9 +385,12 @@ func TestDNSServerUpstreamDeactivateCallback(t *testing.T) {
 	}
 
 	reactivate()
-	expected = "domain0,domain2,domain1"
+	expected = "domain0,domain1,domain2"
 	domains = []string{}
 	for _, item := range server.currentConfig.domains {
+		if item.disabled {
+			continue
+		}
 		domains = append(domains, item.domain)
 	}
 	got = strings.Join(domains, ",")

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -3,15 +3,16 @@ package dns
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/netip"
+	"time"
+
 	"github.com/godbus/dbus/v5"
 	"github.com/miekg/dns"
 	nbdns "github.com/netbirdio/netbird/dns"
 	"github.com/netbirdio/netbird/iface"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
-	"net"
-	"net/netip"
-	"time"
 )
 
 const (
@@ -95,6 +96,9 @@ func (s *systemdDbusConfigurator) applyDNSConfig(config hostDNSConfig) error {
 		domainsInput  []systemdDbusLinkDomainsInput
 	)
 	for _, dConf := range config.domains {
+		if dConf.disabled {
+			continue
+		}
 		domainsInput = append(domainsInput, systemdDbusLinkDomainsInput{
 			Domain:    dns.Fqdn(dConf.domain),
 			MatchOnly: dConf.matchOnly,

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -100,10 +100,15 @@ func (u *upstreamResolver) checkUpstreamFails() {
 		return
 	}
 
-	log.WithField("preiod", reactivatePeriod).Warn("upstream resolving is disabled for")
-	u.deactivate()
-	u.disabled = true
-	go u.waitUntilReactivation()
+	select {
+	case <-u.ctx.Done():
+		return
+	default:
+		log.Warnf("upstream resolving is disabled for %v", reactivatePeriod)
+		u.deactivate()
+		u.disabled = true
+		go u.waitUntilReactivation()
+	}
 }
 
 // waitUntilReactivation reset fails counter and activates upstream resolving

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -3,12 +3,13 @@ package dns
 import (
 	"context"
 	"errors"
-	"github.com/miekg/dns"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -78,6 +78,8 @@ func (u *upstreamResolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		if err != nil {
 			log.WithError(err).Error("got an error while writing the upstream resolver response")
 		}
+		// count the fails only if they happen sequentially
+		u.failsCount.Store(0)
 		return
 	}
 	u.failsCount.Add(1)

--- a/client/internal/dns/upstream_test.go
+++ b/client/internal/dns/upstream_test.go
@@ -18,7 +18,6 @@ func TestUpstreamResolver_ServeDNS(t *testing.T) {
 		timeout             time.Duration
 		cancelCTX           bool
 		expectedAnswer      string
-    localResolver       *mockResolver
 	}{
 		{
 			name:           "Should Resolve A Record",
@@ -49,23 +48,6 @@ func TestUpstreamResolver_ServeDNS(t *testing.T) {
 			timeout:             defaultUpstreamTimeout,
 			responseShouldBeNil: true,
 		},
-    {
-      name: "Should fallback to local resolver",
-      inputMSG: new(dns.Msg).SetQuestion("one.one.one.one", dns.TypeA),
-      InputServers: []string{"0.0.0.0:53", "0.0.0.0:53"},
-      cancelCTX: true,
-      timeout: defaultUpstreamTimeout,
-      responseShouldBeNil: true,
-      expectedAnswer: "1.1.1.1",
-      localResolver: &mockResolver{
-        ServeDNSFunc: func(w dns.ResponseWriter, r *dns.Msg) {
-          msg := new(dns.Msg).SetReply(r)
-          if err := w.WriteMsg(msg); err != nil {
-            t.Errorf("write msg issue: %v", err)
-          }
-        },
-      },
-    },
 		//{
 		//	name:        "Should Resolve CNAME Record",
 		//	inputMSG:    new(dns.Msg).SetQuestion("one.one.one.one", dns.TypeCNAME),


### PR DESCRIPTION
## Describe your changes
This change adds fallback to the host DNS default resolver when the upstream resolver fails several times.
It also reactivates the upstream resolver in 1 min and tries to use it again.

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/620

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
