### PR TITLE
Adjustments for the change server flow

### DIFF
--- a/client/android/login.go
+++ b/client/android/login.go
@@ -63,8 +63,9 @@ func (a *Auth) LoginAndSaveConfigIfSSOSupported() (bool, error) {
 		_, err = internal.GetDeviceAuthorizationFlowInfo(a.ctx, a.config.PrivateKey, a.config.ManagementURL)
 		if s, ok := gstatus.FromError(err); ok && s.Code() == codes.NotFound {
 			supportsSSO = false
+			err = nil
 		}
-		return
+		return err
 	})
 
 	if !supportsSSO {

--- a/client/android/login.go
+++ b/client/android/login.go
@@ -84,6 +84,7 @@ func (a *Auth) SaveConfigIfSSOSupported() (bool, error) {
 
 // LoginWithSetupKeyAndSaveConfig test the connectivity with the management server with the setup key.
 func (a *Auth) LoginWithSetupKeyAndSaveConfig(setupKey string, deviceName string) error {
+	//nolint
 	ctxWithValues := context.WithValue(a.ctx, system.DeviceNameCtxKey, deviceName)
 
 	err := a.withBackOff(a.ctx, func() error {

--- a/client/android/login.go
+++ b/client/android/login.go
@@ -68,7 +68,7 @@ func (a *Auth) LoginAndSaveConfigIfSSOSupported() (bool, error) {
 	})
 
 	if !supportsSSO {
-		return true, nil
+		return false, nil
 	}
 
 	if err != nil {

--- a/client/system/info_android.go
+++ b/client/system/info_android.go
@@ -34,7 +34,7 @@ func GetInfo(ctx context.Context) *Info {
 func extractDeviceName(ctx context.Context) string {
 	v, ok := ctx.Value(DeviceNameCtxKey).(string)
 	if !ok {
-		return ""
+		return "android"
 	}
 	return v
 }

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -3,9 +3,10 @@ package server
 import (
 	"context"
 	"fmt"
-	pb "github.com/golang/protobuf/proto" //nolint
 	"strings"
 	"time"
+
+	pb "github.com/golang/protobuf/proto" //nolint
 
 	"github.com/netbirdio/netbird/management/server/telemetry"
 
@@ -13,14 +14,15 @@ import (
 	"github.com/netbirdio/netbird/management/server/jwtclaims"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/netbirdio/netbird/encryption"
-	"github.com/netbirdio/netbird/management/proto"
-	internalStatus "github.com/netbirdio/netbird/management/server/status"
 	log "github.com/sirupsen/logrus"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"google.golang.org/grpc/codes"
 	gRPCPeer "google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+
+	"github.com/netbirdio/netbird/encryption"
+	"github.com/netbirdio/netbird/management/proto"
+	internalStatus "github.com/netbirdio/netbird/management/server/status"
 )
 
 // GRPCServer an instance of a Management gRPC API server
@@ -222,7 +224,7 @@ func mapError(err error) error {
 		default:
 		}
 	}
-	return status.Errorf(codes.Internal, "failed handling request")
+	return status.Errorf(codes.Internal, "failed handling request, error: %s", err)
 }
 
 func extractPeerMeta(loginReq *proto.LoginRequest) PeerSystemMeta {

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -224,7 +224,8 @@ func mapError(err error) error {
 		default:
 		}
 	}
-	return status.Errorf(codes.Internal, "failed handling request, error: %s", err)
+	log.Errorf("got an unhandled error: %s", err)
+	return status.Errorf(codes.Internal, "failed handling request")
 }
 
 func extractPeerMeta(loginReq *proto.LoginRequest) PeerSystemMeta {


### PR DESCRIPTION
## Describe your changes

* Check SSO support by calling the internal.GetDeviceAuthorizationFlowInfo
* Rename LoginSaveConfigIfSSOSupported to SaveConfigIfSSOSupported
* Receive device name as input for setup-key login
* have a default android name when no context value is provided
* log non parsed errors from management registration calls

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
