### PR TITLE
Use different initialize order for DNS resolver in android/nonandroid…

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -199,7 +199,7 @@ func (e *Engine) Start() error {
 		}
 	}
 
-	if e.dnsServer == nil {
+	if e.dnsServer == nil && runtime.GOOS == "android" {
 		// todo fix custom address
 		dnsServer, err := dns.NewDefaultServer(e.ctx, e.wgInterface, e.config.CustomDNSAddress, dnsCfg)
 		if err != nil {
@@ -257,6 +257,16 @@ func (e *Engine) Start() error {
 		log.Errorf("failed to create ACL manager, policy will not work: %s", err.Error())
 	} else {
 		e.acl = acl
+	}
+
+	if e.dnsServer == nil && runtime.GOOS != "android" {
+		// todo fix custom address
+		dnsServer, err := dns.NewDefaultServer(e.ctx, e.wgInterface, e.config.CustomDNSAddress, dnsCfg)
+		if err != nil {
+			e.close()
+			return err
+		}
+		e.dnsServer = dnsServer
 	}
 
 	e.receiveSignalEvents()


### PR DESCRIPTION
## Describe your changes
Fix the wrong order of DNS resolver initialization in Android and non-android versions of the client.
## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
