### PR TITLE
Add mipsle build to enable netbird for devices such as EdgeRouter X

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ builds:
       - arm64
       - mips
       - mipsle
+      - mips64
+      - mips64le
       - 386
     gomips:
       - hardfloat

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ builds:
       - amd64
       - arm64
       - mips
+      - mipsle
       - 386
     gomips:
       - hardfloat

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,14 +12,7 @@ builds:
       - arm
       - amd64
       - arm64
-      - mips
-      - mipsle
-      - mips64
-      - mips64le
       - 386
-    gomips:
-      - hardfloat
-      - softfloat
     ignore:
       - goos: windows
         goarch: arm64
@@ -27,6 +20,26 @@ builds:
         goarch: arm
       - goos: windows
         goarch: 386
+    ldflags:
+      - -s -w -X github.com/netbirdio/netbird/version.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    tags:
+      - load_wgnt_from_rsrc
+
+  - id: netbird-static
+    dir: client
+    binary: netbird
+    env: [CGO_ENABLED=0]
+    goos:
+      - linux
+    goarch:
+      - mips
+      - mipsle
+      - mips64
+      - mips64le
+    gomips:
+      - hardfloat
+      - softfloat
     ldflags:
       - -s -w -X github.com/netbirdio/netbird/version.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
     mod_timestamp: '{{ .CommitTimestamp }}'
@@ -70,6 +83,7 @@ builds:
 archives:
   - builds:
       - netbird
+      - netbird-static
 
 nfpms:
 


### PR DESCRIPTION
MIPSLE 

## Describe your changes
This enables running netbird on edgerouter x devices, which have mipsle processors.
## Issue ticket number and link

### Checklist
- new build target for netbird client
- Tested on edgerouter x
