### PR TITLE
Fix cache lookup filter for service user

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -902,7 +902,9 @@ func (am *DefaultAccountManager) lookupUserInCacheByEmail(email string, accountI
 func (am *DefaultAccountManager) lookupUserInCache(userID string, account *Account) (*idp.UserData, error) {
 	users := make(map[string]struct{}, len(account.Users))
 	for _, user := range account.Users {
-		users[user.Id] = struct{}{}
+		if !user.IsServiceUser {
+			users[user.Id] = struct{}{}
+		}
 	}
 	log.Debugf("looking up user %s of account %s in cache", userID, account.Id)
 	userData, err := am.lookupCache(users, account.Id)


### PR DESCRIPTION
## Describe your changes
When checking cache, the list of users was not filtered for service user properly.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
