### PR TITLE
Decouple docs generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,16 +206,3 @@ jobs:
           ref: ${{ env.SIGN_PIPE_VER }}
           token: ${{ secrets.SIGN_GITHUB_TOKEN }}
           inputs: '{ "tag": "${{ github.ref }}" }'
-
-  trigger_docs_build:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - name: Trigger API pages generation and docs build
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: docs site build and push
-          repo: netbirdio/docs
-          ref: "refs/heads/main"
-          token: ${{ secrets.SIGN_GITHUB_TOKEN }}
-          inputs: '{ "generateAPI": true }'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,24 @@
+name: update docs
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+    paths:
+      - 'management/server/http/api/openapi.yml'
+
+jobs:
+  trigger_docs_api_update:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Trigger API pages generation
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: generate api pages
+          repo: netbirdio/docs
+          ref: "refs/heads/main"
+          token: ${{ secrets.SIGN_GITHUB_TOKEN }}
+          inputs: '{ "tag": "${{ github.ref }}" }'


### PR DESCRIPTION
## Describe your changes
Adding seperate github actions workflow to decouple docs update from general release flow to only run if openapi doc is updated on release.


## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
