### PR TITLE
Don't drop Rules from file storage after migration to Policies

### DIFF
--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -124,7 +124,6 @@ func restore(file string) (*FileStore, error) {
 				}
 				account.Policies = append(account.Policies, policy)
 			}
-			account.Rules = nil
 		}
 
 		// for data migration. Can be removed once most base will be with labels
@@ -263,6 +262,15 @@ func (s *FileStore) SaveAccount(account *Account) error {
 
 	if accountCopy.DomainCategory == PrivateCategory && accountCopy.IsDomainPrimaryAccount {
 		s.PrivateDomain2AccountID[accountCopy.Domain] = accountCopy.Id
+	}
+
+	if accountCopy.Rules == nil {
+		accountCopy.Rules = make(map[string]*Rule)
+	}
+	for _, policy := range accountCopy.Policies {
+		for _, rule := range policy.Rules {
+			accountCopy.Rules[rule.ID] = rule.ToRule()
+		}
 	}
 
 	return s.persist(s.storeFile)


### PR DESCRIPTION
## Describe your changes
Rego policy migration clears the rules property of the file storage, but it does not allow rollback management upgrade, so this changes pre-saves rules in the file store and updates it from the policies.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
