### PR TITLE
Use global login expiration setting when sending network map

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -314,7 +314,7 @@ func (a *Account) GetPeerNetworkMap(peerID, dnsDomain string) *NetworkMap {
 	var expiredPeers []*Peer
 	for _, p := range aclPeers {
 		expired, _ := p.LoginExpired(a.Settings.PeerLoginExpiration)
-		if expired {
+		if a.Settings.PeerLoginExpirationEnabled && expired {
 			expiredPeers = append(expiredPeers, p)
 			continue
 		}

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -140,7 +140,7 @@ func restore(file string) (*FileStore, error) {
 		// Swap Peer.Key with Peer.ID in the Account.Peers map.
 		migrationPeers := make(map[string]*Peer) // key to Peer
 		for key, peer := range account.Peers {
-			// set LastLogin for the peers that were onboarded before the peer logi nexpiration feature
+			// set LastLogin for the peers that were onboarded before the peer login expiration feature
 			if peer.LastLogin.IsZero() && peer.AddedWithSSOLogin() {
 				peer.LastLogin = time.Now()
 			}

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -140,6 +140,10 @@ func restore(file string) (*FileStore, error) {
 		// Swap Peer.Key with Peer.ID in the Account.Peers map.
 		migrationPeers := make(map[string]*Peer) // key to Peer
 		for key, peer := range account.Peers {
+			// set LastLogin for the peers that were onboarded before the peer logi nexpiration feature
+			if peer.LastLogin.IsZero() && peer.AddedWithSSOLogin() {
+				peer.LastLogin = time.Now()
+			}
 			if peer.ID != "" {
 				continue
 			}

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -141,7 +141,7 @@ func restore(file string) (*FileStore, error) {
 		migrationPeers := make(map[string]*Peer) // key to Peer
 		for key, peer := range account.Peers {
 			// set LastLogin for the peers that were onboarded before the peer login expiration feature
-			if peer.LastLogin.IsZero() && peer.AddedWithSSOLogin() {
+			if peer.LastLogin.IsZero() {
 				peer.LastLogin = time.Now()
 			}
 			if peer.ID != "" {

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -244,7 +244,7 @@ func Test_SyncProtocol(t *testing.T) {
 	}
 
 	if len(networkMap.GetRemotePeers()) != 3 {
-		t.Fatal("expecting SyncResponse to have NetworkMap with 3 remote peers")
+		t.Fatalf("expecting SyncResponse to have NetworkMap with 3 remote peers, got %d", len(networkMap.GetRemotePeers()))
 	}
 
 	// expired peers come separately.

--- a/management/server/testdata/store_with_expired_peers.json
+++ b/management/server/testdata/store_with_expired_peers.json
@@ -5,6 +5,10 @@
             "Domain": "test.com",
             "DomainCategory": "private",
             "IsDomainPrimaryAccount": true,
+            "Settings": {
+                "PeerLoginExpirationEnabled": true,
+                "PeerLoginExpiration": 3600000000000
+            },
             "SetupKeys": {
                 "A2C8E62B-38F5-4553-B31E-DD66C696CEBB": {
                     "Key": "A2C8E62B-38F5-4553-B31E-DD66C696CEBB",


### PR DESCRIPTION
## Describe your changes

Peers were considered expired and not sent to remote peers
when global expiration was disabled.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
