### PR TITLE
Stop macOS app and service on update with pkg and brew

### DIFF
--- a/release_files/darwin-ui-installer.sh
+++ b/release_files/darwin-ui-installer.sh
@@ -30,9 +30,8 @@ fi
 
 if [ -n "$NB_BIN" ]
 then
-  echo "Stopping and uninstalling NetBird daemon"
+  echo "Stopping NetBird daemon"
   netbird service stop || true
-  netbird service uninstall || true
 fi
 
 # start netbird daemon service

--- a/release_files/darwin-ui-installer.sh
+++ b/release_files/darwin-ui-installer.sh
@@ -27,6 +27,14 @@ then
   echo "Please run: brew install netbirdio/tap/netbird"
   echo "to update it"
 fi
+
+if [ -n "$NB_BIN" ]
+then
+  echo "Stopping and uninstalling NetBird daemon"
+  netbird service stop || true
+  netbird service uninstall || true
+fi
+
 # start netbird daemon service
 echo "Starting Netbird daemon"
 netbird service install || true

--- a/release_files/darwin_pkg/postinstall
+++ b/release_files/darwin_pkg/postinstall
@@ -1,8 +1,10 @@
 #!/bin/sh
 
+set -x
+
 APP=/Applications/NetBird.app
 AGENT=/usr/local/bin/netbird
-LOG_FILE=/var/log/netbird/client_install.log
+LOG_FILE=/var/log/netbird/client_post_install.log
 
 mkdir -p /var/log/netbird/
 mkdir -p /usr/local/bin/
@@ -17,18 +19,13 @@ mkdir -p /usr/local/bin/
         exit 1
     fi
 
-    osascript -e 'quit app "Netbird"' || true
-
-    ln -s $APP/Contents/MacOS/netbird $AGENT
+    ln -fs $APP/Contents/MacOS/netbird $AGENT
     if test -f $AGENT; then
         echo "NetBird binary linked successfully."
     else
         echo "NetBird could not create symlink to /usr/local/bin"
         exit 1
     fi
-
-    $AGENT service stop || true
-    $AGENT service uninstall || true
 
     $AGENT service install || true
     $AGENT service start || true
@@ -38,3 +35,4 @@ mkdir -p /usr/local/bin/
     echo "Finished Netbird installation successfully"
     exit 0 # all good
 } &> $LOG_FILE
+

--- a/release_files/darwin_pkg/postinstall
+++ b/release_files/darwin_pkg/postinstall
@@ -17,6 +17,8 @@ mkdir -p /usr/local/bin/
         exit 1
     fi
 
+    osascript -e 'quit app "Netbird"' || true
+
     ln -s $APP/Contents/MacOS/netbird $AGENT
     if test -f $AGENT; then
         echo "NetBird binary linked successfully."
@@ -25,8 +27,11 @@ mkdir -p /usr/local/bin/
         exit 1
     fi
 
-    $AGENT service install
-    $AGENT service start
+    $AGENT service stop || true
+    $AGENT service uninstall || true
+
+    $AGENT service install || true
+    $AGENT service start || true
 
     open $APP
 

--- a/release_files/darwin_pkg/preinstall
+++ b/release_files/darwin_pkg/preinstall
@@ -5,7 +5,10 @@ LOG_FILE=/var/log/netbird/client_install.log
 mkdir -p /var/log/netbird/
 
 {
-    osascript -e 'quit app "Netbird"' || true
+    netbird service stop || true
+    netbird service uninstall || true
+    pkill -f netbird || true
+
     echo "Preinstall complete"
     exit 0 # all good
 } &> $LOG_FILE

--- a/release_files/darwin_pkg/preinstall
+++ b/release_files/darwin_pkg/preinstall
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-LOG_FILE=/var/log/netbird/client_install.log
+set -x
+
+LOG_FILE=/var/log/netbird/client_pre_install.log
+AGENT=/usr/local/bin/netbird
 
 mkdir -p /var/log/netbird/
 
 {
+    osascript -e 'quit app "Netbird"' || true
+    $AGENT service stop || true
+
     echo "Preinstall complete"
     exit 0 # all good
 } &> $LOG_FILE
+

--- a/release_files/darwin_pkg/preinstall
+++ b/release_files/darwin_pkg/preinstall
@@ -5,10 +5,6 @@ LOG_FILE=/var/log/netbird/client_install.log
 mkdir -p /var/log/netbird/
 
 {
-    netbird service stop || true
-    netbird service uninstall || true
-    pkill -f netbird || true
-
     echo "Preinstall complete"
     exit 0 # all good
 } &> $LOG_FILE

--- a/release_files/darwin_pkg/preinstall
+++ b/release_files/darwin_pkg/preinstall
@@ -5,7 +5,7 @@ LOG_FILE=/var/log/netbird/client_install.log
 mkdir -p /var/log/netbird/
 
 {
-    pkill -f netbird || true
+    osascript -e 'quit app "Netbird"' || true
     echo "Preinstall complete"
     exit 0 # all good
 } &> $LOG_FILE

--- a/release_files/darwin_pkg/preinstall
+++ b/release_files/darwin_pkg/preinstall
@@ -5,6 +5,7 @@ LOG_FILE=/var/log/netbird/client_install.log
 mkdir -p /var/log/netbird/
 
 {
+    pkill -f netbird || true
     echo "Preinstall complete"
     exit 0 # all good
 } &> $LOG_FILE


### PR DESCRIPTION
## Describe your changes
The pkg is able to upgrade to the newest version but the currently running instance of netbird-ui app is not closed. So to have a clean state adding pkill before upgrade.
Additionally adding service stop/uninstall to the brew installer to not show errors in case of upgrading.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
