### PR TITLE
Allow to create config file next to binary

### DIFF
--- a/util/file.go
+++ b/util/file.go
@@ -11,8 +11,7 @@ import (
 // The output JSON is pretty-formatted
 func WriteJson(file string, obj interface{}) error {
 
-	configDir, configFileName := filepath.Split(file)
-	err := os.MkdirAll(configDir, 0750)
+	configDir, configFileName, err := prepareConfigFileDir(file)
 	if err != nil {
 		return err
 	}
@@ -99,4 +98,14 @@ func CopyFileContents(src, dst string) (err error) {
 	}
 	err = out.Sync()
 	return
+}
+
+func prepareConfigFileDir(file string) (string, string, error) {
+	configDir, configFileName := filepath.Split(file)
+	if configDir == "" {
+		return "", configFileName, nil
+	}
+
+	err := os.MkdirAll(configDir, 0750)
+	return configDir, configFileName, err
 }


### PR DESCRIPTION
## Describe your changes

Without you set the full path of the config file the Netbird can not 
handle it. We check the path of the given config file's name and 
if it is not contain a folder then skip the step to create a folder 
for it.
You can place the config file next to the binary:
**./netbird  up --config myconfig.json**

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
