### PR TITLE
Fix macOS pkg installer scripts

### DIFF
--- a/release_files/darwin_pkg/postinstall
+++ b/release_files/darwin_pkg/postinstall
@@ -4,6 +4,8 @@ APP=/Applications/NetBird.app
 AGENT=/usr/local/bin/netbird
 LOG_FILE=/var/log/netbird/client_install.log
 
+mkdir -p $LOG_FILE
+
 {
     echo "Installing NetBird..."
 

--- a/release_files/darwin_pkg/preinstall
+++ b/release_files/darwin_pkg/preinstall
@@ -2,6 +2,8 @@
 
 LOG_FILE=/var/log/netbird/client_install.log
 
+mkdir -p $LOG_FILE
+
 {
     echo "Preinstall complete"
     exit 0 # all good


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
The installation fails because the installer can't  write log because the directory does not exist.


### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
