### PR TITLE
Fix github release dependeny for MacOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
 
   trigger_darwin_signer:
     runs-on: ubuntu-latest
-    needs: release_ui_darwin
+    needs: [release,release_ui_darwin]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Trigger Darwin App binaries sign pipeline


### PR DESCRIPTION
## Describe your changes
The signing pipeline failed because it satrted signing before the client binaries are available.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
