### PR TITLE
Fix DefaultAccountManager GetGroupsFromTheToken false positive tests

### DIFF
--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -289,6 +289,10 @@ func (s *FileStore) SaveAccount(account *Account) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
+	if account.Id == "" {
+		return status.Errorf(status.InvalidArgument, "account id should not be empty")
+	}
+
 	accountCopy := account.Copy()
 
 	s.Accounts[accountCopy.Id] = accountCopy


### PR DESCRIPTION
## Describe your changes

This pull request addresses an issue discovered while working on an alternative implementation of the Store module. The issue relates to the current behavior of the SaveAccount functionality, which allows creating an account with an empty ID and fails to validate if the indices are being repointed to another account.

To provide more context, the problem manifests in the following test cases:

1. The `newAccountWithId("", userId, domain)` function is called, resulting in an account with an admin user but an empty account ID.
2. Subsequently, `manager.GetAccountByUserOrAccountID(userId, initAccount.Id, domain)` is executed, which creates an account using the same function from the previous step, but this time providing an ID. This account is stored in FileStore.
3. Within the test cases, certain settings are applied to the initial account with an empty ID, and this account is then stored.
4. The tests pass because `manager.GetAccountFromToken(claims)` is able to locate an account based on the user ID specified in the claim.

The proposed changes in this pull request aim to enhance the existing functionality. Instead of creating new accounts during the tests, the changes ensure that the existing accounts are updated. Additionally, an extra check is introduced to validate the Account ID in the SaveAccount operation.

While this issue may not have a direct impact on production, ensuring the correctness of the tests can have future benefits. By maintaining reliable and accurate tests, we promote the stability and reliability of the codebase.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
