### PR TITLE
Fix disabled DNS resolver fail

### DIFF
--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -275,7 +275,7 @@ func (s *DefaultServer) applyConfiguration(update nbdns.Config) error {
 	// is the service should be disabled, we stop the listener or fake resolver
 	// and proceed with a regular update to clean up the handlers and records
 	if !update.ServiceEnable {
-		if s.wgInterface != nil && s.wgInterface.IsUserspaceBind() {
+		if s.wgInterface != nil && s.wgInterface.IsUserspaceBind() && s.listenerIsRunning {
 			s.fakeResolverWG.Done()
 		} else {
 			if err := s.stopListener(); err != nil {

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -150,6 +150,10 @@ func (s *DefaultServer) listen() {
 	}()
 }
 
+// DnsIP returns the DNS resolver server IP address
+//
+// When kernel space interface used it return real DNS server listener IP address
+// For bind interface, fake DNS resolver address returned (second last IP address from Nebird network)
 func (s *DefaultServer) DnsIP() string {
 	if !s.enabled {
 		return ""
@@ -214,6 +218,7 @@ func (s *DefaultServer) stopListener() error {
 		}
 		s.udpFilterHookID = ""
 		s.listenerIsRunning = false
+		return nil
 	}
 
 	if !s.listenerIsRunning {

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -105,7 +105,6 @@ func NewDefaultServer(ctx context.Context, wgInterface *iface.WGIface, customAdd
 		defaultServer.enabled = hasValidDnsServer(initialDnsCfg)
 	}
 
-	defaultServer.evalRuntimeAddress()
 	return defaultServer, nil
 }
 
@@ -118,6 +117,7 @@ func (s *DefaultServer) Initialize() (err error) {
 		return nil
 	}
 
+	s.evalRuntimeAddress()
 	s.hostManager, err = newHostManager(s.wgInterface)
 	return
 }

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -134,8 +134,6 @@ func (s *DefaultServer) listen() {
 
 			s.mux.Lock()
 			defer s.mux.Unlock()
-			s.setListenerStatus(false)
-
 			if err := s.wgInterface.GetFilter().RemovePacketHook(hookID); err != nil {
 				log.Errorf("unable to remove DNS packet hook: %s", err)
 			}
@@ -280,6 +278,7 @@ func (s *DefaultServer) applyConfiguration(update nbdns.Config) error {
 	if !update.ServiceEnable {
 		if s.wgInterface != nil && s.wgInterface.IsUserspaceBind() && s.listenerIsRunning {
 			s.fakeResolverWG.Done()
+			s.setListenerStatus(false)
 		} else {
 			if err := s.stopListener(); err != nil {
 				log.Error(err)

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -244,7 +244,6 @@ func TestUpdateDNSServer(t *testing.T) {
 			dnsServer.updateSerial = testCase.initSerial
 			// pretend we are running
 			dnsServer.listenerIsRunning = true
-			dnsServer.fakeResolverWG.Add(1)
 
 			err = dnsServer.UpdateDNSServer(testCase.inputSerial, testCase.inputUpdate)
 			if err != nil {
@@ -319,8 +318,8 @@ func TestDNSFakeResolverHandleUpdates(t *testing.T) {
 	packetfilter := pfmock.NewMockPacketFilter(ctrl)
 	packetfilter.EXPECT().SetNetwork(ipNet)
 	packetfilter.EXPECT().DropOutgoing(gomock.Any()).AnyTimes()
-	packetfilter.EXPECT().AddUDPPacketHook(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-	packetfilter.EXPECT().RemovePacketHook(gomock.Any())
+	packetfilter.EXPECT().AddUDPPacketHook(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	packetfilter.EXPECT().RemovePacketHook(gomock.Any()).AnyTimes()
 
 	if err := wgIface.SetFilter(packetfilter); err != nil {
 		t.Errorf("set packet filter: %v", err)

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -5,15 +5,18 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/miekg/dns"
 
 	"github.com/netbirdio/netbird/client/internal/stdnet"
 	nbdns "github.com/netbirdio/netbird/dns"
 	"github.com/netbirdio/netbird/iface"
+	pfmock "github.com/netbirdio/netbird/iface/mocks"
 )
 
 var zoneRecords = []nbdns.SimpleRecord{
@@ -273,6 +276,96 @@ func TestUpdateDNSServer(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDNSFakeResolverHandleUpdates(t *testing.T) {
+	ov := os.Getenv("NB_WG_KERNEL_DISABLED")
+	defer os.Setenv("NB_WG_KERNEL_DISABLED", ov)
+
+	os.Setenv("NB_WG_KERNEL_DISABLED", "true")
+	newNet, err := stdnet.NewNet(nil)
+	if err != nil {
+		t.Errorf("create stdnet: %v", err)
+		return
+	}
+
+	wgIface, err := iface.NewWGIFace("utun2301", "100.66.100.1/32", iface.DefaultMTU, nil, newNet)
+	if err != nil {
+		t.Errorf("build interface wireguard: %v", err)
+		return
+	}
+
+	err = wgIface.Create()
+	if err != nil {
+		t.Errorf("crate and init wireguard interface: %v", err)
+		return
+	}
+	defer func() {
+		if err = wgIface.Close(); err != nil {
+			t.Logf("close wireguard interface: %v", err)
+		}
+	}()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, ipNet, err := net.ParseCIDR("100.66.100.1/32")
+	if err != nil {
+		t.Errorf("parse CIDR: %v", err)
+		return
+	}
+
+	packetfilter := pfmock.NewMockPacketFilter(ctrl)
+	packetfilter.EXPECT().SetNetwork(ipNet)
+	packetfilter.EXPECT().DropOutgoing(gomock.Any()).AnyTimes()
+	packetfilter.EXPECT().AddUDPPacketHook(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	packetfilter.EXPECT().RemovePacketHook(gomock.Any())
+
+	if err := wgIface.SetFilter(packetfilter); err != nil {
+		t.Errorf("set packet filter: %v", err)
+		return
+	}
+
+	dnsServer, err := NewDefaultServer(context.Background(), wgIface, "", nil)
+	if err != nil {
+		t.Errorf("create DNS server: %v", err)
+		return
+	}
+
+	err = dnsServer.Initialize()
+	if err != nil {
+		t.Errorf("run DNS server: %v", err)
+		return
+	}
+	defer func() {
+		if err = dnsServer.hostManager.restoreHostDNS(); err != nil {
+			t.Logf("restore DNS settings on the host: %v", err)
+			return
+		}
+	}()
+
+	dnsServer.dnsMuxMap = registeredHandlerMap{zoneRecords[0].Name: &localResolver{}}
+	dnsServer.localResolver.registeredMap = registrationMap{"netbird.cloud": struct{}{}}
+	dnsServer.updateSerial = 0
+
+	// Start the server with regular configuration
+	if err := dnsServer.UpdateDNSServer(1, nbdns.Config{ServiceEnable: true}); err != nil {
+		t.Fatalf("update dns server should not fail, got error: %v", err)
+		return
+	}
+
+	// Disable the server, stop the listener
+	if err := dnsServer.UpdateDNSServer(2, nbdns.Config{ServiceEnable: false}); err != nil {
+		t.Fatalf("update dns server should not fail, got error: %v", err)
+		return
+	}
+
+	// But service still get updates and we checking that we handle
+	// internal state in the right way
+	if err := dnsServer.UpdateDNSServer(3, nbdns.Config{ServiceEnable: false, CustomZones: []nbdns.CustomZone{}}); err != nil {
+		t.Fatalf("update dns server should not fail, got error: %v", err)
+		return
 	}
 }
 


### PR DESCRIPTION
## Describe your changes
When DNS server runs in a fake resolver, there is an issue with incorrect handling disable state because we still receive updates from the management. Add extra checking and fix panic. 
## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
