### PR TITLE
After add listener automatically trigger peer list change event

### DIFF
--- a/client/internal/peer/notifier.go
+++ b/client/internal/peer/notifier.go
@@ -17,6 +17,7 @@ type notifier struct {
 	listener           Listener
 	currentClientState bool
 	lastNotification   int
+	lastNumberOfPeers  int
 }
 
 func newNotifier() *notifier {
@@ -29,6 +30,7 @@ func (n *notifier) setListener(listener Listener) {
 
 	n.serverStateLock.Lock()
 	n.notifyListener(listener, n.lastNotification)
+	listener.OnPeersListChanged(n.lastNumberOfPeers)
 	n.serverStateLock.Unlock()
 
 	n.listener = listener
@@ -124,6 +126,7 @@ func (n *notifier) calculateState(managementConn, signalConn bool) int {
 }
 
 func (n *notifier) peerListChanged(numOfPeers int) {
+	n.lastNumberOfPeers = numOfPeers
 	n.listenersLock.Lock()
 	defer n.listenersLock.Unlock()
 	if n.listener == nil {

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -353,9 +353,13 @@ func (d *Status) onConnectionChanged() {
 }
 
 func (d *Status) notifyPeerListChanged() {
-	d.notifier.peerListChanged(len(d.peers) + len(d.offlinePeers))
+	d.notifier.peerListChanged(d.numOfPeers())
 }
 
 func (d *Status) notifyAddressChanged() {
 	d.notifier.localAddressChanged(d.localPeer.FQDN, d.localPeer.IP)
+}
+
+func (d *Status) numOfPeers() int {
+	return len(d.peers) + len(d.offlinePeers)
 }


### PR DESCRIPTION
## Describe your changes
In case of alway-on start the peer list was invalid on Android UI.


## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
