### PR TITLE
Do not persist filestore when deleting indices

### DIFF
--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -334,7 +334,7 @@ func (s *FileStore) DeleteHashedPAT2TokenIDIndex(hashedToken string) error {
 
 	delete(s.HashedPAT2TokenID, hashedToken)
 
-	return s.persist(s.storeFile)
+	return nil
 }
 
 // DeleteTokenID2UserIDIndex removes an entry from the indexing map TokenID2UserID
@@ -344,7 +344,7 @@ func (s *FileStore) DeleteTokenID2UserIDIndex(tokenID string) error {
 
 	delete(s.TokenID2UserID, tokenID)
 
-	return s.persist(s.storeFile)
+	return nil
 }
 
 // GetAccountByPrivateDomain returns account by private domain


### PR DESCRIPTION
## Describe your changes

Both `TokenID2UserID` and `HashedPAT2TokenID` are in-memory indices and not stored in the file(`json:"-"` tag is being used).

This change should improve the performance of `DeletePAT` method in `DefaultAccountManager`.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
