### PR TITLE
Proactively expire peers' login per account 

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -158,8 +158,7 @@ type Account struct {
 	NameServerGroups       map[string]*nbdns.NameServerGroup
 	DNSSettings            *DNSSettings
 	// Settings is a dictionary of Account settings
-	Settings        *Settings
-	loginExpiration *Scheduler
+	Settings *Settings
 }
 
 type UserInfo struct {
@@ -606,7 +605,7 @@ func BuildManager(store Store, peersUpdateManager *PeersUpdateManager, idpManage
 	am.singleAccountMode = singleAccountModeDomain != "" && len(allAccounts) <= 1
 	if am.singleAccountMode {
 		if !isDomainValid(singleAccountModeDomain) {
-			return nil, status.Errorf(status.InvalidArgument, "invalid domain \"%s\" provided for single accound mode. Please review your input for --single-account-mode-domain", singleAccountModeDomain)
+			return nil, status.Errorf(status.InvalidArgument, "invalid domain \"%s\" provided for a single account mode. Please review your input for --single-account-mode-domain", singleAccountModeDomain)
 		}
 		am.singleAccountModeDomain = singleAccountModeDomain
 		log.Infof("single account mode enabled, accounts number %d", len(allAccounts))

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -308,7 +308,7 @@ func (a *Account) GetGroup(groupID string) *Group {
 	return a.Groups[groupID]
 }
 
-// GetExpiredPeers returns peers tha have been expired
+// GetExpiredPeers returns peers that have been expired
 func (a *Account) GetExpiredPeers() []*Peer {
 	var peers []*Peer
 	for _, peer := range a.GetPeersWithExpiration() {
@@ -321,32 +321,28 @@ func (a *Account) GetExpiredPeers() []*Peer {
 	return peers
 }
 
-// GetNextPeerExpiration returns the minimum duration in which the next peer of the account will expire and true if it was found.
-// If there is no peer that expires this function returns false and a zero time.Duration
-// This function only considers peers that haven't been expired yet and connected.
+// GetNextPeerExpiration returns the minimum duration in which the next peer of the account will expire it it was found.
+// If there is no peer that expires this function returns nil.
+// This function only considers peers that haven't been expired yet and that are connected.
 func (a *Account) GetNextPeerExpiration() *time.Duration {
 
 	peersWithExpiry := a.GetPeersWithExpiration()
 	if len(peersWithExpiry) == 0 {
 		return nil
 	}
-	nextExpiry := time.Duration(1<<63 - 1) // max duration
+	var nextExpiry *time.Duration
 	for _, peer := range peersWithExpiry {
 		// consider only connected peers because others will require login on connecting to the management server
 		if peer.Status.LoginExpired || !peer.Status.Connected {
 			continue
 		}
 		_, duration := peer.LoginExpired(a.Settings.PeerLoginExpiration)
-		if duration < nextExpiry {
-			nextExpiry = duration
+		if nextExpiry == nil || duration < *nextExpiry {
+			nextExpiry = &duration
 		}
 	}
 
-	if nextExpiry == time.Duration(1<<63-1) {
-		return nil
-	}
-
-	return &nextExpiry
+	return nextExpiry
 }
 
 // GetPeersWithExpiration returns a list of peers that have Peer.LoginExpirationEnabled set to true

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -321,7 +321,7 @@ func (a *Account) GetExpiredPeers() []*Peer {
 	return peers
 }
 
-// GetNextPeerExpiration returns the minimum duration in which the next peer of the account will expire it it was found.
+// GetNextPeerExpiration returns the minimum duration in which the next peer of the account will expire if it was found.
 // If there is no peer that expires this function returns nil.
 // This function only considers peers that haven't been expired yet and that are connected.
 func (a *Account) GetNextPeerExpiration() *time.Duration {
@@ -347,7 +347,7 @@ func (a *Account) GetNextPeerExpiration() *time.Duration {
 
 // GetPeersWithExpiration returns a list of peers that have Peer.LoginExpirationEnabled set to true
 func (a *Account) GetPeersWithExpiration() []*Peer {
-	var peers []*Peer
+	peers := make([]*Peer, 0)
 	for _, peer := range a.Peers {
 		if peer.LoginExpirationEnabled {
 			peers = append(peers, peer)

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -730,6 +730,9 @@ func (am *DefaultAccountManager) peerLoginExpirationJob(accountID string) func()
 
 		var peerIDs []string
 		for _, peer := range account.GetExpiredPeers() {
+			if peer.Status.LoginExpired {
+				continue
+			}
 			peerIDs = append(peerIDs, peer.ID)
 			peer.MarkLoginExpired(true)
 			account.UpdatePeer(peer)

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -120,7 +120,7 @@ type DefaultAccountManager struct {
 	singleAccountModeDomain string
 	// dnsDomain is used for peer resolution. This is appended to the peer's name
 	dnsDomain       string
-	peerLoginExpiry *Scheduler
+	peerLoginExpiry Scheduler
 }
 
 // Settings represents Account settings structure that can be modified via API and Dashboard
@@ -603,7 +603,7 @@ func BuildManager(store Store, peersUpdateManager *PeersUpdateManager, idpManage
 		cacheLoading:       map[string]chan struct{}{},
 		dnsDomain:          dnsDomain,
 		eventStore:         eventStore,
-		peerLoginExpiry:    NewScheduler(),
+		peerLoginExpiry:    NewDefaultScheduler(),
 	}
 	allAccounts := store.GetAllAccounts()
 	// enable single account mode only if configured by user and number of existing accounts is not grater than 1

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1381,7 +1381,7 @@ func TestAccount_GetPeersWithExpiration(t *testing.T) {
 			actual := account.GetPeersWithExpiration()
 			assert.Len(t, actual, len(testCase.expectedPeers))
 			if len(testCase.expectedPeers) > 0 {
-				for k, _ := range testCase.expectedPeers {
+				for k := range testCase.expectedPeers {
 					contains := false
 					for _, peer := range actual {
 						if k == peer.ID {

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1403,7 +1403,8 @@ func TestAccount_GetNextPeerExpiration(t *testing.T) {
 		peers                  map[string]*Peer
 		expiration             time.Duration
 		expirationEnabled      bool
-		expectedNextExpiration *time.Duration
+		expectedNextRun        bool
+		expectedNextExpiration time.Duration
 	}
 
 	expectedNextExpiration := time.Minute
@@ -1413,7 +1414,8 @@ func TestAccount_GetNextPeerExpiration(t *testing.T) {
 			peers:                  map[string]*Peer{},
 			expiration:             time.Second,
 			expirationEnabled:      false,
-			expectedNextExpiration: nil,
+			expectedNextRun:        false,
+			expectedNextExpiration: time.Duration(0),
 		},
 		{
 			name: "No connected peers, no expiration",
@@ -1433,7 +1435,8 @@ func TestAccount_GetNextPeerExpiration(t *testing.T) {
 			},
 			expiration:             time.Second,
 			expirationEnabled:      false,
-			expectedNextExpiration: nil,
+			expectedNextRun:        false,
+			expectedNextExpiration: time.Duration(0),
 		},
 		{
 			name: "Connected peers with disabled expiration, no expiration",
@@ -1453,7 +1456,8 @@ func TestAccount_GetNextPeerExpiration(t *testing.T) {
 			},
 			expiration:             time.Second,
 			expirationEnabled:      false,
-			expectedNextExpiration: nil,
+			expectedNextRun:        false,
+			expectedNextExpiration: time.Duration(0),
 		},
 		{
 			name: "Expired peers, no expiration",
@@ -1475,7 +1479,8 @@ func TestAccount_GetNextPeerExpiration(t *testing.T) {
 			},
 			expiration:             time.Second,
 			expirationEnabled:      false,
-			expectedNextExpiration: nil,
+			expectedNextRun:        false,
+			expectedNextExpiration: time.Duration(0),
 		},
 		{
 			name: "To be expired peer, return expiration",
@@ -1498,7 +1503,8 @@ func TestAccount_GetNextPeerExpiration(t *testing.T) {
 			},
 			expiration:             time.Minute,
 			expirationEnabled:      false,
-			expectedNextExpiration: &expectedNextExpiration,
+			expectedNextRun:        true,
+			expectedNextExpiration: expectedNextExpiration,
 		},
 	}
 	for _, testCase := range testCases {
@@ -1508,11 +1514,12 @@ func TestAccount_GetNextPeerExpiration(t *testing.T) {
 				Settings: &Settings{PeerLoginExpiration: testCase.expiration, PeerLoginExpirationEnabled: testCase.expirationEnabled},
 			}
 
-			expiration := account.GetNextPeerExpiration()
-			if testCase.expectedNextExpiration != nil {
-				assert.True(t, *expiration >= 0 && *expiration <= *testCase.expectedNextExpiration)
+			ok, expiration := account.GetNextPeerExpiration()
+			assert.Equal(t, ok, testCase.expectedNextRun)
+			if testCase.expectedNextRun {
+				assert.True(t, expiration >= 0 && expiration <= testCase.expectedNextExpiration)
 			} else {
-				assert.Nil(t, expiration)
+				assert.Equal(t, expiration, testCase.expectedNextExpiration)
 			}
 
 		})

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1358,7 +1358,7 @@ func TestDefaultAccountManager_MarkPeerConnected_PeerLoginExpiration(t *testing.
 		LoginExpirationEnabled: true,
 	})
 	require.NoError(t, err, "unable to add peer")
-	account, err = manager.UpdateAccountSettings(account.Id, userID, &Settings{
+	_, err = manager.UpdateAccountSettings(account.Id, userID, &Settings{
 		PeerLoginExpiration:        time.Hour,
 		PeerLoginExpirationEnabled: true})
 	require.NoError(t, err, "expecting to update account settings successfully but got error")
@@ -1426,7 +1426,7 @@ func TestDefaultAccountManager_UpdateAccountSettings_PeerLoginExpiration(t *test
 	wg.Add(1)
 
 	// disabling PeerLoginExpirationEnabled should trigger cancel
-	account, err = manager.UpdateAccountSettings(account.Id, userID, &Settings{
+	_, err = manager.UpdateAccountSettings(account.Id, userID, &Settings{
 		PeerLoginExpiration:        time.Hour,
 		PeerLoginExpirationEnabled: false})
 	require.NoError(t, err, "expecting to update account settings successfully but got error")

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1322,7 +1322,7 @@ func TestDefaultAccountManager_UpdatePeer_PeerLoginExpiration(t *testing.T) {
 		CancelFunc: func(IDs []string) {
 			wg.Done()
 		},
-		ScheduleFunc: func(in time.Duration, ID string, job func() (reschedule bool, nextRunIn time.Duration)) {
+		ScheduleFunc: func(in time.Duration, ID string, job func() (nextRunIn time.Duration, reschedule bool)) {
 			wg.Done()
 		},
 	}
@@ -1369,7 +1369,7 @@ func TestDefaultAccountManager_MarkPeerConnected_PeerLoginExpiration(t *testing.
 		CancelFunc: func(IDs []string) {
 			wg.Done()
 		},
-		ScheduleFunc: func(in time.Duration, ID string, job func() (reschedule bool, nextRunIn time.Duration)) {
+		ScheduleFunc: func(in time.Duration, ID string, job func() (nextRunIn time.Duration, reschedule bool)) {
 			wg.Done()
 		},
 	}
@@ -1409,7 +1409,7 @@ func TestDefaultAccountManager_UpdateAccountSettings_PeerLoginExpiration(t *test
 		CancelFunc: func(IDs []string) {
 			wg.Done()
 		},
-		ScheduleFunc: func(in time.Duration, ID string, job func() (reschedule bool, nextRunIn time.Duration)) {
+		ScheduleFunc: func(in time.Duration, ID string, job func() (nextRunIn time.Duration, reschedule bool)) {
 			wg.Done()
 		},
 	}
@@ -1655,7 +1655,7 @@ func TestAccount_GetNextPeerExpiration(t *testing.T) {
 				Settings: &Settings{PeerLoginExpiration: testCase.expiration, PeerLoginExpirationEnabled: testCase.expirationEnabled},
 			}
 
-			ok, expiration := account.GetNextPeerExpiration()
+			expiration, ok := account.GetNextPeerExpiration()
 			assert.Equal(t, ok, testCase.expectedNextRun)
 			if testCase.expectedNextRun {
 				assert.True(t, expiration >= 0 && expiration <= testCase.expectedNextExpiration)

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -136,7 +136,8 @@ func (s *GRPCServer) Sync(req *proto.EncryptedMessage, srv proto.ManagementServi
 	if err != nil {
 		return status.Error(codes.Internal, "internal server error")
 	}
-	expired, left := peer.LoginExpired(account.Settings)
+	expired, left := peer.LoginExpired(account.Settings.PeerLoginExpiration)
+	expired = account.Settings.PeerLoginExpirationEnabled && expired
 	if peer.UserID != "" && (expired || peer.Status.LoginExpired) {
 		err = s.accountManager.MarkPeerLoginExpired(peerKey.String(), true)
 		if err != nil {
@@ -380,7 +381,9 @@ func (s *GRPCServer) Login(ctx context.Context, req *proto.EncryptedMessage) (*p
 	if err != nil {
 		return nil, status.Error(codes.Internal, "internal server error")
 	}
-	expired, left := peer.LoginExpired(account.Settings)
+
+	expired, left := peer.LoginExpired(account.Settings.PeerLoginExpiration)
+	expired = account.Settings.PeerLoginExpirationEnabled && expired
 	if peer.UserID != "" && (expired || peer.Status.LoginExpired) {
 		// it might be that peer expired but user has logged in already, check token then
 		if loginReq.GetJwtToken() == "" {

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -529,7 +529,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 		SSHEnabled:             false,
 		SSHKey:                 peer.SSHKey,
 		LastLogin:              time.Now(),
-		LoginExpirationEnabled: false,
+		LoginExpirationEnabled: true,
 	}
 
 	// add peer to 'All' group

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -57,7 +57,7 @@ func TestPeer_LoginExpired(t *testing.T) {
 				LastLogin:              c.lastLogin,
 			}
 
-			expired, _ := peer.LoginExpired(c.accountSettings)
+			expired, _ := peer.LoginExpired(c.accountSettings.PeerLoginExpiration)
 			assert.Equal(t, expired, c.expected)
 		})
 	}

--- a/management/server/scheduler.go
+++ b/management/server/scheduler.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	log "github.com/sirupsen/logrus"
+	"sync"
+	"time"
+)
+
+// Scheduler is a generic structure that allows to schedule jobs (functions) to run in the future and cancel them.
+type Scheduler struct {
+	// jobs map holds cancellation channels indexed by the job ID
+	jobs map[string]chan struct{}
+	mu   *sync.Mutex
+}
+
+func NewScheduler() *Scheduler {
+	return &Scheduler{
+		jobs: make(map[string]chan struct{}),
+		mu:   &sync.Mutex{},
+	}
+}
+
+func (wm *Scheduler) cancel(ID string) bool {
+	cancel, ok := wm.jobs[ID]
+	if ok {
+		delete(wm.jobs, ID)
+		cancel <- struct{}{}
+		log.Debugf("cancelled scheduled job %s", ID)
+	}
+	return ok
+}
+
+// Cancel cancels the scheduled job by ID if present.
+// If job wasn't found the function returns false.
+func (wm *Scheduler) Cancel(IDs []string) {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+
+	for _, id := range IDs {
+		wm.cancel(id)
+	}
+}
+
+// Schedule a job to run in some time in the future. If job returns true then it will be scheduled one more time.
+func (wm *Scheduler) Schedule(in time.Duration, ID string, job func() (reschedule bool, nextRunIn time.Duration)) {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	cancel := make(chan struct{})
+	if _, ok := wm.jobs[ID]; !ok {
+		wm.jobs[ID] = cancel
+		log.Debugf("scheduled peer login expiration job for account %s to run in %s", ID, in.String())
+		go func() {
+			select {
+			case <-time.After(in):
+				log.Debugf("time to do a scheduled job %s", ID)
+				wm.mu.Lock()
+				defer wm.mu.Unlock()
+				reschedule, runIn := job()
+				delete(wm.jobs, ID)
+				if reschedule {
+					go wm.Schedule(runIn, ID, job)
+				}
+			case <-cancel:
+				log.Debugf("stopped scheduled job %s ", ID)
+				wm.mu.Lock()
+				defer wm.mu.Unlock()
+				delete(wm.jobs, ID)
+				return
+			}
+		}()
+	}
+}

--- a/management/server/scheduler.go
+++ b/management/server/scheduler.go
@@ -13,6 +13,7 @@ type Scheduler struct {
 	mu   *sync.Mutex
 }
 
+// NewScheduler creates an instance of a Scheduler
 func NewScheduler() *Scheduler {
 	return &Scheduler{
 		jobs: make(map[string]chan struct{}),

--- a/management/server/scheduler.go
+++ b/management/server/scheduler.go
@@ -12,6 +12,7 @@ type Scheduler interface {
 	Schedule(in time.Duration, ID string, job func() (reschedule bool, nextRunIn time.Duration))
 }
 
+// MockScheduler is a mock implementation of  Scheduler
 type MockScheduler struct {
 	CancelFunc   func(IDs []string)
 	ScheduleFunc func(in time.Duration, ID string, job func() (reschedule bool, nextRunIn time.Duration))

--- a/management/server/scheduler.go
+++ b/management/server/scheduler.go
@@ -30,6 +30,7 @@ func (wm *Scheduler) cancel(ID string) bool {
 			log.Debugf("cancelled scheduled job %s", ID)
 		default:
 			log.Warnf("couldn't cancel job %s because there was no routine listening on the cancel event", ID)
+			return false
 		}
 
 	}
@@ -48,6 +49,7 @@ func (wm *Scheduler) Cancel(IDs []string) {
 }
 
 // Schedule a job to run in some time in the future. If job returns true then it will be scheduled one more time.
+// If job with the provided ID already exists, a new one won't be scheduled.
 func (wm *Scheduler) Schedule(in time.Duration, ID string, job func() (reschedule bool, nextRunIn time.Duration)) {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()

--- a/management/server/scheduler_test.go
+++ b/management/server/scheduler_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestScheduler_Performance(t *testing.T) {
-	scheduler := NewScheduler()
+	scheduler := NewDefaultScheduler()
 	n := 1000
 	wg := sync.WaitGroup{}
 	wg.Add(n)
@@ -31,7 +31,7 @@ func TestScheduler_Performance(t *testing.T) {
 func TestScheduler_Cancel(t *testing.T) {
 	jobID1 := "test-scheduler-job-1"
 	jobID2 := "test-scheduler-job-2"
-	scheduler := NewScheduler()
+	scheduler := NewDefaultScheduler()
 	scheduler.Schedule(2*time.Second, jobID1, func() (reschedule bool, nextRunIn time.Duration) {
 		return false, 0
 	})
@@ -47,7 +47,7 @@ func TestScheduler_Cancel(t *testing.T) {
 
 func TestScheduler_Schedule(t *testing.T) {
 	jobID := "test-scheduler-job-1"
-	scheduler := NewScheduler()
+	scheduler := NewDefaultScheduler()
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	// job without reschedule should be triggered once

--- a/management/server/scheduler_test.go
+++ b/management/server/scheduler_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestScheduler_Performance(t *testing.T) {
 	scheduler := NewDefaultScheduler()
-	n := 1000
+	n := 500
 	wg := &sync.WaitGroup{}
 	wg.Add(n)
 	maxMs := 500
@@ -26,7 +26,7 @@ func TestScheduler_Performance(t *testing.T) {
 	}
 
 	assert.True(t, len(scheduler.jobs) > 0)
-	failed := waitTimeout(wg, time.Second)
+	failed := waitTimeout(wg, 3*time.Second)
 	if failed {
 		t.Fatal("timed out while waiting for test to finish")
 		return

--- a/management/server/scheduler_test.go
+++ b/management/server/scheduler_test.go
@@ -24,8 +24,6 @@ func TestScheduler_Performance(t *testing.T) {
 			return 0, false
 		})
 	}
-
-	assert.True(t, len(scheduler.jobs) > 0)
 	failed := waitTimeout(wg, 3*time.Second)
 	if failed {
 		t.Fatal("timed out while waiting for test to finish")

--- a/management/server/scheduler_test.go
+++ b/management/server/scheduler_test.go
@@ -14,8 +14,10 @@ func TestScheduler_Performance(t *testing.T) {
 	n := 1000
 	wg := &sync.WaitGroup{}
 	wg.Add(n)
+	maxMs := 500
+	minMs := 50
 	for i := 0; i < n; i++ {
-		millis := time.Duration(rand.Intn(500-50)+50) * time.Millisecond
+		millis := time.Duration(rand.Intn(maxMs-minMs)+minMs) * time.Millisecond
 		go scheduler.Schedule(millis, fmt.Sprintf("test-scheduler-job-%d", i), func() (nextRunIn time.Duration, reschedule bool) {
 			time.Sleep(millis)
 			wg.Done()

--- a/management/server/scheduler_test.go
+++ b/management/server/scheduler_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestScheduler_Cancel(t *testing.T) {
+	jobID1 := "test-scheduler-job-1"
+	jobID2 := "test-scheduler-job-2"
+	scheduler := NewScheduler()
+	scheduler.Schedule(2*time.Second, jobID1, func() (reschedule bool, nextRunIn time.Duration) {
+		return false, 0
+	})
+	scheduler.Schedule(2*time.Second, jobID2, func() (reschedule bool, nextRunIn time.Duration) {
+		return false, 0
+	})
+
+	assert.Len(t, scheduler.jobs, 2)
+	scheduler.Cancel([]string{jobID1})
+	assert.Len(t, scheduler.jobs, 1)
+	assert.NotNil(t, scheduler.jobs[jobID2])
+}
+
+func TestScheduler_Schedule(t *testing.T) {
+	jobID := "test-scheduler-job-1"
+	scheduler := NewScheduler()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	// job without reschedule should be triggered once
+	job := func() (reschedule bool, nextRunIn time.Duration) {
+		wg.Done()
+		return false, 0
+	}
+	scheduler.Schedule(300*time.Millisecond, jobID, job)
+	wg.Wait()
+
+	// job with reschedule should be triggered at least twice
+	wg = sync.WaitGroup{}
+	wg.Add(2)
+	job = func() (reschedule bool, nextRunIn time.Duration) {
+		wg.Done()
+		return true, 300 * time.Millisecond
+	}
+
+	scheduler.Schedule(300*time.Millisecond, jobID, job)
+	wg.Wait()
+	scheduler.cancel(jobID)
+
+}

--- a/management/server/turncredentials.go
+++ b/management/server/turncredentials.go
@@ -115,6 +115,7 @@ func (m *TimeBasedAuthSecretsManager) SetupRefresh(peerID string) {
 						Turns: turns,
 					},
 				}
+				log.Debugf("sending new TURN credentials to peer %s", peerID)
 				err := m.updateManager.SendUpdate(peerID, &UpdateMessage{Update: update})
 				if err != nil {
 					log.Errorf("error while sending TURN update to peer %s %v", peerID, err)

--- a/management/server/updatechannel.go
+++ b/management/server/updatechannel.go
@@ -60,16 +60,29 @@ func (p *PeersUpdateManager) CreateChannel(peerID string) chan *UpdateMessage {
 	return channel
 }
 
-// CloseChannel closes updates channel of a given peer
-func (p *PeersUpdateManager) CloseChannel(peerID string) {
-	p.channelsMux.Lock()
-	defer p.channelsMux.Unlock()
+func (p *PeersUpdateManager) closeChannel(peerID string) {
 	if channel, ok := p.peerChannels[peerID]; ok {
 		delete(p.peerChannels, peerID)
 		close(channel)
 	}
 
 	log.Debugf("closed updates channel of a peer %s", peerID)
+}
+
+// CloseChannels closes updates channel for each given peer
+func (p *PeersUpdateManager) CloseChannels(peerIDs []string) {
+	p.channelsMux.Lock()
+	defer p.channelsMux.Unlock()
+	for _, id := range peerIDs {
+		p.closeChannel(id)
+	}
+}
+
+// CloseChannel closes updates channel of a given peer
+func (p *PeersUpdateManager) CloseChannel(peerID string) {
+	p.channelsMux.Lock()
+	defer p.channelsMux.Unlock()
+	p.closeChannel(peerID)
 }
 
 // GetAllConnectedPeers returns a copy of the connected peers map


### PR DESCRIPTION
## Describe your changes

Goals:
- Enable peer login expiration when adding new peer
- Expire peer's login when the time comes

The account manager triggers peer expiration routine in future if the 
following conditions are true:
- peer expiration is enabled for the account
- there is at least one peer that has expiration enabled and is connected

The time of the next expiration check is based on the nearest peer expiration.
Account manager finds a peer with the oldest last login (auth) timestamp and
calculates the time when it has to run the routine as a sum of the configured
peer login expiration duration and the peer's last login time. 

When triggered, the expiration routine checks whether there are expired peers.
The management server closes the update channel of these peers and updates
network map of other peers to exclude expired peers so that the expired peers
are not able to connect anywhere. 

The account manager can reschedule or cancel peer expiration in the following cases:
- when admin changes account setting (peer expiration enable/disable)
- when admin updates the expiration duration of the account
- when admin updates peer expiration (enable/disable)
- when peer connects (Sync)  
  
P.S. The network map calculation was updated to exclude peers that have login expired.  

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
