### PR TITLE
FIx error on ip6tables not available

### DIFF
--- a/client/firewall/iptables/manager_linux.go
+++ b/client/firewall/iptables/manager_linux.go
@@ -58,19 +58,31 @@ func Create(wgIface iFaceMapper) (*Manager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("iptables is not installed in the system or not supported")
 	}
-	m.ipv4Client = ipv4Client
+	if isIptablesClientAvailable(ipv4Client) {
+		m.ipv4Client = ipv4Client
+	}
 
 	ipv6Client, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
 	if err != nil {
 		log.Errorf("ip6tables is not installed in the system or not supported: %v", err)
 	} else {
-		m.ipv6Client = ipv6Client
+		if isIptablesClientAvailable(ipv6Client) {
+			m.ipv6Client = ipv6Client
+		}
 	}
 
 	if err := m.Reset(); err != nil {
 		return nil, fmt.Errorf("failed to reset firewall: %v", err)
 	}
 	return m, nil
+}
+
+func isIptablesClientAvailable(client *iptables.IPTables) bool {
+	_, err := client.ListChains("filter")
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 // AddFiltering rule to the firewall

--- a/client/firewall/iptables/manager_linux.go
+++ b/client/firewall/iptables/manager_linux.go
@@ -79,10 +79,10 @@ func Create(wgIface iFaceMapper) (*Manager, error) {
 
 func isIptablesClientAvailable(client *iptables.IPTables) bool {
 	_, err := client.ListChains("filter")
-	if err != nil {
-		return false
+	if err == nil {
+		return true
 	}
-	return true
+	return false
 }
 
 // AddFiltering rule to the firewall

--- a/client/firewall/iptables/manager_linux.go
+++ b/client/firewall/iptables/manager_linux.go
@@ -79,10 +79,7 @@ func Create(wgIface iFaceMapper) (*Manager, error) {
 
 func isIptablesClientAvailable(client *iptables.IPTables) bool {
 	_, err := client.ListChains("filter")
-	if err == nil {
-		return true
-	}
-	return false
+	return err == nil
 }
 
 // AddFiltering rule to the firewall

--- a/client/internal/routemanager/firewall_linux.go
+++ b/client/internal/routemanager/firewall_linux.go
@@ -35,7 +35,15 @@ func NewFirewall(parentCTX context.Context) firewallManager {
 	if isIptablesSupported() {
 		log.Debugf("iptables is supported")
 		ipv4Client, _ := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if !isIptablesClientAvailable(ipv4Client) {
+			log.Infof("iptables is missing for ipv4")
+			ipv4Client = nil
+		}
 		ipv6Client, _ := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if !isIptablesClientAvailable(ipv6Client) {
+			log.Infof("iptables is missing for ipv6")
+			ipv6Client = nil
+		}
 
 		return &iptablesManager{
 			ctx:        ctx,
@@ -57,6 +65,14 @@ func NewFirewall(parentCTX context.Context) firewallManager {
 	}
 
 	return manager
+}
+
+func isIptablesClientAvailable(client *iptables.IPTables) bool {
+	_, err := client.ListChains("filter")
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 func getInPair(pair routerPair) routerPair {

--- a/client/internal/routemanager/firewall_linux.go
+++ b/client/internal/routemanager/firewall_linux.go
@@ -69,10 +69,10 @@ func NewFirewall(parentCTX context.Context) firewallManager {
 
 func isIptablesClientAvailable(client *iptables.IPTables) bool {
 	_, err := client.ListChains("filter")
-	if err != nil {
-		return false
+	if err == nil {
+		return true
 	}
-	return true
+	return false
 }
 
 func getInPair(pair routerPair) routerPair {

--- a/client/internal/routemanager/firewall_linux.go
+++ b/client/internal/routemanager/firewall_linux.go
@@ -69,10 +69,7 @@ func NewFirewall(parentCTX context.Context) firewallManager {
 
 func isIptablesClientAvailable(client *iptables.IPTables) bool {
 	_, err := client.ListChains("filter")
-	if err == nil {
-		return true
-	}
-	return false
+	return err == nil
 }
 
 func getInPair(pair routerPair) routerPair {


### PR DESCRIPTION
## Describe your changes
On machines where ip6tables was not available we would fail and throw an error without adding ip v4 routes. Whit this change the client can continue even though ip6tables is not available. 

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/917

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
