### PR TITLE
Remove the number of status notifications on disconnected peers

### DIFF
--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -146,8 +146,7 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 
 	d.peers[receivedState.PubKey] = peerState
 
-	if receivedState.ConnStatus == StatusConnecting ||
-		(receivedState.ConnStatus == StatusDisconnected && peerState.ConnStatus == StatusConnecting) {
+	if shouldSkipNotify(receivedState, peerState) {
 		return nil
 	}
 
@@ -159,6 +158,19 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 
 	d.notifyPeerListChanged()
 	return nil
+}
+
+func shouldSkipNotify(new, curr State) bool {
+	switch {
+	case new.ConnStatus == StatusConnecting:
+		return true
+	case new.ConnStatus == StatusDisconnected && curr.ConnStatus == StatusConnecting:
+		return true
+	case new.ConnStatus == StatusDisconnected && curr.ConnStatus == StatusDisconnected:
+		return curr.IP != ""
+	default:
+		return false
+	}
 }
 
 // UpdatePeerFQDN update peer's state fqdn only


### PR DESCRIPTION
## Describe your changes

Only send notifications when disconnected once, at peer's IP update.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
