### PR TITLE
Add support for refreshing signing keys on expiry

### DIFF
--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -80,6 +80,7 @@ var (
 			if err != nil {
 				return fmt.Errorf("failed reading provided config file: %s: %v", mgmtConfig, err)
 			}
+			config.HttpConfig.KeyRotationEnabled = UseKeyCacheHeaders
 
 			tlsEnabled := false
 			if mgmtLetsencryptDomain != "" || (config.HttpConfig.CertFile != "" && config.HttpConfig.CertKey != "") {
@@ -186,6 +187,7 @@ var (
 				config.HttpConfig.AuthIssuer,
 				config.GetAuthAudiences(),
 				config.HttpConfig.AuthKeysLocation,
+				config.HttpConfig.KeyRotationEnabled,
 			)
 			if err != nil {
 				return fmt.Errorf("failed creating JWT validator: %v", err)

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -80,7 +80,7 @@ var (
 			if err != nil {
 				return fmt.Errorf("failed reading provided config file: %s: %v", mgmtConfig, err)
 			}
-			config.HttpConfig.KeyRotationEnabled = UseKeyCacheHeaders
+			config.HttpConfig.KeyRotationEnabled = useKeyCacheHeaders
 
 			tlsEnabled := false
 			if mgmtLetsencryptDomain != "" || (config.HttpConfig.CertFile != "" && config.HttpConfig.CertKey != "") {

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -80,7 +80,7 @@ var (
 			if err != nil {
 				return fmt.Errorf("failed reading provided config file: %s: %v", mgmtConfig, err)
 			}
-			config.HttpConfig.KeyRotationEnabled = useKeyCacheHeaders
+			config.HttpConfig.IdpSignKeyRefreshEnabled = idpSignKeyRefreshEnabled
 
 			tlsEnabled := false
 			if mgmtLetsencryptDomain != "" || (config.HttpConfig.CertFile != "" && config.HttpConfig.CertKey != "") {
@@ -187,7 +187,7 @@ var (
 				config.HttpConfig.AuthIssuer,
 				config.GetAuthAudiences(),
 				config.HttpConfig.AuthKeysLocation,
-				config.HttpConfig.KeyRotationEnabled,
+				config.HttpConfig.IdpSignKeyRefreshEnabled,
 			)
 			if err != nil {
 				return fmt.Errorf("failed creating JWT validator: %v", err)

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -23,7 +23,7 @@ var (
 	logFile              string
 	disableMetrics       bool
 	disableSingleAccMode bool
-	UseKeyCacheHeaders   bool
+	useKeyCacheHeaders   bool
 
 	rootCmd = &cobra.Command{
 		Use:          "netbird-mgmt",
@@ -55,7 +55,7 @@ func init() {
 	mgmtCmd.Flags().StringVar(&certKey, "cert-key", "", "Location of your SSL certificate private key. Can be used when you have an existing certificate and don't want a new certificate be generated automatically. If letsencrypt-domain is specified this property has no effect")
 	mgmtCmd.Flags().BoolVar(&disableMetrics, "disable-anonymous-metrics", false, "disables push of anonymous usage metrics to NetBird")
 	mgmtCmd.Flags().StringVar(&dnsDomain, "dns-domain", defaultSingleAccModeDomain, fmt.Sprintf("Domain used for peer resolution. This is appended to the peer's name, e.g. pi-server. %s. Max lenght is 192 characters to allow appending to a peer name with up to 63 characters.", defaultSingleAccModeDomain))
-	mgmtCmd.Flags().BoolVar(&UseKeyCacheHeaders, "use-key-cache-headers", false, "Enable cache headers evaluation to determine signing key rotation period. This will refresh the signing key upon expiry.")
+	mgmtCmd.Flags().BoolVar(&useKeyCacheHeaders, "use-key-cache-headers", false, "Enable cache headers evaluation to determine signing key rotation period. This will refresh the signing key upon expiry.")
 	rootCmd.MarkFlagRequired("config") //nolint
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "")

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -23,6 +23,7 @@ var (
 	logFile              string
 	disableMetrics       bool
 	disableSingleAccMode bool
+	UseKeyCacheHeaders   bool
 
 	rootCmd = &cobra.Command{
 		Use:          "netbird-mgmt",
@@ -54,6 +55,7 @@ func init() {
 	mgmtCmd.Flags().StringVar(&certKey, "cert-key", "", "Location of your SSL certificate private key. Can be used when you have an existing certificate and don't want a new certificate be generated automatically. If letsencrypt-domain is specified this property has no effect")
 	mgmtCmd.Flags().BoolVar(&disableMetrics, "disable-anonymous-metrics", false, "disables push of anonymous usage metrics to NetBird")
 	mgmtCmd.Flags().StringVar(&dnsDomain, "dns-domain", defaultSingleAccModeDomain, fmt.Sprintf("Domain used for peer resolution. This is appended to the peer's name, e.g. pi-server. %s. Max lenght is 192 characters to allow appending to a peer name with up to 63 characters.", defaultSingleAccModeDomain))
+	mgmtCmd.Flags().BoolVar(&UseKeyCacheHeaders, "use-key-cache-headers", false, "Enable cache headers evaluation to determine signing key rotation period. This will refresh the signing key upon expiry.")
 	rootCmd.MarkFlagRequired("config") //nolint
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "")

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -16,14 +16,14 @@ const (
 )
 
 var (
-	dnsDomain            string
-	mgmtDataDir          string
-	mgmtConfig           string
-	logLevel             string
-	logFile              string
-	disableMetrics       bool
-	disableSingleAccMode bool
-	useKeyCacheHeaders   bool
+	dnsDomain                string
+	mgmtDataDir              string
+	mgmtConfig               string
+	logLevel                 string
+	logFile                  string
+	disableMetrics           bool
+	disableSingleAccMode     bool
+	idpSignKeyRefreshEnabled bool
 
 	rootCmd = &cobra.Command{
 		Use:          "netbird-mgmt",
@@ -55,7 +55,7 @@ func init() {
 	mgmtCmd.Flags().StringVar(&certKey, "cert-key", "", "Location of your SSL certificate private key. Can be used when you have an existing certificate and don't want a new certificate be generated automatically. If letsencrypt-domain is specified this property has no effect")
 	mgmtCmd.Flags().BoolVar(&disableMetrics, "disable-anonymous-metrics", false, "disables push of anonymous usage metrics to NetBird")
 	mgmtCmd.Flags().StringVar(&dnsDomain, "dns-domain", defaultSingleAccModeDomain, fmt.Sprintf("Domain used for peer resolution. This is appended to the peer's name, e.g. pi-server. %s. Max lenght is 192 characters to allow appending to a peer name with up to 63 characters.", defaultSingleAccModeDomain))
-	mgmtCmd.Flags().BoolVar(&useKeyCacheHeaders, "use-key-cache-headers", false, "Enable cache headers evaluation to determine signing key rotation period. This will refresh the signing key upon expiry.")
+	mgmtCmd.Flags().BoolVar(&idpSignKeyRefreshEnabled, "idp-sign-key-refresh-enabled", false, "Enable cache headers evaluation to determine signing key rotation period. This will refresh the signing key upon expiry.")
 	rootCmd.MarkFlagRequired("config") //nolint
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "")

--- a/management/server/config.go
+++ b/management/server/config.go
@@ -80,8 +80,8 @@ type HttpServerConfig struct {
 	AuthKeysLocation string
 	// OIDCConfigEndpoint is the endpoint of an IDP manager to get OIDC configuration
 	OIDCConfigEndpoint string
-	// KeyRotationEnabled identifies the signing key is currently being rotated or not
-	KeyRotationEnabled bool
+	// IdpSignKeyRefreshEnabled identifies the signing key is currently being rotated or not
+	IdpSignKeyRefreshEnabled bool
 }
 
 // Host represents a Wiretrustee host (e.g. STUN, TURN, Signal)

--- a/management/server/config.go
+++ b/management/server/config.go
@@ -80,6 +80,8 @@ type HttpServerConfig struct {
 	AuthKeysLocation string
 	// OIDCConfigEndpoint is the endpoint of an IDP manager to get OIDC configuration
 	OIDCConfigEndpoint string
+	// KeyRotationEnabled identifies the signing key is currently being rotated or not
+	KeyRotationEnabled bool
 }
 
 // Host represents a Wiretrustee host (e.g. STUN, TURN, Signal)

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -53,7 +53,7 @@ func NewServer(config *Config, accountManager AccountManager, peersUpdateManager
 			config.HttpConfig.AuthIssuer,
 			config.GetAuthAudiences(),
 			config.HttpConfig.AuthKeysLocation,
-			config.HttpConfig.KeyRotationEnabled,
+			config.HttpConfig.IdpSignKeyRefreshEnabled,
 		)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to create new jwt middleware, err: %v", err)

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -52,7 +52,9 @@ func NewServer(config *Config, accountManager AccountManager, peersUpdateManager
 		jwtValidator, err = jwtclaims.NewJWTValidator(
 			config.HttpConfig.AuthIssuer,
 			config.GetAuthAudiences(),
-			config.HttpConfig.AuthKeysLocation)
+			config.HttpConfig.AuthKeysLocation,
+			config.HttpConfig.KeyRotationEnabled,
+		)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to create new jwt middleware, err: %v", err)
 		}

--- a/management/server/jwtclaims/jwtValidator.go
+++ b/management/server/jwtclaims/jwtValidator.go
@@ -12,6 +12,9 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/golang-jwt/jwt"
 	log "github.com/sirupsen/logrus"
@@ -45,7 +48,8 @@ type Options struct {
 
 // Jwks is a collection of JSONWebKey obtained from Config.HttpServerConfig.AuthKeysLocation
 type Jwks struct {
-	Keys []JSONWebKey `json:"keys"`
+	Keys          []JSONWebKey `json:"keys"`
+	expiresInTime time.Time
 }
 
 // JSONWebKey is a representation of a Jason Web Key
@@ -64,7 +68,7 @@ type JWTValidator struct {
 }
 
 // NewJWTValidator constructor
-func NewJWTValidator(issuer string, audienceList []string, keysLocation string) (*JWTValidator, error) {
+func NewJWTValidator(issuer string, audienceList []string, keysLocation string, keyRotationEnabled bool) (*JWTValidator, error) {
 	keys, err := getPemKeys(keysLocation)
 	if err != nil {
 		return nil, err
@@ -87,6 +91,19 @@ func NewJWTValidator(issuer string, audienceList []string, keysLocation string) 
 			checkIss := token.Claims.(jwt.MapClaims).VerifyIssuer(issuer, false)
 			if !checkIss {
 				return token, errors.New("invalid issuer")
+			}
+
+			// If keys are rotated, verify the keys prior to token validation
+			if keyRotationEnabled {
+				// If the keys are invalid, retrieve new ones
+				if !keys.stillValid() {
+
+					keys, err = getPemKeys(keysLocation)
+					if err != nil {
+						log.Errorf("cannot get JSONWebKey: %v", err)
+						return nil, err
+					}
+				}
 			}
 
 			cert, err := getPemCert(token, keys)
@@ -154,6 +171,11 @@ func (m *JWTValidator) ValidateAndParse(token string) (*jwt.Token, error) {
 	return parsedToken, nil
 }
 
+// stillValid returns true if the JSONWebKey still valid and have enough time to be used
+func (jwks *Jwks) stillValid() bool {
+	return jwks.expiresInTime.IsZero() && time.Now().Add(5*time.Second).Before(jwks.expiresInTime)
+}
+
 func getPemKeys(keysLocation string) (*Jwks, error) {
 	resp, err := http.Get(keysLocation)
 	if err != nil {
@@ -166,6 +188,10 @@ func getPemKeys(keysLocation string) (*Jwks, error) {
 	if err != nil {
 		return jwks, err
 	}
+
+	cacheControlHeader := resp.Header.Get("Cache-Control")
+	expiresIn := getMaxAgeFromCacheHeader(cacheControlHeader)
+	jwks.expiresInTime = time.Now().Add(time.Duration(expiresIn) * time.Second)
 
 	return jwks, err
 }
@@ -247,4 +273,27 @@ func convertExponentStringToInt(stringExponent string) (int, error) {
 	}
 
 	return int(exponent), nil
+}
+
+// getMaxAgeFromCacheHeader extracts max-age directive from the Cache-Control header
+func getMaxAgeFromCacheHeader(cacheControl string) int {
+	// Split into individual directives
+	directives := strings.Split(cacheControl, ",")
+
+	for _, directive := range directives {
+		directive = strings.TrimSpace(directive)
+		if strings.HasPrefix(directive, "max-age=") {
+			// Extract the max-age value
+			maxAgeStr := strings.TrimPrefix(directive, "max-age=")
+			maxAge, err := strconv.Atoi(maxAgeStr)
+			if err != nil {
+				log.Debugf("error parsing max-age: %v", err)
+				return 0
+			}
+
+			return maxAge
+		}
+	}
+
+	return 0
 }

--- a/management/server/jwtclaims/jwtValidator.go
+++ b/management/server/jwtclaims/jwtValidator.go
@@ -101,11 +101,14 @@ func NewJWTValidator(issuer string, audienceList []string, keysLocation string, 
 				if !keys.stillValid() {
 					lock.Lock()
 					defer lock.Unlock()
-					keys, err = getPemKeys(keysLocation)
+
+					refreshedKeys, err := getPemKeys(keysLocation)
 					if err != nil {
-						log.Debugf("cannot get JSONWebKey: %v", err)
-						return nil, err
+						log.Debugf("cannot get JSONWebKey: %v, falling back to old keys", err)
+						refreshedKeys = keys
 					}
+
+					keys = refreshedKeys
 				}
 			}
 

--- a/management/server/jwtclaims/jwtValidator.go
+++ b/management/server/jwtclaims/jwtValidator.go
@@ -68,7 +68,7 @@ type JWTValidator struct {
 }
 
 // NewJWTValidator constructor
-func NewJWTValidator(issuer string, audienceList []string, keysLocation string, keyRotationEnabled bool) (*JWTValidator, error) {
+func NewJWTValidator(issuer string, audienceList []string, keysLocation string, idpSignkeyRefreshEnabled bool) (*JWTValidator, error) {
 	keys, err := getPemKeys(keysLocation)
 	if err != nil {
 		return nil, err
@@ -94,13 +94,12 @@ func NewJWTValidator(issuer string, audienceList []string, keysLocation string, 
 			}
 
 			// If keys are rotated, verify the keys prior to token validation
-			if keyRotationEnabled {
+			if idpSignkeyRefreshEnabled {
 				// If the keys are invalid, retrieve new ones
 				if !keys.stillValid() {
-
 					keys, err = getPemKeys(keysLocation)
 					if err != nil {
-						log.Errorf("cannot get JSONWebKey: %v", err)
+						log.Debugf("cannot get JSONWebKey: %v", err)
 						return nil, err
 					}
 				}

--- a/management/server/jwtclaims/jwtValidator.go
+++ b/management/server/jwtclaims/jwtValidator.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt"
@@ -74,6 +75,7 @@ func NewJWTValidator(issuer string, audienceList []string, keysLocation string, 
 		return nil, err
 	}
 
+	var lock sync.Mutex
 	options := Options{
 		ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
 			// Verify 'aud' claim
@@ -97,6 +99,8 @@ func NewJWTValidator(issuer string, audienceList []string, keysLocation string, 
 			if idpSignkeyRefreshEnabled {
 				// If the keys are invalid, retrieve new ones
 				if !keys.stillValid() {
+					lock.Lock()
+					defer lock.Unlock()
 					keys, err = getPemKeys(keysLocation)
 					if err != nil {
 						log.Debugf("cannot get JSONWebKey: %v", err)


### PR DESCRIPTION
## Describe your changes
Introduces a new flag `--idp-sign-key-refresh-enabled` that enables the Cache-Control header to be checked when fetching signing keys to determine the rotation period for signing keys. This feature will automatically refresh the signing key upon its expiry.

## Issue ticket number and link
* Add support for rotating signing keys on expiry  ([#806][i806])

[i806]: https://github.com/netbirdio/netbird/issues/806
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
