### PR TITLE
Feature/permanent dns

### DIFF
--- a/client/android/client.go
+++ b/client/android/client.go
@@ -49,6 +49,7 @@ type Client struct {
 	ctxCancelLock *sync.Mutex
 	deviceName    string
 	routeListener routemanager.RouteListener
+	onHostDnsFn   *func([]string)
 }
 
 // NewClient instantiate a new Client
@@ -90,7 +91,7 @@ func (c *Client) Run(urlOpener URLOpener, dns *DNSList) error {
 
 	// todo do not throw error in case of cancelled context
 	ctx = internal.CtxInitState(ctx)
-	return internal.RunClientMobile(ctx, cfg, c.recorder, c.tunAdapter, c.iFaceDiscover, c.routeListener, dns.items)
+	return internal.RunClientMobile(ctx, cfg, c.recorder, c.tunAdapter, c.iFaceDiscover, c.routeListener, dns.items, c.onHostDnsFn)
 }
 
 // Stop the internal client and free the resources
@@ -126,8 +127,11 @@ func (c *Client) PeersList() *PeerInfoArray {
 	return &PeerInfoArray{items: peerInfos}
 }
 
-func (c *Client) UpdateDNSUpstreams(list DNSList) {
-
+func (c *Client) OnUpdateHostDNS(list DNSList) {
+	if c.onHostDnsFn == nil {
+		return
+	}
+	(*c.onHostDnsFn)(list.items)
 }
 
 // SetConnectionListener set the network connection listener

--- a/client/android/client.go
+++ b/client/android/client.go
@@ -49,7 +49,7 @@ type Client struct {
 	ctxCancelLock *sync.Mutex
 	deviceName    string
 	routeListener routemanager.RouteListener
-	onHostDnsFn   *func([]string)
+	onHostDnsFn   func([]string)
 }
 
 // NewClient instantiate a new Client
@@ -91,7 +91,8 @@ func (c *Client) Run(urlOpener URLOpener, dns *DNSList) error {
 
 	// todo do not throw error in case of cancelled context
 	ctx = internal.CtxInitState(ctx)
-	return internal.RunClientMobile(ctx, cfg, c.recorder, c.tunAdapter, c.iFaceDiscover, c.routeListener, dns.items, c.onHostDnsFn)
+	c.onHostDnsFn = func([]string) {}
+	return internal.RunClientMobile(ctx, cfg, c.recorder, c.tunAdapter, c.iFaceDiscover, c.routeListener, dns.items, &c.onHostDnsFn)
 }
 
 // Stop the internal client and free the resources
@@ -127,11 +128,12 @@ func (c *Client) PeersList() *PeerInfoArray {
 	return &PeerInfoArray{items: peerInfos}
 }
 
-func (c *Client) OnUpdateHostDNS(list DNSList) {
+func (c *Client) OnUpdateHostDNS(list *DNSList) {
 	if c.onHostDnsFn == nil {
 		return
 	}
-	(*c.onHostDnsFn)(list.items)
+
+	c.onHostDnsFn(list.items)
 }
 
 // SetConnectionListener set the network connection listener

--- a/client/android/client.go
+++ b/client/android/client.go
@@ -65,7 +65,7 @@ func NewClient(cfgFile, deviceName string, tunAdapter TunAdapter, iFaceDiscover 
 }
 
 // Run start the internal client. It is a blocker function
-func (c *Client) Run(urlOpener URLOpener) error {
+func (c *Client) Run(urlOpener URLOpener, dns *DNSList) error {
 	cfg, err := internal.UpdateOrCreateConfig(internal.ConfigInput{
 		ConfigPath: c.cfgFile,
 	})
@@ -90,7 +90,7 @@ func (c *Client) Run(urlOpener URLOpener) error {
 
 	// todo do not throw error in case of cancelled context
 	ctx = internal.CtxInitState(ctx)
-	return internal.RunClient(ctx, cfg, c.recorder, c.tunAdapter, c.iFaceDiscover, c.routeListener)
+	return internal.RunClientMobile(ctx, cfg, c.recorder, c.tunAdapter, c.iFaceDiscover, c.routeListener, dns.items)
 }
 
 // Stop the internal client and free the resources
@@ -124,6 +124,10 @@ func (c *Client) PeersList() *PeerInfoArray {
 		peerInfos[n] = pi
 	}
 	return &PeerInfoArray{items: peerInfos}
+}
+
+func (c *Client) UpdateDNSUpstreams(list DNSList) {
+
 }
 
 // SetConnectionListener set the network connection listener

--- a/client/android/dns_list.go
+++ b/client/android/dns_list.go
@@ -1,0 +1,21 @@
+package android
+
+// DNSList is a wrapper of []string
+type DNSList struct {
+	items []string
+}
+
+// Add new DNS address to the collection
+func (array *DNSList) Add(s string) {
+	array.items = append(array.items, s)
+}
+
+// Get return an element of the collection
+func (array *DNSList) Get(i int) string {
+	return array.items[i]
+}
+
+// Size return with the size of the collection
+func (array *DNSList) Size() int {
+	return len(array.items)
+}

--- a/client/android/dns_list.go
+++ b/client/android/dns_list.go
@@ -1,5 +1,7 @@
 package android
 
+import "fmt"
+
 // DNSList is a wrapper of []string
 type DNSList struct {
 	items []string
@@ -11,8 +13,11 @@ func (array *DNSList) Add(s string) {
 }
 
 // Get return an element of the collection
-func (array *DNSList) Get(i int) string {
-	return array.items[i]
+func (array *DNSList) Get(i int) (string, error) {
+	if i >= len(array.items) || i < 0 {
+		return "", fmt.Errorf("out of range")
+	}
+	return array.items[i], nil
 }
 
 // Size return with the size of the collection

--- a/client/android/dns_list_test.go
+++ b/client/android/dns_list_test.go
@@ -17,7 +17,7 @@ func TestDNSList_Get(t *testing.T) {
 		t.Errorf("expected error but got nil")
 	}
 
-	_, err = l.Get(-1)
+	_, err = l.Get(1)
 	if err == nil {
 		t.Errorf("expected error but got nil")
 	}

--- a/client/android/dns_list_test.go
+++ b/client/android/dns_list_test.go
@@ -1,0 +1,24 @@
+package android
+
+import "testing"
+
+func TestDNSList_Get(t *testing.T) {
+	l := DNSList{
+		items: make([]string, 1),
+	}
+
+	_, err := l.Get(0)
+	if err != nil {
+		t.Errorf("invalid error: %s", err)
+	}
+
+	_, err = l.Get(-1)
+	if err == nil {
+		t.Errorf("expected error but got nil")
+	}
+
+	_, err = l.Get(-1)
+	if err == nil {
+		t.Errorf("expected error but got nil")
+	}
+}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -104,7 +104,7 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command) error {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
 	SetupCloseHandler(ctx, cancel)
-	return internal.RunClient(ctx, config, peer.NewRecorder(config.ManagementURL.String()), nil, nil, nil)
+	return internal.RunClient(ctx, config, peer.NewRecorder(config.ManagementURL.String()))
 }
 
 func runInDaemonMode(ctx context.Context, cmd *cobra.Command) error {

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
 
+	"github.com/netbirdio/netbird/client/internal/dns"
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/routemanager"
 	"github.com/netbirdio/netbird/client/internal/stdnet"
@@ -29,14 +30,14 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 }
 
 // RunClientMobile with main logic on mobile system
-func RunClientMobile(ctx context.Context, config *Config, statusRecorder *peer.Status, tunAdapter iface.TunAdapter, iFaceDiscover stdnet.ExternalIFaceDiscover, routeListener routemanager.RouteListener, dnsAddresses []string, onHostDnsUpdateFn *func([]string)) error {
+func RunClientMobile(ctx context.Context, config *Config, statusRecorder *peer.Status, tunAdapter iface.TunAdapter, iFaceDiscover stdnet.ExternalIFaceDiscover, routeListener routemanager.RouteListener, dnsAddresses []string, dnsReadyListener dns.ReadyListener) error {
 	// in case of non Android os these variables will be nil
 	mobileDependency := MobileDependency{
-		TunAdapter:        tunAdapter,
-		IFaceDiscover:     iFaceDiscover,
-		RouteListener:     routeListener,
-		HostDNSAddresses:  dnsAddresses,
-		onHostDnsUpdateFn: onHostDnsUpdateFn,
+		TunAdapter:       tunAdapter,
+		IFaceDiscover:    iFaceDiscover,
+		RouteListener:    routeListener,
+		HostDNSAddresses: dnsAddresses,
+		DnsReadyListener: dnsReadyListener,
 	}
 	return runClient(ctx, config, statusRecorder, mobileDependency)
 }

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -29,13 +29,14 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 }
 
 // RunClientMobile with main logic on mobile system
-func RunClientMobile(ctx context.Context, config *Config, statusRecorder *peer.Status, tunAdapter iface.TunAdapter, iFaceDiscover stdnet.ExternalIFaceDiscover, routeListener routemanager.RouteListener, dnsAddresses []string) error {
+func RunClientMobile(ctx context.Context, config *Config, statusRecorder *peer.Status, tunAdapter iface.TunAdapter, iFaceDiscover stdnet.ExternalIFaceDiscover, routeListener routemanager.RouteListener, dnsAddresses []string, onHostDnsUpdateFn *func([]string)) error {
 	// in case of non Android os these variables will be nil
 	mobileDependency := MobileDependency{
-		TunAdapter:       tunAdapter,
-		IFaceDiscover:    iFaceDiscover,
-		RouteListener:    routeListener,
-		HostDNSAddresses: dnsAddresses,
+		TunAdapter:        tunAdapter,
+		IFaceDiscover:     iFaceDiscover,
+		RouteListener:     routeListener,
+		HostDNSAddresses:  dnsAddresses,
+		onHostDnsUpdateFn: onHostDnsUpdateFn,
 	}
 	return runClient(ctx, config, statusRecorder, mobileDependency)
 }

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -32,10 +32,10 @@ func RunClient(ctx context.Context, config *Config, statusRecorder *peer.Status)
 func RunClientMobile(ctx context.Context, config *Config, statusRecorder *peer.Status, tunAdapter iface.TunAdapter, iFaceDiscover stdnet.ExternalIFaceDiscover, routeListener routemanager.RouteListener, dnsAddresses []string) error {
 	// in case of non Android os these variables will be nil
 	mobileDependency := MobileDependency{
-		TunAdapter:           tunAdapter,
-		IFaceDiscover:        iFaceDiscover,
-		RouteListener:        routeListener,
-		UpstreamDNSAddresses: dnsAddresses,
+		TunAdapter:       tunAdapter,
+		IFaceDiscover:    iFaceDiscover,
+		RouteListener:    routeListener,
+		HostDNSAddresses: dnsAddresses,
 	}
 	return runClient(ctx, config, statusRecorder, mobileDependency)
 }

--- a/client/internal/dns/host_android.go
+++ b/client/internal/dns/host_android.go
@@ -1,13 +1,9 @@
 package dns
 
-import (
-	"github.com/netbirdio/netbird/iface"
-)
-
 type androidHostManager struct {
 }
 
-func newHostManager(wgInterface *iface.WGIface) (hostManager, error) {
+func newHostManager(wgInterface WGIface) (hostManager, error) {
 	return &androidHostManager{}, nil
 }
 

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/netbirdio/netbird/iface"
 )
 
 const (
@@ -34,7 +32,7 @@ type systemConfigurator struct {
 	createdKeys      map[string]struct{}
 }
 
-func newHostManager(_ *iface.WGIface) (hostManager, error) {
+func newHostManager(_ WGIface) (hostManager, error) {
 	return &systemConfigurator{
 		createdKeys: make(map[string]struct{}),
 	}, nil

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -5,10 +5,10 @@ package dns
 import (
 	"bufio"
 	"fmt"
-	"github.com/netbirdio/netbird/iface"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -25,7 +25,7 @@ const (
 
 type osManagerType int
 
-func newHostManager(wgInterface *iface.WGIface) (hostManager, error) {
+func newHostManager(wgInterface WGIface) (hostManager, error) {
 	osManager, err := getOSDNSManagerType()
 	if err != nil {
 		return nil, err

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -6,8 +6,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/registry"
-
-	"github.com/netbirdio/netbird/iface"
 )
 
 const (
@@ -33,7 +31,7 @@ type registryConfigurator struct {
 	existingSearchDomains []string
 }
 
-func newHostManager(wgInterface *iface.WGIface) (hostManager, error) {
+func newHostManager(wgInterface WGIface) (hostManager, error) {
 	guid, err := wgInterface.GetInterfaceGUIDString()
 	if err != nil {
 		return nil, err

--- a/client/internal/dns/mockServer.go
+++ b/client/internal/dns/mockServer.go
@@ -12,8 +12,8 @@ type MockServer struct {
 	UpdateDNSServerFunc func(serial uint64, update nbdns.Config) error
 }
 
-// Initialize mock implementation of Initialize from Server interface
-func (m *MockServer) Initialize() error {
+// InitializeHostMgr mock implementation of Initialize from Server interface
+func (m *MockServer) InitializeHostMgr() error {
 	if m.InitializeFunc != nil {
 		return m.InitializeFunc()
 	}

--- a/client/internal/dns/mockServer.go
+++ b/client/internal/dns/mockServer.go
@@ -12,8 +12,8 @@ type MockServer struct {
 	UpdateDNSServerFunc func(serial uint64, update nbdns.Config) error
 }
 
-// InitializeHostMgr mock implementation of Initialize from Server interface
-func (m *MockServer) InitializeHostMgr() error {
+// Initialize mock implementation of Initialize from Server interface
+func (m *MockServer) Initialize() error {
 	if m.InitializeFunc != nil {
 		return m.InitializeFunc()
 	}
@@ -29,6 +29,11 @@ func (m *MockServer) Stop() {
 
 func (m *MockServer) DnsIP() string {
 	return ""
+}
+
+func (m *MockServer) OnUpdatedHostDNSServer(strings []string) {
+	//TODO implement me
+	panic("implement me")
 }
 
 // UpdateDNSServer mock implementation of UpdateDNSServer from Server interface

--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -14,8 +14,6 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/netbirdio/netbird/iface"
 )
 
 const (
@@ -72,7 +70,7 @@ func (s networkManagerConnSettings) cleanDeprecatedSettings() {
 	}
 }
 
-func newNetworkManagerDbusConfigurator(wgInterface *iface.WGIface) (hostManager, error) {
+func newNetworkManagerDbusConfigurator(wgInterface WGIface) (hostManager, error) {
 	obj, closeConn, err := getDbusObject(networkManagerDest, networkManagerDbusObjectNode)
 	if err != nil {
 		return nil, err

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/netbirdio/netbird/iface"
 )
 
 const resolvconfCommand = "resolvconf"
@@ -18,7 +16,7 @@ type resolvconf struct {
 	ifaceName string
 }
 
-func newResolvConfConfigurator(wgInterface *iface.WGIface) (hostManager, error) {
+func newResolvConfConfigurator(wgInterface WGIface) (hostManager, error) {
 	return &resolvconf{
 		ifaceName: wgInterface.Name(),
 	}, nil

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -218,7 +218,7 @@ func (s *DefaultServer) applyConfiguration(update nbdns.Config) error {
 	// and proceed with a regular update to clean up the handlers and records
 	if update.ServiceEnable {
 		_ = s.service.Listen()
-	} else {
+	} else if !s.permanent {
 		s.service.Stop()
 	}
 

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -34,7 +34,6 @@ type DefaultServer struct {
 	ctx                context.Context
 	ctxCancel          context.CancelFunc
 	mux                sync.Mutex
-	udpFilterHookID    string
 	service            service
 	dnsMuxMap          registeredHandlerMap
 	localResolver      *localResolver
@@ -45,9 +44,8 @@ type DefaultServer struct {
 	currentConfig      hostDNSConfig
 
 	// permanent related properties
-	permanent     bool
-	hostsDnsList  []string
-	readyListener ReadyListener
+	permanent    bool
+	hostsDnsList []string
 }
 
 type handlerWithStop interface {

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -81,14 +81,13 @@ func NewDefaultServer(ctx context.Context, wgInterface WGIface, customAddress st
 }
 
 // NewDefaultServerPermanentUpstream returns a new dns server. It optimized for mobile systems
-func NewDefaultServerPermanentUpstream(ctx context.Context, wgInterface WGIface, hostsDnsList []string, readyListener ReadyListener) *DefaultServer {
+func NewDefaultServerPermanentUpstream(ctx context.Context, wgInterface WGIface, hostsDnsList []string) *DefaultServer {
 	log.Debugf("host dns address list is: %v", hostsDnsList)
 	ds := newDefaultServer(ctx, wgInterface, newServiceViaMemory(wgInterface))
 	ds.permanent = true
 	ds.hostsDnsList = hostsDnsList
 	ds.addHostRootZone()
 	setServerDns(ds)
-	go readyListener.OnReady()
 	return ds
 }
 

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -74,10 +74,11 @@ func NewDefaultServer(ctx context.Context, wgInterface WGIface, customAddress st
 
 // NewDefaultServerPermanentUpstream returns a new dns server. It optimized for mobile systems
 func NewDefaultServerPermanentUpstream(ctx context.Context, wgInterface WGIface, initialDnsCfg nbdns.Config, hostsDnsList []string) *DefaultServer {
-	ds := newDefaultServer(ctx, wgInterface, newServiceViaListener(wgInterface, nil))
+	log.Debugf("host dns address list is: %v", hostsDnsList)
+	ds := newDefaultServer(ctx, wgInterface, newServiceViaMemory(wgInterface))
 	ds.hostsDnsList = hostsDnsList
-	ds.addHostRootZone()
 	ds.service.Listen()
+	ds.addHostRootZone()
 
 	// suppose the ctx is not done in this phase so we can ignore the error
 	_ = ds.UpdateDNSServer(0, initialDnsCfg)
@@ -442,5 +443,6 @@ func (s *DefaultServer) addHostRootZone() {
 	for n, ua := range s.hostsDnsList {
 		handler.upstreamServers[n] = fmt.Sprintf("%s:53", ua)
 	}
+	log.Debugf("register dns handler for zone: '%s'", nbdns.RootZone)
 	s.service.RegisterMux(nbdns.RootZone, handler)
 }

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -82,7 +82,7 @@ func NewDefaultServer(ctx context.Context, wgInterface WGIface, customAddress st
 }
 
 // NewDefaultServerPermanentUpstream returns a new dns server. It optimized for mobile systems
-func NewDefaultServerPermanentUpstream(ctx context.Context, wgInterface WGIface, initialDnsCfg nbdns.Config, hostsDnsList []string, readyListener ReadyListener) *DefaultServer {
+func NewDefaultServerPermanentUpstream(ctx context.Context, wgInterface WGIface, hostsDnsList []string, readyListener ReadyListener) *DefaultServer {
 	log.Debugf("host dns address list is: %v", hostsDnsList)
 	ds := newDefaultServer(ctx, wgInterface, newServiceViaMemory(wgInterface))
 	ds.permanent = true

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -213,7 +213,6 @@ func (s *DefaultServer) UpdateDNSServer(serial uint64, update nbdns.Config) erro
 }
 
 func (s *DefaultServer) applyConfiguration(update nbdns.Config) error {
-	// todo should it handle in case of permanent dns service?
 	// is the service should be disabled, we stop the listener or fake resolver
 	// and proceed with a regular update to clean up the handlers and records
 	if update.ServiceEnable {

--- a/client/internal/dns/server_export.go
+++ b/client/internal/dns/server_export.go
@@ -1,0 +1,29 @@
+package dns
+
+import (
+	"fmt"
+	"sync"
+)
+
+var (
+	mutex  sync.Mutex
+	server Server
+)
+
+// GetServerDns export the DNS server instance in static way. It used by the Mobile client
+func GetServerDns() (Server, error) {
+	mutex.Lock()
+	if server == nil {
+		mutex.Unlock()
+		return nil, fmt.Errorf("DNS server not instantiated yet")
+	}
+	s := server
+	mutex.Unlock()
+	return s, nil
+}
+
+func setServerDns(newServerServer Server) {
+	mutex.Lock()
+	server = newServerServer
+	defer mutex.Unlock()
+}

--- a/client/internal/dns/server_export_test.go
+++ b/client/internal/dns/server_export_test.go
@@ -1,0 +1,24 @@
+package dns
+
+import (
+	"testing"
+)
+
+func TestGetServerDns(t *testing.T) {
+	_, err := GetServerDns()
+	if err == nil {
+		t.Errorf("invalid dns server instance")
+	}
+
+	srv := &MockServer{}
+	setServerDns(srv)
+
+	srvB, err := GetServerDns()
+	if err != nil {
+		t.Errorf("invalid dns server instance: %s", err)
+	}
+
+	if srvB != srv {
+		t.Errorf("missmatch dns instances")
+	}
+}

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -286,11 +286,6 @@ func TestUpdateDNSServer(t *testing.T) {
 			dnsServer.dnsMuxMap = testCase.initUpstreamMap
 			dnsServer.localResolver.registeredMap = testCase.initLocalMap
 			dnsServer.updateSerial = testCase.initSerial
-			// pretend we are running
-			/*
-				dnsServer.listenerIsRunning = true
-				dnsServer.fakeResolverWG.Add(1)
-			*/
 
 			err = dnsServer.UpdateDNSServer(testCase.inputSerial, testCase.inputUpdate)
 			if err != nil {
@@ -478,11 +473,6 @@ func TestDNSServerStartStop(t *testing.T) {
 				t.Fatalf("dns server is not running: %s", err)
 			}
 			time.Sleep(100 * time.Millisecond)
-			// todo fix test
-			/*
-				if !dnsServer.service.listenerIsRunning {
-					t.Fatal("dns server listener is not running")
-				}*/
 			defer dnsServer.Stop()
 			err = dnsServer.localResolver.registerRecord(zoneRecords[0])
 			if err != nil {

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -459,9 +459,13 @@ func TestDNSServerStartStop(t *testing.T) {
 				t.Fatalf("%v", err)
 			}
 			dnsServer.hostManager = newNoopHostMocker()
-			dnsServer.service.Listen()
+			err = dnsServer.service.Listen()
+			if err != nil {
+				t.Fatalf("dns server is not running: %s", err)
+			}
 			time.Sleep(100 * time.Millisecond)
-			/*
+            // todo fix test
+            /*
 				if !dnsServer.service.listenerIsRunning {
 					t.Fatal("dns server listener is not running")
 				}*/

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -19,6 +19,33 @@ import (
 	pfmock "github.com/netbirdio/netbird/iface/mocks"
 )
 
+type mocWGIface struct {
+}
+
+func (w mocWGIface) Name() string {
+	panic("implement me")
+}
+
+func (w mocWGIface) Address() iface.WGAddress {
+	panic("implement me")
+}
+
+func (w mocWGIface) GetFilter() iface.PacketFilter {
+	panic("implement me")
+}
+
+func (w mocWGIface) GetDevice() *iface.DeviceWrapper {
+	panic("implement me")
+}
+
+func (w mocWGIface) GetInterfaceGUIDString() (string, error) {
+	panic("implement me")
+}
+
+func (w mocWGIface) IsUserspaceBind() bool {
+	return false
+}
+
 var zoneRecords = []nbdns.SimpleRecord{
 	{
 		Name:  "peera.netbird.cloud",
@@ -572,6 +599,7 @@ func getDefaultServerWithNoHostManager(t *testing.T, addrPort string) *DefaultSe
 		},
 		customAddress: parsedAddrPort,
 	}
+	ds.wgInterface = mocWGIface{}
 	ds.evalRuntimeAddress()
 	return ds
 }

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -258,7 +258,7 @@ func TestUpdateDNSServer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = dnsServer.InitializeHostMgr()
+			err = dnsServer.Initialize()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -365,7 +365,7 @@ func TestDNSFakeResolverHandleUpdates(t *testing.T) {
 		return
 	}
 
-	err = dnsServer.InitializeHostMgr()
+	err = dnsServer.Initialize()
 	if err != nil {
 		t.Errorf("run DNS server: %v", err)
 		return

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -522,7 +522,6 @@ func TestDNSServerStartStop(t *testing.T) {
 func TestDNSServerUpstreamDeactivateCallback(t *testing.T) {
 	hostManager := &mockHostConfigurator{}
 	server := DefaultServer{
-		//dnsMux: dns.DefaultServeMux,
 		service: newServiceViaMemory(&mocWGIface{}),
 		localResolver: &localResolver{
 			registeredMap: make(registrationMap),

--- a/client/internal/dns/service.go
+++ b/client/internal/dns/service.go
@@ -9,7 +9,7 @@ const (
 )
 
 type service interface {
-	Listen()
+	Listen() error
 	Stop()
 	RegisterMux(domain string, handler dns.Handler)
 	DeregisterMux(key string)

--- a/client/internal/dns/service.go
+++ b/client/internal/dns/service.go
@@ -1,0 +1,18 @@
+package dns
+
+import (
+	"github.com/miekg/dns"
+)
+
+const (
+	defaultPort = 53
+)
+
+type service interface {
+	Listen()
+	Stop()
+	RegisterMux(domain string, handler dns.Handler)
+	DeregisterMux(key string)
+	RuntimePort() int
+	RuntimeIP() string
+}

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -1,0 +1,143 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	customPort = 5053
+	defaultIP  = "127.0.0.1"
+	customIP   = "127.0.0.153"
+)
+
+type serviceViaListener struct {
+	wgInterface WGIface
+
+	dnsMux            *dns.ServeMux
+	server            *dns.Server
+	runtimeIP         string
+	runtimePort       int
+	listenerIsRunning bool
+	listenerFlagLock  sync.Mutex
+}
+
+func newServiceViaListener(wgIface WGIface, customAddr *netip.AddrPort) *serviceViaListener {
+	mux := dns.NewServeMux()
+
+	s := &serviceViaListener{
+		wgInterface: wgIface,
+		dnsMux:      mux,
+	}
+	// todo: run eval after WGIface creation
+	s.runtimeIP, s.runtimePort = s.evalRuntimeAddress(customAddr)
+	s.server = &dns.Server{
+		Net:     "udp",
+		Handler: mux,
+		Addr:    fmt.Sprintf("%s:%d", s.runtimeIP, s.runtimePort),
+		UDPSize: 65535,
+	}
+	return s
+}
+
+func (s *serviceViaListener) Listen() {
+	s.listenerFlagLock.Lock()
+	defer s.listenerFlagLock.Unlock()
+
+	if s.listenerIsRunning {
+		return
+	}
+
+	log.Debugf("starting dns on %s", s.server.Addr)
+	go func() {
+		s.setListenerStatus(true)
+		defer s.setListenerStatus(false)
+
+		err := s.server.ListenAndServe()
+		if err != nil {
+			log.Errorf("dns server running with %d port returned an error: %v. Will not retry", s.runtimePort, err)
+		}
+	}()
+}
+
+func (s *serviceViaListener) Stop() {
+	s.listenerFlagLock.Lock()
+	defer s.listenerFlagLock.Unlock()
+
+	if !s.listenerIsRunning {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := s.server.ShutdownContext(ctx)
+	if err != nil {
+		log.Errorf("stopping dns server listener returned an error: %v", err)
+	}
+}
+
+func (s *serviceViaListener) RegisterMux(pattern string, handler dns.Handler) {
+	s.dnsMux.Handle(pattern, handler)
+}
+
+func (s *serviceViaListener) DeregisterMux(pattern string) {
+	s.dnsMux.HandleRemove(pattern)
+}
+
+func (s *serviceViaListener) RuntimePort() int {
+	return s.runtimePort
+}
+
+func (s *serviceViaListener) RuntimeIP() string {
+	return s.runtimeIP
+}
+
+func (s *serviceViaListener) setListenerStatus(running bool) {
+	s.listenerIsRunning = running
+}
+
+func (s *serviceViaListener) getFirstListenerAvailable() (string, int, error) {
+	ips := []string{defaultIP, customIP}
+	if runtime.GOOS != "darwin" {
+		ips = append([]string{s.wgInterface.Address().IP.String()}, ips...)
+	}
+	ports := []int{defaultPort, customPort}
+	for _, port := range ports {
+		for _, ip := range ips {
+			addrString := fmt.Sprintf("%s:%d", ip, port)
+			udpAddr := net.UDPAddrFromAddrPort(netip.MustParseAddrPort(addrString))
+			probeListener, err := net.ListenUDP("udp", udpAddr)
+			if err == nil {
+				err = probeListener.Close()
+				if err != nil {
+					log.Errorf("got an error closing the probe listener, error: %s", err)
+				}
+				return ip, port, nil
+			}
+			log.Warnf("binding dns on %s is not available, error: %s", addrString, err)
+		}
+	}
+	return "", 0, fmt.Errorf("unable to find an unused ip and port combination. IPs tested: %v and ports %v", ips, ports)
+}
+
+func (s *serviceViaListener) evalRuntimeAddress(customAddress *netip.AddrPort) (string, int) {
+	if customAddress != nil {
+		return customAddress.Addr().String(), int(customAddress.Port())
+	}
+
+	ip, port, err := s.getFirstListenerAvailable()
+	if err != nil {
+		// todo error handling
+		log.Error(err)
+	}
+	return ip, port
+}

--- a/client/internal/dns/service_memory.go
+++ b/client/internal/dns/service_memory.go
@@ -1,0 +1,132 @@
+package dns
+
+import (
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+	"math/big"
+	"net"
+	"sync"
+)
+
+type serviceViaMemory struct {
+	wgInterface       WGIface
+	dnsMux            *dns.ServeMux
+	runtimeIP         string
+	runtimePort       int
+	udpFilterHookID   string
+	listenerIsRunning bool
+	listenerFlagLock  sync.Mutex
+}
+
+func newServiceViaMemory(wgIface WGIface) *serviceViaMemory {
+	s := &serviceViaMemory{
+		wgInterface: wgIface,
+		dnsMux:      dns.NewServeMux(),
+
+		runtimeIP:   getLastIPFromNetwork(wgIface.Address().Network, 1),
+		runtimePort: defaultPort,
+	}
+	return s
+}
+
+func (s *serviceViaMemory) Listen() {
+	s.listenerFlagLock.Lock()
+	defer s.listenerFlagLock.Unlock()
+
+	if s.listenerIsRunning {
+		return
+	}
+
+	s.udpFilterHookID = s.filterDNSTraffic()
+	s.listenerIsRunning = true
+
+}
+
+func (s *serviceViaMemory) Stop() {
+	s.listenerFlagLock.Lock()
+	defer s.listenerFlagLock.Unlock()
+
+	if !s.listenerIsRunning {
+		return
+	}
+
+	if err := s.wgInterface.GetFilter().RemovePacketHook(s.udpFilterHookID); err != nil {
+		log.Errorf("unable to remove DNS packet hook: %s", err)
+	}
+
+	s.listenerIsRunning = false
+}
+
+func (s *serviceViaMemory) RegisterMux(pattern string, handler dns.Handler) {
+	s.dnsMux.Handle(pattern, handler)
+}
+
+func (s *serviceViaMemory) DeregisterMux(pattern string) {
+	s.dnsMux.HandleRemove(pattern)
+}
+
+func (s *serviceViaMemory) RuntimePort() int {
+	return s.runtimePort
+}
+
+func (s *serviceViaMemory) RuntimeIP() string {
+	return s.runtimeIP
+}
+
+func (s *serviceViaMemory) filterDNSTraffic() string {
+	filter := s.wgInterface.GetFilter()
+	if filter == nil {
+		log.Error("can't set DNS filter, filter not initialized")
+		return ""
+	}
+
+	firstLayerDecoder := layers.LayerTypeIPv4
+	if s.wgInterface.Address().Network.IP.To4() == nil {
+		firstLayerDecoder = layers.LayerTypeIPv6
+	}
+
+	hook := func(packetData []byte) bool {
+		// Decode the packet
+		packet := gopacket.NewPacket(packetData, firstLayerDecoder, gopacket.Default)
+
+		// Get the UDP layer
+		udpLayer := packet.Layer(layers.LayerTypeUDP)
+		udp := udpLayer.(*layers.UDP)
+
+		msg := new(dns.Msg)
+		if err := msg.Unpack(udp.Payload); err != nil {
+			log.Tracef("parse DNS request: %v", err)
+			return true
+		}
+
+		writer := responseWriter{
+			packet: packet,
+			device: s.wgInterface.GetDevice().Device,
+		}
+		go s.dnsMux.ServeDNS(&writer, msg)
+		return true
+	}
+
+	return filter.AddUDPPacketHook(false, net.ParseIP(s.runtimeIP), uint16(s.runtimePort), hook)
+}
+
+func getLastIPFromNetwork(network *net.IPNet, fromEnd int) string {
+	// Calculate the last IP in the CIDR range
+	var endIP net.IP
+	for i := 0; i < len(network.IP); i++ {
+		endIP = append(endIP, network.IP[i]|^network.Mask[i])
+	}
+
+	// convert to big.Int
+	endInt := big.NewInt(0)
+	endInt.SetBytes(endIP)
+
+	// subtract fromEnd from the last ip
+	fromEndBig := big.NewInt(int64(fromEnd))
+	resultInt := big.NewInt(0)
+	resultInt.Sub(endInt, fromEndBig)
+
+	return net.IP(resultInt.Bytes()).String()
+}

--- a/client/internal/dns/service_memory.go
+++ b/client/internal/dns/service_memory.go
@@ -42,6 +42,7 @@ func (s *serviceViaMemory) Listen() {
 	s.udpFilterHookID = s.filterDNSTraffic()
 	s.listenerIsRunning = true
 
+	log.Debugf("dns service listening on: %s", s.RuntimeIP())
 }
 
 func (s *serviceViaMemory) Stop() {

--- a/client/internal/dns/service_memory_test.go
+++ b/client/internal/dns/service_memory_test.go
@@ -1,0 +1,31 @@
+package dns
+
+import (
+	"net"
+	"testing"
+)
+
+func TestGetLastIPFromNetwork(t *testing.T) {
+	tests := []struct {
+		addr string
+		ip   string
+	}{
+		{"2001:db8::/32", "2001:db8:ffff:ffff:ffff:ffff:ffff:fffe"},
+		{"192.168.0.0/30", "192.168.0.2"},
+		{"192.168.0.0/16", "192.168.255.254"},
+		{"192.168.0.0/24", "192.168.0.254"},
+	}
+
+	for _, tt := range tests {
+		_, ipnet, err := net.ParseCIDR(tt.addr)
+		if err != nil {
+			t.Errorf("Error parsing CIDR: %v", err)
+			return
+		}
+
+		lastIP := getLastIPFromNetwork(ipnet, 1)
+		if lastIP != tt.ip {
+			t.Errorf("wrong IP address, expected %s: got %s", tt.ip, lastIP)
+		}
+	}
+}

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	nbdns "github.com/netbirdio/netbird/dns"
-	"github.com/netbirdio/netbird/iface"
 )
 
 const (
@@ -53,7 +52,7 @@ type systemdDbusLinkDomainsInput struct {
 	MatchOnly bool
 }
 
-func newSystemdDbusConfigurator(wgInterface *iface.WGIface) (hostManager, error) {
+func newSystemdDbusConfigurator(wgInterface WGIface) (hostManager, error) {
 	iface, err := net.InterfaceByName(wgInterface.Name())
 	if err != nil {
 		return nil, err

--- a/client/internal/dns/wgiface.go
+++ b/client/internal/dns/wgiface.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package dns
+
+import "github.com/netbirdio/netbird/iface"
+
+// WGIface defines subset methods of interface required for manager
+type WGIface interface {
+	Name() string
+	Address() iface.WGAddress
+	IsUserspaceBind() bool
+	GetFilter() iface.PacketFilter
+	GetDevice() *iface.DeviceWrapper
+}

--- a/client/internal/dns/wgiface_windows.go
+++ b/client/internal/dns/wgiface_windows.go
@@ -1,5 +1,7 @@
 package dns
 
+import "github.com/netbirdio/netbird/iface"
+
 // WGIface defines subset methods of interface required for manager
 type WGIface interface {
 	Name() string

--- a/client/internal/dns/wgiface_windows.go
+++ b/client/internal/dns/wgiface_windows.go
@@ -1,0 +1,11 @@
+package dns
+
+// WGIface defines subset methods of interface required for manager
+type WGIface interface {
+	Name() string
+	Address() iface.WGAddress
+	IsUserspaceBind() bool
+	GetFilter() iface.PacketFilter
+	GetDevice() *iface.DeviceWrapper
+	GetInterfaceGUIDString() (string, error)
+}

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"context"
 	"fmt"
-	"github.com/pion/ice/v2"
 	"io"
 	"math/rand"
 	"net"
@@ -14,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pion/ice/v2"
 	log "github.com/sirupsen/logrus"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
@@ -198,11 +198,7 @@ func (e *Engine) Start() error {
 			return err
 		}
 		if e.dnsServer == nil {
-			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, dnsCfg, e.mobileDep.HostDNSAddresses)
-		}
-
-		*e.mobileDep.onHostDnsUpdateFn = func(dnsList []string) {
-			e.dnsServer.UpdateHostDNSServer(dnsList)
+			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, dnsCfg, e.mobileDep.HostDNSAddresses, e.mobileDep.DnsReadyListener)
 		}
 	} else {
 		// todo fix custom address

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -190,15 +190,14 @@ func (e *Engine) Start() error {
 	}
 
 	var routes []*route.Route
-	var dnsCfg nbdns.Config
 
 	if runtime.GOOS == "android" {
-		routes, dnsCfg, err = e.readInitialSettings()
+		routes, err = e.readInitialSettings()
 		if err != nil {
 			return err
 		}
 		if e.dnsServer == nil {
-			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, dnsCfg, e.mobileDep.HostDNSAddresses, e.mobileDep.DnsReadyListener)
+			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, e.mobileDep.HostDNSAddresses, e.mobileDep.DnsReadyListener)
 		}
 	} else {
 		// todo fix custom address
@@ -1047,14 +1046,13 @@ func (e *Engine) close() {
 	}
 }
 
-func (e *Engine) readInitialSettings() ([]*route.Route, nbdns.Config, error) {
+func (e *Engine) readInitialSettings() ([]*route.Route, error) {
 	netMap, err := e.mgmClient.GetNetworkMap()
 	if err != nil {
-		return nil, nbdns.Config{}, err
+		return nil, err
 	}
 	routes := toRoutes(netMap.GetRoutes())
-	dnsCfg := toDNSConfig(netMap.GetDNSConfig())
-	return routes, dnsCfg, nil
+	return routes, nil
 }
 
 func findIPFromInterfaceName(ifaceName string) (net.IP, error) {

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -190,7 +190,7 @@ func (e *Engine) Start() error {
 	}
 
 	var routes []*route.Route
-	var dnsCfg *nbdns.Config
+	var dnsCfg nbdns.Config
 
 	if runtime.GOOS == "android" {
 		routes, dnsCfg, err = e.readInitialSettings()
@@ -198,7 +198,7 @@ func (e *Engine) Start() error {
 			return err
 		}
 		if e.dnsServer == nil {
-			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, dnsCfg, e.mobileDep.UpstreamDNSAddresses)
+			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, dnsCfg, e.mobileDep.HostDNSAddresses)
 		}
 	} else {
 		// todo fix custom address
@@ -1047,14 +1047,14 @@ func (e *Engine) close() {
 	}
 }
 
-func (e *Engine) readInitialSettings() ([]*route.Route, *nbdns.Config, error) {
+func (e *Engine) readInitialSettings() ([]*route.Route, nbdns.Config, error) {
 	netMap, err := e.mgmClient.GetNetworkMap()
 	if err != nil {
-		return nil, nil, err
+		return nil, nbdns.Config{}, err
 	}
 	routes := toRoutes(netMap.GetRoutes())
 	dnsCfg := toDNSConfig(netMap.GetDNSConfig())
-	return routes, &dnsCfg, nil
+	return routes, dnsCfg, nil
 }
 
 func findIPFromInterfaceName(ifaceName string) (net.IP, error) {

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -200,6 +200,11 @@ func (e *Engine) Start() error {
 		if e.dnsServer == nil {
 			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, dnsCfg, e.mobileDep.HostDNSAddresses)
 		}
+
+		hostDnsUpdateFn := func(dnsList []string) {
+			e.dnsServer.UpdateHostDNSServer(dnsList)
+		}
+		e.mobileDep.onHostDnsUpdateFn = &hostDnsUpdateFn
 	} else {
 		// todo fix custom address
 		if e.dnsServer == nil {

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -197,7 +197,8 @@ func (e *Engine) Start() error {
 			return err
 		}
 		if e.dnsServer == nil {
-			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, e.mobileDep.HostDNSAddresses, e.mobileDep.DnsReadyListener)
+			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, e.mobileDep.HostDNSAddresses)
+			go e.mobileDep.DnsReadyListener.OnReady()
 		}
 	} else {
 		// todo fix custom address

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -201,10 +201,9 @@ func (e *Engine) Start() error {
 			e.dnsServer = dns.NewDefaultServerPermanentUpstream(e.ctx, e.wgInterface, dnsCfg, e.mobileDep.HostDNSAddresses)
 		}
 
-		hostDnsUpdateFn := func(dnsList []string) {
+		*e.mobileDep.onHostDnsUpdateFn = func(dnsList []string) {
 			e.dnsServer.UpdateHostDNSServer(dnsList)
 		}
-		e.mobileDep.onHostDnsUpdateFn = &hostDnsUpdateFn
 	} else {
 		// todo fix custom address
 		if e.dnsServer == nil {
@@ -266,7 +265,7 @@ func (e *Engine) Start() error {
 		e.acl = acl
 	}
 
-	err = e.dnsServer.InitializeHostMgr()
+	err = e.dnsServer.Initialize()
 	if err != nil {
 		e.close()
 		return err

--- a/client/internal/mobile_dependency.go
+++ b/client/internal/mobile_dependency.go
@@ -8,7 +8,8 @@ import (
 
 // MobileDependency collect all dependencies for mobile platform
 type MobileDependency struct {
-	TunAdapter    iface.TunAdapter
-	IFaceDiscover stdnet.ExternalIFaceDiscover
-	RouteListener routemanager.RouteListener
+	TunAdapter           iface.TunAdapter
+	IFaceDiscover        stdnet.ExternalIFaceDiscover
+	RouteListener        routemanager.RouteListener
+	UpstreamDNSAddresses []string
 }

--- a/client/internal/mobile_dependency.go
+++ b/client/internal/mobile_dependency.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"github.com/netbirdio/netbird/client/internal/dns"
 	"github.com/netbirdio/netbird/client/internal/routemanager"
 	"github.com/netbirdio/netbird/client/internal/stdnet"
 	"github.com/netbirdio/netbird/iface"
@@ -8,9 +9,9 @@ import (
 
 // MobileDependency collect all dependencies for mobile platform
 type MobileDependency struct {
-	TunAdapter        iface.TunAdapter
-	IFaceDiscover     stdnet.ExternalIFaceDiscover
-	RouteListener     routemanager.RouteListener
-	HostDNSAddresses  []string
-	onHostDnsUpdateFn *func([]string)
+	TunAdapter       iface.TunAdapter
+	IFaceDiscover    stdnet.ExternalIFaceDiscover
+	RouteListener    routemanager.RouteListener
+	HostDNSAddresses []string
+	DnsReadyListener dns.ReadyListener
 }

--- a/client/internal/mobile_dependency.go
+++ b/client/internal/mobile_dependency.go
@@ -8,8 +8,9 @@ import (
 
 // MobileDependency collect all dependencies for mobile platform
 type MobileDependency struct {
-	TunAdapter       iface.TunAdapter
-	IFaceDiscover    stdnet.ExternalIFaceDiscover
-	RouteListener    routemanager.RouteListener
-	HostDNSAddresses []string
+	TunAdapter        iface.TunAdapter
+	IFaceDiscover     stdnet.ExternalIFaceDiscover
+	RouteListener     routemanager.RouteListener
+	HostDNSAddresses  []string
+	onHostDnsUpdateFn *func([]string)
 }

--- a/client/internal/mobile_dependency.go
+++ b/client/internal/mobile_dependency.go
@@ -8,8 +8,8 @@ import (
 
 // MobileDependency collect all dependencies for mobile platform
 type MobileDependency struct {
-	TunAdapter           iface.TunAdapter
-	IFaceDiscover        stdnet.ExternalIFaceDiscover
-	RouteListener        routemanager.RouteListener
-	UpstreamDNSAddresses []string
+	TunAdapter       iface.TunAdapter
+	IFaceDiscover    stdnet.ExternalIFaceDiscover
+	RouteListener    routemanager.RouteListener
+	HostDNSAddresses []string
 }

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -102,7 +102,7 @@ func (s *Server) Start() error {
 	}
 
 	go func() {
-		if err := internal.RunClient(ctx, config, s.statusRecorder, nil, nil, nil); err != nil {
+		if err := internal.RunClient(ctx, config, s.statusRecorder); err != nil {
 			log.Errorf("init connections: %v", err)
 		}
 	}()
@@ -391,7 +391,7 @@ func (s *Server) Up(callerCtx context.Context, _ *proto.UpRequest) (*proto.UpRes
 	}
 
 	go func() {
-		if err := internal.RunClient(ctx, s.config, s.statusRecorder, nil, nil, nil); err != nil {
+		if err := internal.RunClient(ctx, s.config, s.statusRecorder); err != nil {
 			log.Errorf("run client connection: %v", err)
 			return
 		}

--- a/iface/iface_android.go
+++ b/iface/iface_android.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/pion/transport/v2"
-	log "github.com/sirupsen/logrus"
 )
 
 // NewWGIFace Creates a new WireGuard interface instance
@@ -34,7 +33,6 @@ func NewWGIFace(ifaceName string, address string, mtu int, tunAdapter TunAdapter
 func (w *WGIface) CreateOnMobile(mIFaceArgs MobileIFaceArguments) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	log.Debugf("create WireGuard interface %s", w.tun.DeviceName())
 	return w.tun.Create(mIFaceArgs)
 }
 

--- a/iface/iface_nonandroid.go
+++ b/iface/iface_nonandroid.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/pion/transport/v2"
-	log "github.com/sirupsen/logrus"
 )
 
 // NewWGIFace Creates a new WireGuard interface instance
@@ -38,6 +37,5 @@ func (w *WGIface) CreateOnMobile(mIFaceArgs MobileIFaceArguments) error {
 func (w *WGIface) Create() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	log.Debugf("create WireGuard interface %s", w.tun.DeviceName())
 	return w.tun.Create()
 }

--- a/iface/tun_android.go
+++ b/iface/tun_android.go
@@ -34,6 +34,7 @@ func newTunDevice(address WGAddress, mtu int, tunAdapter TunAdapter, transportNe
 }
 
 func (t *tunDevice) Create(mIFaceArgs MobileIFaceArguments) error {
+	log.Info("create tun interface")
 	var err error
 	routesString := t.routesToString(mIFaceArgs.Routes)
 	t.fd, err = t.tunAdapter.ConfigureInterface(t.address.String(), t.mtu, mIFaceArgs.Dns, routesString)

--- a/iface/tun_linux.go
+++ b/iface/tun_linux.go
@@ -12,14 +12,14 @@ import (
 
 func (c *tunDevice) Create() error {
 	if WireGuardModuleIsLoaded() {
-		log.Info("using kernel WireGuard")
+		log.Info("create tun interface with kernel WireGuard support: %s", c.DeviceName())
 		return c.createWithKernel()
 	}
 
 	if !tunModuleIsLoaded() {
 		return fmt.Errorf("couldn't check or load tun module")
 	}
-	log.Info("using userspace WireGuard")
+	log.Infof("create tun interface with userspace WireGuard support: %s", c.DeviceName())
 	var err error
 	c.netInterface, err = c.createWithUserspace()
 	if err != nil {

--- a/iface/tun_linux.go
+++ b/iface/tun_linux.go
@@ -12,7 +12,7 @@ import (
 
 func (c *tunDevice) Create() error {
 	if WireGuardModuleIsLoaded() {
-		log.Info("create tun interface with kernel WireGuard support: %s", c.DeviceName())
+		log.Infof("create tun interface with kernel WireGuard support: %s", c.DeviceName())
 		return c.createWithKernel()
 	}
 


### PR DESCRIPTION
## Describe your changes

Because on Android system hard to update DNS settings the system will set our DNS service as permanent DNS server on mobile system.
This PR modify the original logic. Now the DNS service can functional in two different way
1. the DNS service will start listen when get update from mgm server
2. the DNS service start listening immediately when it instantiated

In the second case the upstream DNS server will be the DNS servers from the host machine.
The relevant Android code: https://github.com/netbirdio/react-native-app/pull/24

### Android
The Android code track the network changes and update the DNS configuration when it has been changed on the host machine. For example when switch from 4G to WIFI.

### Test
Because this change refactor the whole logic necessary to test all combination of the supported systems
- Mac, Win, Linux, Android
- On Linux with WG bind interface and with kernel module support
- On Linux with systemd, resolve.conf

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
