### PR TITLE
fix: check if dns listener can bind before switching

### DIFF
--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -289,7 +289,7 @@ func TestDNSServerStartStop(t *testing.T) {
 			dnsServer := getDefaultServerWithNoHostManager(t, testCase.addrPort)
 
 			dnsServer.hostManager = newNoopHostMocker()
-			dnsServer.Start()
+			_ = dnsServer.Start()
 			time.Sleep(100 * time.Millisecond)
 			if !dnsServer.listenerIsRunning {
 				t.Fatal("dns server listener is not running")


### PR DESCRIPTION
## Describe your changes

Currently, there's no check if DNS listener with custom address can bind to the specified `IP:Port`. In cases where the DNS listener fails to bind, the system's `resolvconf` is still changed even though the DNS listener is not running. This causes DNS to spectacularly fail on the client system until the user runs `netbird down`, replacing the netbird `resolvconf` with the original file.

This PR tries to fix the issue by not letting netbird change `resolvconf` if the DNS listener fails to bind in any case.

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
