### PR TITLE
Fix nil pointer exception in error handling

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -127,12 +127,10 @@ func interfaceFilter(blackList []string) func(string) bool {
 		wg, err := wgctrl.New()
 		if err != nil {
 			log.Debugf("trying to create a wgctrl client failed with: %v", err)
+			return true
 		}
 		defer func() {
-			err := wg.Close()
-			if err != nil {
-				return
-			}
+			_ = wg.Close()
 		}()
 
 		_, err = wg.Device(iFace)


### PR DESCRIPTION
## Describe your changes

In case if the wgctrl.New() return with err, should not close the 
resource.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
