### PR TITLE
Block user through HTTP API

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -58,7 +58,7 @@ type AccountManager interface {
 	GetAccountFromToken(claims jwtclaims.AuthorizationClaims) (*Account, *User, error)
 	GetAccountFromPAT(pat string) (*Account, *User, *PersonalAccessToken, error)
 	MarkPATUsed(tokenID string) error
-	IsUserAdmin(claims jwtclaims.AuthorizationClaims) (bool, error)
+	GetUser(claims jwtclaims.AuthorizationClaims) (*User, error)
 	AccountExists(accountId string) (*bool, error)
 	GetPeerByKey(peerKey string) (*Peer, error)
 	GetPeers(accountID, userID string) ([]*Peer, error)

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -179,6 +179,7 @@ type UserInfo struct {
 	AutoGroups    []string `json:"auto_groups"`
 	Status        string   `json:"-"`
 	IsServiceUser bool     `json:"is_service_user"`
+	IsBlocked     bool     `json:"is_blocked"`
 }
 
 // getRoutesToSync returns the enabled routes for the peer ID and the routes

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -49,10 +49,10 @@ type AccountManager interface {
 	CreateSetupKey(accountID string, keyName string, keyType SetupKeyType, expiresIn time.Duration,
 		autoGroups []string, usageLimit int, userID string) (*SetupKey, error)
 	SaveSetupKey(accountID string, key *SetupKey, userID string) (*SetupKey, error)
-	CreateUser(accountID, executingUserID string, key *UserInfo) (*UserInfo, error)
-	DeleteUser(accountID, executingUserID string, targetUserID string) error
+	CreateUser(accountID, initiatorUserID string, key *UserInfo) (*UserInfo, error)
+	DeleteUser(accountID, initiatorUserID string, targetUserID string) error
 	ListSetupKeys(accountID, userID string) ([]*SetupKey, error)
-	SaveUser(accountID, userID string, update *User) (*UserInfo, error)
+	SaveUser(accountID, initiatorUserID string, update *User) (*UserInfo, error)
 	GetSetupKey(accountID, userID, keyID string) (*SetupKey, error)
 	GetAccountByUserOrAccountID(userID, accountID, domain string) (*Account, error)
 	GetAccountFromToken(claims jwtclaims.AuthorizationClaims) (*Account, *User, error)
@@ -69,10 +69,10 @@ type AccountManager interface {
 	GetNetworkMap(peerID string) (*NetworkMap, error)
 	GetPeerNetwork(peerID string) (*Network, error)
 	AddPeer(setupKey, userID string, peer *Peer) (*Peer, *NetworkMap, error)
-	CreatePAT(accountID string, executingUserID string, targetUserID string, tokenName string, expiresIn int) (*PersonalAccessTokenGenerated, error)
-	DeletePAT(accountID string, executingUserID string, targetUserID string, tokenID string) error
-	GetPAT(accountID string, executingUserID string, targetUserID string, tokenID string) (*PersonalAccessToken, error)
-	GetAllPATs(accountID string, executingUserID string, targetUserID string) ([]*PersonalAccessToken, error)
+	CreatePAT(accountID string, initiatorUserID string, targetUserID string, tokenName string, expiresIn int) (*PersonalAccessTokenGenerated, error)
+	DeletePAT(accountID string, initiatorUserID string, targetUserID string, tokenID string) error
+	GetPAT(accountID string, initiatorUserID string, targetUserID string, tokenID string) (*PersonalAccessToken, error)
+	GetAllPATs(accountID string, initiatorUserID string, targetUserID string) ([]*PersonalAccessToken, error)
 	UpdatePeerSSHKey(peerID string, sshKey string) error
 	GetUsersFromAccount(accountID, userID string) ([]*UserInfo, error)
 	GetGroup(accountId, groupID string) (*Group, error)

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -226,63 +226,6 @@ func TestNewAccount(t *testing.T) {
 	verifyNewAccountHasDefaultFields(t, account, userId, domain, []string{userId})
 }
 
-func TestDefaultAccountManager_SaveUser(t *testing.T) {
-	manager, err := createManager(t)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	tt := []struct {
-		name        string
-		update      *User
-		expectedErr bool
-	}{
-		{
-			name:        "Should_Fail_To_Update_Admin_Role",
-			expectedErr: true,
-			update: &User{
-				Id:      userID,
-				Role:    UserRoleUser,
-				Blocked: false,
-			},
-		}, {
-			name:        "Should_Fail_When_Admin_Blocks_Themselves",
-			expectedErr: true,
-			update: &User{
-				Id:      userID,
-				Role:    UserRoleAdmin,
-				Blocked: true,
-			},
-		},
-		{
-			name:        "Should_Fail_To_Update_Non_Existing_User",
-			expectedErr: true,
-			update: &User{
-				Id:      userID,
-				Role:    UserRoleAdmin,
-				Blocked: true,
-			},
-		},
-	}
-
-	for _, tc := range tt {
-		account, err := manager.GetOrCreateAccountByUser(userID, "")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		updated, err := manager.SaveUser(account.Id, userID, tc.update)
-		if tc.expectedErr {
-			require.Errorf(t, err, "expecting SaveUser to throw an error")
-		} else {
-			require.NoError(t, err, "expecting SaveUser not to throw an error")
-			assert.NotNil(t, updated)
-		}
-	}
-
-}
-
 func TestAccountManager_GetOrCreateAccountByUser(t *testing.T) {
 	manager, err := createManager(t)
 	if err != nil {

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -226,6 +226,63 @@ func TestNewAccount(t *testing.T) {
 	verifyNewAccountHasDefaultFields(t, account, userId, domain, []string{userId})
 }
 
+func TestDefaultAccountManager_SaveUser(t *testing.T) {
+	manager, err := createManager(t)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	tt := []struct {
+		name        string
+		update      *User
+		expectedErr bool
+	}{
+		{
+			name:        "Should_Fail_To_Update_Admin_Role",
+			expectedErr: true,
+			update: &User{
+				Id:      userID,
+				Role:    UserRoleUser,
+				Blocked: false,
+			},
+		}, {
+			name:        "Should_Fail_When_Admin_Blocks_Themselves",
+			expectedErr: true,
+			update: &User{
+				Id:      userID,
+				Role:    UserRoleAdmin,
+				Blocked: true,
+			},
+		},
+		{
+			name:        "Should_Fail_To_Update_Non_Existing_User",
+			expectedErr: true,
+			update: &User{
+				Id:      userID,
+				Role:    UserRoleAdmin,
+				Blocked: true,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		account, err := manager.GetOrCreateAccountByUser(userID, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		updated, err := manager.SaveUser(account.Id, userID, tc.update)
+		if tc.expectedErr {
+			require.Errorf(t, err, "expecting SaveUser to throw an error")
+		} else {
+			require.NoError(t, err, "expecting SaveUser not to throw an error")
+			assert.NotNil(t, updated)
+		}
+	}
+
+}
+
 func TestAccountManager_GetOrCreateAccountByUser(t *testing.T) {
 	manager, err := createManager(t)
 	if err != nil {

--- a/management/server/activity/codes.go
+++ b/management/server/activity/codes.go
@@ -91,6 +91,10 @@ const (
 	ServiceUserCreated
 	// ServiceUserDeleted indicates that a user deleted a service user
 	ServiceUserDeleted
+	// UserBlocked indicates that a user blocked another user
+	UserBlocked
+	// UserUnblocked indicates that a user unblocked another user
+	UserUnblocked
 )
 
 const (
@@ -184,6 +188,10 @@ const (
 	ServiceUserCreatedMessage string = "Service user created"
 	// ServiceUserDeletedMessage is a human-readable text message of the ServiceUserDeleted activity
 	ServiceUserDeletedMessage string = "Service user deleted"
+	// UserBlockedMessage is a human-readable text message of the UserBlocked activity
+	UserBlockedMessage string = "User blocked"
+	// UserUnblockedMessage is a human-readable text message of the UserUnblocked activity
+	UserUnblockedMessage string = "User unblocked"
 )
 
 // Activity that triggered an Event
@@ -282,6 +290,10 @@ func (a Activity) Message() string {
 		return ServiceUserCreatedMessage
 	case ServiceUserDeleted:
 		return ServiceUserDeletedMessage
+	case UserBlocked:
+		return UserBlockedMessage
+	case UserUnblocked:
+		return UserUnblockedMessage
 	default:
 		return "UNKNOWN_ACTIVITY"
 	}
@@ -300,6 +312,10 @@ func (a Activity) StringCode() string {
 		return "user.join"
 	case UserInvited:
 		return "user.invite"
+	case UserBlocked:
+		return "user.block"
+	case UserUnblocked:
+		return "user.unblock"
 	case AccountCreated:
 		return "account.create"
 	case RuleAdded:

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -65,7 +65,7 @@ components:
         status:
           description: User's status
           type: string
-          enum: [ "active","invited","disabled" ]
+          enum: [ "active","invited","blocked" ]
         auto_groups:
           description: Groups to auto-assign to peers registered by this user
           type: array
@@ -79,6 +79,9 @@ components:
           description: Is true if this user is a service user
           type: boolean
           readOnly: true
+        is_blocked:
+          description: Is true if this user is blocked. Blocked users can't use the system
+          type: boolean
       required:
         - id
         - email
@@ -86,6 +89,7 @@ components:
         - role
         - auto_groups
         - status
+        - is_blocked
     UserRequest:
       type: object
       properties:
@@ -97,9 +101,13 @@ components:
           type: array
           items:
             type: string
+        is_blocked:
+          description: If set to true then user is blocked and can't use the system
+          type: boolean
       required:
         - role
         - auto_groups
+        - is_blocked
     UserCreateRequest:
       type: object
       properties:
@@ -645,7 +653,7 @@ components:
           description: The string code of the activity that occurred during the event
           type: string
           enum: [ "user.peer.delete", "user.join", "user.invite", "user.peer.add", "user.group.add", "user.group.delete",
-                  "user.role.update",
+                  "user.role.update", "user.block", "user.unblock",
                   "setupkey.peer.add", "setupkey.add", "setupkey.update", "setupkey.revoke", "setupkey.overuse",
                   "setupkey.group.delete", "setupkey.group.add",
                   "rule.add", "rule.delete", "rule.update",

--- a/management/server/http/api/types.gen.go
+++ b/management/server/http/api/types.gen.go
@@ -46,6 +46,7 @@ const (
 	EventActivityCodeSetupkeyPeerAdd                          EventActivityCode = "setupkey.peer.add"
 	EventActivityCodeSetupkeyRevoke                           EventActivityCode = "setupkey.revoke"
 	EventActivityCodeSetupkeyUpdate                           EventActivityCode = "setupkey.update"
+	EventActivityCodeUserBlock                                EventActivityCode = "user.block"
 	EventActivityCodeUserGroupAdd                             EventActivityCode = "user.group.add"
 	EventActivityCodeUserGroupDelete                          EventActivityCode = "user.group.delete"
 	EventActivityCodeUserInvite                               EventActivityCode = "user.invite"
@@ -53,6 +54,7 @@ const (
 	EventActivityCodeUserPeerAdd                              EventActivityCode = "user.peer.add"
 	EventActivityCodeUserPeerDelete                           EventActivityCode = "user.peer.delete"
 	EventActivityCodeUserRoleUpdate                           EventActivityCode = "user.role.update"
+	EventActivityCodeUserUnblock                              EventActivityCode = "user.unblock"
 )
 
 // Defines values for NameserverNsType.
@@ -68,9 +70,9 @@ const (
 
 // Defines values for UserStatus.
 const (
-	UserStatusActive   UserStatus = "active"
-	UserStatusDisabled UserStatus = "disabled"
-	UserStatusInvited  UserStatus = "invited"
+	UserStatusActive  UserStatus = "active"
+	UserStatusBlocked UserStatus = "blocked"
+	UserStatusInvited UserStatus = "invited"
 )
 
 // Account defines model for Account.
@@ -552,6 +554,9 @@ type User struct {
 	// Id User ID
 	Id string `json:"id"`
 
+	// IsBlocked Is true if this user is blocked. Blocked users can't use the system
+	IsBlocked bool `json:"is_blocked"`
+
 	// IsCurrent Is true if authenticated user is the same as this user
 	IsCurrent *bool `json:"is_current,omitempty"`
 
@@ -593,6 +598,9 @@ type UserCreateRequest struct {
 type UserRequest struct {
 	// AutoGroups Groups to auto-assign to peers registered by this user
 	AutoGroups []string `json:"auto_groups"`
+
+	// IsBlocked If set to true then user is blocked and can't use the system
+	IsBlocked bool `json:"is_blocked"`
 
 	// Role User's NetBird account role
 	Role string `json:"role"`

--- a/management/server/http/handler.go
+++ b/management/server/http/handler.go
@@ -43,7 +43,7 @@ func APIHandler(accountManager s.AccountManager, jwtValidator jwtclaims.JWTValid
 	acMiddleware := middleware.NewAccessControl(
 		authCfg.Audience,
 		authCfg.UserIDClaim,
-		accountManager.IsUserAdmin)
+		accountManager.GetUser)
 
 	rootRouter := mux.NewRouter()
 	metricsMiddleware := appMetrics.HTTPMiddleware()

--- a/management/server/http/middleware/access_control.go
+++ b/management/server/http/middleware/access_control.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/netbirdio/netbird/management/server"
 	"github.com/netbirdio/netbird/management/server/http/util"
 	"github.com/netbirdio/netbird/management/server/status"
 
@@ -13,21 +14,22 @@ import (
 )
 
 type IsUserAdminFunc func(claims jwtclaims.AuthorizationClaims) (bool, error)
+type GetUser func(claims jwtclaims.AuthorizationClaims) (*server.User, error)
 
 // AccessControl middleware to restrict to make POST/PUT/DELETE requests by admin only
 type AccessControl struct {
-	isUserAdmin   IsUserAdminFunc
 	claimsExtract jwtclaims.ClaimsExtractor
+	getUser       GetUser
 }
 
 // NewAccessControl instance constructor
-func NewAccessControl(audience, userIDClaim string, isUserAdmin IsUserAdminFunc) *AccessControl {
+func NewAccessControl(audience, userIDClaim string, getUser GetUser) *AccessControl {
 	return &AccessControl{
-		isUserAdmin: isUserAdmin,
 		claimsExtract: *jwtclaims.NewClaimsExtractor(
 			jwtclaims.WithAudience(audience),
 			jwtclaims.WithUserIDClaim(userIDClaim),
 		),
+		getUser: getUser,
 	}
 }
 
@@ -37,23 +39,29 @@ func (a *AccessControl) Handler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		claims := a.claimsExtract.FromRequestContext(r)
 
-		ok, err := a.isUserAdmin(claims)
+		user, err := a.getUser(claims)
 		if err != nil {
 			util.WriteError(status.Errorf(status.Unauthorized, "invalid JWT"), w)
 			return
 		}
-		if !ok {
+
+		if user.IsBlocked() {
+			util.WriteError(status.Errorf(status.PermissionDenied, "the user has no access to the API or is blocked"), w)
+			return
+		}
+
+		if !user.IsAdmin() {
 			switch r.Method {
 			case http.MethodDelete, http.MethodPost, http.MethodPatch, http.MethodPut:
 
 				ok, err := regexp.MatchString(`^.*/api/users/.*/tokens.*$`, r.URL.Path)
 				if err != nil {
-					log.Debugf("Regex failed")
+					log.Debugf("regex failed")
 					util.WriteError(status.Errorf(status.Internal, ""), w)
 					return
 				}
 				if ok {
-					log.Debugf("Valid Path")
+					log.Debugf("valid Path")
 					h.ServeHTTP(w, r)
 					return
 				}

--- a/management/server/http/middleware/access_control.go
+++ b/management/server/http/middleware/access_control.go
@@ -13,7 +13,7 @@ import (
 	"github.com/netbirdio/netbird/management/server/jwtclaims"
 )
 
-type IsUserAdminFunc func(claims jwtclaims.AuthorizationClaims) (bool, error)
+// GetUser function defines a function to fetch user from Account by jwtclaims.AuthorizationClaims
 type GetUser func(claims jwtclaims.AuthorizationClaims) (*server.User, error)
 
 // AccessControl middleware to restrict to make POST/PUT/DELETE requests by admin only

--- a/management/server/http/pat_handler_test.go
+++ b/management/server/http/pat_handler_test.go
@@ -63,7 +63,7 @@ var testAccount = &server.Account{
 func initPATTestData() *PATHandler {
 	return &PATHandler{
 		accountManager: &mock_server.MockAccountManager{
-			CreatePATFunc: func(accountID string, executingUserID string, targetUserID string, tokenName string, expiresIn int) (*server.PersonalAccessTokenGenerated, error) {
+			CreatePATFunc: func(accountID string, initiatorUserID string, targetUserID string, tokenName string, expiresIn int) (*server.PersonalAccessTokenGenerated, error) {
 				if accountID != existingAccountID {
 					return nil, status.Errorf(status.NotFound, "account with ID %s not found", accountID)
 				}
@@ -79,7 +79,7 @@ func initPATTestData() *PATHandler {
 			GetAccountFromTokenFunc: func(_ jwtclaims.AuthorizationClaims) (*server.Account, *server.User, error) {
 				return testAccount, testAccount.Users[existingUserID], nil
 			},
-			DeletePATFunc: func(accountID string, executingUserID string, targetUserID string, tokenID string) error {
+			DeletePATFunc: func(accountID string, initiatorUserID string, targetUserID string, tokenID string) error {
 				if accountID != existingAccountID {
 					return status.Errorf(status.NotFound, "account with ID %s not found", accountID)
 				}
@@ -91,7 +91,7 @@ func initPATTestData() *PATHandler {
 				}
 				return nil
 			},
-			GetPATFunc: func(accountID string, executingUserID string, targetUserID string, tokenID string) (*server.PersonalAccessToken, error) {
+			GetPATFunc: func(accountID string, initiatorUserID string, targetUserID string, tokenID string) (*server.PersonalAccessToken, error) {
 				if accountID != existingAccountID {
 					return nil, status.Errorf(status.NotFound, "account with ID %s not found", accountID)
 				}
@@ -103,7 +103,7 @@ func initPATTestData() *PATHandler {
 				}
 				return testAccount.Users[existingUserID].PATs[existingTokenID], nil
 			},
-			GetAllPATsFunc: func(accountID string, executingUserID string, targetUserID string) ([]*server.PersonalAccessToken, error) {
+			GetAllPATsFunc: func(accountID string, initiatorUserID string, targetUserID string) ([]*server.PersonalAccessToken, error) {
 				if accountID != existingAccountID {
 					return nil, status.Errorf(status.NotFound, "account with ID %s not found", accountID)
 				}

--- a/management/server/http/users_handler.go
+++ b/management/server/http/users_handler.go
@@ -71,7 +71,9 @@ func (h *UsersHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		Id:         userID,
 		Role:       userRole,
 		AutoGroups: req.AutoGroups,
+		Blocked:    req.IsBlocked,
 	})
+
 	if err != nil {
 		util.WriteError(err, w)
 		return
@@ -214,7 +216,11 @@ func toUserResponse(user *server.UserInfo, currenUserID string) *api.User {
 	case "invited":
 		userStatus = api.UserStatusInvited
 	default:
-		userStatus = api.UserStatusDisabled
+		userStatus = api.UserStatusBlocked
+	}
+
+	if user.IsBlocked {
+		userStatus = api.UserStatusBlocked
 	}
 
 	isCurrent := user.ID == currenUserID
@@ -227,5 +233,6 @@ func toUserResponse(user *server.UserInfo, currenUserID string) *api.User {
 		Status:        userStatus,
 		IsCurrent:     &isCurrent,
 		IsServiceUser: &user.IsServiceUser,
+		IsBlocked:     user.IsBlocked,
 	}
 }

--- a/management/server/http/users_handler.go
+++ b/management/server/http/users_handler.go
@@ -61,6 +61,11 @@ func (h *UsersHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req.AutoGroups == nil {
+		util.WriteErrorResponse("auto_groups field can't be absent", http.StatusBadRequest, w)
+		return
+	}
+
 	userRole := server.StrRoleToUserRole(req.Role)
 	if userRole == server.UserRoleUnknown {
 		util.WriteError(status.Errorf(status.InvalidArgument, "invalid user role"), w)

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -19,7 +19,7 @@ type MockAccountManager struct {
 		expiresIn time.Duration, autoGroups []string, usageLimit int, userID string) (*server.SetupKey, error)
 	GetSetupKeyFunc                 func(accountID, userID, keyID string) (*server.SetupKey, error)
 	GetAccountByUserOrAccountIdFunc func(userId, accountId, domain string) (*server.Account, error)
-	IsUserAdminFunc                 func(claims jwtclaims.AuthorizationClaims) (bool, error)
+	GetUserFunc                     func(claims jwtclaims.AuthorizationClaims) (*server.User, error)
 	AccountExistsFunc               func(accountId string) (*bool, error)
 	GetPeerByKeyFunc                func(peerKey string) (*server.Peer, error)
 	GetPeersFunc                    func(accountID, userID string) ([]*server.Peer, error)
@@ -385,12 +385,12 @@ func (am *MockAccountManager) UpdatePeerMeta(peerID string, meta server.PeerSyst
 	return status.Errorf(codes.Unimplemented, "method UpdatePeerMetaFunc is not implemented")
 }
 
-// IsUserAdmin mock implementation of IsUserAdmin from server.AccountManager interface
-func (am *MockAccountManager) IsUserAdmin(claims jwtclaims.AuthorizationClaims) (bool, error) {
-	if am.IsUserAdminFunc != nil {
-		return am.IsUserAdminFunc(claims)
+// GetUser mock implementation of GetUser from server.AccountManager interface
+func (am *MockAccountManager) GetUser(claims jwtclaims.AuthorizationClaims) (*server.User, error) {
+	if am.GetUserFunc != nil {
+		return am.GetUserFunc(claims)
 	}
-	return false, status.Errorf(codes.Unimplemented, "method IsUserAdmin is not implemented")
+	return nil, status.Errorf(codes.Unimplemented, "method IsUserGetUserAdmin is not implemented")
 }
 
 // UpdatePeerSSHKey mocks UpdatePeerSSHKey function of the account manager

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -60,11 +60,11 @@ type MockAccountManager struct {
 	SaveSetupKeyFunc                func(accountID string, key *server.SetupKey, userID string) (*server.SetupKey, error)
 	ListSetupKeysFunc               func(accountID, userID string) ([]*server.SetupKey, error)
 	SaveUserFunc                    func(accountID, userID string, user *server.User) (*server.UserInfo, error)
-	DeleteUserFunc                  func(accountID string, executingUserID string, targetUserID string) error
-	CreatePATFunc                   func(accountID string, executingUserID string, targetUserId string, tokenName string, expiresIn int) (*server.PersonalAccessTokenGenerated, error)
-	DeletePATFunc                   func(accountID string, executingUserID string, targetUserId string, tokenID string) error
-	GetPATFunc                      func(accountID string, executingUserID string, targetUserId string, tokenID string) (*server.PersonalAccessToken, error)
-	GetAllPATsFunc                  func(accountID string, executingUserID string, targetUserId string) ([]*server.PersonalAccessToken, error)
+	DeleteUserFunc                  func(accountID string, initiatorUserID string, targetUserID string) error
+	CreatePATFunc                   func(accountID string, initiatorUserID string, targetUserId string, tokenName string, expiresIn int) (*server.PersonalAccessTokenGenerated, error)
+	DeletePATFunc                   func(accountID string, initiatorUserID string, targetUserId string, tokenID string) error
+	GetPATFunc                      func(accountID string, initiatorUserID string, targetUserId string, tokenID string) (*server.PersonalAccessToken, error)
+	GetAllPATsFunc                  func(accountID string, initiatorUserID string, targetUserId string) ([]*server.PersonalAccessToken, error)
 	GetNameServerGroupFunc          func(accountID, nsGroupID string) (*nbdns.NameServerGroup, error)
 	CreateNameServerGroupFunc       func(accountID string, name, description string, nameServerList []nbdns.NameServer, groups []string, primary bool, domains []string, enabled bool, userID string) (*nbdns.NameServerGroup, error)
 	SaveNameServerGroupFunc         func(accountID, userID string, nsGroupToSave *nbdns.NameServerGroup) error
@@ -190,33 +190,33 @@ func (am *MockAccountManager) MarkPATUsed(pat string) error {
 }
 
 // CreatePAT mock implementation of GetPAT from server.AccountManager interface
-func (am *MockAccountManager) CreatePAT(accountID string, executingUserID string, targetUserID string, name string, expiresIn int) (*server.PersonalAccessTokenGenerated, error) {
+func (am *MockAccountManager) CreatePAT(accountID string, initiatorUserID string, targetUserID string, name string, expiresIn int) (*server.PersonalAccessTokenGenerated, error) {
 	if am.CreatePATFunc != nil {
-		return am.CreatePATFunc(accountID, executingUserID, targetUserID, name, expiresIn)
+		return am.CreatePATFunc(accountID, initiatorUserID, targetUserID, name, expiresIn)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method CreatePAT is not implemented")
 }
 
 // DeletePAT mock implementation of DeletePAT from server.AccountManager interface
-func (am *MockAccountManager) DeletePAT(accountID string, executingUserID string, targetUserID string, tokenID string) error {
+func (am *MockAccountManager) DeletePAT(accountID string, initiatorUserID string, targetUserID string, tokenID string) error {
 	if am.DeletePATFunc != nil {
-		return am.DeletePATFunc(accountID, executingUserID, targetUserID, tokenID)
+		return am.DeletePATFunc(accountID, initiatorUserID, targetUserID, tokenID)
 	}
 	return status.Errorf(codes.Unimplemented, "method DeletePAT is not implemented")
 }
 
 // GetPAT mock implementation of GetPAT from server.AccountManager interface
-func (am *MockAccountManager) GetPAT(accountID string, executingUserID string, targetUserID string, tokenID string) (*server.PersonalAccessToken, error) {
+func (am *MockAccountManager) GetPAT(accountID string, initiatorUserID string, targetUserID string, tokenID string) (*server.PersonalAccessToken, error) {
 	if am.GetPATFunc != nil {
-		return am.GetPATFunc(accountID, executingUserID, targetUserID, tokenID)
+		return am.GetPATFunc(accountID, initiatorUserID, targetUserID, tokenID)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method GetPAT is not implemented")
 }
 
 // GetAllPATs mock implementation of GetAllPATs from server.AccountManager interface
-func (am *MockAccountManager) GetAllPATs(accountID string, executingUserID string, targetUserID string) ([]*server.PersonalAccessToken, error) {
+func (am *MockAccountManager) GetAllPATs(accountID string, initiatorUserID string, targetUserID string) ([]*server.PersonalAccessToken, error) {
 	if am.GetAllPATsFunc != nil {
-		return am.GetAllPATsFunc(accountID, executingUserID, targetUserID)
+		return am.GetAllPATsFunc(accountID, initiatorUserID, targetUserID)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method GetAllPATs is not implemented")
 }
@@ -493,9 +493,9 @@ func (am *MockAccountManager) SaveUser(accountID, userID string, user *server.Us
 }
 
 // DeleteUser mocks DeleteUser of the AccountManager interface
-func (am *MockAccountManager) DeleteUser(accountID string, executingUserID string, targetUserID string) error {
+func (am *MockAccountManager) DeleteUser(accountID string, initiatorUserID string, targetUserID string) error {
 	if am.DeleteUserFunc != nil {
-		return am.DeleteUserFunc(accountID, executingUserID, targetUserID)
+		return am.DeleteUserFunc(accountID, initiatorUserID, targetUserID)
 	}
 	return status.Errorf(codes.Unimplemented, "method DeleteUser is not implemented")
 }

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -690,10 +690,10 @@ func checkIfPeerOwnerIsBlocked(peer *Peer, account *Account) error {
 	if peer.AddedWithSSOLogin() {
 		user, err := account.FindUser(peer.UserID)
 		if err != nil {
-			return status.Errorf(status.PermissionDenied, "user doesn't exist or was blocked")
+			return status.Errorf(status.PermissionDenied, "user doesn't exist")
 		}
 		if user.IsBlocked() {
-			return status.Errorf(status.PermissionDenied, "user doesn't exist or was blocked")
+			return status.Errorf(status.PermissionDenied, "user is blocked")
 		}
 	}
 	return nil

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -268,7 +268,7 @@ func (am *DefaultAccountManager) inviteNewUser(accountID, userID string, invite 
 
 }
 
-// GetUser	looks up a user by provided authorization claims.
+// GetUser looks up a user by provided authorization claims.
 // It will also create an account if didn't exist for this user before.
 func (am *DefaultAccountManager) GetUser(claims jwtclaims.AuthorizationClaims) (*User, error) {
 	account, _, err := am.GetAccountFromToken(claims)

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -70,8 +70,8 @@ func (u *User) IsAdmin() bool {
 	return u.Role == UserRoleAdmin
 }
 
-// toUserInfo converts a User object to a UserInfo object.
-func (u *User) toUserInfo(userData *idp.UserData) (*UserInfo, error) {
+// ToUserInfo converts a User object to a UserInfo object.
+func (u *User) ToUserInfo(userData *idp.UserData) (*UserInfo, error) {
 	autoGroups := u.AutoGroups
 	if autoGroups == nil {
 		autoGroups = []string{}
@@ -264,12 +264,11 @@ func (am *DefaultAccountManager) inviteNewUser(accountID, userID string, invite 
 
 	am.storeEvent(userID, newUser.Id, accountID, activity.UserInvited, nil)
 
-	return newUser.toUserInfo(idpUser)
+	return newUser.ToUserInfo(idpUser)
 
 }
 
-//	looks up a user by provi	ded claims.
-//
+// GetUser	looks up a user by provided authorization claims.
 // It will also create an account if didn't exist for this user before.
 func (am *DefaultAccountManager) GetUser(claims jwtclaims.AuthorizationClaims) (*User, error) {
 	account, _, err := am.GetAccountFromToken(claims)
@@ -590,9 +589,9 @@ func (am *DefaultAccountManager) SaveUser(accountID, initiatorUserID string, upd
 		if userData == nil {
 			return nil, status.Errorf(status.NotFound, "user %s not found in the IdP", newUser.Id)
 		}
-		return newUser.toUserInfo(userData)
+		return newUser.ToUserInfo(userData)
 	}
-	return newUser.toUserInfo(nil)
+	return newUser.ToUserInfo(nil)
 }
 
 // GetOrCreateAccountByUser returns an existing account for a given user id or creates a new one if doesn't exist
@@ -668,7 +667,7 @@ func (am *DefaultAccountManager) GetUsersFromAccount(accountID, userID string) (
 				// if user is not an admin then show only current user and do not show other users
 				continue
 			}
-			info, err := accountUser.toUserInfo(nil)
+			info, err := accountUser.ToUserInfo(nil)
 			if err != nil {
 				return nil, err
 			}
@@ -685,7 +684,7 @@ func (am *DefaultAccountManager) GetUsersFromAccount(accountID, userID string) (
 
 		var info *UserInfo
 		if queriedUser, contains := findUserInIDPUserdata(localUser.Id, queriedUsers); contains {
-			info, err = localUser.toUserInfo(queriedUser)
+			info, err = localUser.ToUserInfo(queriedUser)
 			if err != nil {
 				return nil, err
 			}

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -520,6 +520,10 @@ func (am *DefaultAccountManager) SaveUser(accountID, initiatorUserID string, upd
 		return nil, status.Errorf(status.PermissionDenied, "admins can't block or unblock themselves")
 	}
 
+	if initiatorUser.IsAdmin() && initiatorUserID == update.Id && update.Role != UserRoleAdmin {
+		return nil, status.Errorf(status.PermissionDenied, "admins can't change their role")
+	}
+
 	// only auto groups, revoked status, and name can be updated for now
 	newUser := oldUser.Copy()
 	newUser.AutoGroups = update.AutoGroups

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -508,7 +508,7 @@ func (am *DefaultAccountManager) SaveUser(accountID, initiatorUserID string, upd
 	}
 
 	if !initiatorUser.IsAdmin() || initiatorUser.IsBlocked() {
-		return nil, status.Errorf(status.PermissionDenied, "only admins are authorized to perform user %s update operation", update.Id)
+		return nil, status.Errorf(status.PermissionDenied, "only admins are authorized to perform user update operations")
 	}
 
 	oldUser := account.Users[update.Id]

--- a/management/server/user_test.go
+++ b/management/server/user_test.go
@@ -265,6 +265,7 @@ func TestUser_Copy(t *testing.T) {
 				LastUsed:       time.Now(),
 			},
 		},
+		Blocked: false,
 	}
 
 	err := validateStruct(user)
@@ -288,7 +289,7 @@ func validateStruct(s interface{}) (err error) {
 		field := structVal.Field(i)
 		fieldName := structType.Field(i).Name
 
-		isSet := field.IsValid() && !field.IsZero()
+		isSet := field.IsValid() && (!field.IsZero() || field.Type().String() == "bool")
 
 		if !isSet {
 			err = fmt.Errorf("%v%s in not set; ", err, fieldName)

--- a/management/server/user_test.go
+++ b/management/server/user_test.go
@@ -470,14 +470,6 @@ func TestDefaultAccountManager_GetUser(t *testing.T) {
 	assert.False(t, user.IsBlocked())
 }
 
-func TestUser_IsBlocked(t *testing.T) {
-	user := NewAdminUser(mockUserID)
-	assert.False(t, user.IsBlocked())
-
-	user.Block()
-	assert.True(t, user.IsBlocked())
-}
-
 func TestUser_IsAdmin(t *testing.T) {
 
 	user := NewAdminUser(mockUserID)
@@ -553,8 +545,6 @@ func TestDefaultAccountManager_SaveUser(t *testing.T) {
 
 	tt := []struct {
 		name           string
-		adminUserID    string
-		regularUserID  string
 		adminInitiator bool
 		update         *User
 		expectedErr    bool
@@ -563,8 +553,6 @@ func TestDefaultAccountManager_SaveUser(t *testing.T) {
 			name:           "Should_Fail_To_Update_Admin_Role",
 			expectedErr:    true,
 			adminInitiator: true,
-			adminUserID:    userID,
-			regularUserID:  regularUserID,
 			update: &User{
 				Id:      userID,
 				Role:    UserRoleUser,
@@ -573,9 +561,7 @@ func TestDefaultAccountManager_SaveUser(t *testing.T) {
 		}, {
 			name:           "Should_Fail_When_Admin_Blocks_Themselves",
 			expectedErr:    true,
-			adminUserID:    userID,
 			adminInitiator: true,
-			regularUserID:  regularUserID,
 			update: &User{
 				Id:      userID,
 				Role:    UserRoleAdmin,
@@ -585,9 +571,7 @@ func TestDefaultAccountManager_SaveUser(t *testing.T) {
 		{
 			name:           "Should_Fail_To_Update_Non_Existing_User",
 			expectedErr:    true,
-			adminUserID:    userID,
 			adminInitiator: true,
-			regularUserID:  regularUserID,
 			update: &User{
 				Id:      userID,
 				Role:    UserRoleAdmin,
@@ -597,9 +581,7 @@ func TestDefaultAccountManager_SaveUser(t *testing.T) {
 		{
 			name:           "Should_Fail_To_Update_When_Initiator_Is_Not_An_Admin",
 			expectedErr:    true,
-			adminUserID:    userID,
 			adminInitiator: false,
-			regularUserID:  regularUserID,
 			update: &User{
 				Id:      userID,
 				Role:    UserRoleAdmin,
@@ -609,9 +591,7 @@ func TestDefaultAccountManager_SaveUser(t *testing.T) {
 		{
 			name:           "Should_Update_User",
 			expectedErr:    false,
-			adminUserID:    userID,
 			adminInitiator: true,
-			regularUserID:  regularUserID,
 			update: &User{
 				Id:      regularUserID,
 				Role:    UserRoleAdmin,
@@ -623,21 +603,21 @@ func TestDefaultAccountManager_SaveUser(t *testing.T) {
 	for _, tc := range tt {
 
 		// create an account and an admin user
-		account, err := manager.GetOrCreateAccountByUser(tc.adminUserID, "netbird.io")
+		account, err := manager.GetOrCreateAccountByUser(userID, "netbird.io")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// create a regular user
-		account.Users[tc.regularUserID] = NewRegularUser(tc.regularUserID)
+		account.Users[regularUserID] = NewRegularUser(regularUserID)
 		err = manager.Store.SaveAccount(account)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		initiatorID := tc.adminUserID
+		initiatorID := userID
 		if !tc.adminInitiator {
-			initiatorID = tc.regularUserID
+			initiatorID = regularUserID
 		}
 
 		updated, err := manager.SaveUser(account.Id, initiatorID, tc.update)


### PR DESCRIPTION
## Describe your changes

The new functionality allows to block a user in the Management service .
Blocked users loose access to the Dashboard, aren't able to modify network map,
and all of their connected devices disconnect and set to "login expired" state.

Technically all above achieved with the updated PUT /api/users endpoint,
that was extended with is_blocked field.    

![image](https://github.com/netbirdio/netbird/assets/700848/5060cf4c-29ad-43b0-a51e-7559452626b7)


## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
