### PR TITLE
Fix ssh connection freeze

### DIFF
--- a/client/cmd/ssh.go
+++ b/client/cmd/ssh.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"syscall"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/netbirdio/netbird/client/internal"
@@ -73,7 +72,8 @@ var sshCmd = &cobra.Command{
 		go func() {
 			// blocking
 			if err := runSSH(sshctx, host, []byte(config.SSHKey), cmd); err != nil {
-				log.Print(err)
+				os.Exit(1)
+				// log.Print(err)
 			}
 			cancel()
 		}()
@@ -92,11 +92,9 @@ func runSSH(ctx context.Context, addr string, pemKey []byte, cmd *cobra.Command)
 	c, err := nbssh.DialWithKey(fmt.Sprintf("%s:%d", addr, port), user, pemKey)
 	if err != nil {
 		cmd.Printf("Error: %v\n", err)
-		cmd.Printf("Couldn't connect. " +
-			"You might be disconnected from the NetBird network, or the NetBird agent isn't running.\n" +
-			"Run the status command: \n\n" +
-			" netbird status\n\n" +
-			"It might also be that the SSH server is disabled on the agent you are trying to connect to.\n")
+		cmd.Printf("Couldn't connect. Please check the connection status or if the ssh server is enabled on the other peer" +
+			"You can verify the connection by running:\n\n" +
+			" netbird status\n\n")
 		return nil
 	}
 	go func() {

--- a/client/cmd/ssh.go
+++ b/client/cmd/ssh.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/netbirdio/netbird/client/internal"
@@ -72,8 +73,8 @@ var sshCmd = &cobra.Command{
 		go func() {
 			// blocking
 			if err := runSSH(sshctx, host, []byte(config.SSHKey), cmd); err != nil {
+				log.Debug(err)
 				os.Exit(1)
-				// log.Print(err)
 			}
 			cancel()
 		}()
@@ -95,7 +96,7 @@ func runSSH(ctx context.Context, addr string, pemKey []byte, cmd *cobra.Command)
 		cmd.Printf("Couldn't connect. Please check the connection status or if the ssh server is enabled on the other peer" +
 			"You can verify the connection by running:\n\n" +
 			" netbird status\n\n")
-		return nil
+		return err
 	}
 	go func() {
 		<-ctx.Done()

--- a/client/ssh/server.go
+++ b/client/ssh/server.go
@@ -23,6 +23,9 @@ const DefaultSSHPort = 44338
 // TerminalTimeout is the timeout for terminal session to be ready
 const TerminalTimeout = 10 * time.Second
 
+// TerminalBackoffDelay is the delay between terminal session readiness checks
+const TerminalBackoffDelay = 500 * time.Millisecond
+
 // DefaultSSHServer is a function that creates DefaultServer
 func DefaultSSHServer(hostKeyPEM []byte, addr string) (Server, error) {
 	return newDefaultServer(hostKeyPEM, addr)
@@ -220,6 +223,7 @@ func (srv *DefaultServer) stdInOut(file *os.File, session ssh.Session) {
 		}
 	}()
 
+	// AWS Linux 2 machines need some time to open the terminal so we need to wait for it
 	timer := time.NewTimer(TerminalTimeout)
 	for {
 		select {
@@ -234,6 +238,7 @@ func (srv *DefaultServer) stdInOut(file *os.File, session ssh.Session) {
 				_ = session.Exit(0)
 				return
 			}
+			time.Sleep(TerminalBackoffDelay)
 		}
 	}
 }


### PR DESCRIPTION
## Describe your changes
The ssh connection was freezing when accessing amazon linux to nodes or if the username did not exist.

Changes:
- wait for terminal session to be ready to avoid freeze
- sending proper error codes to cli if failure
- sending log message on ssh session attempt

### To Test
- ssh connections between Linux <-> Mac, Mac <-> Mac, Linux <-> Linux **(Either one or all cases)**
- test ssh connection to an Amazon Linux 2 machine
- test connection to offline peer
- test connection to non existing peer
- test connection to online peer but non existing user

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/514

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
