### PR TITLE
Use backoff.retry to check if upstreams are responsive

### DIFF
--- a/client/internal/dns/local.go
+++ b/client/internal/dns/local.go
@@ -18,7 +18,6 @@ type localResolver struct {
 }
 
 func (d *localResolver) stop() {
-	return
 }
 
 // ServeDNS handles a DNS request

--- a/client/internal/dns/local.go
+++ b/client/internal/dns/local.go
@@ -2,10 +2,12 @@ package dns
 
 import (
 	"fmt"
-	"github.com/miekg/dns"
-	nbdns "github.com/netbirdio/netbird/dns"
-	log "github.com/sirupsen/logrus"
 	"sync"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+
+	nbdns "github.com/netbirdio/netbird/dns"
 )
 
 type registrationMap map[string]struct{}
@@ -13,6 +15,10 @@ type registrationMap map[string]struct{}
 type localResolver struct {
 	registeredMap registrationMap
 	records       sync.Map
+}
+
+func (d *localResolver) stop() {
+	return
 }
 
 // ServeDNS handles a DNS request

--- a/client/internal/dns/server_nonandroid.go
+++ b/client/internal/dns/server_nonandroid.go
@@ -310,7 +310,8 @@ func (s *DefaultServer) buildUpstreamHandlerUpdate(nameServerGroups []*nbdns.Nam
 			log.Warn("received a nameserver group with empty nameserver list")
 			continue
 		}
-
+		// todo fix the lint warning regarding not canceling the context within the loop
+		//nolint
 		ctx, cancel := context.WithCancel(s.ctx)
 
 		handler := newUpstreamResolver(ctx)

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -41,7 +41,7 @@ func TestUpdateDNSServer(t *testing.T) {
 		},
 	}
 
-	_, cancel := context.WithCancel(context.TODO())
+	dummyHandler := &localResolver{}
 
 	testCases := []struct {
 		name                string
@@ -79,13 +79,13 @@ func TestUpdateDNSServer(t *testing.T) {
 					},
 				},
 			},
-			expectedUpstreamMap: registeredHandlerMap{"netbird.io": cancel, "netbird.cloud": cancel, nbdns.RootZone: cancel},
+			expectedUpstreamMap: registeredHandlerMap{"netbird.io": dummyHandler, "netbird.cloud": dummyHandler, nbdns.RootZone: dummyHandler},
 			expectedLocalMap:    registrationMap{buildRecordKey(zoneRecords[0].Name, 1, 1): struct{}{}},
 		},
 		{
 			name:            "New Config Should Succeed",
 			initLocalMap:    registrationMap{"netbird.cloud": struct{}{}},
-			initUpstreamMap: registeredHandlerMap{buildRecordKey(zoneRecords[0].Name, 1, 1): cancel},
+			initUpstreamMap: registeredHandlerMap{buildRecordKey(zoneRecords[0].Name, 1, 1): dummyHandler},
 			initSerial:      0,
 			inputSerial:     1,
 			inputUpdate: nbdns.Config{
@@ -103,7 +103,7 @@ func TestUpdateDNSServer(t *testing.T) {
 					},
 				},
 			},
-			expectedUpstreamMap: registeredHandlerMap{"netbird.io": cancel, "netbird.cloud": cancel},
+			expectedUpstreamMap: registeredHandlerMap{"netbird.io": dummyHandler, "netbird.cloud": dummyHandler},
 			expectedLocalMap:    registrationMap{buildRecordKey(zoneRecords[0].Name, 1, 1): struct{}{}},
 		},
 		{
@@ -183,7 +183,7 @@ func TestUpdateDNSServer(t *testing.T) {
 		{
 			name:                "Empty Config Should Succeed and Clean Maps",
 			initLocalMap:        registrationMap{"netbird.cloud": struct{}{}},
-			initUpstreamMap:     registeredHandlerMap{zoneRecords[0].Name: cancel},
+			initUpstreamMap:     registeredHandlerMap{zoneRecords[0].Name: dummyHandler},
 			initSerial:          0,
 			inputSerial:         1,
 			inputUpdate:         nbdns.Config{ServiceEnable: true},
@@ -193,7 +193,7 @@ func TestUpdateDNSServer(t *testing.T) {
 		{
 			name:                "Disabled Service Should clean map",
 			initLocalMap:        registrationMap{"netbird.cloud": struct{}{}},
-			initUpstreamMap:     registeredHandlerMap{zoneRecords[0].Name: cancel},
+			initUpstreamMap:     registeredHandlerMap{zoneRecords[0].Name: dummyHandler},
 			initSerial:          0,
 			inputSerial:         1,
 			inputUpdate:         nbdns.Config{ServiceEnable: false},

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -157,6 +157,7 @@ func (u *upstreamResolver) waitUntilResponse() {
 	err := backoff.Retry(operation, exponentialBackOff)
 	if err != nil {
 		log.Warn(err)
+		return
 	}
 
 	log.Infof("upstreams %s are responsive again. Adding them back to system", u.upstreamServers)

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -122,7 +122,7 @@ func (u *upstreamResolver) waitUntilResponse() {
 	exponentialBackOff := &backoff.ExponentialBackOff{
 		InitialInterval:     500 * time.Millisecond,
 		RandomizationFactor: 0.5,
-		Multiplier:          2,
+		Multiplier:          1.1,
 		MaxInterval:         u.reactivatePeriod,
 		MaxElapsedTime:      0,
 		Stop:                backoff.Stop,
@@ -134,7 +134,7 @@ func (u *upstreamResolver) waitUntilResponse() {
 	operation := func() error {
 		select {
 		case <-u.ctx.Done():
-			return backoff.Permanent(fmt.Errorf("exiting upstream retry loop: parent context has been canceled"))
+			return backoff.Permanent(fmt.Errorf("exiting upstream retry loop for upstreams %s: parent context has been canceled", u.upstreamServers))
 		default:
 		}
 
@@ -150,7 +150,7 @@ func (u *upstreamResolver) waitUntilResponse() {
 			}
 		}
 
-		log.Debugf("checking connectivity with upstreams %s failed with error: %s. Retrying in %s", err, u.upstreamServers, exponentialBackOff.NextBackOff())
+		log.Tracef("checking connectivity with upstreams %s failed with error: %s. Retrying in %s", err, u.upstreamServers, exponentialBackOff.NextBackOff())
 		return fmt.Errorf("got an error from upstream check call")
 	}
 


### PR DESCRIPTION
## Describe your changes
Retry, in an exponential interval, querying the upstream servers until it gets a positive response

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
