### PR TITLE
Struct Engine has methods on both value

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -799,14 +799,14 @@ func (e *Engine) connWorker(conn *peer.Conn, peerKey string) {
 	}
 }
 
-func (e Engine) peerExists(peerKey string) bool {
+func (e *Engine) peerExists(peerKey string) bool {
 	e.syncMsgMux.Lock()
 	defer e.syncMsgMux.Unlock()
 	_, ok := e.peerConns[peerKey]
 	return ok
 }
 
-func (e Engine) createPeerConn(pubKey string, allowedIPs string) (*peer.Conn, error) {
+func (e *Engine) createPeerConn(pubKey string, allowedIPs string) (*peer.Conn, error) {
 	log.Debugf("creating peer connection %s", pubKey)
 	var stunTurn []*ice.URL
 	stunTurn = append(stunTurn, e.STUNs...)


### PR DESCRIPTION
## Describe your changes

Struct Engine has methods on both value and pointer receivers. 
Such usage is not recommended by the Go Documentation.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
