### PR TITLE
Add single line installer

### DIFF
--- a/.github/workflows/install-test-darwin.yml
+++ b/.github/workflows/install-test-darwin.yml
@@ -1,12 +1,10 @@
 name: Test installation script
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    paths:
-      - "release_files/install.sh"
-  push:
+  pull_request:
     paths:
       - "release_files/install.sh"
 
@@ -17,9 +15,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Rename brew package
+        if: ${{ matrix.check_bin_install }}
+        run: mv /opt/homebrew/bin/brew /opt/homebrew/bin/brew.bak
+
       - name: Run install script
         run: |
-          sudo sh ./release_files/install.sh
+          sh ./release_files/install.sh
         env:
           SKIP_UI_APP: true
 
@@ -35,9 +37,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Rename brew package
+        if: ${{ matrix.check_bin_install }}
+        run: mv /opt/homebrew/bin/brew /opt/homebrew/bin/brew.bak
+
       - name: Run install script
         run: |
-          sudo sh ./release_files/install.sh
+          sh ./release_files/install.sh
 
       - name: Run tests
         run: |

--- a/.github/workflows/install-test-darwin.yml
+++ b/.github/workflows/install-test-darwin.yml
@@ -1,4 +1,4 @@
-name: Test installation script
+name: Test installation Darwin
 
 on:
   push:

--- a/.github/workflows/install-test-darwin.yml
+++ b/.github/workflows/install-test-darwin.yml
@@ -1,0 +1,52 @@
+name: Test installation script
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "release_files/install.sh"
+  push:
+    paths:
+      - "release_files/install.sh"
+
+jobs:
+  install-cli-only:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run install script
+        run: |
+          sudo sh ./release_files/install.sh
+        env:
+          SKIP_UI_APP: true
+
+      - name: Run tests
+        run: |
+          if ! command -v netbird &> /dev/null; then
+            echo "Error: netbird is not installed"
+            exit 1
+          fi
+  install-all:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run install script
+        run: |
+          sudo sh ./release_files/install.sh
+
+      - name: Run tests
+        run: |
+          if ! command -v netbird &> /dev/null; then
+              echo "Error: netbird is not installed"
+              exit 1
+          fi
+
+          if [[ $(mdfind "kMDItemContentType == 'com.apple.application-bundle' && kMDItemFSName == '*NetBird UI.app'") ]]; then
+            echo "Error: NetBird UI is not installed"
+            exit 1
+          fi

--- a/.github/workflows/install-test-linux.yml
+++ b/.github/workflows/install-test-linux.yml
@@ -1,4 +1,4 @@
-name: Test installation script
+name: Test installation Linux
 
 on:
   push:
@@ -21,8 +21,8 @@ jobs:
       - name: Rename apt package
         if: ${{ matrix.check_bin_install }}
         run: |
-          mv /usr/bin/apt /usr/bin/apt.bak
-          mv /usr/bin/apt-get /usr/bin/apt-get.bak
+          sudo mv /usr/bin/apt /usr/bin/apt.bak
+          sudo mv /usr/bin/apt-get /usr/bin/apt-get.bak
 
       - name: Run install script
         run: |

--- a/.github/workflows/install-test-linux.yml
+++ b/.github/workflows/install-test-linux.yml
@@ -1,54 +1,36 @@
 name: Test installation script
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    paths:
-      - "release_files/install.sh"
-  push:
+  pull_request:
     paths:
       - "release_files/install.sh"
 
 jobs:
   install-cli-only:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        check_bin_install: [true, false]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Rename apt package
+        if: ${{ matrix.check_bin_install }}
+        run: |
+          mv /usr/bin/apt /usr/bin/apt.bak
+          mv /usr/bin/apt-get /usr/bin/apt-get.bak
+
       - name: Run install script
         run: |
-          sudo sh ./release_files/install.sh
-        env:
-          SKIP_UI_APP: true
+          sh ./release_files/install.sh
 
       - name: Run tests
         run: |
           if ! command -v netbird &> /dev/null; then
             echo "Error: netbird is not installed"
             exit 1
-          fi
-  install-all:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Run install script
-        run: |
-          sudo sh ./release_files/install.sh
-
-      - name: Run tests
-        run: |
-          if ! command -v netbird &> /dev/null; then
-              echo "Error: netbird is not installed"
-              exit 1
-          fi
-
-          if [ -z "$XDG_CURRENT_DESKTOP" ];then
-              if ! dpkg -s "NetBird UI" >/dev/null 2>&1; then
-                echo "Error: NetBird UI is not installed"
-                exit 1
-              fi
           fi

--- a/.github/workflows/install-test-linux.yml
+++ b/.github/workflows/install-test-linux.yml
@@ -1,0 +1,54 @@
+name: Test installation script
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "release_files/install.sh"
+  push:
+    paths:
+      - "release_files/install.sh"
+
+jobs:
+  install-cli-only:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run install script
+        run: |
+          sudo sh ./release_files/install.sh
+        env:
+          SKIP_UI_APP: true
+
+      - name: Run tests
+        run: |
+          if ! command -v netbird &> /dev/null; then
+            echo "Error: netbird is not installed"
+            exit 1
+          fi
+  install-all:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run install script
+        run: |
+          sudo sh ./release_files/install.sh
+
+      - name: Run tests
+        run: |
+          if ! command -v netbird &> /dev/null; then
+              echo "Error: netbird is not installed"
+              exit 1
+          fi
+
+          if [ -z "$XDG_CURRENT_DESKTOP" ];then
+              if ! dpkg -s "NetBird UI" >/dev/null 2>&1; then
+                echo "Error: NetBird UI is not installed"
+                exit 1
+              fi
+          fi

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -62,13 +62,13 @@ add_apt_repo() {
 }
 
 add_rpm_repo() {
-cat <<-EOF | sudo tee /etc/yum.repos.d/wiretrustee.repo
-[Wiretrustee]
-name=Wiretrustee
-baseurl=https://pkgs.wiretrustee.com/yum/
+cat <<-EOF | sudo tee /etc/yum.repos.d/netbird.repo
+[Netbird]
+name=Netbird
+baseurl=https://pkgs.netbird.io/yum/
 enabled=1
 gpgcheck=0
-gpgkey=https://pkgs.wiretrustee.com/yum/repodata/repomd.xml.key
+gpgkey=https://pkgs.netbird.io/yum/repodata/repomd.xml.key
 repo_gpgcheck=1
 EOF
 } 
@@ -211,7 +211,7 @@ install_netbird() {
     dnf)
         add_rpm_repo
         sudo dnf -y install dnf-plugin-config-manager
-        sudo dnf config-manager --add-repo /etc/yum.repos.d/wiretrustee.repo
+        sudo dnf config-manager --add-repo /etc/yum.repos.d/netbird.repo
         sudo dnf -y install netbird
 
         if ! $SKIP_UI_APP; then 

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -48,6 +48,19 @@ download_release_binary() {
     fi
 }
 
+add_apt_repo() {
+    sudo apt-get update
+    sudo apt-get install ca-certificates gnupg -y
+        
+    curl -sSL https://pkgs.wiretrustee.com/debian/public.key \
+    |  gpg --dearmor --output /usr/share/keyrings/wiretrustee-archive-keyring.gpg
+
+    APT_REPO="deb [signed-by=/usr/share/keyrings/wiretrustee-archive-keyring.gpg] https://pkgs.wiretrustee.com/debian stable main"
+    echo "$APT_REPO" | sudo tee /etc/apt/sources.list.d/wiretrustee.list
+
+    sudo apt-get update
+}
+
 add_rpm_repo() {
 cat <<-EOF | sudo tee /etc/yum.repos.d/wiretrustee.repo
 [Wiretrustee]
@@ -181,16 +194,7 @@ install_netbird() {
     # only the CLI will be installed
     case "$PACKAGE_MANAGER" in
     apt)
-        sudo apt-get update
-        sudo apt-get install ca-certificates gnupg -y
-        
-        curl -sSL https://pkgs.wiretrustee.com/debian/public.key \
-        |  gpg --dearmor --output /usr/share/keyrings/wiretrustee-archive-keyring.gpg
-
-        APT_REPO="deb [signed-by=/usr/share/keyrings/wiretrustee-archive-keyring.gpg] https://pkgs.wiretrustee.com/debian stable main"
-        echo "$APT_REPO" | sudo tee /etc/apt/sources.list.d/wiretrustee.list
-
-        sudo apt-get update
+        add_apt_repo
         sudo apt-get install netbird -y
         
         if ! $SKIP_UI_APP; then 

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -100,6 +100,11 @@ install_netbird() {
     # Checks if SKIP_UI_APP env is set
     if [ -z "$SKIP_UI_APP" ]; then
         SKIP_UI_APP=false
+    else
+        if $SKIP_UI_APP; then 
+            echo "SKIP_UI_APP has been set to true in the environment"
+            echo "Netbird UI installation will be omitted based on your preference"
+        fi
     fi
 
     # Identify OS name and default package manager
@@ -113,27 +118,32 @@ install_netbird() {
             # Allow netbird UI installation for x64 arch only
             if [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ] \
                 && [ "$ARCH" != "x86_64" ];then
-                echo "$ARCH is not a compatible architecture for Netbird UI"
                 SKIP_UI_APP=true
+                echo "Netbird UI installation will be omitted as $ARCH is not a compactible architecture"
             fi
 
             # Allow netbird UI installation for linux running desktop enviroment
             if [ -z "$XDG_CURRENT_DESKTOP" ];then
                     SKIP_UI_APP=true
+                    echo "Netbird UI installation will be omitted as Linux does not run desktop environment"
             fi
 
-            # Check the availability of a compatible package manager
+            # Check the availability of a compactible package manager
             if [ -x "$(command -v apt)" ]; then
                 PACKAGE_MANAGER="apt"
+                echo "The installation will be performed using apt package manager"
             fi
             if [ -x "$(command -v yum)" ]; then
                 PACKAGE_MANAGER="yum"
+                echo "The installation will be performed using yum package manager"
             fi
             if [ -x "$(command -v dnf)" ]; then
                 PACKAGE_MANAGER="dnf"
+                echo "The installation will be performed using dnf package manager"
             fi
             if [ -x "$(command -v pacman)" ]; then
                 PACKAGE_MANAGER="pacman"
+                echo "The installation will be performed using pacman package manager"
             fi
 		;;
 		Darwin)
@@ -144,6 +154,7 @@ install_netbird() {
             # Check the availability of a compatible package manager
             if [ -x "$(command -v brew)" ]; then 
                 PACKAGE_MANAGER="brew"
+                echo "The installation will be performed using brew package manager"
             fi
 		;;
 	esac

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -270,14 +270,14 @@ install_netbird() {
     ;;
     esac
 
-    # Initiate the service for all OS except for Ubuntu
-    # prevent the script from failing with an error, 
-    # since the service has already been initialized on Ubuntu
-    if [ "$OS_NAME" != "ubuntu" ] ; then
-        sudo netbird service start
+    # Load and start netbird service
+    if  ! sudo netbird service install 2>&1; then 
+        echo "Netbird service has already been loaded"
     fi
-    sudo netbird service start
-    
+    if  ! sudo netbird service start 2>&1; then 
+        echo "Netbird service has already been started"
+    fi
+
 
     echo "Installation has been finished. To connect, you need to run NetBird by executing the following command:"
     echo ""

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -127,6 +127,16 @@ install_native_binaries() {
 }
 
 install_netbird() {
+    # Check if netbird CLI is installed
+    if [ -x "$(command -v netbird)" ]; then
+        if  netbird status > /dev/null 2>&1; then
+            echo "Netbird service is running, please stop it before proceeding"
+        fi
+
+        echo "Netbird seems to be installed already, please remove it before proceeding"
+        exit 1
+    fi
+
     # Checks if SKIP_UI_APP env is set
     if [ -z "$SKIP_UI_APP" ]; then
         SKIP_UI_APP=false
@@ -260,10 +270,9 @@ install_netbird() {
     ;;
     esac
 
-    # Start client daemon service if only CLI is installed
-    if ! $SKIP_UI_APP; then
+    if netbird status > /dev/null 2>&1; then
         sudo netbird service install 2>/dev/null
-        sudo netbird service start 2>/dev/null
+        sudo netbird service start
     fi
 
     echo "Installation has been finished. To connect, you need to run NetBird by executing the following command:"

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -60,7 +60,7 @@ download_release_binary() {
 }
 
 add_rpm_repo() {
-cat <<-EOF |  tee /etc/yum.repos.d/wiretrustee.repo
+cat <<-EOF | sudo tee /etc/yum.repos.d/wiretrustee.repo
 [Wiretrustee]
 name=Wiretrustee
 baseurl=https://pkgs.wiretrustee.com/yum/
@@ -75,13 +75,13 @@ install_native_binaries() {
     # Checks  for supported architecture
     case "$ARCH" in
         x86_64|amd64)
-            ARCH='amd64'
+            ARCH="amd64"
         ;;
         i?86|x86)
-            ARCH='386'
+            ARCH="386"
         ;;
         aarch64|arm64)
-            ARCH='arm64'
+            ARCH="arm64"
         ;;
         *)
             echo "Architecture ${ARCH} not supported"
@@ -153,37 +153,37 @@ install_netbird() {
     # only the CLI will be installed
     case "$PACKAGE_MANAGER" in
     apt)
-        apt-get update
-        apt-get install ca-certificates gnupg -y
+        sudo apt-get update
+        sudo apt-get install ca-certificates gnupg -y
         
         curl -sSL https://pkgs.wiretrustee.com/debian/public.key \
         |  gpg --dearmor --output /usr/share/keyrings/wiretrustee-archive-keyring.gpg
 
         APT_REPO="deb [signed-by=/usr/share/keyrings/wiretrustee-archive-keyring.gpg] https://pkgs.wiretrustee.com/debian stable main"
-        echo "$APT_REPO" |  tee /etc/apt/sources.list.d/wiretrustee.list
+        echo "$APT_REPO" | sudo tee /etc/apt/sources.list.d/wiretrustee.list
 
-        apt-get update
-        apt-get install netbird -y
+        sudo apt-get update
+        sudo apt-get install netbird -y
         
         if ! $SKIP_UI_APP; then 
-            apt-get install netbird-ui -y
+            sudo apt-get install netbird-ui -y
         fi
     ;;
     yum)
         add_rpm_repo
-        yum -y install netbird
+        sudo yum -y install netbird
         if ! $SKIP_UI_APP; then 
-            yum -y install netbird-ui
+            sudo yum -y install netbird-ui
         fi
     ;;
     dnf)
         add_rpm_repo
-        dnf -y install dnf-plugin-config-manager
-        dnf config-manager --add-repo /etc/yum.repos.d/wiretrustee.repo
-        dnf -y install netbird
+        sudo dnf -y install dnf-plugin-config-manager
+        sudo dnf config-manager --add-repo /etc/yum.repos.d/wiretrustee.repo
+        sudo dnf -y install netbird
 
         if ! $SKIP_UI_APP; then 
-            dnf -y install netbird-ui
+            sudo dnf -y install netbird-ui
         fi
     ;;
     pacman)
@@ -242,6 +242,10 @@ install_netbird() {
         sudo netbird service install 2>/dev/null
         sudo netbird service start 2>/dev/null
     fi
+
+    echo "Installation has been finished. To connect, you need to run NetBird by executing the following command:"
+    echo ""
+    echo "sudo netbird up"
 }
 
 install_netbird

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -74,11 +74,17 @@ install_native_binaries() {
             exit 2
         ;;
     esac
-    
+
     # download and extract netbird binaries to INSTAD_DIR
     download_and_extract_tar "$CLI_APP"
     if ! $SKIP_UI_APP; then 
         download_and_extract_tar "$UI_APP"
+    fi
+
+    # Start client daemon service if only CLI is installed
+    if SKIP_UI_APP; then 
+        netbird service install
+        netbird service start
     fi
 }
 
@@ -162,7 +168,7 @@ install_netbird() {
     ;;
     dnf)
         add_rpm_repo
-        dnf install dnf-plugin-config-manager
+        dnf -y install dnf-plugin-config-manager
         dnf config-manager --add-repo /etc/yum.repos.d/wiretrustee.repo
         dnf -y install netbird
 
@@ -207,10 +213,6 @@ install_netbird() {
         install_native_binaries
     ;;
     esac
-
-    # Start client daemon service if only CLI is installed
-    netbird service install
-    netbird service start
 }
 
 install_netbird

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -37,22 +37,11 @@ download_release_binary() {
     cd /tmp && curl -LO "$DOWNLOAD_URL" 
     
     if [ "$OS_TYPE" = "darwin" ] && [ "$1" = "$UI_APP" ]; then
-        # Unzip the app
+        INSTALL_DIR="/Applications/NetBird UI.app"
+        
+        # Unzip the app and move to INSTALL_DIR
         unzip -q -o "$BINARY_NAME"
-
-        INSTALL_DIR="/Applications/NetBird UI.app/Contents"
-        UNZIPPED_FOLDER="netbird_ui_${OS_TYPE}_${ARCH}"
-    
-        if mkdir -p "${INSTALL_DIR}/MacOS/"; then
-            mv "$UNZIPPED_FOLDER"/netbird-ui "${INSTALL_DIR}/MacOS/"
-        fi
-
-        if mkdir -p "${INSTALL_DIR}/Resources/"; then
-            mv "$UNZIPPED_FOLDER"/Netbird.icns "${INSTALL_DIR}/Resources/"
-        fi
-
-        mv "$UNZIPPED_FOLDER"/Info.plist "${INSTALL_DIR}/"
-        mv "$UNZIPPED_FOLDER"/_CodeSignature/ "${INSTALL_DIR}/"
+        mv "netbird_ui_${OS_TYPE}_${ARCH}" "$INSTALL_DIR"
     else
         tar -xzvf "$BINARY_NAME"
         sudo mv "${1%_"${BINARY_BASE_NAME}"}" "$INSTALL_DIR"

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -270,10 +270,14 @@ install_netbird() {
     ;;
     esac
 
-    if netbird status > /dev/null 2>&1; then
-        sudo netbird service install 2>/dev/null
+    # Initiate the service for all OS except for Ubuntu
+    # prevent the script from failing with an error, 
+    # since the service has already been initialized on Ubuntu
+    if [ "$OS_NAME" != "ubuntu" ] ; then
         sudo netbird service start
     fi
+    sudo netbird service start
+    
 
     echo "Installation has been finished. To connect, you need to run NetBird by executing the following command:"
     echo ""

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -1,0 +1,216 @@
+#!/bin/sh
+# This code is based on the netbird-installer contribution by physk on GitHub.
+# Source: https://github.com/physk/netbird-installer
+set -e
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+OWNER="netbirdio"
+REPO="netbird"
+CLI_APP="netbird"
+UI_APP="netbird-ui"
+
+# Set default variable
+OS_NAME=""
+OS_TYPE=""
+ARCH="$(uname -m)"
+PACKAGE_MANAGER=""
+INSTALL_DIR="/usr/bin/"
+
+get_latest_release() {
+    curl -s "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" \
+    | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+download_and_extract_tar() {
+    VERSION=$(get_latest_release)
+    BASE_URL="https://github.com/${OWNER}/${REPO}/releases/download"
+    BINARY_BASE_NAME="${VERSION#v}_${OS_TYPE}_${ARCH}.tar.gz"
+    
+    BINARY_NAME="$1_${BINARY_BASE_NAME}"
+    DOWNLOAD_URL="${BASE_URL}/${VERSION}/${BINARY_NAME}"
+
+    echo "Downloading $1 from $DOWNLOAD_URL"
+    curl -LO "$DOWNLOAD_URL" 
+  
+    if tar -xzvf "$BINARY_NAME"; then
+        echo "Extraction $1 completed"
+        mv "${1%_"${BINARY_BASE_NAME}"}" "$INSTALL_DIR"
+    else
+      echo "Failed to extract $1"
+      exit 2
+    fi
+}
+
+add_rpm_repo() {
+cat <<-EOF |  tee /etc/yum.repos.d/wiretrustee.repo
+[Wiretrustee]
+name=Wiretrustee
+baseurl=https://pkgs.wiretrustee.com/yum/
+enabled=1
+gpgcheck=0
+gpgkey=https://pkgs.wiretrustee.com/yum/repodata/repomd.xml.key
+repo_gpgcheck=1
+EOF
+} 
+
+install_native_binaries() {
+    # Checks  for supported architecture
+    case "$ARCH" in
+        x86_64|amd64)
+            ARCH='amd64'
+        ;;
+        i?86|x86)
+            ARCH='386'
+        ;;
+        aarch64|arm64)
+            ARCH='arm64'
+        ;;
+        *)
+            echo "Architecture ${ARCH} not supported"
+            exit 2
+        ;;
+    esac
+    
+    # download and extract netbird binaries to INSTAD_DIR
+    download_and_extract_tar "$CLI_APP"
+    if ! $SKIP_UI_APP; then 
+        download_and_extract_tar "$UI_APP"
+    fi
+}
+
+install_netbird() {
+    # Checks if SKIP_UI_APP env is set
+    if [ -z "$SKIP_UI_APP" ]; then
+        SKIP_UI_APP=false
+    fi
+
+    # Identify OS name and default package manager
+    if type uname >/dev/null 2>&1; then
+	case "$(uname)" in
+        Linux)
+            OS_NAME="$(. /etc/os-release && echo "$ID")" 
+            OS_TYPE="linux"
+            
+            # Allow netbird UI installation for x64 arch only
+            if [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ] \
+                && [ "$ARCH" != "x86_64" ];then
+                echo "$ARCH is not a compatible architecture for Netbird UI"
+                SKIP_UI_APP=true
+            fi
+
+            # Allow netbird UI installation for linux running desktop enviroment
+            if [ -z "$XDG_CURRENT_DESKTOP" ];then
+                    SKIP_UI_APP=true
+            fi
+
+            # Check the availability of a compatible package manager
+            if [ -x "$(command -v apt)" ]; then
+                PACKAGE_MANAGER="apt"
+            fi
+            if [ -x "$(command -v yum)" ]; then
+                PACKAGE_MANAGER="yum"
+            fi
+            if [ -x "$(command -v dnf)" ]; then
+                PACKAGE_MANAGER="dnf"
+            fi
+		;;
+		Darwin)
+            OS_NAME="macos"
+			OS_TYPE="darwin"
+            PACKAGE_MANAGER="brew"
+
+            # If Homebrew is not installed, install it
+            if [ -z "$(command -v $PACKAGE_MANAGER)" ]; then 
+                echo "Homebrew is not installed. Installing Homebrew..."
+                /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+                echo "Homebrew has been installed."
+            fi
+		;;
+	esac
+    fi
+
+    # Run the installation, if a desktop environment is not detected
+    # only the CLI will be installed
+    case "$PACKAGE_MANAGER" in
+    apt)
+        apt-get update
+        apt-get install ca-certificates gnupg -y
+        
+        curl -sSL https://pkgs.wiretrustee.com/debian/public.key \
+        |  gpg --dearmor --output /usr/share/keyrings/wiretrustee-archive-keyring.gpg
+
+        APT_REPO="deb [signed-by=/usr/share/keyrings/wiretrustee-archive-keyring.gpg] https://pkgs.wiretrustee.com/debian stable main"
+        echo "$APT_REPO" |  tee /etc/apt/sources.list.d/wiretrustee.list
+
+        apt-get update
+        apt-get install netbird -y
+        
+        if ! $SKIP_UI_APP; then 
+            apt-get install netbird-ui -y
+        fi
+    ;;
+    yum)
+        add_rpm_repo
+        yum -y install netbird
+        if ! $SKIP_UI_APP; then 
+            yum -y install netbird-ui
+        fi
+    ;;
+    dnf)
+        add_rpm_repo
+        dnf install dnf-plugin-config-manager
+        dnf config-manager --add-repo /etc/yum.repos.d/wiretrustee.repo
+        dnf -y install netbird
+
+        if ! $SKIP_UI_APP; then 
+            dnf -y install netbird-ui
+        fi
+    ;;
+    brew)
+        # Remove Wiretrustee if it had been installed using Homebrew before
+        if brew ls --versions wiretrustee >/dev/null 2>&1; then
+            echo "Removing existing wiretrustee client"
+            
+            # Stop and uninstall daemon service:
+            wiretrustee service stop
+            wiretrustee service uninstall 
+
+            # Unlik the app
+            brew unlink wiretrustee
+        fi
+
+        brew install netbirdio/tap/netbird
+        if ! $SKIP_UI_APP; then 
+            brew install --cask netbirdio/tap/netbird-ui
+        fi
+    ;;
+    *)
+        if [ "$OS_NAME" = "nixos" ];then
+            echo "Please add Netbird to your NixOS configuration.nix directly:"
+			echo
+			echo "services.netbird.enable = true;"
+
+            if ! $SKIP_UI_APP; then 
+                 echo "environment.systemPackages = [ pkgs.netbird-ui ];"
+            fi
+
+            echo "Build and apply new configuration:"
+            echo
+            echo "sudo nixos-rebuild switch"
+			exit 0
+        fi   
+
+        install_native_binaries
+    ;;
+    esac
+
+    # Start client daemon service if only CLI is installed
+    netbird service install
+    netbird service start
+}
+
+install_netbird


### PR DESCRIPTION
## Describe your changes
This is a shell script that installs the Netbird applications (CLI and UI) on a Linux or macOS system.

The shell script is designed to work with various Linux operating systems, including but not limited to Ubuntu, Fedora, Debian, CentOS, Raspberry Pi OS, Arch Linux, Alpine Linux, etc. The supported architectures include amd64, arm64, and 386. It can also be used on Mac OS, both on Intel and Apple Silicon architectures.

### Features
- Detects for officially supported package managers (apt, dnf, yum, brew) and installs via the respective package manager.
- Installs appropriate binaries based on the system's architecture and operating system type if package manager is not supported.
- Skip netbird-ui installation for Linux systems that lack a desktop environment or for systems that have an unsupported architecture.

For testing
`curl -fsSL https://raw.githubusercontent.com/bcmmbaga/netbird/main/release_files/install.sh | sh`

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
