### PR TITLE
Fix pre-shared key query name for android wg configuration

### DIFF
--- a/iface/ipc_parser_android.go
+++ b/iface/ipc_parser_android.go
@@ -33,7 +33,7 @@ func toWgUserspaceString(wgCfg wgtypes.Config) string {
 
 		if p.PresharedKey != nil {
 			preSharedHexKey := hex.EncodeToString(p.PresharedKey[:])
-			sb.WriteString(fmt.Sprintf("public_key=%s\n", preSharedHexKey))
+			sb.WriteString(fmt.Sprintf("preshared_key=%s\n", preSharedHexKey))
 		}
 
 		if p.Remove {


### PR DESCRIPTION
## Describe your changes
update the query name to fix setting preshared key request

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
