### PR TITLE
Fix nil pointer exception when create config

### DIFF
--- a/client/server/server.go
+++ b/client/server/server.go
@@ -78,7 +78,7 @@ func (s *Server) Start() error {
 	// on failure we return error to retry
 	config, err := internal.UpdateConfig(s.latestConfigInput)
 	if errorStatus, ok := gstatus.FromError(err); ok && errorStatus.Code() == codes.NotFound {
-		config, err = internal.UpdateOrCreateConfig(s.latestConfigInput)
+		s.config, err = internal.UpdateOrCreateConfig(s.latestConfigInput)
 		if err != nil {
 			log.Warnf("unable to create configuration file: %v", err)
 			return err


### PR DESCRIPTION
## Describe your changes

The config stored in a wrong variable when has been generated a 
new config

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/764

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
