### PR TITLE
Prevent setting primary resolver if using custom DNS port

### DIFF
--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -32,6 +32,10 @@ func newFileConfigurator() (hostManager, error) {
 	return &fileConfigurator{}, nil
 }
 
+func (f *fileConfigurator) supportCustomPort() bool {
+	return false
+}
+
 func (f *fileConfigurator) applyDNSConfig(config hostDNSConfig) error {
 	backupFileExist := false
 	_, err := os.Stat(fileDefaultResolvConfBackupLocation)

--- a/client/internal/dns/host.go
+++ b/client/internal/dns/host.go
@@ -10,6 +10,7 @@ import (
 type hostManager interface {
 	applyDNSConfig(config hostDNSConfig) error
 	restoreHostDNS() error
+	supportCustomPort() bool
 }
 
 type hostDNSConfig struct {
@@ -26,8 +27,9 @@ type domainConfig struct {
 }
 
 type mockHostConfigurator struct {
-	applyDNSConfigFunc func(config hostDNSConfig) error
-	restoreHostDNSFunc func() error
+	applyDNSConfigFunc    func(config hostDNSConfig) error
+	restoreHostDNSFunc    func() error
+	supportCustomPortFunc func() bool
 }
 
 func (m *mockHostConfigurator) applyDNSConfig(config hostDNSConfig) error {
@@ -44,10 +46,18 @@ func (m *mockHostConfigurator) restoreHostDNS() error {
 	return fmt.Errorf("method restoreHostDNS is not implemented")
 }
 
+func (m *mockHostConfigurator) supportCustomPort() bool {
+	if m.supportCustomPortFunc != nil {
+		return m.supportCustomPortFunc()
+	}
+	return false
+}
+
 func newNoopHostMocker() hostManager {
 	return &mockHostConfigurator{
-		applyDNSConfigFunc: func(config hostDNSConfig) error { return nil },
-		restoreHostDNSFunc: func() error { return nil },
+		applyDNSConfigFunc:    func(config hostDNSConfig) error { return nil },
+		restoreHostDNSFunc:    func() error { return nil },
+		supportCustomPortFunc: func() bool { return true },
 	}
 }
 

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -8,8 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/netbirdio/netbird/iface"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/iface"
 )
 
 const (
@@ -37,6 +38,10 @@ func newHostManager(_ *iface.WGIface) (hostManager, error) {
 	return &systemConfigurator{
 		createdKeys: make(map[string]struct{}),
 	}, nil
+}
+
+func (s *systemConfigurator) supportCustomPort() bool {
+	return true
 }
 
 func (s *systemConfigurator) applyDNSConfig(config hostDNSConfig) error {

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/netbirdio/netbird/iface"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/registry"
+
+	"github.com/netbirdio/netbird/iface"
 )
 
 const (
@@ -40,6 +41,10 @@ func newHostManager(wgInterface *iface.WGIface) (hostManager, error) {
 	return &registryConfigurator{
 		guid: guid,
 	}, nil
+}
+
+func (s *registryConfigurator) supportCustomPort() bool {
+	return false
 }
 
 func (r *registryConfigurator) applyDNSConfig(config hostDNSConfig) error {

--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -11,8 +11,9 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/hashicorp/go-version"
 	"github.com/miekg/dns"
-	"github.com/netbirdio/netbird/iface"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/iface"
 )
 
 const (
@@ -86,6 +87,10 @@ func newNetworkManagerDbusConfigurator(wgInterface *iface.WGIface) (hostManager,
 	return &networkManagerDbusConfigurator{
 		dbusLinkObject: dbus.ObjectPath(s),
 	}, nil
+}
+
+func (n *networkManagerDbusConfigurator) supportCustomPort() bool {
+	return false
 }
 
 func (n *networkManagerDbusConfigurator) applyDNSConfig(config hostDNSConfig) error {

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -5,8 +5,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/netbirdio/netbird/iface"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/iface"
 )
 
 const resolvconfCommand = "resolvconf"
@@ -19,6 +20,10 @@ func newResolvConfConfigurator(wgInterface *iface.WGIface) (hostManager, error) 
 	return &resolvconf{
 		ifaceName: wgInterface.Name(),
 	}, nil
+}
+
+func (r *resolvconf) supportCustomPort() bool {
+	return false
 }
 
 func (r *resolvconf) applyDNSConfig(config hostDNSConfig) error {

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/godbus/dbus/v5"
 	"github.com/miekg/dns"
-	nbdns "github.com/netbirdio/netbird/dns"
-	"github.com/netbirdio/netbird/iface"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+
+	nbdns "github.com/netbirdio/netbird/dns"
+	"github.com/netbirdio/netbird/iface"
 )
 
 const (
@@ -73,6 +74,10 @@ func newSystemdDbusConfigurator(wgInterface *iface.WGIface) (hostManager, error)
 	return &systemdDbusConfigurator{
 		dbusLinkObject: dbus.ObjectPath(s),
 	}, nil
+}
+
+func (s *systemdDbusConfigurator) supportCustomPort() bool {
+	return true
 }
 
 func (s *systemdDbusConfigurator) applyDNSConfig(config hostDNSConfig) error {


### PR DESCRIPTION
## Describe your changes
Most host managers doesn't support using custom DNS ports. We are now disabling setting it up to avoid unwanted results

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
