### PR TITLE
Fix routes allow acl rule

### DIFF
--- a/client/firewall/iptables/manager_linux_test.go
+++ b/client/firewall/iptables/manager_linux_test.go
@@ -10,14 +10,49 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fw "github.com/netbirdio/netbird/client/firewall"
+	"github.com/netbirdio/netbird/iface"
 )
+
+// iFaceMapper defines subset methods of interface required for manager
+type iFaceMock struct {
+	NameFunc    func() string
+	AddressFunc func() iface.WGAddress
+}
+
+func (i *iFaceMock) Name() string {
+	if i.NameFunc != nil {
+		return i.NameFunc()
+	}
+	panic("NameFunc is not set")
+}
+func (i *iFaceMock) Address() iface.WGAddress {
+	if i.AddressFunc != nil {
+		return i.AddressFunc()
+	}
+	panic("AddressFunc is not set")
+}
 
 func TestIptablesManager(t *testing.T) {
 	ipv4Client, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 	require.NoError(t, err)
 
+	mock := &iFaceMock{
+		NameFunc: func() string {
+			return "lo"
+		},
+		AddressFunc: func() iface.WGAddress {
+			return iface.WGAddress{
+				IP: net.ParseIP("10.20.0.1"),
+				Network: &net.IPNet{
+					IP:   net.ParseIP("10.20.0.0"),
+					Mask: net.IPv4Mask(255, 255, 255, 0),
+				},
+			}
+		},
+	}
+
 	// just check on the local interface
-	manager, err := Create("lo")
+	manager, err := Create(mock)
 	require.NoError(t, err)
 	time.Sleep(time.Second)
 
@@ -94,10 +129,25 @@ func checkRuleSpecs(t *testing.T, ipv4Client *iptables.IPTables, chainName strin
 }
 
 func TestIptablesCreatePerformance(t *testing.T) {
+	mock := &iFaceMock{
+		NameFunc: func() string {
+			return "lo"
+		},
+		AddressFunc: func() iface.WGAddress {
+			return iface.WGAddress{
+				IP: net.ParseIP("10.20.0.1"),
+				Network: &net.IPNet{
+					IP:   net.ParseIP("10.20.0.0"),
+					Mask: net.IPv4Mask(255, 255, 255, 0),
+				},
+			}
+		},
+	}
+
 	for _, testMax := range []int{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000} {
 		t.Run(fmt.Sprintf("Testing %d rules", testMax), func(t *testing.T) {
 			// just check on the local interface
-			manager, err := Create("lo")
+			manager, err := Create(mock)
 			require.NoError(t, err)
 			time.Sleep(time.Second)
 

--- a/client/firewall/iptables/manager_linux_test.go
+++ b/client/firewall/iptables/manager_linux_test.go
@@ -25,6 +25,7 @@ func (i *iFaceMock) Name() string {
 	}
 	panic("NameFunc is not set")
 }
+
 func (i *iFaceMock) Address() iface.WGAddress {
 	if i.AddressFunc != nil {
 		return i.AddressFunc()

--- a/client/internal/acl/manager.go
+++ b/client/internal/acl/manager.go
@@ -17,6 +17,7 @@ import (
 // iFaceMapper defines subset methods of interface required for manager
 type iFaceMapper interface {
 	Name() string
+	Address() iface.WGAddress
 	IsUserspaceBind() bool
 	SetFiltering(iface.PacketFilter) error
 }

--- a/client/internal/acl/manager.go
+++ b/client/internal/acl/manager.go
@@ -14,8 +14,8 @@ import (
 	mgmProto "github.com/netbirdio/netbird/management/proto"
 )
 
-// iFaceMapper defines subset methods of interface required for manager
-type iFaceMapper interface {
+// IFaceMapper defines subset methods of interface required for manager
+type IFaceMapper interface {
 	Name() string
 	Address() iface.WGAddress
 	IsUserspaceBind() bool

--- a/client/internal/acl/manager_create_linux.go
+++ b/client/internal/acl/manager_create_linux.go
@@ -19,10 +19,10 @@ func Create(iface iFaceMapper) (manager *DefaultManager, err error) {
 			return nil, err
 		}
 	} else {
-		if fm, err = nftables.Create(iface.Name()); err != nil {
+		if fm, err = nftables.Create(iface); err != nil {
 			log.Debugf("failed to create nftables manager: %s", err)
 			// fallback to iptables
-			if fm, err = iptables.Create(iface.Name()); err != nil {
+			if fm, err = iptables.Create(iface); err != nil {
 				log.Errorf("failed to create iptables manager: %s", err)
 				return nil, err
 			}

--- a/client/internal/acl/manager_create_linux.go
+++ b/client/internal/acl/manager_create_linux.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Create creates a firewall manager instance for the Linux
-func Create(iface iFaceMapper) (manager *DefaultManager, err error) {
+func Create(iface IFaceMapper) (manager *DefaultManager, err error) {
 	var fm firewall.Manager
 	if iface.IsUserspaceBind() {
 		// use userspace packet filtering firewall

--- a/client/internal/acl/mocks/README.md
+++ b/client/internal/acl/mocks/README.md
@@ -1,0 +1,7 @@
+## Mocks
+
+To generate (or refresh) mocks from acl package please install [mockgen](https://github.com/golang/mock).
+Run this command from the `./client/internal/acl` folder to update iface mapper interface mock:
+```bash
+mockgen -destination mocks/iface_mapper.go -package mocks . IFaceMapper
+```

--- a/client/internal/acl/mocks/iface_mapper.go
+++ b/client/internal/acl/mocks/iface_mapper.go
@@ -34,6 +34,20 @@ func (m *MockIFaceMapper) EXPECT() *MockIFaceMapperMockRecorder {
 	return m.recorder
 }
 
+// Address mocks base method.
+func (m *MockIFaceMapper) Address() iface.WGAddress {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Address")
+	ret0, _ := ret[0].(iface.WGAddress)
+	return ret0
+}
+
+// Address indicates an expected call of Address.
+func (mr *MockIFaceMapperMockRecorder) Address() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockIFaceMapper)(nil).Address))
+}
+
 // IsUserspaceBind mocks base method.
 func (m *MockIFaceMapper) IsUserspaceBind() bool {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Describe your changes
Modify rules in iptables and nftables to accept all traffic not from netbird network but routed through it.
## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
