### PR TITLE
Add peer login expiration

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -613,6 +613,7 @@ func (am *DefaultAccountManager) warmupIDPCache() error {
 	return nil
 }
 
+// GetAccountByPeerID returns account from the store by a provided peer ID
 func (am *DefaultAccountManager) GetAccountByPeerID(peerID string) (*Account, error) {
 	return am.Store.GetAccountByPeerID(peerID)
 }

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -93,6 +93,7 @@ type AccountManager interface {
 	GetDNSSettings(accountID string, userID string) (*DNSSettings, error)
 	SaveDNSSettings(accountID string, userID string, dnsSettingsToSave *DNSSettings) error
 	GetPeer(accountID, peerID, userID string) (*Peer, error)
+	UpdatePeerLastLogin(peerID string) error
 }
 
 type DefaultAccountManager struct {

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -81,6 +81,11 @@ func restore(file string) (*FileStore, error) {
 	store.PeerID2AccountID = make(map[string]string)
 
 	for accountID, account := range store.Accounts {
+
+		if account.PeerLoginExpiration.Seconds() == 0 {
+			account.PeerLoginExpiration = DefaultPeerLoginExpiration
+		}
+
 		for setupKeyId := range account.SetupKeys {
 			store.SetupKeyID2AccountID[strings.ToUpper(setupKeyId)] = accountID
 		}

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -354,6 +354,11 @@ func (s *GRPCServer) Login(ctx context.Context, req *proto.EncryptedMessage) (*p
 		}
 	}
 
+	expired, left := peer.LoginExpired(24 * time.Hour)
+	if peer.UserID != "" && expired {
+		return nil, status.Errorf(codes.PermissionDenied, "peer login has expired %v ago. Please login once more", left)
+	}
+
 	var sshKey []byte
 	if loginReq.GetPeerKeys() != nil {
 		sshKey = loginReq.GetPeerKeys().GetSshPubKey()

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -67,6 +67,8 @@ type MockAccountManager struct {
 	GetDNSSettingsFunc              func(accountID, userID string) (*server.DNSSettings, error)
 	SaveDNSSettingsFunc             func(accountID, userID string, dnsSettingsToSave *server.DNSSettings) error
 	GetPeerFunc                     func(accountID, peerID, userID string) (*server.Peer, error)
+	GetAccountByPeerIDFunc          func(peerID string) (*server.Account, error)
+	UpdatePeerLastLoginFunc         func(peerID string) error
 }
 
 // GetUsersFromAccount mock implementation of GetUsersFromAccount from server.AccountManager interface
@@ -525,4 +527,20 @@ func (am *MockAccountManager) GetPeer(accountID, peerID, userID string) (*server
 		return am.GetPeerFunc(accountID, peerID, userID)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method GetPeer is not implemented")
+}
+
+// GetAccountByPeerID mocks GetAccountByPeerID of the AccountManager interface
+func (am *MockAccountManager) GetAccountByPeerID(peerID string) (*server.Account, error) {
+	if am.GetAccountByPeerIDFunc != nil {
+		return am.GetAccountByPeerIDFunc(peerID)
+	}
+	return nil, status.Errorf(codes.Unimplemented, "method GetAccountByPeerID is not implemented")
+}
+
+// UpdatePeerLastLogin mocks UpdatePeerLastLogin of the AccountManager interface
+func (am *MockAccountManager) UpdatePeerLastLogin(peerID string) error {
+	if am.UpdatePeerLastLoginFunc != nil {
+		return am.UpdatePeerLastLoginFunc(peerID)
+	}
+	return status.Errorf(codes.Unimplemented, "method UpdatePeerLastLogin is not implemented")
 }

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -453,18 +453,19 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 	}
 
 	newPeer := &Peer{
-		ID:         xid.New().String(),
-		Key:        peer.Key,
-		SetupKey:   upperKey,
-		IP:         nextIp,
-		Meta:       peer.Meta,
-		Name:       peer.Name,
-		DNSLabel:   newLabel,
-		UserID:     userID,
-		Status:     &PeerStatus{Connected: false, LastSeen: time.Now()},
-		SSHEnabled: false,
-		SSHKey:     peer.SSHKey,
-		LastLogin:  time.Now(),
+		ID:                     xid.New().String(),
+		Key:                    peer.Key,
+		SetupKey:               upperKey,
+		IP:                     nextIp,
+		Meta:                   peer.Meta,
+		Name:                   peer.Name,
+		DNSLabel:               newLabel,
+		UserID:                 userID,
+		Status:                 &PeerStatus{Connected: false, LastSeen: time.Now()},
+		SSHEnabled:             false,
+		SSHKey:                 peer.SSHKey,
+		LastLogin:              time.Now(),
+		LoginExpirationEnabled: false,
 	}
 
 	// add peer to 'All' group

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -464,6 +464,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 		Status:     &PeerStatus{Connected: false, LastSeen: time.Now()},
 		SSHEnabled: false,
 		SSHKey:     peer.SSHKey,
+		LastLogin:  time.Now(),
 	}
 
 	// add peer to 'All' group

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -510,6 +510,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 	return newPeer, nil
 }
 
+// UpdatePeerLastLogin sets Peer.LastLogin to the current timestamp.
 func (am *DefaultAccountManager) UpdatePeerLastLogin(peerID string) error {
 	account, err := am.Store.GetAccountByPeerID(peerID)
 	if err != nil {


### PR DESCRIPTION
## Describe your changes
This PR adds a peer login expiration logic that requires 
peers created by a user to re-authenticate (re-login) after
a certain threshold of time (24h by default). 

The Account object now has a PeerLoginExpiration
property that indicates the duration after which a peer's
login will expire and a login will be required. Defaults to 24h.

There are two new properties added to the Peer object:
LastLogin that indicates the last time peer successfully used
the Login gRPC endpoint and LoginExpirationEnabled that 
enables/disables peer login expiration.

The login expiration logic applies only to peers that were created
by a user and not those that were added with a setup key.

_P.S. The expiration is disabled always for now. Will be enabled in the future versions.
Next PRs:
HTTP Peer API will have a method to enable/disable expiration.
HTTP Peer API GET Peers will return the indicator that peer's login
has expired.
HTTP API for system settings to globally enable/disable expiration and set expiration duration._

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
