### PR TITLE
Fix/always on boot

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -179,8 +179,6 @@ func runClient(ctx context.Context, config *Config, statusRecorder *peer.Status,
 		log.Print("Netbird engine started, my IP is: ", peerConfig.Address)
 		state.Set(StatusConnected)
 
-		statusRecorder.ClientStart()
-
 		<-engineCtx.Done()
 		statusRecorder.ClientTeardown()
 
@@ -201,6 +199,7 @@ func runClient(ctx context.Context, config *Config, statusRecorder *peer.Status,
 		return nil
 	}
 
+	statusRecorder.ClientStart()
 	err = backoff.Retry(operation, backOff)
 	if err != nil {
 		log.Debugf("exiting client retry loop due to unrecoverable error: %s", err)

--- a/client/internal/peer/notifier.go
+++ b/client/internal/peer/notifier.go
@@ -114,7 +114,7 @@ func (n *notifier) calculateState(managementConn, signalConn bool) int {
 		return stateConnected
 	}
 
-	if !managementConn && !signalConn && n.currentClientState == false {
+	if !managementConn && !signalConn && !n.currentClientState {
 		return stateDisconnected
 	}
 

--- a/client/internal/peer/notifier.go
+++ b/client/internal/peer/notifier.go
@@ -61,7 +61,7 @@ func (n *notifier) clientStart() {
 	n.serverStateLock.Lock()
 	defer n.serverStateLock.Unlock()
 	n.currentClientState = true
-	n.lastNotification = stateConnected
+	n.lastNotification = stateConnecting
 	n.notify(n.lastNotification)
 }
 
@@ -114,7 +114,7 @@ func (n *notifier) calculateState(managementConn, signalConn bool) int {
 		return stateConnected
 	}
 
-	if !managementConn && !signalConn {
+	if !managementConn && !signalConn && n.currentClientState == false {
 		return stateDisconnected
 	}
 


### PR DESCRIPTION
## Describe your changes

In case of 'always-on' feature has switched on, after the reboot the service do not start properly in all cases.
If the device is in offline state (no internet connection) the auth login steps will fail and the service will stop.
For the auth steps make no sense in this case because if the OS start the service we do not have option for
the user interaction.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
