### PR TITLE
Move Login business logic from gRPC API to Accountmanager

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -95,7 +95,6 @@ type AccountManager interface {
 	GetDNSSettings(accountID string, userID string) (*DNSSettings, error)
 	SaveDNSSettings(accountID string, userID string, dnsSettingsToSave *DNSSettings) error
 	GetPeer(accountID, peerID, userID string) (*Peer, error)
-	UpdatePeerLastLogin(peerID string) error
 	UpdateAccountSettings(accountID, userID string, newSettings *Settings) (*Account, error)
 	LoginPeer(login PeerLogin) (*Peer, error)
 }

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/netbirdio/netbird/management/server/http/middleware"
 	"math/rand"
 	"net"
 	"net/netip"
@@ -63,7 +64,6 @@ type AccountManager interface {
 	GetNetworkMap(peerID string) (*NetworkMap, error)
 	GetPeerNetwork(peerID string) (*Network, error)
 	AddPeer(setupKey, userID string, peer *Peer) (*Peer, error)
-	UpdatePeerMeta(peerID string, meta PeerSystemMeta) error
 	UpdatePeerSSHKey(peerID string, sshKey string) error
 	GetUsersFromAccount(accountID, userID string) ([]*UserInfo, error)
 	GetGroup(accountId, groupID string) (*Group, error)
@@ -98,6 +98,7 @@ type AccountManager interface {
 	GetPeer(accountID, peerID, userID string) (*Peer, error)
 	UpdatePeerLastLogin(peerID string) error
 	UpdateAccountSettings(accountID, userID string, newSettings *Settings) (*Account, error)
+	LoginPeer(login PeerLogin) (*Peer, error)
 }
 
 type DefaultAccountManager struct {
@@ -119,8 +120,10 @@ type DefaultAccountManager struct {
 	// singleAccountModeDomain is a domain to use in singleAccountMode setup
 	singleAccountModeDomain string
 	// dnsDomain is used for peer resolution. This is appended to the peer's name
-	dnsDomain       string
-	peerLoginExpiry Scheduler
+	dnsDomain          string
+	peerLoginExpiry    Scheduler
+	jwtMiddleware      *middleware.JWTMiddleware
+	jwtClaimsExtractor *jwtclaims.ClaimsExtractor
 }
 
 // Settings represents Account settings structure that can be modified via API and Dashboard

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -97,6 +97,7 @@ type AccountManager interface {
 	GetPeer(accountID, peerID, userID string) (*Peer, error)
 	UpdateAccountSettings(accountID, userID string, newSettings *Settings) (*Account, error)
 	LoginPeer(login PeerLogin) (*Peer, error)
+	SyncPeer(sync PeerSync) (*Peer, *NetworkMap, error)
 }
 
 type DefaultAccountManager struct {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/netbirdio/netbird/management/server/http/middleware"
 	"math/rand"
 	"net"
 	"net/netip"
@@ -120,10 +119,8 @@ type DefaultAccountManager struct {
 	// singleAccountModeDomain is a domain to use in singleAccountMode setup
 	singleAccountModeDomain string
 	// dnsDomain is used for peer resolution. This is appended to the peer's name
-	dnsDomain          string
-	peerLoginExpiry    Scheduler
-	jwtMiddleware      *middleware.JWTMiddleware
-	jwtClaimsExtractor *jwtclaims.ClaimsExtractor
+	dnsDomain       string
+	peerLoginExpiry Scheduler
 }
 
 // Settings represents Account settings structure that can be modified via API and Dashboard

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -544,8 +544,7 @@ func TestAccountManager_AddPeer(t *testing.T) {
 
 	peer, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  expectedPeerKey,
-		Meta: PeerSystemMeta{},
-		Name: expectedPeerKey,
+		Meta: PeerSystemMeta{Hostname: expectedPeerKey},
 	})
 	if err != nil {
 		t.Errorf("expecting peer to be added, got failure %v", err)
@@ -613,8 +612,7 @@ func TestAccountManager_AddPeerWithUserID(t *testing.T) {
 
 	peer, err := manager.AddPeer("", userID, &Peer{
 		Key:  expectedPeerKey,
-		Meta: PeerSystemMeta{},
-		Name: expectedPeerKey,
+		Meta: PeerSystemMeta{Hostname: expectedPeerKey},
 	})
 	if err != nil {
 		t.Errorf("expecting peer to be added, got failure %v, account users: %v", err, account.CreatedBy)
@@ -696,8 +694,7 @@ func TestAccountManager_NetworkUpdates(t *testing.T) {
 
 		peer, err := manager.AddPeer(setupKey.Key, "", &Peer{
 			Key:  expectedPeerKey,
-			Meta: PeerSystemMeta{},
-			Name: expectedPeerKey,
+			Meta: PeerSystemMeta{Hostname: expectedPeerKey},
 		})
 		if err != nil {
 			t.Fatalf("expecting peer1 to be added, got failure %v", err)
@@ -866,8 +863,7 @@ func TestAccountManager_DeletePeer(t *testing.T) {
 
 	peer, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey,
-		Meta: PeerSystemMeta{},
-		Name: peerKey,
+		Meta: PeerSystemMeta{Hostname: peerKey},
 	})
 	if err != nil {
 		t.Errorf("expecting peer to be added, got failure %v", err)
@@ -1304,8 +1300,7 @@ func TestDefaultAccountManager_UpdatePeer_PeerLoginExpiration(t *testing.T) {
 	require.NoError(t, err, "unable to generate WireGuard key")
 	peer, err := manager.AddPeer("", userID, &Peer{
 		Key:                    key.PublicKey().String(),
-		Meta:                   PeerSystemMeta{},
-		Name:                   "test-peer",
+		Meta:                   PeerSystemMeta{Hostname: "test-peer"},
 		LoginExpirationEnabled: true,
 	})
 	require.NoError(t, err, "unable to add peer")
@@ -1353,8 +1348,7 @@ func TestDefaultAccountManager_MarkPeerConnected_PeerLoginExpiration(t *testing.
 	require.NoError(t, err, "unable to generate WireGuard key")
 	_, err = manager.AddPeer("", userID, &Peer{
 		Key:                    key.PublicKey().String(),
-		Meta:                   PeerSystemMeta{},
-		Name:                   "test-peer",
+		Meta:                   PeerSystemMeta{Hostname: "test-peer"},
 		LoginExpirationEnabled: true,
 	})
 	require.NoError(t, err, "unable to add peer")
@@ -1395,8 +1389,7 @@ func TestDefaultAccountManager_UpdateAccountSettings_PeerLoginExpiration(t *test
 	require.NoError(t, err, "unable to generate WireGuard key")
 	_, err = manager.AddPeer("", userID, &Peer{
 		Key:                    key.PublicKey().String(),
-		Meta:                   PeerSystemMeta{},
-		Name:                   "test-peer",
+		Meta:                   PeerSystemMeta{Hostname: "test-peer"},
 		LoginExpirationEnabled: true,
 	})
 	require.NoError(t, err, "unable to add peer")

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -951,7 +951,7 @@ func TestGetUsersFromAccount(t *testing.T) {
 	}
 }
 
-func TestAccountManager_UpdatePeerMeta(t *testing.T) {
+/*func TestAccountManager_UpdatePeerMeta(t *testing.T) {
 	manager, err := createManager(t)
 	if err != nil {
 		t.Fatal(err)
@@ -1018,7 +1018,7 @@ func TestAccountManager_UpdatePeerMeta(t *testing.T) {
 	}
 
 	assert.Equal(t, newMeta, p.Meta)
-}
+}*/
 
 func TestAccount_GetPeerRules(t *testing.T) {
 

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -225,7 +225,6 @@ func (s *FileStore) SaveAccount(account *Account) error {
 
 	accountCopy := account.Copy()
 
-	// todo will override, handle existing keys
 	s.Accounts[accountCopy.Id] = accountCopy
 
 	// todo check that account.Id and keyId are not exist already
@@ -354,6 +353,14 @@ func (s *FileStore) GetAccountByPeerID(peerID string) (*Account, error) {
 		return nil, err
 	}
 
+	// this protection is needed because when we delete a peer, we don't really remove index peerID -> accountID.
+	// check Account.Peers for a match
+	if _, ok := account.Peers[peerID]; !ok {
+		delete(s.PeerID2AccountID, peerID)
+		log.Warnf("removed stale peerID %s to accountID %s index", peerID, accountID)
+		return nil, status.Errorf(status.NotFound, "provided peer doesn't exists %s", peerID)
+	}
+
 	return account.Copy(), nil
 }
 
@@ -370,6 +377,21 @@ func (s *FileStore) GetAccountByPeerPubKey(peerKey string) (*Account, error) {
 	account, err := s.getAccount(accountID)
 	if err != nil {
 		return nil, err
+	}
+
+	// this protection is needed because when we delete a peer, we don't really remove index peerKey -> accountID.
+	// check Account.Peers for a match
+	stale := true
+	for _, peer := range account.Peers {
+		if peer.Key == peerKey {
+			stale = false
+			break
+		}
+	}
+	if stale {
+		delete(s.PeerKeyID2AccountID, peerKey)
+		log.Warnf("removed stale peerKey %s to accountID %s index", peerKey, accountID)
+		return nil, status.Errorf(status.NotFound, "provided peer doesn't exists %s", peerKey)
 	}
 
 	return account.Copy(), nil

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -230,84 +230,54 @@ func (s *GRPCServer) validateToken(jwtToken string) (string, error) {
 	return claims.UserId, nil
 }
 
-func (s *GRPCServer) registerPeer(peerKey wgtypes.Key, req *proto.LoginRequest) (*Peer, error) {
-	var (
-		reqSetupKey string
-		userID      string
-		err         error
-	)
-
-	if req.GetJwtToken() != "" {
-		log.Debugln("using jwt token to register peer")
-		userID, err = s.validateToken(req.JwtToken)
-		if err != nil {
-			return nil, err
+// maps internal internalStatus.Error to gRPC status.Error
+func mapError(err error) error {
+	if e, ok := internalStatus.FromError(err); ok {
+		switch e.Type() {
+		case internalStatus.PermissionDenied:
+			return status.Errorf(codes.PermissionDenied, e.Message)
+		case internalStatus.Unauthorized:
+			return status.Errorf(codes.PermissionDenied, e.Message)
+		case internalStatus.Unauthenticated:
+			return status.Errorf(codes.PermissionDenied, e.Message)
+		case internalStatus.PreconditionFailed:
+			return status.Errorf(codes.FailedPrecondition, e.Message)
+		case internalStatus.NotFound:
+			return status.Errorf(codes.NotFound, e.Message)
+		default:
 		}
-	} else {
-		log.Debugln("using setup key to register peer")
-		reqSetupKey = req.GetSetupKey()
-		userID = ""
 	}
+	return status.Errorf(codes.Internal, "failed handling request")
+}
 
-	meta := req.GetMeta()
-	if meta == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "peer meta data was not provided")
+func extractPeerMeta(loginReq *proto.LoginRequest) PeerSystemMeta {
+	return PeerSystemMeta{
+		Hostname:  loginReq.GetMeta().GetHostname(),
+		GoOS:      loginReq.GetMeta().GetGoOS(),
+		Kernel:    loginReq.GetMeta().GetKernel(),
+		Core:      loginReq.GetMeta().GetCore(),
+		Platform:  loginReq.GetMeta().GetPlatform(),
+		OS:        loginReq.GetMeta().GetOS(),
+		WtVersion: loginReq.GetMeta().GetWiretrusteeVersion(),
+		UIVersion: loginReq.GetMeta().GetUiVersion(),
 	}
+}
 
-	var sshKey []byte
-	if req.GetPeerKeys() != nil {
-		sshKey = req.GetPeerKeys().GetSshPubKey()
-	}
-
-	peer, err := s.accountManager.AddPeer(reqSetupKey, userID, &Peer{
-		Key:    peerKey.String(),
-		Name:   meta.GetHostname(),
-		SSHKey: string(sshKey),
-		Meta: PeerSystemMeta{
-			Hostname:  meta.GetHostname(),
-			GoOS:      meta.GetGoOS(),
-			Kernel:    meta.GetKernel(),
-			Core:      meta.GetCore(),
-			Platform:  meta.GetPlatform(),
-			OS:        meta.GetOS(),
-			WtVersion: meta.GetWiretrusteeVersion(),
-			UIVersion: meta.GetUiVersion(),
-		},
-	})
+func (s *GRPCServer) parseLoginRequest(req *proto.EncryptedMessage) (*proto.LoginRequest, wgtypes.Key, error) {
+	peerKey, err := wgtypes.ParseKey(req.GetWgPubKey())
 	if err != nil {
-		if e, ok := internalStatus.FromError(err); ok {
-			switch e.Type() {
-			case internalStatus.PreconditionFailed:
-				return nil, status.Errorf(codes.FailedPrecondition, e.Message)
-			case internalStatus.NotFound:
-				return nil, status.Errorf(codes.NotFound, e.Message)
-			default:
-			}
-		}
-		return nil, status.Errorf(codes.Internal, "failed registering new peer")
+		log.Warnf("error while parsing peer's WireGuard public key %s.", req.WgPubKey)
+		return nil, wgtypes.Key{}, status.Errorf(codes.InvalidArgument, "provided wgPubKey %s is invalid", req.WgPubKey)
 	}
 
-	// todo move to DefaultAccountManager the code below
-	networkMap, err := s.accountManager.GetNetworkMap(peer.ID)
+	loginReq := &proto.LoginRequest{}
+	err = encryption.DecryptMessage(peerKey, s.wgKey, req.Body, loginReq)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to fetch network map after registering peer, error: %v", err)
-	}
-	// notify other peers of our registration
-	for _, remotePeer := range networkMap.Peers {
-		remotePeerNetworkMap, err := s.accountManager.GetNetworkMap(remotePeer.ID)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to fetch network map after registering peer, error: %v", err)
-		}
-
-		update := toSyncResponse(s.config, remotePeer, nil, remotePeerNetworkMap, s.accountManager.GetDNSDomain())
-		err = s.peersUpdateManager.SendUpdate(remotePeer.ID, &UpdateMessage{Update: update})
-		if err != nil {
-			// todo rethink if we should keep this return
-			return nil, status.Errorf(codes.Internal, "unable to send update after registering peer, error: %v", err)
-		}
+		return nil, wgtypes.Key{}, status.Errorf(codes.InvalidArgument, "invalid request message")
 	}
 
-	return peer, nil
+	return loginReq, peerKey, nil
+
 }
 
 // Login endpoint first checks whether peer is registered under any account
@@ -323,99 +293,43 @@ func (s *GRPCServer) Login(ctx context.Context, req *proto.EncryptedMessage) (*p
 		log.Debugf("Login request from peer [%s] [%s]", req.WgPubKey, p.Addr.String())
 	}
 
-	peerKey, err := wgtypes.ParseKey(req.GetWgPubKey())
+	loginReq, peerKey, err := s.parseLoginRequest(req)
 	if err != nil {
-		log.Warnf("error while parsing peer's Wireguard public key %s on Sync request.", req.WgPubKey)
-		return nil, status.Errorf(codes.InvalidArgument, "provided wgPubKey %s is invalid", req.WgPubKey)
+		return nil, err
 	}
 
-	loginReq := &proto.LoginRequest{}
-	err = encryption.DecryptMessage(peerKey, s.wgKey, req.Body, loginReq)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid request message")
+	if loginReq.GetMeta() == nil {
+		msg := status.Errorf(codes.FailedPrecondition,
+			"peer system meta has to be provided to log in. Peer %s, remote addr %s", peerKey.String(),
+			p.Addr.String())
+		log.Warn(msg)
+		return nil, msg
 	}
 
-	peer, err := s.accountManager.GetPeerByKey(peerKey.String())
-	if err != nil {
-		if errStatus, ok := internalStatus.FromError(err); ok && errStatus.Type() == internalStatus.NotFound {
-			// peer doesn't exist -> check if setup key was provided
-			if loginReq.GetJwtToken() == "" && loginReq.GetSetupKey() == "" {
-				// absent setup key or jwt -> permission denied
-				p, _ := gRPCPeer.FromContext(ctx)
-				msg := status.Errorf(codes.PermissionDenied,
-					"provided peer with the key wgPubKey %s is not registered and no setup key or jwt was provided,"+
-						" remote addr is %s", peerKey.String(), p.Addr.String())
-				log.Debug(msg)
-				return nil, msg
-			}
-
-			// setup key or jwt is present -> try normal registration flow
-			peer, err = s.registerPeer(peerKey, loginReq)
-			if err != nil {
-				return nil, err
-			}
-
-		} else {
-			return nil, status.Error(codes.Internal, "internal server error")
-		}
-	} else if loginReq.GetMeta() != nil {
-		// update peer's system meta data on Login
-		err = s.accountManager.UpdatePeerMeta(peer.ID, PeerSystemMeta{
-			Hostname:  loginReq.GetMeta().GetHostname(),
-			GoOS:      loginReq.GetMeta().GetGoOS(),
-			Kernel:    loginReq.GetMeta().GetKernel(),
-			Core:      loginReq.GetMeta().GetCore(),
-			Platform:  loginReq.GetMeta().GetPlatform(),
-			OS:        loginReq.GetMeta().GetOS(),
-			WtVersion: loginReq.GetMeta().GetWiretrusteeVersion(),
-			UIVersion: loginReq.GetMeta().GetUiVersion(),
-		},
-		)
+	userID := ""
+	// JWT token is not always provided, it is fine for userID to be empty cuz it might be that peer is already registered,
+	// or it uses a setup key to register.
+	if loginReq.GetJwtToken() != "" {
+		// todo what about the case when JWT provided expired?
+		userID, err = s.validateToken(loginReq.GetJwtToken())
 		if err != nil {
-			log.Errorf("failed updating peer system meta data %s", peerKey.String())
-			return nil, status.Error(codes.Internal, "internal server error")
+			return nil, mapError(err)
 		}
 	}
-
-	// check if peer login has expired
-	account, err := s.accountManager.GetAccountByPeerID(peer.ID)
-	if err != nil {
-		return nil, status.Error(codes.Internal, "internal server error")
-	}
-
-	expired, left := peer.LoginExpired(account.Settings.PeerLoginExpiration)
-	expired = account.Settings.PeerLoginExpirationEnabled && expired
-	if peer.UserID != "" && (expired || peer.Status.LoginExpired) {
-		// it might be that peer expired but user has logged in already, check token then
-		if loginReq.GetJwtToken() == "" {
-			err = s.accountManager.MarkPeerLoginExpired(peerKey.String(), true)
-			if err != nil {
-				log.Warnf("failed marking peer login expired %s %v", peerKey, err)
-			}
-			return nil, status.Errorf(codes.PermissionDenied,
-				"peer login has expired %v ago. Please log in once more", left)
-		}
-		_, err = s.validateToken(loginReq.GetJwtToken())
-		if err != nil {
-			return nil, err
-		}
-
-		err = s.accountManager.UpdatePeerLastLogin(peer.ID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	var sshKey []byte
 	if loginReq.GetPeerKeys() != nil {
 		sshKey = loginReq.GetPeerKeys().GetSshPubKey()
 	}
 
-	if len(sshKey) > 0 {
-		err = s.accountManager.UpdatePeerSSHKey(peer.ID, string(sshKey))
-		if err != nil {
-			return nil, err
-		}
+	peer, err := s.accountManager.LoginPeer(PeerLogin{
+		WireGuardPubKey: peerKey.String(),
+		SSHKey:          string(sshKey),
+		Meta:            extractPeerMeta(loginReq),
+		UserID:          userID,
+		SetupKey:        loginReq.GetSetupKey(),
+	})
+	if err != nil {
+		return nil, mapError(err)
 	}
 
 	network, err := s.accountManager.GetPeerNetwork(peer.ID)

--- a/management/server/http/handler.go
+++ b/management/server/http/handler.go
@@ -54,17 +54,16 @@ func APIHandler(accountManager s.AccountManager, appMetrics telemetry.AppMetrics
 		AuthCfg:        authCfg,
 	}
 
-	api.
-		addAccountsEndpoint().
-		addPeersEndpoint().
-		addUsersEndpoint().
-		addSetupKeysEndpoint().
-		addRulesEndpoint().
-		addGroupsEndpoint().
-		addRoutesEndpoint().
-		addDNSNameserversEndpoint().
-		addDNSSettingEndpoint().
-		addEventsEndpoint()
+	api.addAccountsEndpoint()
+	api.addPeersEndpoint()
+	api.addUsersEndpoint()
+	api.addSetupKeysEndpoint()
+	api.addRulesEndpoint()
+	api.addGroupsEndpoint()
+	api.addRoutesEndpoint()
+	api.addDNSNameserversEndpoint()
+	api.addDNSSettingEndpoint()
+	api.addEventsEndpoint()
 
 	err = api.Router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
 		methods, err := route.GetMethods()
@@ -90,39 +89,35 @@ func APIHandler(accountManager s.AccountManager, appMetrics telemetry.AppMetrics
 	return rootRouter, nil
 }
 
-func (apiHandler *apiHandler) addAccountsEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addAccountsEndpoint() {
 	accountsHandler := NewAccountsHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/accounts/{id}", accountsHandler.UpdateAccount).Methods("PUT", "OPTIONS")
 	apiHandler.Router.HandleFunc("/accounts", accountsHandler.GetAllAccounts).Methods("GET", "OPTIONS")
-	return apiHandler
 }
 
-func (apiHandler *apiHandler) addPeersEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addPeersEndpoint() {
 	peersHandler := NewPeersHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/peers", peersHandler.GetAllPeers).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/peers/{id}", peersHandler.HandlePeer).
 		Methods("GET", "PUT", "DELETE", "OPTIONS")
-	return apiHandler
 }
 
-func (apiHandler *apiHandler) addUsersEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addUsersEndpoint() {
 	userHandler := NewUsersHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/users", userHandler.GetAllUsers).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/users/{id}", userHandler.UpdateUser).Methods("PUT", "OPTIONS")
 	apiHandler.Router.HandleFunc("/users", userHandler.CreateUser).Methods("POST", "OPTIONS")
-	return apiHandler
 }
 
-func (apiHandler *apiHandler) addSetupKeysEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addSetupKeysEndpoint() {
 	keysHandler := NewSetupKeysHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/setup-keys", keysHandler.GetAllSetupKeys).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/setup-keys", keysHandler.CreateSetupKey).Methods("POST", "OPTIONS")
 	apiHandler.Router.HandleFunc("/setup-keys/{id}", keysHandler.GetSetupKey).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/setup-keys/{id}", keysHandler.UpdateSetupKey).Methods("PUT", "OPTIONS")
-	return apiHandler
 }
 
-func (apiHandler *apiHandler) addRulesEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addRulesEndpoint() {
 	rulesHandler := NewRulesHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/rules", rulesHandler.GetAllRules).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/rules", rulesHandler.CreateRule).Methods("POST", "OPTIONS")
@@ -130,10 +125,9 @@ func (apiHandler *apiHandler) addRulesEndpoint() *apiHandler {
 	apiHandler.Router.HandleFunc("/rules/{id}", rulesHandler.PatchRule).Methods("PATCH", "OPTIONS")
 	apiHandler.Router.HandleFunc("/rules/{id}", rulesHandler.GetRule).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/rules/{id}", rulesHandler.DeleteRule).Methods("DELETE", "OPTIONS")
-	return apiHandler
 }
 
-func (apiHandler *apiHandler) addGroupsEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addGroupsEndpoint() {
 	groupsHandler := NewGroupsHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/groups", groupsHandler.GetAllGroups).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/groups", groupsHandler.CreateGroup).Methods("POST", "OPTIONS")
@@ -141,10 +135,9 @@ func (apiHandler *apiHandler) addGroupsEndpoint() *apiHandler {
 	apiHandler.Router.HandleFunc("/groups/{id}", groupsHandler.PatchGroup).Methods("PATCH", "OPTIONS")
 	apiHandler.Router.HandleFunc("/groups/{id}", groupsHandler.GetGroup).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/groups/{id}", groupsHandler.DeleteGroup).Methods("DELETE", "OPTIONS")
-	return apiHandler
 }
 
-func (apiHandler *apiHandler) addRoutesEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addRoutesEndpoint() {
 	routesHandler := NewRoutesHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/routes", routesHandler.GetAllRoutes).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/routes", routesHandler.CreateRoute).Methods("POST", "OPTIONS")
@@ -152,10 +145,9 @@ func (apiHandler *apiHandler) addRoutesEndpoint() *apiHandler {
 	apiHandler.Router.HandleFunc("/routes/{id}", routesHandler.PatchRoute).Methods("PATCH", "OPTIONS")
 	apiHandler.Router.HandleFunc("/routes/{id}", routesHandler.GetRoute).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/routes/{id}", routesHandler.DeleteRoute).Methods("DELETE", "OPTIONS")
-	return apiHandler
 }
 
-func (apiHandler *apiHandler) addDNSNameserversEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addDNSNameserversEndpoint() {
 	nameserversHandler := NewNameserversHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/dns/nameservers", nameserversHandler.GetAllNameservers).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/dns/nameservers", nameserversHandler.CreateNameserverGroup).Methods("POST", "OPTIONS")
@@ -163,18 +155,15 @@ func (apiHandler *apiHandler) addDNSNameserversEndpoint() *apiHandler {
 	apiHandler.Router.HandleFunc("/dns/nameservers/{id}", nameserversHandler.PatchNameserverGroup).Methods("PATCH", "OPTIONS")
 	apiHandler.Router.HandleFunc("/dns/nameservers/{id}", nameserversHandler.GetNameserverGroup).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/dns/nameservers/{id}", nameserversHandler.DeleteNameserverGroup).Methods("DELETE", "OPTIONS")
-	return apiHandler
 }
 
-func (apiHandler *apiHandler) addDNSSettingEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addDNSSettingEndpoint() {
 	dnsSettingsHandler := NewDNSSettingsHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/dns/settings", dnsSettingsHandler.GetDNSSettings).Methods("GET", "OPTIONS")
 	apiHandler.Router.HandleFunc("/dns/settings", dnsSettingsHandler.UpdateDNSSettings).Methods("PUT", "OPTIONS")
-	return apiHandler
 }
 
-func (apiHandler *apiHandler) addEventsEndpoint() *apiHandler {
+func (apiHandler *apiHandler) addEventsEndpoint() {
 	eventsHandler := NewEventsHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/events", eventsHandler.GetAllEvents).Methods("GET", "OPTIONS")
-	return apiHandler
 }

--- a/management/server/management_test.go
+++ b/management/server/management_test.go
@@ -240,7 +240,8 @@ var _ = Describe("Management service", func() {
 		Context("with an invalid setup key", func() {
 			Specify("an error is returned", func() {
 				key, _ := wgtypes.GenerateKey()
-				message, err := encryption.EncryptMessage(serverPubKey, key, &mgmtProto.LoginRequest{SetupKey: "invalid setup key"})
+				message, err := encryption.EncryptMessage(serverPubKey, key, &mgmtProto.LoginRequest{SetupKey: "invalid setup key",
+					Meta: &mgmtProto.PeerSystemMeta{}})
 				Expect(err).NotTo(HaveOccurred())
 
 				resp, err := client.Login(context.TODO(), &mgmtProto.EncryptedMessage{
@@ -269,7 +270,7 @@ var _ = Describe("Management service", func() {
 				Expect(regResp).NotTo(BeNil())
 
 				// just login without registration
-				message, err := encryption.EncryptMessage(serverPubKey, key, &mgmtProto.LoginRequest{})
+				message, err := encryption.EncryptMessage(serverPubKey, key, &mgmtProto.LoginRequest{Meta: &mgmtProto.PeerSystemMeta{}})
 				Expect(err).NotTo(HaveOccurred())
 				loginResp, err := client.Login(context.TODO(), &mgmtProto.EncryptedMessage{
 					WgPubKey: key.PublicKey().String(),

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -73,6 +73,7 @@ type MockAccountManager struct {
 	GetAccountByPeerIDFunc          func(peerID string) (*server.Account, error)
 	UpdateAccountSettingsFunc       func(accountID, userID string, newSettings *server.Settings) (*server.Account, error)
 	LoginPeerFunc                   func(login server.PeerLogin) (*server.Peer, error)
+	SyncPeerFunc                    func(sync server.PeerSync) (*server.Peer, *server.NetworkMap, error)
 }
 
 // GetUsersFromAccount mock implementation of GetUsersFromAccount from server.AccountManager interface
@@ -563,4 +564,12 @@ func (am *MockAccountManager) LoginPeer(login server.PeerLogin) (*server.Peer, e
 		return am.LoginPeerFunc(login)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method LoginPeer is not implemented")
+}
+
+// SyncPeer mocks SyncPeer of the AccountManager interface
+func (am *MockAccountManager) SyncPeer(sync server.PeerSync) (*server.Peer, *server.NetworkMap, error) {
+	if am.SyncPeerFunc != nil {
+		return am.SyncPeerFunc(sync)
+	}
+	return nil, nil, status.Errorf(codes.Unimplemented, "method SyncPeer is not implemented")
 }

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -71,7 +71,6 @@ type MockAccountManager struct {
 	SaveDNSSettingsFunc             func(accountID, userID string, dnsSettingsToSave *server.DNSSettings) error
 	GetPeerFunc                     func(accountID, peerID, userID string) (*server.Peer, error)
 	GetAccountByPeerIDFunc          func(peerID string) (*server.Account, error)
-	UpdatePeerLastLoginFunc         func(peerID string) error
 	UpdateAccountSettingsFunc       func(accountID, userID string, newSettings *server.Settings) (*server.Account, error)
 	LoginPeerFunc                   func(login server.PeerLogin) (*server.Peer, error)
 }
@@ -548,14 +547,6 @@ func (am *MockAccountManager) GetAccountByPeerID(peerID string) (*server.Account
 		return am.GetAccountByPeerIDFunc(peerID)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method GetAccountByPeerID is not implemented")
-}
-
-// UpdatePeerLastLogin mocks UpdatePeerLastLogin of the AccountManager interface
-func (am *MockAccountManager) UpdatePeerLastLogin(peerID string) error {
-	if am.UpdatePeerLastLoginFunc != nil {
-		return am.UpdatePeerLastLoginFunc(peerID)
-	}
-	return status.Errorf(codes.Unimplemented, "method UpdatePeerLastLogin is not implemented")
 }
 
 // UpdateAccountSettings mocks UpdateAccountSettings of the AccountManager interface

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -73,6 +73,7 @@ type MockAccountManager struct {
 	GetAccountByPeerIDFunc          func(peerID string) (*server.Account, error)
 	UpdatePeerLastLoginFunc         func(peerID string) error
 	UpdateAccountSettingsFunc       func(accountID, userID string, newSettings *server.Settings) (*server.Account, error)
+	LoginPeerFunc                   func(login server.PeerLogin) (*server.Peer, error)
 }
 
 // GetUsersFromAccount mock implementation of GetUsersFromAccount from server.AccountManager interface
@@ -563,4 +564,12 @@ func (am *MockAccountManager) UpdateAccountSettings(accountID, userID string, ne
 		return am.UpdateAccountSettingsFunc(accountID, userID, newSettings)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateAccountSettings is not implemented")
+}
+
+// LoginPeer mocks LoginPeer of the AccountManager interface
+func (am *MockAccountManager) LoginPeer(login server.PeerLogin) (*server.Peer, error) {
+	if am.LoginPeerFunc != nil {
+		return am.LoginPeerFunc(login)
+	}
+	return nil, status.Errorf(codes.Unimplemented, "method LoginPeer is not implemented")
 }

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -682,7 +682,7 @@ func (am *DefaultAccountManager) LoginPeer(login PeerLogin) (*Peer, error) {
 	if peer.UserID != "" && (expired || peer.Status.LoginExpired) {
 		if login.UserID == "" {
 			// absence of a user ID indicates that JWT wasn't provided.
-			peer, err = am.markPeerLoginExpired(peer, account, true)
+			_, err = am.markPeerLoginExpired(peer, account, true)
 			if err != nil {
 				return nil, err
 			}

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -568,7 +568,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 	takenIps := account.getTakenIPs()
 	existingLabels := account.getPeerDNSLabels()
 
-	newLabel, err := getPeerHostLabel(peer.Name, existingLabels)
+	newLabel, err := getPeerHostLabel(peer.Meta.Hostname, existingLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -663,7 +663,7 @@ func (am *DefaultAccountManager) checkPeerLoginExpiration(login PeerLogin, peer 
 					log.Warnf("user mismatch when loggin in peer %s: peer user %s, login user %s ", peer.ID, peer.UserID, login.UserID)
 					return status.Errorf(status.Unauthenticated, "can't login")
 				}
-				peer = am.updatePeerLastLogin(peer, account)
+				_ = am.updatePeerLastLogin(peer, account)
 			}
 		}
 	}

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -92,8 +92,7 @@ func TestAccountManager_GetNetworkMap(t *testing.T) {
 
 	peer1, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey1.PublicKey().String(),
-		Meta: PeerSystemMeta{},
-		Name: "test-peer-2",
+		Meta: PeerSystemMeta{Hostname: "test-peer-1"},
 	})
 
 	if err != nil {
@@ -108,8 +107,7 @@ func TestAccountManager_GetNetworkMap(t *testing.T) {
 	}
 	_, err = manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey2.PublicKey().String(),
-		Meta: PeerSystemMeta{},
-		Name: "test-peer-2",
+		Meta: PeerSystemMeta{Hostname: "test-peer-2"},
 	})
 
 	if err != nil {
@@ -165,8 +163,7 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 
 	peer1, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey1.PublicKey().String(),
-		Meta: PeerSystemMeta{},
-		Name: "test-peer-2",
+		Meta: PeerSystemMeta{Hostname: "test-peer-1"},
 	})
 
 	if err != nil {
@@ -181,8 +178,7 @@ func TestAccountManager_GetNetworkMapWithRule(t *testing.T) {
 	}
 	peer2, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey2.PublicKey().String(),
-		Meta: PeerSystemMeta{},
-		Name: "test-peer-2",
+		Meta: PeerSystemMeta{Hostname: "test-peer-2"},
 	})
 
 	if err != nil {
@@ -334,8 +330,7 @@ func TestAccountManager_GetPeerNetwork(t *testing.T) {
 
 	peer1, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey1.PublicKey().String(),
-		Meta: PeerSystemMeta{},
-		Name: "test-peer-2",
+		Meta: PeerSystemMeta{Hostname: "test-peer-1"},
 	})
 
 	if err != nil {
@@ -350,8 +345,7 @@ func TestAccountManager_GetPeerNetwork(t *testing.T) {
 	}
 	_, err = manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey2.PublicKey().String(),
-		Meta: PeerSystemMeta{},
-		Name: "test-peer-2",
+		Meta: PeerSystemMeta{Hostname: "test-peer-2"},
 	})
 
 	if err != nil {
@@ -403,8 +397,7 @@ func TestDefaultAccountManager_GetPeer(t *testing.T) {
 
 	peer1, err := manager.AddPeer("", someUser, &Peer{
 		Key:  peerKey1.PublicKey().String(),
-		Meta: PeerSystemMeta{},
-		Name: "test-peer-2",
+		Meta: PeerSystemMeta{Hostname: "test-peer-2"},
 	})
 
 	if err != nil {
@@ -421,8 +414,7 @@ func TestDefaultAccountManager_GetPeer(t *testing.T) {
 	// the second peer added with a setup key
 	peer2, err := manager.AddPeer(setupKey.Key, "", &Peer{
 		Key:  peerKey2.PublicKey().String(),
-		Meta: PeerSystemMeta{},
-		Name: "test-peer-2",
+		Meta: PeerSystemMeta{Hostname: "test-peer-2"},
 	})
 
 	if err != nil {

--- a/management/server/status/error.go
+++ b/management/server/status/error.go
@@ -31,6 +31,9 @@ const (
 
 	// BadRequest indicates that user is not authorized
 	BadRequest Type = 9
+
+	// Unauthenticated indicates that user is not authenticated due to absence of valid credentials
+	Unauthenticated Type = 10
 )
 
 // Type is a type of the Error


### PR DESCRIPTION
## Describe your changes

The Management gRPC API has too much of a business logic happening while it has to be in the Account manager. 
This also makes too many requests to the store through the account manager.  

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
