### PR TITLE
Fix nil pointer exception in config parser

### DIFF
--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -242,13 +242,12 @@ func GetConfig(input ConfigInput) (*Config, error) {
 	if _, err := os.Stat(input.ConfigPath); os.IsNotExist(err) {
 		log.Infof("generating new config %s", input.ConfigPath)
 		return createNewConfig(input)
-	} else {
-		// don't overwrite pre-shared key if we receive asterisks from UI
-		if *input.PreSharedKey == "**********" {
-			input.PreSharedKey = nil
-		}
-		return ReadConfig(input)
 	}
+
+	if isPreSharedKeyHidden(input.PreSharedKey) {
+		input.PreSharedKey = nil
+	}
+	return ReadConfig(input)
 }
 
 // generateKey generates a new Wireguard private key
@@ -363,4 +362,12 @@ func isProviderConfigValid(config ProviderConfig) error {
 		return fmt.Errorf(errorMSGFormat, "Device Auth Endpoint")
 	}
 	return nil
+}
+
+// don't overwrite pre-shared key if we receive asterisks from UI
+func isPreSharedKeyHidden(preSharedKey *string) bool {
+	if preSharedKey != nil && *preSharedKey == "**********" {
+		return true
+	}
+	return false
 }

--- a/client/internal/config_test.go
+++ b/client/internal/config_test.go
@@ -85,3 +85,40 @@ func TestGetConfig(t *testing.T) {
 	}
 	assert.Equal(t, readConf.(*Config).ManagementURL.String(), newManagementURL)
 }
+
+func TestHiddenPreSharedKey(t *testing.T) {
+	hidden := "**********"
+	samplePreSharedKey := "mysecretpresharedkey"
+	tests := []struct {
+		name         string
+		preSharedKey *string
+		want         string
+	}{
+		{"nil", nil, ""},
+		{"hidden", &hidden, ""},
+		{"filled", &samplePreSharedKey, samplePreSharedKey},
+	}
+
+	// generate default cfg
+	cfgFile := filepath.Join(t.TempDir(), "config.json")
+	_, _ = GetConfig(ConfigInput{
+		ConfigPath: cfgFile,
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := GetConfig(ConfigInput{
+				ConfigPath:   cfgFile,
+				PreSharedKey: tt.preSharedKey,
+			})
+
+			if err != nil {
+				t.Fatalf("failed to get cfg: %s", err)
+			}
+
+			if cfg.PreSharedKey != tt.want {
+				t.Fatalf("invalid preshared key: '%s', expected: '%s' ", cfg.PreSharedKey, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes

In config reader if the **input.PreSharedKey** is nil then the **GetConfig** 
throw nil pointer exception

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
