### PR TITLE
Fix created_by field

### DIFF
--- a/management/server/user.go
+++ b/management/server/user.go
@@ -324,7 +324,7 @@ func (am *DefaultAccountManager) CreatePAT(accountID string, executingUserID str
 		return nil, status.Errorf(status.PermissionDenied, "no permission to create PAT for this user")
 	}
 
-	pat, err := CreateNewPAT(tokenName, expiresIn, targetUser.Id)
+	pat, err := CreateNewPAT(tokenName, expiresIn, executingUser.Id)
 	if err != nil {
 		return nil, status.Errorf(status.Internal, "failed to create PAT: %v", err)
 	}

--- a/management/server/user_test.go
+++ b/management/server/user_test.go
@@ -105,6 +105,9 @@ func TestUser_CreatePAT_ForServiceUser(t *testing.T) {
 	}
 
 	pat, err := am.CreatePAT(mockAccountID, mockUserID, mockTargetUserId, mockTokenName, mockExpiresIn)
+	if err != nil {
+		t.Fatalf("Error when adding PAT to user: %s", err)
+	}
 
 	assert.Equal(t, pat.CreatedBy, mockUserID)
 }


### PR DESCRIPTION
## Describe your changes
The created_by filed for PATs was storing the the target user ID instead of the execution user ID. This way UI was always showing the owner as the creator.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
