### PR TITLE
Fix preshared key command line arg handling

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -46,12 +46,16 @@ var loginCmd = &cobra.Command{
 				return err
 			}
 
-			config, err := internal.UpdateOrCreateConfig(internal.ConfigInput{
+			ic := internal.ConfigInput{
 				ManagementURL: managementURL,
 				AdminURL:      adminURL,
 				ConfigPath:    configPath,
-				PreSharedKey:  &preSharedKey,
-			})
+			}
+			if preSharedKey != "" {
+				ic.PreSharedKey = &preSharedKey
+			}
+
+			config, err := internal.UpdateOrCreateConfig(ic)
 			if err != nil {
 				return fmt.Errorf("get config file: %v", err)
 			}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -78,14 +78,18 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command) error {
 		return err
 	}
 
-	config, err := internal.UpdateOrCreateConfig(internal.ConfigInput{
+	ic := internal.ConfigInput{
 		ManagementURL:    managementURL,
 		AdminURL:         adminURL,
 		ConfigPath:       configPath,
-		PreSharedKey:     &preSharedKey,
 		NATExternalIPs:   natExternalIPs,
 		CustomDNSAddress: customDNSAddressConverted,
-	})
+	}
+	if preSharedKey != "" {
+		ic.PreSharedKey = &preSharedKey
+	}
+
+	config, err := internal.UpdateOrCreateConfig(ic)
 	if err != nil {
 		return fmt.Errorf("get config file: %v", err)
 	}


### PR DESCRIPTION
## Describe your changes

Fix preshared key command line arg handling

The cmd line arg processing does not differentiate the sting from the 
string pointer. So if the user does not set a preshared-key the code 
will overwrite it with empty string.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
