### PR TITLE
Improve userspace filter performance

### DIFF
--- a/client/firewall/uspfilter/uspfilter.go
+++ b/client/firewall/uspfilter/uspfilter.go
@@ -129,10 +129,10 @@ func (m *Manager) AddFiltering(
 	var p int
 	if direction == fw.RuleDirectionIN {
 		m.incomingRules[r.ip.String()] = append(m.incomingRules[r.ip.String()], r)
-		p = len(m.incomingRules) - 1
+		p = len(m.incomingRules[r.ip.String()]) - 1
 	} else {
 		m.outgoingRules[r.ip.String()] = append(m.outgoingRules[r.ip.String()], r)
-		p = len(m.outgoingRules) - 1
+		p = len(m.outgoingRules[r.ip.String()]) - 1
 	}
 	m.rulesIndex[r.id] = p
 	m.mutex.Unlock()
@@ -234,18 +234,18 @@ func (m *Manager) dropFilter(packetData []byte, rules map[string][]Rule, isIncom
 	case layers.LayerTypeIPv4:
 		if isIncomingPacket {
 			srcIP = d.ip4.SrcIP
-			ipRules = rules[srcIP.String()]
+			ipRules = append(rules[srcIP.String()], rules["0.0.0.0"]...)
 		} else {
 			dstIP = d.ip4.DstIP
-			ipRules = rules[dstIP.String()]
+			ipRules = append(rules[dstIP.String()], rules["0.0.0.0"]...)
 		}
 	case layers.LayerTypeIPv6:
 		if isIncomingPacket {
 			srcIP = d.ip6.SrcIP
-			ipRules = rules[srcIP.String()]
+			ipRules = append(rules[srcIP.String()], rules["::"]...)
 		} else {
 			dstIP = d.ip6.DstIP
-			ipRules = rules[dstIP.String()]
+			ipRules = append(rules[dstIP.String()], rules["::"]...)
 		}
 	}
 

--- a/client/firewall/uspfilter/uspfilter.go
+++ b/client/firewall/uspfilter/uspfilter.go
@@ -238,13 +238,7 @@ func (m *Manager) dropFilter(packetData []byte, rules map[string]map[string]Rule
 		}
 	}
 
-	_, ok := rules["0.0.0.0"]
-	if ok {
-		return false
-	}
-
-	_, ok = rules["::"]
-	if ok {
+	if len(rules["0.0.0.0"]) > 0 || len(rules["::"]) > 0 {
 		return false
 	}
 

--- a/client/firewall/uspfilter/uspfilter_test.go
+++ b/client/firewall/uspfilter/uspfilter_test.go
@@ -169,8 +169,8 @@ func TestAddUDPPacketHook(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := &Manager{
-				incomingRules: map[string]map[string]Rule{},
-				outgoingRules: map[string]map[string]Rule{},
+				incomingRules: map[string]RuleSet{},
+				outgoingRules: map[string]RuleSet{},
 			}
 
 			manager.AddUDPPacketHook(tt.in, tt.ip, tt.dPort, tt.hook)


### PR DESCRIPTION
## Describe your changes
Switched rule set from array to map (as lookup table grouped by IP) to reduce number of rules checked for each packet when filtering) this way increasing throughput.

To test:
- throughput when thousands of rules active
- startup time when thousands of rules active
- memory consumption between old and new impl.
- functionality

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
