### PR TITLE
fix/use-regex-in-formatter-test

### DIFF
--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -20,8 +20,7 @@ func TestLogMessageFormat(t *testing.T) {
 	formatter := NewTextFormatter()
 	result, _ := formatter.Format(someEntry)
 
-	expectedString := "2021-02-21T01:10:30Z WARN [att1: 1, att2: 2] some/fancy/path.go:46: Some Message\n"
 	parsedString := string(result)
-	assert.Equal(t, expectedString, parsedString, "The log messages don't match.")
-
+	expectedString := "^2021-02-21T01:10:30Z WARN \\[(att1: 1, att2: 2|att2: 2, att1: 1)\\] some/fancy/path.go:46: Some Message\\s+$"
+	assert.Regexp(t, expectedString, parsedString)
 }


### PR DESCRIPTION
## Describe your changes
Fix test for formatter where the attributes are changing order for some reason to not have random test failures.
Used regex to catch both cases.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
