### PR TITLE
Add fqdn and address for notification listener

### DIFF
--- a/client/internal/peer/listener.go
+++ b/client/internal/peer/listener.go
@@ -5,5 +5,6 @@ type Listener interface {
 	OnConnected()
 	OnDisconnected()
 	OnConnecting()
+	OnAddressChanged(string, string)
 	OnPeersListChanged(int)
 }

--- a/client/internal/peer/notifier.go
+++ b/client/internal/peer/notifier.go
@@ -122,3 +122,12 @@ func (n *notifier) peerListChanged(numOfPeers int) {
 		l.OnPeersListChanged(numOfPeers)
 	}
 }
+
+func (n *notifier) localAddressChanged(fqdn, address string) {
+	n.listenersLock.Lock()
+	defer n.listenersLock.Unlock()
+
+	for l := range n.listeners {
+		l.OnAddressChanged(fqdn, address)
+	}
+}

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -190,6 +190,7 @@ func (d *Status) UpdateLocalPeerState(localPeerState LocalPeerState) {
 	defer d.mux.Unlock()
 
 	d.localPeer = localPeerState
+	d.notifyAddressChanged()
 }
 
 // CleanLocalPeerState cleans local peer status
@@ -198,6 +199,7 @@ func (d *Status) CleanLocalPeerState() {
 	defer d.mux.Unlock()
 
 	d.localPeer = LocalPeerState{}
+	d.notifyAddressChanged()
 }
 
 // MarkManagementDisconnected sets ManagementState to disconnected
@@ -215,7 +217,7 @@ func (d *Status) MarkManagementConnected() {
 	defer d.mux.Unlock()
 	defer d.onConnectionChanged()
 
-    d.managementState = true
+	d.managementState = true
 }
 
 // UpdateSignalAddress update the address of the signal server
@@ -238,7 +240,7 @@ func (d *Status) MarkSignalDisconnected() {
 	defer d.mux.Unlock()
 	defer d.onConnectionChanged()
 
-    d.signalState = false
+	d.signalState = false
 }
 
 // MarkSignalConnected sets SignalState to connected
@@ -302,4 +304,8 @@ func (d *Status) onConnectionChanged() {
 
 func (d *Status) notifyPeerListChanged() {
 	d.notifier.peerListChanged(len(d.peers))
+}
+
+func (d *Status) notifyAddressChanged() {
+	d.notifier.localAddressChanged(d.localPeer.FQDN, d.localPeer.IP)
 }


### PR DESCRIPTION
## Describe your changes

Extend the status notification listeners with FQDN and address 
changes. It is required for mobile services.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
