### PR TITLE
Fix connstate indication

### DIFF
--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -94,7 +94,7 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command) error {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
 	SetupCloseHandler(ctx, cancel)
-	return internal.RunClient(ctx, config, peer.NewRecorder())
+	return internal.RunClient(ctx, config, peer.NewRecorder(config.ManagementURL.String()))
 }
 
 func runInDaemonMode(ctx context.Context, cmd *cobra.Command) error {

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -80,6 +80,9 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 
 		log.Debugf("conecting to the Management service %s", config.ManagementURL.Host)
 		mgmClient, err := mgm.NewClient(engineCtx, config.ManagementURL.Host, myPrivateKey, mgmTlsEnabled)
+		mgmNotifier := statusRecorderToMgmConnStateNotifier(statusRecorder)
+		mgmClient.SetConnStateListener(mgmNotifier)
+
 		if err != nil {
 			return wrapErr(gstatus.Errorf(codes.FailedPrecondition, "failed connecting to Management Service : %s", err))
 		}
@@ -319,4 +322,10 @@ func UpdateOldManagementPort(ctx context.Context, config *Config, configPath str
 	}
 
 	return config, nil
+}
+
+func statusRecorderToMgmConnStateNotifier(statusRecorder *peer.Status) mgm.ConnStateNotifier {
+	var sri interface{} = statusRecorder
+	mgmNotifier, _ := sri.(mgm.ConnStateNotifier)
+	return mgmNotifier
 }

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -58,8 +58,7 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 		return err
 	}
 
-	managementURL := config.ManagementURL.String()
-	statusRecorder.MarkManagementDisconnected(managementURL)
+	statusRecorder.MarkManagementDisconnected()
 
 	operation := func() error {
 		// if context cancelled we not start new backoff cycle
@@ -73,7 +72,7 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 
 		engineCtx, cancel := context.WithCancel(ctx)
 		defer func() {
-			statusRecorder.MarkManagementDisconnected(managementURL)
+			statusRecorder.MarkManagementDisconnected()
 			statusRecorder.CleanLocalPeerState()
 			cancel()
 		}()
@@ -104,7 +103,7 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 			}
 			return wrapErr(err)
 		}
-		statusRecorder.MarkManagementConnected(managementURL)
+		statusRecorder.MarkManagementConnected()
 
 		localPeerState := peer.LocalPeerState{
 			IP:              loginResp.GetPeerConfig().GetAddress(),
@@ -119,6 +118,8 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 			strings.ToLower(loginResp.GetWiretrusteeConfig().GetSignal().GetProtocol().String()),
 			loginResp.GetWiretrusteeConfig().GetSignal().GetUri(),
 		)
+
+		statusRecorder.UpdateSignalAddress(signalURL)
 
 		statusRecorder.MarkSignalDisconnected(signalURL)
 		defer statusRecorder.MarkSignalDisconnected(signalURL)

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -121,8 +121,8 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 
 		statusRecorder.UpdateSignalAddress(signalURL)
 
-		statusRecorder.MarkSignalDisconnected(signalURL)
-		defer statusRecorder.MarkSignalDisconnected(signalURL)
+		statusRecorder.MarkSignalDisconnected()
+		defer statusRecorder.MarkSignalDisconnected()
 
 		// with the global Wiretrustee config in hand connect (just a connection, no stream yet) Signal
 		signalClient, err := connectToSignal(engineCtx, loginResp.GetWiretrusteeConfig(), myPrivateKey)
@@ -137,7 +137,10 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 			}
 		}()
 
-		statusRecorder.MarkSignalConnected(signalURL)
+		signalNotifier := statusRecorderToSignalConnStateNotifier(statusRecorder)
+		signalClient.SetConnStateListener(signalNotifier)
+
+		statusRecorder.MarkSignalConnected()
 
 		peerConfig := loginResp.GetPeerConfig()
 
@@ -329,4 +332,10 @@ func statusRecorderToMgmConnStateNotifier(statusRecorder *peer.Status) mgm.ConnS
 	var sri interface{} = statusRecorder
 	mgmNotifier, _ := sri.(mgm.ConnStateNotifier)
 	return mgmNotifier
+}
+
+func statusRecorderToSignalConnStateNotifier(statusRecorder *peer.Status) signal.ConnStateNotifier {
+	var sri interface{} = statusRecorder
+	notifier, _ := sri.(signal.ConnStateNotifier)
+	return notifier
 }

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -72,7 +72,7 @@ func TestEngine_SSH(t *testing.T) {
 		WgAddr:       "100.64.0.1/24",
 		WgPrivateKey: key,
 		WgPort:       33100,
-	}, peer.NewRecorder())
+	}, peer.NewRecorder("https://mgm"))
 
 	engine.dnsServer = &dns.MockServer{
 		UpdateDNSServerFunc: func(serial uint64, update nbdns.Config) error { return nil },
@@ -206,7 +206,7 @@ func TestEngine_UpdateNetworkMap(t *testing.T) {
 		WgAddr:       "100.64.0.1/24",
 		WgPrivateKey: key,
 		WgPort:       33100,
-	}, peer.NewRecorder())
+	}, peer.NewRecorder("https://mgm"))
 	engine.wgInterface, err = iface.NewWGIFace("utun102", "100.64.0.1/24", iface.DefaultMTU)
 	engine.routeManager = routemanager.NewManager(ctx, key.PublicKey().String(), engine.wgInterface, engine.statusRecorder)
 	engine.dnsServer = &dns.MockServer{
@@ -390,7 +390,7 @@ func TestEngine_Sync(t *testing.T) {
 		WgAddr:       "100.64.0.1/24",
 		WgPrivateKey: key,
 		WgPort:       33100,
-	}, peer.NewRecorder())
+	}, peer.NewRecorder("https://mgm"))
 
 	engine.dnsServer = &dns.MockServer{
 		UpdateDNSServerFunc: func(serial uint64, update nbdns.Config) error { return nil },
@@ -713,7 +713,7 @@ func TestEngine_UpdateNetworkMapWithDNSUpdate(t *testing.T) {
 				WgAddr:       wgAddr,
 				WgPrivateKey: key,
 				WgPort:       33100,
-			}, peer.NewRecorder())
+			}, peer.NewRecorder("https://mgm"))
 			engine.wgInterface, err = iface.NewWGIFace(wgIfaceName, wgAddr, iface.DefaultMTU)
 			assert.NoError(t, err, "shouldn't return error")
 

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -548,7 +548,7 @@ func TestEngine_UpdateNetworkMapWithRoutes(t *testing.T) {
 				WgAddr:       wgAddr,
 				WgPrivateKey: key,
 				WgPort:       33100,
-			}, peer.NewRecorder())
+			}, peer.NewRecorder("https://mgm"))
 			engine.wgInterface, err = iface.NewWGIFace(wgIfaceName, wgAddr, iface.DefaultMTU)
 			assert.NoError(t, err, "shouldn't return error")
 			input := struct {
@@ -978,7 +978,7 @@ func createEngine(ctx context.Context, cancel context.CancelFunc, setupKey strin
 		WgPort:       wgPort,
 	}
 
-	return NewEngine(ctx, cancel, signalClient, mgmtClient, conf, peer.NewRecorder()), nil
+	return NewEngine(ctx, cancel, signalClient, mgmtClient, conf, peer.NewRecorder("https://mgm")), nil
 }
 
 func startSignal() (*grpc.Server, string, error) {

--- a/client/internal/peer/conn_test.go
+++ b/client/internal/peer/conn_test.go
@@ -47,7 +47,7 @@ func TestConn_GetKey(t *testing.T) {
 
 func TestConn_OnRemoteOffer(t *testing.T) {
 
-	conn, err := NewConn(connConf, NewRecorder())
+	conn, err := NewConn(connConf, NewRecorder("https://mgm"))
 	if err != nil {
 		return
 	}
@@ -81,7 +81,7 @@ func TestConn_OnRemoteOffer(t *testing.T) {
 
 func TestConn_OnRemoteAnswer(t *testing.T) {
 
-	conn, err := NewConn(connConf, NewRecorder())
+	conn, err := NewConn(connConf, NewRecorder("https://mgm"))
 	if err != nil {
 		return
 	}
@@ -114,7 +114,7 @@ func TestConn_OnRemoteAnswer(t *testing.T) {
 }
 func TestConn_Status(t *testing.T) {
 
-	conn, err := NewConn(connConf, NewRecorder())
+	conn, err := NewConn(connConf, NewRecorder("https://mgm"))
 	if err != nil {
 		return
 	}
@@ -141,7 +141,7 @@ func TestConn_Status(t *testing.T) {
 
 func TestConn_Close(t *testing.T) {
 
-	conn, err := NewConn(connConf, NewRecorder())
+	conn, err := NewConn(connConf, NewRecorder("https://mgm"))
 	if err != nil {
 		return
 	}

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -52,11 +52,12 @@ type Status struct {
 	mux             sync.Mutex
 	peers           map[string]State
 	changeNotify    map[string]chan struct{}
-	signalState     SignalState
+	signalState     bool
 	managementState bool
 	localPeer       LocalPeerState
 	offlinePeers    []State
 	mgmAddress      string
+	signalAddress   string
 }
 
 // NewRecorder returns a new Status instance
@@ -208,24 +209,24 @@ func (d *Status) MarkManagementConnected() {
 	d.managementState = true
 }
 
-// MarkSignalDisconnected sets SignalState to disconnected
-func (d *Status) MarkSignalDisconnected(signalURL string) {
+func (d *Status) UpdateSignalAddress(signalURL string) {
 	d.mux.Lock()
 	defer d.mux.Unlock()
-	d.signalState = SignalState{
-		signalURL,
-		false,
-	}
+	d.signalAddress = signalURL
+}
+
+// MarkSignalDisconnected sets SignalState to disconnected
+func (d *Status) MarkSignalDisconnected() {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+	d.signalState = false
 }
 
 // MarkSignalConnected sets SignalState to connected
-func (d *Status) MarkSignalConnected(signalURL string) {
+func (d *Status) MarkSignalConnected() {
 	d.mux.Lock()
 	defer d.mux.Unlock()
-	d.signalState = SignalState{
-		signalURL,
-		true,
-	}
+	d.signalState = true
 }
 
 // GetFullStatus gets full status
@@ -238,7 +239,10 @@ func (d *Status) GetFullStatus() FullStatus {
 			d.mgmAddress,
 			d.managementState,
 		},
-		SignalState:    d.signalState,
+		SignalState: SignalState{
+			d.signalAddress,
+			d.signalState,
+		},
 		LocalPeerState: d.localPeer,
 	}
 

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -209,6 +209,7 @@ func (d *Status) MarkManagementConnected() {
 	d.managementState = true
 }
 
+// UpdateSignalAddress update the address of the signal server
 func (d *Status) UpdateSignalAddress(signalURL string) {
 	d.mux.Lock()
 	defer d.mux.Unlock()

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -216,6 +216,13 @@ func (d *Status) UpdateSignalAddress(signalURL string) {
 	d.signalAddress = signalURL
 }
 
+// UpdateManagementAddress update the address of the management server
+func (d *Status) UpdateManagementAddress(mgmAddress string) {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+	d.mgmAddress = mgmAddress
+}
+
 // MarkSignalDisconnected sets SignalState to disconnected
 func (d *Status) MarkSignalDisconnected() {
 	d.mux.Lock()

--- a/client/internal/peer/status_test.go
+++ b/client/internal/peer/status_test.go
@@ -173,7 +173,7 @@ func TestUpdateSignalState(t *testing.T) {
 			} else {
 				status.MarkSignalDisconnected(url)
 			}
-			assert.Equal(t, test.want, status.signal, "signal status should be equal")
+			assert.Equal(t, test.want, status.signalState, "signal status should be equal")
 		})
 	}
 }
@@ -205,7 +205,7 @@ func TestUpdateManagementState(t *testing.T) {
 			} else {
 				status.MarkManagementDisconnected(url)
 			}
-			assert.Equal(t, test.want, status.management, "signal status should be equal")
+			assert.Equal(t, test.want, status.managementState, "signalState status should be equal")
 		})
 	}
 }
@@ -231,8 +231,8 @@ func TestGetFullStatus(t *testing.T) {
 
 	status := NewRecorder()
 
-	status.management = managementState
-	status.signal = signalState
+	status.managementState = managementState
+	status.signalState = signalState
 	status.peers[key1] = peerState1
 	status.peers[key2] = peerState2
 

--- a/client/internal/routemanager/manager_test.go
+++ b/client/internal/routemanager/manager_test.go
@@ -398,7 +398,7 @@ func TestManagerUpdateRoutes(t *testing.T) {
 			err = wgInterface.Create()
 			require.NoError(t, err, "should create testing wireguard interface")
 
-			statusRecorder := peer.NewRecorder()
+			statusRecorder := peer.NewRecorder("https://mgm")
 			ctx := context.TODO()
 			routeManager := NewManager(ctx, localPeerKey, wgInterface, statusRecorder)
 			defer routeManager.Stop()

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -97,6 +97,8 @@ func (s *Server) Start() error {
 
 	if s.statusRecorder == nil {
 		s.statusRecorder = peer.NewRecorder(config.ManagementURL.String())
+	} else {
+		s.statusRecorder.UpdateManagementAddress(config.ManagementURL.String())
 	}
 
 	go func() {
@@ -387,6 +389,8 @@ func (s *Server) Up(callerCtx context.Context, _ *proto.UpRequest) (*proto.UpRes
 
 	if s.statusRecorder == nil {
 		s.statusRecorder = peer.NewRecorder(s.config.ManagementURL.String())
+	} else {
+		s.statusRecorder.UpdateManagementAddress(s.config.ManagementURL.String())
 	}
 
 	go func() {
@@ -431,6 +435,8 @@ func (s *Server) Status(
 
 	if s.statusRecorder == nil {
 		s.statusRecorder = peer.NewRecorder(s.config.ManagementURL.String())
+	} else {
+		s.statusRecorder.UpdateManagementAddress(s.config.ManagementURL.String())
 	}
 
 	if msg.GetFullPeerStatus {

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -96,7 +96,7 @@ func (s *Server) Start() error {
 	s.config = config
 
 	if s.statusRecorder == nil {
-		s.statusRecorder = peer.NewRecorder()
+		s.statusRecorder = peer.NewRecorder(config.ManagementURL.String())
 	}
 
 	go func() {
@@ -386,7 +386,7 @@ func (s *Server) Up(callerCtx context.Context, _ *proto.UpRequest) (*proto.UpRes
 	}
 
 	if s.statusRecorder == nil {
-		s.statusRecorder = peer.NewRecorder()
+		s.statusRecorder = peer.NewRecorder(s.config.ManagementURL.String())
 	}
 
 	go func() {
@@ -430,7 +430,7 @@ func (s *Server) Status(
 	statusResponse := proto.StatusResponse{Status: string(status), DaemonVersion: system.NetbirdVersion()}
 
 	if s.statusRecorder == nil {
-		s.statusRecorder = peer.NewRecorder()
+		s.statusRecorder = peer.NewRecorder(s.config.ManagementURL.String())
 	}
 
 	if msg.GetFullPeerStatus {

--- a/management/client/grpc.go
+++ b/management/client/grpc.go
@@ -26,8 +26,8 @@ import (
 )
 
 type ConnStateNotifier interface {
-	MarkManagementDisconnected(signalURL string)
-	MarkManagementConnected(signalURL string)
+	MarkManagementDisconnected()
+	MarkManagementConnected()
 }
 
 type GrpcClient struct {
@@ -322,7 +322,7 @@ func (c *GrpcClient) notifyDisconnected() {
 	if c.connStateCallback == nil {
 		return
 	}
-	c.connStateCallback.MarkManagementConnected(c.conn.Target())
+	c.connStateCallback.MarkManagementDisconnected()
 }
 
 func (c *GrpcClient) notifyConnected() {
@@ -332,7 +332,7 @@ func (c *GrpcClient) notifyConnected() {
 	if c.connStateCallback == nil {
 		return
 	}
-	c.connStateCallback.MarkManagementConnected(c.conn.Target())
+	c.connStateCallback.MarkManagementConnected()
 }
 
 func infoToMetaData(info *system.Info) *proto.PeerSystemMeta {

--- a/management/client/grpc.go
+++ b/management/client/grpc.go
@@ -66,10 +66,11 @@ func NewClient(ctx context.Context, addr string, ourPrivateKey wgtypes.Key, tlsE
 	realClient := proto.NewManagementServiceClient(conn)
 
 	return &GrpcClient{
-		key:        ourPrivateKey,
-		realClient: realClient,
-		ctx:        ctx,
-		conn:       conn,
+		key:                   ourPrivateKey,
+		realClient:            realClient,
+		ctx:                   ctx,
+		conn:                  conn,
+		connStateCallbackLock: sync.RWMutex{},
 	}, nil
 }
 

--- a/management/client/grpc.go
+++ b/management/client/grpc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/netbirdio/netbird/management/proto"
 )
 
+// ConnStateNotifier is a wrapper interface of the status recorders
 type ConnStateNotifier interface {
 	MarkManagementDisconnected()
 	MarkManagementConnected()
@@ -79,6 +80,7 @@ func (c *GrpcClient) Close() error {
 	return c.conn.Close()
 }
 
+// SetConnStateListener set the ConnStateNotifier
 func (c *GrpcClient) SetConnStateListener(notifier ConnStateNotifier) {
 	c.connStateCallbackLock.Lock()
 	defer c.connStateCallbackLock.Unlock()

--- a/signal/client/grpc.go
+++ b/signal/client/grpc.go
@@ -22,6 +22,11 @@ import (
 	"time"
 )
 
+type ConnStateNotifier interface {
+	MarkSignalDisconnected()
+	MarkSignalConnected()
+}
+
 // GrpcClient Wraps the Signal Exchange Service gRpc client
 type GrpcClient struct {
 	key        wgtypes.Key
@@ -34,6 +39,9 @@ type GrpcClient struct {
 	mux         sync.Mutex
 	// StreamConnected indicates whether this client is StreamConnected to the Signal stream
 	status Status
+
+	connStateCallback     ConnStateNotifier
+	connStateCallbackLock sync.RWMutex
 }
 
 func (c *GrpcClient) StreamConnected() bool {
@@ -78,13 +86,20 @@ func NewClient(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled boo
 	log.Debugf("connected to Signal Service: %v", conn.Target())
 
 	return &GrpcClient{
-		realClient: proto.NewSignalExchangeClient(conn),
-		ctx:        ctx,
-		signalConn: conn,
-		key:        key,
-		mux:        sync.Mutex{},
-		status:     StreamDisconnected,
+		realClient:            proto.NewSignalExchangeClient(conn),
+		ctx:                   ctx,
+		signalConn:            conn,
+		key:                   key,
+		mux:                   sync.Mutex{},
+		status:                StreamDisconnected,
+		connStateCallbackLock: sync.RWMutex{},
 	}, nil
+}
+
+func (c *GrpcClient) SetConnStateListener(notifier ConnStateNotifier) {
+	c.connStateCallbackLock.Lock()
+	defer c.connStateCallbackLock.Unlock()
+	c.connStateCallback = notifier
 }
 
 // defaultBackoff is a basic backoff mechanism for general issues
@@ -134,13 +149,14 @@ func (c *GrpcClient) Receive(msgHandler func(msg *proto.Message) error) error {
 		c.notifyStreamConnected()
 
 		log.Infof("connected to the Signal Service stream")
-
+		c.notifyConnected()
 		// start receiving messages from the Signal stream (from other peers through signal)
 		err = c.receive(stream, msgHandler)
 		if err != nil {
 			// we need this reset because after a successful connection and a consequent error, backoff lib doesn't
 			// reset times and next try will start with a long delay
 			backOff.Reset()
+			c.notifyDisconnected()
 			log.Warnf("disconnected from the Signal service but will retry silently. Reason: %v", err)
 			return err
 		}
@@ -340,4 +356,24 @@ func (c *GrpcClient) receive(stream proto.SignalExchange_ConnectStreamClient,
 			//todo send something??
 		}
 	}
+}
+
+func (c *GrpcClient) notifyDisconnected() {
+	c.connStateCallbackLock.RLock()
+	defer c.connStateCallbackLock.RUnlock()
+
+	if c.connStateCallback == nil {
+		return
+	}
+	c.connStateCallback.MarkSignalDisconnected()
+}
+
+func (c *GrpcClient) notifyConnected() {
+	c.connStateCallbackLock.RLock()
+	defer c.connStateCallbackLock.RUnlock()
+
+	if c.connStateCallback == nil {
+		return
+	}
+	c.connStateCallback.MarkSignalConnected()
 }

--- a/signal/client/grpc.go
+++ b/signal/client/grpc.go
@@ -22,6 +22,7 @@ import (
 	"time"
 )
 
+// ConnStateNotifier is a wrapper interface of the status recorder
 type ConnStateNotifier interface {
 	MarkSignalDisconnected()
 	MarkSignalConnected()
@@ -96,6 +97,7 @@ func NewClient(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled boo
 	}, nil
 }
 
+// SetConnStateListener set the ConnStateNotifier
 func (c *GrpcClient) SetConnStateListener(notifier ConnStateNotifier) {
 	c.connStateCallbackLock.Lock()
 	defer c.connStateCallbackLock.Unlock()


### PR DESCRIPTION
## Describe your changes

Fix the status indication in the client service. The status of the 
management server and the signal server was incorrect if the network 
connection was broken. Basically the status update was not used by 
the management and signal library.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
