### PR TITLE
Fallback to console log when can't write log file

### DIFF
--- a/util/log.go
+++ b/util/log.go
@@ -21,7 +21,6 @@ func InitLog(logLevel string, logPath string) error {
 		return err
 	}
 
-	logPath = "/tmp/netbird/netbird/netbird.log"
 	if logPath != "" && logPath != "console" {
 
 		canWrite, _ := canWrite(logPath)


### PR DESCRIPTION
## Describe your changes

Skip writing log file when permissions don't allow write operations.
Fallback to CONSOLE log output.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
