### PR TITLE
Fix incomplete verification URI issue in device auth flow

### DIFF
--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -172,7 +172,7 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command) error {
 
 	if loginResp.NeedsSSOLogin {
 
-		openURL(cmd, loginResp.VerificationURIComplete)
+		openURL(cmd, loginResp.VerificationURIComplete, loginResp.UserCode)
 
 		_, err = client.WaitSSOLogin(ctx, &proto.WaitSSOLoginRequest{UserCode: loginResp.UserCode})
 		if err != nil {

--- a/client/internal/oauth.go
+++ b/client/internal/oauth.go
@@ -148,6 +148,11 @@ func (h *Hosted) RequestDeviceCode(ctx context.Context) (DeviceAuthInfo, error) 
 		return DeviceAuthInfo{}, fmt.Errorf("unmarshaling response failed with error: %v", err)
 	}
 
+	// Fallback to the verification_uri if the IdP doesn't support verification_uri_complete
+	if deviceCode.VerificationURIComplete == "" {
+		deviceCode.VerificationURIComplete = deviceCode.VerificationURI
+	}
+
 	return deviceCode, err
 }
 


### PR DESCRIPTION
## Describe your changes
adds functionality to support Identity Provider (IdP) managers that do not support a complete verification URI in the device authentication flow. In cases where the `verification_uri_complete` field is empty, the user will be prompted with their `user_code`, and the `verification_uri ` field will be used as a fallback

## Issue ticket number and link

* Azure application device flow not supported - ([#673](https://github.com/netbirdio/netbird/issues/673))

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
