### PR TITLE
Fix: Skip state notification should use a copy of the previous peer state

### DIFF
--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -135,6 +135,8 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 		peerState.IP = receivedState.IP
 	}
 
+	previousState := peerState
+
 	if receivedState.ConnStatus != peerState.ConnStatus {
 		peerState.ConnStatus = receivedState.ConnStatus
 		peerState.ConnStatusUpdate = receivedState.ConnStatusUpdate
@@ -146,7 +148,7 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 
 	d.peers[receivedState.PubKey] = peerState
 
-	if shouldSkipNotify(receivedState, peerState) {
+	if shouldSkipNotify(receivedState, previousState) {
 		return nil
 	}
 

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -135,7 +135,7 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 		peerState.IP = receivedState.IP
 	}
 
-	previousState := peerState
+	skipNotification := shouldSkipNotify(receivedState, peerState)
 
 	if receivedState.ConnStatus != peerState.ConnStatus {
 		peerState.ConnStatus = receivedState.ConnStatus
@@ -148,7 +148,7 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 
 	d.peers[receivedState.PubKey] = peerState
 
-	if shouldSkipNotify(receivedState, previousState) {
+	if skipNotification {
 		return nil
 	}
 


### PR DESCRIPTION
## Describe your changes

This was affecting the behavior of the route manager, causing issues with HA and with cases of flaky connections.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
