### PR TITLE
Check multiple audience values

### DIFF
--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -184,7 +184,7 @@ var (
 
 			jwtValidator, err := jwtclaims.NewJWTValidator(
 				config.HttpConfig.AuthIssuer,
-				config.HttpConfig.AuthAudience,
+				config.GetAuthAudiences(),
 				config.HttpConfig.AuthKeysLocation,
 			)
 			if err != nil {

--- a/management/server/config.go
+++ b/management/server/config.go
@@ -39,6 +39,23 @@ type Config struct {
 	DeviceAuthorizationFlow *DeviceAuthorizationFlow
 }
 
+// GetAuthAudiences returns the audience from the http config and device authorization flow config
+func (c Config) GetAuthAudiences() []string {
+	register := make(map[string]struct{})
+
+	register[c.HttpConfig.AuthAudience] = struct{}{}
+
+	if c.DeviceAuthorizationFlow != nil && c.DeviceAuthorizationFlow.ProviderConfig.Audience != "" {
+		register[c.DeviceAuthorizationFlow.ProviderConfig.Audience] = struct{}{}
+	}
+
+	var audiences []string
+	for aud := range register {
+		audiences = append(audiences, aud)
+	}
+	return audiences
+}
+
 // TURNConfig is a config of the TURNCredentialsManager
 type TURNConfig struct {
 	TimeBasedCredentials bool

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -51,7 +51,7 @@ func NewServer(config *Config, accountManager AccountManager, peersUpdateManager
 	if config.HttpConfig != nil && config.HttpConfig.AuthIssuer != "" && config.HttpConfig.AuthAudience != "" && validateURL(config.HttpConfig.AuthKeysLocation) {
 		jwtValidator, err = jwtclaims.NewJWTValidator(
 			config.HttpConfig.AuthIssuer,
-			config.HttpConfig.AuthAudience,
+			config.GetAuthAudiences(),
 			config.HttpConfig.AuthKeysLocation)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to create new jwt middleware, err: %v", err)

--- a/management/server/jwtclaims/jwtValidator.go
+++ b/management/server/jwtclaims/jwtValidator.go
@@ -64,7 +64,7 @@ type JWTValidator struct {
 }
 
 // NewJWTValidator constructor
-func NewJWTValidator(issuer string, audience string, keysLocation string) (*JWTValidator, error) {
+func NewJWTValidator(issuer string, audienceList []string, keysLocation string) (*JWTValidator, error) {
 	keys, err := getPemKeys(keysLocation)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,13 @@ func NewJWTValidator(issuer string, audience string, keysLocation string) (*JWTV
 	options := Options{
 		ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
 			// Verify 'aud' claim
-			checkAud := token.Claims.(jwt.MapClaims).VerifyAudience(audience, false)
+			var checkAud bool
+			for _, audience := range audienceList {
+				checkAud = token.Claims.(jwt.MapClaims).VerifyAudience(audience, false)
+				if checkAud {
+					break
+				}
+			}
 			if !checkAud {
 				return token, errors.New("invalid audience")
 			}


### PR DESCRIPTION
## Describe your changes
Some IDP use different audience for different clients. This update checks HTTP and Device authorization flow audience values.



## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
