### PR TITLE
Ignore ipv6 labeled address

### DIFF
--- a/client/internal/stdnet/discover_mobile.go
+++ b/client/internal/stdnet/discover_mobile.go
@@ -78,6 +78,9 @@ func (m *mobileIFaceDiscover) parseInterfacesString(interfaces string) []*transp
 		addrs := strings.Trim(fields[1], " \n")
 		foundAddress := false
 		for _, addr := range strings.Split(addrs, " ") {
+			if strings.Contains(addr, "%") {
+				continue
+			}
 			ip, ipNet, err := net.ParseCIDR(addr)
 			if err != nil {
 				log.Warnf("%s", err)

--- a/client/internal/stdnet/discover_mobile_test.go
+++ b/client/internal/stdnet/discover_mobile_test.go
@@ -3,6 +3,8 @@ package stdnet
 import (
 	"fmt"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func Test_parseInterfacesString(t *testing.T) {
@@ -20,6 +22,7 @@ func Test_parseInterfacesString(t *testing.T) {
 		{"wlan0", 30, 1500, true, true, false, false, true, "10.1.10.131/24"},
 		{"rmnet0", 30, 1500, true, true, false, false, true, "192.168.0.56/24"},
 		{"rmnet_data1", 30, 1500, true, true, false, false, true, "fec0::118c:faf7:8d97:3cb2/64"},
+		{"rmnet_data2", 30, 1500, true, true, false, false, true, "fec0::118c:faf7:8d97:3cb2%rmnet2/64"},
 	}
 
 	var exampleString string
@@ -35,13 +38,13 @@ func Test_parseInterfacesString(t *testing.T) {
 			d.multicast,
 			d.addr)
 	}
-
 	d := mobileIFaceDiscover{}
 	nets := d.parseInterfacesString(exampleString)
 	if len(nets) == 0 {
 		t.Fatalf("failed to parse interfaces")
 	}
 
+	log.Printf("%d", len(nets))
 	for i, net := range nets {
 		if net.MTU != testData[i].mtu {
 			t.Errorf("invalid mtu: %d, expected: %d", net.MTU, testData[0].mtu)
@@ -60,7 +63,7 @@ func Test_parseInterfacesString(t *testing.T) {
 		if len(addr) == 0 {
 			t.Errorf("invalid address parsing")
 		}
-
+		log.Printf("%v", addr)
 		if addr[0].String() != testData[i].addr {
 			t.Errorf("invalid address: %s, expected: %s", addr[0].String(), testData[i].addr)
 		}


### PR DESCRIPTION
## Describe your changes

Ignore ipv6 labeled address.
Make no sense shows warning messages in log

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
