### PR TITLE
Validate input of expiration time for setup-keys

### DIFF
--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -369,6 +369,8 @@ components:
         expires_in:
           description: Expiration time in seconds
           type: integer
+          minimum: 86400
+          maximum: 31536000
           example: 43200
         revoked:
           description: Setup key revocation status

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -371,7 +371,7 @@ components:
           type: integer
           minimum: 86400
           maximum: 31536000
-          example: 43200
+          example: 86400
         revoked:
           description: Setup key revocation status
           type: boolean

--- a/management/server/http/setupkeys_handler.go
+++ b/management/server/http/setupkeys_handler.go
@@ -60,6 +60,13 @@ func (h *SetupKeysHandler) CreateSetupKey(w http.ResponseWriter, r *http.Request
 
 	expiresIn := time.Duration(req.ExpiresIn) * time.Second
 
+	day := time.Hour * 24
+	year := day * 365
+	if expiresIn < day || expiresIn > year {
+		util.WriteError(status.Errorf(status.InvalidArgument, "expiresIn should be between 1 day and 365 days"), w)
+		return
+	}
+
 	if req.AutoGroups == nil {
 		req.AutoGroups = []string{}
 	}

--- a/management/server/http/setupkeys_handler_test.go
+++ b/management/server/http/setupkeys_handler_test.go
@@ -143,7 +143,7 @@ func TestSetupKeysHandlers(t *testing.T) {
 			requestType: http.MethodPost,
 			requestPath: "/api/setup-keys",
 			requestBody: bytes.NewBuffer(
-				[]byte(fmt.Sprintf("{\"name\":\"%s\",\"type\":\"%s\"}", newSetupKey.Name, newSetupKey.Type))),
+				[]byte(fmt.Sprintf("{\"name\":\"%s\",\"type\":\"%s\",\"expires_in\":86400}", newSetupKey.Name, newSetupKey.Type))),
 			expectedStatus:   http.StatusOK,
 			expectedBody:     true,
 			expectedSetupKey: toResponseBody(newSetupKey),


### PR DESCRIPTION
## Describe your changes

So far we accepted any value for setup keys, including negative values

Now we are checking if it is less than 1 day or greater than 365 days

## Issue ticket number and link
https://github.com/netbirdio/dashboard/issues/251
### Checklist
- [x] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
