### PR TITLE
Exclude second last IP from allocation to use it in the Fake DNS

### DIFF
--- a/management/server/network.go
+++ b/management/server/network.go
@@ -119,14 +119,15 @@ func generateIPs(ipNet *net.IPNet, exclusions map[string]struct{}) ([]net.IP, in
 		}
 	}
 
-	// remove network address and broadcast address
+	// remove network address, broadcast and Fake DNS resolver address
 	lenIPs := len(ips)
 	switch {
 	case lenIPs < 2:
 		return ips, lenIPs
-
-	default:
+	case lenIPs < 3:
 		return ips[1 : len(ips)-1], lenIPs - 2
+	default:
+		return ips[1 : len(ips)-2], lenIPs - 3
 	}
 }
 

--- a/management/server/network_test.go
+++ b/management/server/network_test.go
@@ -1,9 +1,10 @@
 package server
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewNetwork(t *testing.T) {
@@ -15,10 +16,9 @@ func TestNewNetwork(t *testing.T) {
 }
 
 func TestAllocatePeerIP(t *testing.T) {
-
 	ipNet := net.IPNet{IP: net.ParseIP("100.64.0.0"), Mask: net.IPMask{255, 255, 255, 0}}
 	var ips []net.IP
-	for i := 0; i < 253; i++ {
+	for i := 0; i < 252; i++ {
 		ip, err := AllocatePeerIP(ipNet, ips)
 		if err != nil {
 			t.Fatal(err)
@@ -26,7 +26,7 @@ func TestAllocatePeerIP(t *testing.T) {
 		ips = append(ips, ip)
 	}
 
-	assert.Len(t, ips, 253)
+	assert.Len(t, ips, 252)
 
 	uniq := make(map[string]struct{})
 	for _, ip := range ips {
@@ -35,5 +35,17 @@ func TestAllocatePeerIP(t *testing.T) {
 		} else {
 			t.Errorf("found duplicate IP %s", ip.String())
 		}
+	}
+}
+
+func TestGenerateIPs(t *testing.T) {
+	ipNet := net.IPNet{IP: net.ParseIP("100.64.0.0"), Mask: net.IPMask{255, 255, 255, 0}}
+	ips, ipsLen := generateIPs(&ipNet, map[string]struct{}{"100.64.0.0": {}})
+	if ipsLen != 252 {
+		t.Errorf("expected 252 ips, got %d", len(ips))
+		return
+	}
+	if ips[len(ips)-1].String() != "100.64.0.253" {
+		t.Errorf("expected last ip to be: 100.64.0.253, got %s", ips[len(ips)-1].String())
 	}
 }


### PR DESCRIPTION
## Describe your changes
Exclude the second last IP from allocation to use it in the Fake DNS

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
