### PR TITLE
Squash firewall rules by protocol if they affects all peers

### DIFF
--- a/client/internal/acl/manager_test.go
+++ b/client/internal/acl/manager_test.go
@@ -10,20 +10,22 @@ import (
 )
 
 func TestDefaultManager(t *testing.T) {
-	fwRules := []*mgmProto.FirewallRule{
-		{
-			PeerIP:    "10.93.0.1",
-			Direction: mgmProto.FirewallRule_OUT,
-			Action:    mgmProto.FirewallRule_ACCEPT,
-			Protocol:  mgmProto.FirewallRule_TCP,
-			Port:      "80",
-		},
-		{
-			PeerIP:    "10.93.0.2",
-			Direction: mgmProto.FirewallRule_OUT,
-			Action:    mgmProto.FirewallRule_DROP,
-			Protocol:  mgmProto.FirewallRule_UDP,
-			Port:      "53",
+	networkMap := &mgmProto.NetworkMap{
+		FirewallRules: []*mgmProto.FirewallRule{
+			{
+				PeerIP:    "10.93.0.1",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_TCP,
+				Port:      "80",
+			},
+			{
+				PeerIP:    "10.93.0.2",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_DROP,
+				Protocol:  mgmProto.FirewallRule_UDP,
+				Port:      "53",
+			},
 		},
 	}
 
@@ -44,7 +46,7 @@ func TestDefaultManager(t *testing.T) {
 	defer acl.Stop()
 
 	t.Run("apply firewall rules", func(t *testing.T) {
-		acl.ApplyFiltering(fwRules, false)
+		acl.ApplyFiltering(networkMap)
 
 		if len(acl.rulesPairs) != 2 {
 			t.Errorf("firewall rules not applied: %v", acl.rulesPairs)
@@ -54,20 +56,23 @@ func TestDefaultManager(t *testing.T) {
 
 	t.Run("add extra rules", func(t *testing.T) {
 		// remove first rule
-		fwRules = fwRules[1:]
-		fwRules = append(fwRules, &mgmProto.FirewallRule{
-			PeerIP:    "10.93.0.3",
-			Direction: mgmProto.FirewallRule_IN,
-			Action:    mgmProto.FirewallRule_DROP,
-			Protocol:  mgmProto.FirewallRule_ICMP,
-		})
+		networkMap.FirewallRules = networkMap.FirewallRules[1:]
+		networkMap.FirewallRules = append(
+			networkMap.FirewallRules,
+			&mgmProto.FirewallRule{
+				PeerIP:    "10.93.0.3",
+				Direction: mgmProto.FirewallRule_IN,
+				Action:    mgmProto.FirewallRule_DROP,
+				Protocol:  mgmProto.FirewallRule_ICMP,
+			},
+		)
 
 		existedRulesID := map[string]struct{}{}
 		for id := range acl.rulesPairs {
 			existedRulesID[id] = struct{}{}
 		}
 
-		acl.ApplyFiltering(fwRules, false)
+		acl.ApplyFiltering(networkMap)
 
 		// we should have one old and one new rule in the existed rules
 		if len(acl.rulesPairs) != 2 {
@@ -85,16 +90,183 @@ func TestDefaultManager(t *testing.T) {
 	})
 
 	t.Run("handle default rules", func(t *testing.T) {
-		acl.ApplyFiltering(nil, false)
-		if len(acl.rulesPairs) != 0 {
-			t.Errorf("rules should be empty if default not allowed, got: %v rules", len(acl.rulesPairs))
+		networkMap.FirewallRules = networkMap.FirewallRules[:0]
+
+		networkMap.FirewallRulesIsEmpty = true
+		if acl.ApplyFiltering(networkMap); len(acl.rulesPairs) != 0 {
+			t.Errorf("rules should be empty if FirewallRulesIsEmpty is set, got: %v", len(acl.rulesPairs))
 			return
 		}
 
-		acl.ApplyFiltering(nil, true)
+		networkMap.FirewallRulesIsEmpty = false
+		acl.ApplyFiltering(networkMap)
 		if len(acl.rulesPairs) != 2 {
-			t.Errorf("two default rules should be set if default is allowed, got: %v rules", len(acl.rulesPairs))
+			t.Errorf("rules should contain 2 rules if FirewallRulesIsEmpty is not set, got: %v", len(acl.rulesPairs))
 			return
 		}
 	})
+}
+
+func TestDefaultManagerSquashRules(t *testing.T) {
+	networkMap := &mgmProto.NetworkMap{
+		RemotePeers: []*mgmProto.RemotePeerConfig{
+			{AllowedIps: []string{"10.93.0.1"}},
+			{AllowedIps: []string{"10.93.0.2"}},
+			{AllowedIps: []string{"10.93.0.3"}},
+			{AllowedIps: []string{"10.93.0.4"}},
+		},
+		FirewallRules: []*mgmProto.FirewallRule{
+			{
+				PeerIP:    "10.93.0.1",
+				Direction: mgmProto.FirewallRule_IN,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.2",
+				Direction: mgmProto.FirewallRule_IN,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.3",
+				Direction: mgmProto.FirewallRule_IN,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.4",
+				Direction: mgmProto.FirewallRule_IN,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.1",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.2",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.3",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.4",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+		},
+	}
+
+	manager := &DefaultManager{}
+	rules := manager.squashAcceptRules(networkMap)
+	if len(rules) != 2 {
+		t.Errorf("rules should contain 2, got: %v", rules)
+		return
+	}
+
+	r := rules[0]
+	if r.PeerIP != "0.0.0.0" {
+		t.Errorf("IP should be 0.0.0.0, got: %v", r.PeerIP)
+		return
+	} else if r.Direction != mgmProto.FirewallRule_IN {
+		t.Errorf("direction should be IN, got: %v", r.Direction)
+		return
+	} else if r.Protocol != mgmProto.FirewallRule_ALL {
+		t.Errorf("protocol should be ALL, got: %v", r.Protocol)
+		return
+	} else if r.Action != mgmProto.FirewallRule_ACCEPT {
+		t.Errorf("action should be ACCEPT, got: %v", r.Action)
+		return
+	}
+
+	r = rules[1]
+	if r.PeerIP != "0.0.0.0" {
+		t.Errorf("IP should be 0.0.0.0, got: %v", r.PeerIP)
+		return
+	} else if r.Direction != mgmProto.FirewallRule_OUT {
+		t.Errorf("direction should be OUT, got: %v", r.Direction)
+		return
+	} else if r.Protocol != mgmProto.FirewallRule_ALL {
+		t.Errorf("protocol should be ALL, got: %v", r.Protocol)
+		return
+	} else if r.Action != mgmProto.FirewallRule_ACCEPT {
+		t.Errorf("action should be ACCEPT, got: %v", r.Action)
+		return
+	}
+}
+
+func TestDefaultManagerSquashRulesNoAffect(t *testing.T) {
+	networkMap := &mgmProto.NetworkMap{
+		RemotePeers: []*mgmProto.RemotePeerConfig{
+			{AllowedIps: []string{"10.93.0.1"}},
+			{AllowedIps: []string{"10.93.0.2"}},
+			{AllowedIps: []string{"10.93.0.3"}},
+			{AllowedIps: []string{"10.93.0.4"}},
+		},
+		FirewallRules: []*mgmProto.FirewallRule{
+			{
+				PeerIP:    "10.93.0.1",
+				Direction: mgmProto.FirewallRule_IN,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.2",
+				Direction: mgmProto.FirewallRule_IN,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.3",
+				Direction: mgmProto.FirewallRule_IN,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.4",
+				Direction: mgmProto.FirewallRule_IN,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_TCP,
+			},
+			{
+				PeerIP:    "10.93.0.1",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.2",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.3",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_ALL,
+			},
+			{
+				PeerIP:    "10.93.0.4",
+				Direction: mgmProto.FirewallRule_OUT,
+				Action:    mgmProto.FirewallRule_ACCEPT,
+				Protocol:  mgmProto.FirewallRule_UDP,
+			},
+		},
+	}
+
+	manager := &DefaultManager{}
+	if rules := manager.squashAcceptRules(networkMap); len(rules) != len(networkMap.FirewallRules) {
+		t.Errorf("we should got same amount of rules as intput, got %v", len(rules))
+	}
 }

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -637,13 +637,7 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 	}
 
 	if e.acl != nil {
-		// if we got empty rules list but management not set networkMap.FirewallRulesIsEmpty flag
-		// we have old version of management without rules handling, we should allow all traffic
-		allowByDefault := len(networkMap.FirewallRules) == 0 && !networkMap.FirewallRulesIsEmpty
-		if allowByDefault {
-			log.Warn("this peer is connected to a NetBird Management service with an older version. Allowing all traffic from connected peers")
-		}
-		e.acl.ApplyFiltering(networkMap.FirewallRules, allowByDefault)
+		e.acl.ApplyFiltering(networkMap)
 	}
 	e.networkSerial = serial
 	return nil


### PR DESCRIPTION
## Describe your changes
Squash firewall "accept policy" rules by protocol type if they affect all peers in the network, and the network map doesn't contain any other rules for the same protocol with port definitions or drop policy.
## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
