### PR TITLE
Remove stale peer indices when getting peer by key after removing

### DIFF
--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -353,7 +353,7 @@ func (s *FileStore) GetAccountByPeerID(peerID string) (*Account, error) {
 		return nil, err
 	}
 
-	// this protection is needed because when we delete a peer, we don't really remove index peerKey -> accountID.
+	// this protection is needed because when we delete a peer, we don't really remove index peerID -> accountID.
 	// check Account.Peers for a match
 	if _, ok := account.Peers[peerID]; !ok {
 		delete(s.PeerID2AccountID, peerID)


### PR DESCRIPTION
## Describe your changes

When we delete a peer from an account, we save the account in the file store.
The file store maintains peerID -> accountID and peerKey -> accountID indices.
Those can't be updated when we delete a peer because the store saves the whole account
without a peer already and has no access to the removed peer.
In this PR, we dynamically check if there are stale indices when GetAccountByPeerPubKey 
and GetAccountByPeerID.    

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
