### PR TITLE
Use by default nftables on the linux systems

### DIFF
--- a/client/internal/acl/manager_create_linux.go
+++ b/client/internal/acl/manager_create_linux.go
@@ -19,11 +19,11 @@ func Create(iface iFaceMapper) (manager *DefaultManager, err error) {
 			return nil, err
 		}
 	} else {
-		if fm, err = iptables.Create(iface.Name()); err != nil {
-			log.Debugf("failed to create iptables manager: %s", err)
-			// fallback to nftables
-			if fm, err = nftables.Create(iface.Name()); err != nil {
-				log.Errorf("failed to create nftables manager: %s", err)
+		if fm, err = nftables.Create(iface.Name()); err != nil {
+			log.Debugf("failed to create nftables manager: %s", err)
+			// fallback to iptables
+			if fm, err = iptables.Create(iface.Name()); err != nil {
+				log.Errorf("failed to create iptables manager: %s", err)
 				return nil, err
 			}
 		}


### PR DESCRIPTION
## Describe your changes
Use nftables by default on the Linux

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
