### PR TITLE
Keep confiured nameservers as fallback

### DIFF
--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -15,7 +15,8 @@ const (
 	fileGeneratedResolvConfSearchBeginContent = "search "
 	fileGeneratedResolvConfContentFormat      = fileGeneratedResolvConfContentHeader +
 		"\n# If needed you can restore the original file by copying back %s\n\nnameserver %s\n" +
-		fileGeneratedResolvConfSearchBeginContent + "%s\n"
+		fileGeneratedResolvConfSearchBeginContent + "%s\n\n" +
+		"%s\n"
 )
 
 const (
@@ -91,7 +92,12 @@ func (f *fileConfigurator) applyDNSConfig(config hostDNSConfig) error {
 		searchDomains += " " + dConf.domain
 		appendedDomains++
 	}
-	content := fmt.Sprintf(fileGeneratedResolvConfContentFormat, fileDefaultResolvConfBackupLocation, config.serverIP, searchDomains)
+
+	originalContent, err := os.ReadFile(fileDefaultResolvConfBackupLocation)
+	if err != nil {
+		log.Errorf("Could not read existing resolv.conf")
+	}
+	content := fmt.Sprintf(fileGeneratedResolvConfContentFormat, fileDefaultResolvConfBackupLocation, config.serverIP, searchDomains, string(originalContent))
 	err = writeDNSConfig(content, defaultResolvConfPath, f.originalPerms)
 	if err != nil {
 		err = f.restore()

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -59,7 +59,11 @@ func (r *resolvconf) applyDNSConfig(config hostDNSConfig) error {
 		appendedDomains++
 	}
 
-	content := fmt.Sprintf(fileGeneratedResolvConfContentFormat, fileDefaultResolvConfBackupLocation, config.serverIP, searchDomains)
+	originalContent, err := os.ReadFile(fileDefaultResolvConfBackupLocation)
+	if err != nil {
+		log.Errorf("Could not read existing resolv.conf")
+	}
+	content := fmt.Sprintf(fileGeneratedResolvConfContentFormat, fileDefaultResolvConfBackupLocation, config.serverIP, searchDomains, string(originalContent))
 
 	err = r.applyConfig(content)
 	if err != nil {

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -4,6 +4,7 @@ package dns
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -13,8 +13,6 @@ import (
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
-
-	nbdns "github.com/netbirdio/netbird/dns"
 )
 
 const (
@@ -123,10 +121,6 @@ func (s *systemdDbusConfigurator) applyDNSConfig(config hostDNSConfig) error {
 		if err != nil {
 			return fmt.Errorf("setting link as default dns router, failed with error: %s", err)
 		}
-		domainsInput = append(domainsInput, systemdDbusLinkDomainsInput{
-			Domain:    nbdns.RootZone,
-			MatchOnly: true,
-		})
 		s.routingAll = true
 	} else if s.routingAll {
 		log.Infof("removing %s:%d as main DNS forwarder for this peer", config.serverIP, config.serverPort)


### PR DESCRIPTION
## Describe your changes
Sometimes if the client is stopped forcefully the old DNS configuration was not restored. This was casuing nameresolution to fail because the netbird resolver was down. At the same time the netbird resolver could not start because it could not connect to management due to failing name resolution.

In this PR the netbird resolver was chnaged to keep the previous configured nameserver as fallback in case the netbird resolver is not resopnding.


## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
