### PR TITLE
Check if the cancel function was set before using it

### DIFF
--- a/client/server/server.go
+++ b/client/server/server.go
@@ -236,7 +236,9 @@ func (s *Server) Login(callerCtx context.Context, msg *proto.LoginRequest) (*pro
 				}, nil
 			} else {
 				log.Warnf("canceling previous waiting execution")
-				s.oauthAuthFlow.waitCancel()
+				if s.oauthAuthFlow.waitCancel != nil {
+					s.oauthAuthFlow.waitCancel()
+				}
 			}
 		}
 


### PR DESCRIPTION
## Describe your changes

in some cases an IDP device flow expiration time might be shorter than 90s we should check if the cancel context was set before using it

We will need a follow-up to identify and document the IDP with lower defaults.




## Issue ticket number and link

fixes #890

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
