### PR TITLE
Implement SQLite Store using gorm and relational approach

### DIFF
--- a/.github/workflows/golang-test-darwin.yml
+++ b/.github/workflows/golang-test-darwin.yml
@@ -12,6 +12,9 @@ concurrency:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        store: ['JsonFile', 'Sqlite']
     runs-on: macos-latest
     steps:
       - name: Install Go
@@ -33,4 +36,4 @@ jobs:
         run: go mod tidy
 
       - name: Test
-        run: go test -exec 'sudo --preserve-env=CI' -timeout 5m -p 1 ./...
+        run: NETBIRD_STORE_KIND=${{ matrix.store }} go test -exec 'sudo --preserve-env=CI' -timeout 5m -p 1 ./...

--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         arch: ['386','amd64']
+        store: ['JsonFile', 'Sqlite']
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -41,7 +42,7 @@ jobs:
         run: go mod tidy
 
       - name: Test
-        run: CGO_ENABLED=1 GOARCH=${{ matrix.arch }} go test -exec 'sudo --preserve-env=CI' -timeout 5m -p 1 ./...
+        run: CGO_ENABLED=1 GOARCH=${{ matrix.arch }} NETBIRD_STORE_KIND=${{ matrix.store }} go test -exec 'sudo --preserve-env=CI' -timeout 5m -p 1 ./...
 
   test_client_on_docker:
     runs-on: ubuntu-20.04
@@ -50,7 +51,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.20.x"
-
 
       - name: Cache Go modules
         uses: actions/cache@v3
@@ -101,8 +101,11 @@ jobs:
       - name: Run nftables Manager tests in docker
         run: docker run -t --cap-add=NET_ADMIN --privileged --rm -v $PWD:/ci -w /ci/client/firewall --entrypoint /busybox/sh gcr.io/distroless/base:debug -c /ci/nftablesmanager-testing.bin  -test.timeout 5m -test.parallel 1
 
-      - name: Run Engine tests in docker
-        run: docker run -t --cap-add=NET_ADMIN --privileged --rm -v $PWD:/ci -w /ci/client/internal --entrypoint /busybox/sh gcr.io/distroless/base:debug -c /ci/engine-testing.bin  -test.timeout 5m -test.parallel 1
+      - name: Run Engine tests in docker with file store
+        run: docker run -t --cap-add=NET_ADMIN --privileged --rm -v $PWD:/ci -w /ci/client/internal -e NETBIRD_STORE_KIND="JsonFile" --entrypoint /busybox/sh gcr.io/distroless/base:debug -c /ci/engine-testing.bin  -test.timeout 5m -test.parallel 1
+      
+      - name: Run Engine tests in docker with sqlite store
+        run: docker run -t --cap-add=NET_ADMIN --privileged --rm -v $PWD:/ci -w /ci/client/internal -e NETBIRD_STORE_KIND="Sqlite" --entrypoint /busybox/sh gcr.io/distroless/base:debug -c /ci/engine-testing.bin  -test.timeout 5m -test.parallel 1
 
       - name: Run Peer tests in docker
         run: docker run -t --cap-add=NET_ADMIN --privileged --rm -v $PWD:/ci -w /ci/client/internal/peer  --entrypoint /busybox/sh gcr.io/distroless/base:debug -c /ci/peer-testing.bin  -test.timeout 5m -test.parallel 1

--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -44,7 +44,7 @@ jobs:
         run: CGO_ENABLED=1 GOARCH=${{ matrix.arch }} go test -exec 'sudo --preserve-env=CI' -timeout 5m -p 1 ./...
 
   test_client_on_docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install Go
         uses: actions/setup-go@v4
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt update && sudo apt install -y -q libgtk-3-dev libayatana-appindicator3-dev libgl1-mesa-dev xorg-dev
+        run: sudo apt update && sudo apt install -y -q libgtk-3-dev libayatana-appindicator3-dev libgl1-mesa-dev xorg-dev gcc-multilib
 
       - name: Install modules
         run: go mod tidy
@@ -82,7 +82,7 @@ jobs:
         run: CGO_ENABLED=0 go test -c -o nftablesmanager-testing.bin ./client/firewall/nftables/...
 
       - name: Generate Engine Test bin
-        run: CGO_ENABLED=0 go test -c -o engine-testing.bin ./client/internal
+        run: CGO_ENABLED=1 go test -c -o engine-testing.bin ./client/internal
 
       - name: Generate Peer Test bin
         run: CGO_ENABLED=0 go test -c -o peer-testing.bin ./client/internal/peer/...
@@ -94,7 +94,6 @@ jobs:
 
       - name: Run Iface tests in docker
         run: docker run -t --cap-add=NET_ADMIN --privileged --rm -v $PWD:/ci -w /ci/iface --entrypoint /busybox/sh gcr.io/distroless/base:debug -c /ci/iface-testing.bin -test.timeout 5m -test.parallel 1
-
 
       - name: Run RouteManager tests in docker
         run: docker run -t --cap-add=NET_ADMIN --privileged --rm -v $PWD:/ci -w /ci/client/internal/routemanager --entrypoint /busybox/sh gcr.io/distroless/base:debug -c /ci/routemanager-testing.bin  -test.timeout 5m -test.parallel 1

--- a/.github/workflows/golang-test-windows.yml
+++ b/.github/workflows/golang-test-windows.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     strategy:
       matrix:
-        store: ['JsonFile'] # ignore Sqlite for now
+        store: ['JsonFile', 'Sqlite']
     runs-on: windows-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/golang-test-windows.yml
+++ b/.github/workflows/golang-test-windows.yml
@@ -14,6 +14,9 @@ concurrency:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        store: ['JsonFile'] # ignore Sqlite for now
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -40,6 +43,8 @@ jobs:
       - run: mv ${{ env.downloadPath }}/wintun/bin/amd64/wintun.dll 'C:\Windows\System32\'
 
       - run: choco install -y sysinternals
+      - run: choco install -y mingw
+      
       - run: PsExec64 -s -w ${{ github.workspace }} C:\hostedtoolcache\windows\go\${{ steps.go.outputs.go-version }}\x64\bin\go.exe env -w GOMODCACHE=C:\Users\runneradmin\go\pkg\mod
       - run: PsExec64 -s -w ${{ github.workspace }} C:\hostedtoolcache\windows\go\${{ steps.go.outputs.go-version }}\x64\bin\go.exe env -w GOCACHE=C:\Users\runneradmin\AppData\Local\go-build
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ infrastructure_files/setup.env
 infrastructure_files/setup-*.env
 .vscode
 .DS_Store
+*.db

--- a/client/cmd/testutil.go
+++ b/client/cmd/testutil.go
@@ -65,7 +65,11 @@ func startManagement(t *testing.T, config *mgmt.Config) (*grpc.Server, net.Liste
 		t.Fatal(err)
 	}
 	s := grpc.NewServer()
-	store, err := mgmt.NewFileStore(config.Datadir, nil)
+	fstore, err := mgmt.NewFileStore(config.Datadir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := mgmt.NewSqliteStoreFromFileStore(fstore, config.Datadir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/cmd/testutil.go
+++ b/client/cmd/testutil.go
@@ -65,11 +65,7 @@ func startManagement(t *testing.T, config *mgmt.Config) (*grpc.Server, net.Liste
 		t.Fatal(err)
 	}
 	s := grpc.NewServer()
-	fstore, err := mgmt.NewFileStore(config.Datadir, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	store, err := mgmt.NewSqliteStoreFromFileStore(fstore, config.Datadir, nil)
+	store, err := mgmt.NewStoreFromJson(config.Datadir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -1039,11 +1039,7 @@ func startManagement(dataDir string) (*grpc.Server, string, error) {
 		return nil, "", err
 	}
 	s := grpc.NewServer(grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp))
-	fstore, err := server.NewFileStore(config.Datadir, nil)
-	if err != nil {
-		return nil, "", err
-	}
-	store, err := server.NewSqliteStoreFromFileStore(fstore, config.Datadir, nil)
+	store, err := server.NewStoreFromJson(config.Datadir, nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -1039,10 +1039,15 @@ func startManagement(dataDir string) (*grpc.Server, string, error) {
 		return nil, "", err
 	}
 	s := grpc.NewServer(grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp))
-	store, err := server.NewFileStore(config.Datadir, nil)
+	fstore, err := server.NewFileStore(config.Datadir, nil)
 	if err != nil {
-		log.Fatalf("failed creating a store: %s: %v", config.Datadir, err)
+		return nil, "", err
 	}
+	store, err := server.NewSqliteStoreFromFileStore(fstore, config.Datadir, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
 	peersUpdateManager := server.NewPeersUpdateManager()
 	eventStore := &activity.InMemoryEventStore{}
 	if err != nil {

--- a/dns/nameserver.go
+++ b/dns/nameserver.go
@@ -50,19 +50,21 @@ func ToNameServerType(typeString string) NameServerType {
 // NameServerGroup group of nameservers and with group ids
 type NameServerGroup struct {
 	// ID identifier of group
-	ID string
+	ID string `gorm:"primaryKey"`
+	// AccountID is a reference to Account that this object belongs
+	AccountID string `gorm:"index"`
 	// Name group name
 	Name string
 	// Description group description
 	Description string
 	// NameServers list of nameservers
-	NameServers []NameServer
+	NameServers []NameServer `gorm:"serializer:json"`
 	// Groups list of peer group IDs to distribute the nameservers information
-	Groups []string
+	Groups []string `gorm:"serializer:json"`
 	// Primary indicates that the nameserver group is the primary resolver for any dns query
 	Primary bool
 	// Domains indicate the dns query domains to use with this nameserver group
-	Domains []string
+	Domains []string `gorm:"serializer:json"`
 	// Enabled group status
 	Enabled bool
 }

--- a/go.mod
+++ b/go.mod
@@ -74,8 +74,8 @@ require (
 	golang.org/x/term v0.8.0
 	google.golang.org/api v0.126.0
 	gopkg.in/yaml.v3 v3.0.1
-	gorm.io/driver/sqlite v1.5.2
-	gorm.io/gorm v1.25.2
+	gorm.io/driver/sqlite v1.5.3
+	gorm.io/gorm v1.25.4
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/magiconair/properties v1.8.5
-	github.com/mattn/go-sqlite3 v1.14.16
+	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/mdlayher/socket v0.4.0
 	github.com/miekg/dns v1.1.43
 	github.com/mitchellh/hashstructure/v2 v2.0.2
@@ -74,6 +74,8 @@ require (
 	golang.org/x/term v0.8.0
 	google.golang.org/api v0.126.0
 	gopkg.in/yaml.v3 v3.0.1
+	gorm.io/driver/sqlite v1.5.2
+	gorm.io/gorm v1.25.2
 )
 
 require (
@@ -110,6 +112,8 @@ require (
 	github.com/googleapis/gax-go/v2 v2.10.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/native v1.0.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,10 @@ github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackmordaunt/icns v0.0.0-20181231085925-4f16af745526/go.mod h1:UQkeMHVoNcyXYq9otUupF7/h/2tmHlhrS2zw7ZVvUqc=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
+github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/josephspurrier/goversioninfo v0.0.0-20200309025242-14b0ab84c6ca/go.mod h1:eJTEwMjXb7kZ633hO3Ln9mBUCOjX2+FlTljvpl9SYdE=
 github.com/josharian/native v0.0.0-20200817173448-b6b71def0850/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
@@ -441,8 +445,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
-github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
-github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
+github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -1189,6 +1193,10 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/sqlite v1.5.2 h1:TpQ+/dqCY4uCigCFyrfnrJnrW9zjpelWVoEVNy5qJkc=
+gorm.io/driver/sqlite v1.5.2/go.mod h1:qxAuCol+2r6PannQDpOP1FP6ag3mKi4esLnB/jHed+4=
+gorm.io/gorm v1.25.2 h1:gs1o6Vsa+oVKG/a9ElL3XgyGfghFfkKA2SInQaCyMho=
+gorm.io/gorm v1.25.2/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
 gvisor.dev/gvisor v0.0.0-20221203005347-703fd9b7fbc0 h1:Wobr37noukisGxpKo5jAsLREcpj61RxrWYzD8uwveOY=

--- a/go.sum
+++ b/go.sum
@@ -1193,10 +1193,10 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gorm.io/driver/sqlite v1.5.2 h1:TpQ+/dqCY4uCigCFyrfnrJnrW9zjpelWVoEVNy5qJkc=
-gorm.io/driver/sqlite v1.5.2/go.mod h1:qxAuCol+2r6PannQDpOP1FP6ag3mKi4esLnB/jHed+4=
-gorm.io/gorm v1.25.2 h1:gs1o6Vsa+oVKG/a9ElL3XgyGfghFfkKA2SInQaCyMho=
-gorm.io/gorm v1.25.2/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
+gorm.io/driver/sqlite v1.5.3 h1:7/0dUgX28KAcopdfbRWWl68Rflh6osa4rDh+m51KL2g=
+gorm.io/driver/sqlite v1.5.3/go.mod h1:qxAuCol+2r6PannQDpOP1FP6ag3mKi4esLnB/jHed+4=
+gorm.io/gorm v1.25.4 h1:iyNd8fNAe8W9dvtlgeRI5zSVZPsq3OpcTu37cYcpCmw=
+gorm.io/gorm v1.25.4/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
 gvisor.dev/gvisor v0.0.0-20221203005347-703fd9b7fbc0 h1:Wobr37noukisGxpKo5jAsLREcpj61RxrWYzD8uwveOY=

--- a/management/client/client_test.go
+++ b/management/client/client_test.go
@@ -53,11 +53,7 @@ func startManagement(t *testing.T) (*grpc.Server, net.Listener) {
 		t.Fatal(err)
 	}
 	s := grpc.NewServer()
-	fstore, err := mgmt.NewFileStore(config.Datadir, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	store, err := mgmt.NewSqliteStoreFromFileStore(fstore, config.Datadir, nil)
+	store, err := mgmt.NewStoreFromJson(config.Datadir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/management/client/client_test.go
+++ b/management/client/client_test.go
@@ -53,7 +53,11 @@ func startManagement(t *testing.T) (*grpc.Server, net.Listener) {
 		t.Fatal(err)
 	}
 	s := grpc.NewServer()
-	store, err := mgmt.NewFileStore(config.Datadir, nil)
+	fstore, err := mgmt.NewFileStore(config.Datadir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := mgmt.NewSqliteStoreFromFileStore(fstore, config.Datadir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -126,7 +126,7 @@ var (
 			if err != nil {
 				return err
 			}
-			store, err := server.NewFileStore(config.Datadir, appMetrics)
+			store, err := server.NewSqliteStore(config.Datadir, appMetrics)
 			if err != nil {
 				return fmt.Errorf("failed creating Store: %s: %v", config.Datadir, err)
 			}

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -126,7 +126,7 @@ var (
 			if err != nil {
 				return err
 			}
-			store, err := server.NewSqliteStore(config.Datadir, appMetrics)
+			store, err := server.NewStore(config.StoreKind, config.Datadir, appMetrics)
 			if err != nil {
 				return fmt.Errorf("failed creating Store: %s: %v", config.Datadir, err)
 			}

--- a/management/cmd/migration.go
+++ b/management/cmd/migration.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/netbirdio/netbird/management/server"
+	"github.com/netbirdio/netbird/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var short = "Migrate JSON file store to SQLite store. Please make a backup of the store json file before running this command."
+
+var migrationCmd = &cobra.Command{
+	Use:   "migration [--datadir directory] [--log-file console]",
+	Short: short,
+	Long: short +
+		"\n\n" +
+		"This command reads the content of {datadir}/store.json and migrates it to {datadir}/store.db that can be used by SQLite store driver.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		flag.Parse()
+		err := util.InitLog(logLevel, logFile)
+		if err != nil {
+			return fmt.Errorf("failed initializing log %v", err)
+		}
+
+		fileStorePath := path.Join(mgmtDataDir, "store.json")
+		if _, err := os.Stat(fileStorePath); errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s doesn't exist, couldn't continue the operation", fileStorePath)
+		}
+
+		sqlStorePath := path.Join(mgmtDataDir, "store.db")
+		if _, err := os.Stat(sqlStorePath); err == nil {
+			return fmt.Errorf("%s already exists, couldn't continue the operation", sqlStorePath)
+		}
+
+		fstore, err := server.NewFileStore(mgmtDataDir, nil)
+		if err != nil {
+			return fmt.Errorf("failed creating file store: %s: %v", mgmtDataDir, err)
+		}
+
+		fsStoreAccounts := len(fstore.GetAllAccounts())
+		log.Infof("%d account will be migrated from file store %s to sqlite store %s",
+			fsStoreAccounts, fileStorePath, sqlStorePath)
+
+		store, err := server.NewSqliteStoreFromFileStore(fstore, mgmtDataDir, nil)
+		if err != nil {
+			return fmt.Errorf("failed creating file store: %s: %v", mgmtDataDir, err)
+		}
+
+		sqliteStoreAccounts := len(store.GetAllAccounts())
+		if fsStoreAccounts != sqliteStoreAccounts {
+			return fmt.Errorf("failed to migrate accounts from file to sqlite. Expected accounts: %d, got: %d",
+				fsStoreAccounts, sqliteStoreAccounts)
+		}
+
+		log.Info("Migration finished successfully")
+
+		return nil
+	},
+}

--- a/management/cmd/migration.go
+++ b/management/cmd/migration.go
@@ -13,12 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var short = "Migrate JSON file store to SQLite store. Please make a backup of the store json file before running this command."
+var shortMigration = "Migrate JSON file store to SQLite store. Please make a backup of the store json file before running this command."
 
 var migrationCmd = &cobra.Command{
 	Use:   "migration [--datadir directory] [--log-file console]",
-	Short: short,
-	Long: short +
+	Short: shortMigration,
+	Long: shortMigration +
 		"\n\n" +
 		"This command reads the content of {datadir}/store.json and migrates it to {datadir}/store.db that can be used by SQLite store driver.",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/management/cmd/migration_down.go
+++ b/management/cmd/migration_down.go
@@ -13,12 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var shortRollback = "Rollback SQLite store to JSON filestore. Please make a backup of the SQLite file before running this command."
+var shortDown = "Rollback SQLite store to JSON filestore. Please make a backup of the SQLite file before running this command."
 
-var rollbackCmd = &cobra.Command{
-	Use:   "rollback [--datadir directory] [--log-file console]",
-	Short: shortRollback,
-	Long: shortRollback +
+var downCmd = &cobra.Command{
+	Use:   "down [--datadir directory] [--log-file console]",
+	Short: shortDown,
+	Long: shortDown +
 		"\n\n" +
 		"This command reads the content of {datadir}/store.db and migrates it to {datadir}/store.json that can be used by File store driver.",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/management/cmd/migration_down.go
+++ b/management/cmd/migration_down.go
@@ -13,11 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var shortDown = "Rollback SQLite store to JSON filestore. Please make a backup of the SQLite file before running this command."
+var shortDown = "Rollback SQLite store to JSON file store. Please make a backup of the SQLite file before running this command."
 
 var downCmd = &cobra.Command{
-	Use:   "down [--datadir directory] [--log-file console]",
-	Short: shortDown,
+	Use:     "downgrade [--datadir directory] [--log-file console]",
+	Aliases: []string{"down"},
+	Short:   shortDown,
 	Long: shortDown +
 		"\n\n" +
 		"This command reads the content of {datadir}/store.db and migrates it to {datadir}/store.json that can be used by File store driver.",

--- a/management/cmd/migration_up.go
+++ b/management/cmd/migration_up.go
@@ -13,12 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var shortMigration = "Migrate JSON file store to SQLite store. Please make a backup of the store json file before running this command."
+var shortUp = "Migrate JSON file store to SQLite store. Please make a backup of the JSON file before running this command."
 
-var migrationCmd = &cobra.Command{
-	Use:   "migration [--datadir directory] [--log-file console]",
-	Short: shortMigration,
-	Long: shortMigration +
+var upCmd = &cobra.Command{
+	Use:   "up [--datadir directory] [--log-file console]",
+	Short: shortUp,
+	Long: shortUp +
 		"\n\n" +
 		"This command reads the content of {datadir}/store.json and migrates it to {datadir}/store.db that can be used by SQLite store driver.",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/management/cmd/migration_up.go
+++ b/management/cmd/migration_up.go
@@ -16,8 +16,9 @@ import (
 var shortUp = "Migrate JSON file store to SQLite store. Please make a backup of the JSON file before running this command."
 
 var upCmd = &cobra.Command{
-	Use:   "up [--datadir directory] [--log-file console]",
-	Short: shortUp,
+	Use:     "upgrade [--datadir directory] [--log-file console]",
+	Aliases: []string{"up"},
+	Short:   shortUp,
 	Long: shortUp +
 		"\n\n" +
 		"This command reads the content of {datadir}/store.json and migrates it to {datadir}/store.db that can be used by SQLite store driver.",

--- a/management/cmd/rollback.go
+++ b/management/cmd/rollback.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/netbirdio/netbird/management/server"
+	"github.com/netbirdio/netbird/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var shortRollback = "Rollback SQLite store to JSON filestore. Please make a backup of the SQLite file before running this command."
+
+var rollbackCmd = &cobra.Command{
+	Use:   "rollback [--datadir directory] [--log-file console]",
+	Short: shortRollback,
+	Long: shortRollback +
+		"\n\n" +
+		"This command reads the content of {datadir}/store.db and migrates it to {datadir}/store.json that can be used by File store driver.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		flag.Parse()
+		err := util.InitLog(logLevel, logFile)
+		if err != nil {
+			return fmt.Errorf("failed initializing log %v", err)
+		}
+
+		sqliteStorePath := path.Join(mgmtDataDir, "store.db")
+		if _, err := os.Stat(sqliteStorePath); errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s doesn't exist, couldn't continue the operation", sqliteStorePath)
+		}
+
+		fileStorePath := path.Join(mgmtDataDir, "store.json")
+		if _, err := os.Stat(fileStorePath); err == nil {
+			return fmt.Errorf("%s already exists, couldn't continue the operation", fileStorePath)
+		}
+
+		sqlstore, err := server.NewSqliteStore(mgmtDataDir, nil)
+		if err != nil {
+			return fmt.Errorf("failed creating file store: %s: %v", mgmtDataDir, err)
+		}
+
+		sqliteStoreAccounts := len(sqlstore.GetAllAccounts())
+		log.Infof("%d account will be migrated from sqlite store %s to file store %s",
+			sqliteStoreAccounts, sqliteStorePath, fileStorePath)
+
+		store, err := server.NewFilestoreFromSqliteStore(sqlstore, mgmtDataDir, nil)
+		if err != nil {
+			return fmt.Errorf("failed creating file store: %s: %v", mgmtDataDir, err)
+		}
+
+		fsStoreAccounts := len(store.GetAllAccounts())
+		if fsStoreAccounts != sqliteStoreAccounts {
+			return fmt.Errorf("failed to migrate accounts from sqlite to file[]. Expected accounts: %d, got: %d",
+				sqliteStoreAccounts, fsStoreAccounts)
+		}
+
+		log.Info("Migration finished successfully")
+
+		return nil
+	},
+}

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -67,6 +67,10 @@ func init() {
 	migrationCmd.Flags().StringVar(&mgmtDataDir, "datadir", defaultMgmtDataDir, "server data directory location")
 	migrationCmd.MarkFlagRequired("datadir") //nolint
 	rootCmd.AddCommand(migrationCmd)
+
+	rollbackCmd.Flags().StringVar(&mgmtDataDir, "datadir", defaultMgmtDataDir, "server data directory location")
+	rollbackCmd.MarkFlagRequired("datadir") //nolint
+	rootCmd.AddCommand(rollbackCmd)
 }
 
 // SetupCloseHandler handles SIGTERM signal and exits with success

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -34,6 +34,12 @@ var (
 		SilenceUsage: true,
 	}
 
+	migrationCmd = &cobra.Command{
+		Use:          "sqlite-migration",
+		Short:        "Contains sub commands to perform filesotre to sqlite store migration and rollback",
+		Long:         "",
+		SilenceUsage: true,
+	}
 	// Execution control channel for stopCh signal
 	stopCh chan int
 )
@@ -64,13 +70,13 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the the log will be output to stdout")
 	rootCmd.AddCommand(mgmtCmd)
 
-	migrationCmd.Flags().StringVar(&mgmtDataDir, "datadir", defaultMgmtDataDir, "server data directory location")
+	migrationCmd.PersistentFlags().StringVar(&mgmtDataDir, "datadir", defaultMgmtDataDir, "server data directory location")
 	migrationCmd.MarkFlagRequired("datadir") //nolint
-	rootCmd.AddCommand(migrationCmd)
 
-	rollbackCmd.Flags().StringVar(&mgmtDataDir, "datadir", defaultMgmtDataDir, "server data directory location")
-	rollbackCmd.MarkFlagRequired("datadir") //nolint
-	rootCmd.AddCommand(rollbackCmd)
+	migrationCmd.AddCommand(upCmd)
+	migrationCmd.AddCommand(downCmd)
+
+	rootCmd.AddCommand(migrationCmd)
 }
 
 // SetupCloseHandler handles SIGTERM signal and exits with success

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -63,6 +63,10 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the the log will be output to stdout")
 	rootCmd.AddCommand(mgmtCmd)
+
+	migrationCmd.Flags().StringVar(&mgmtDataDir, "datadir", defaultMgmtDataDir, "server data directory location")
+	migrationCmd.MarkFlagRequired("datadir") //nolint
+	rootCmd.AddCommand(migrationCmd)
 }
 
 // SetupCloseHandler handles SIGTERM signal and exits with success

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -36,7 +36,7 @@ var (
 
 	migrationCmd = &cobra.Command{
 		Use:          "sqlite-migration",
-		Short:        "Contains sub commands to perform filesotre to sqlite store migration and rollback",
+		Short:        "Contains sub-commands to perform JSON file store to SQLite store migration and rollback",
 		Long:         "",
 		SilenceUsage: true,
 	}

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -166,7 +166,7 @@ func (s *Settings) Copy() *Settings {
 // Account represents a unique account of the system
 type Account struct {
 	// we have to name column to aid as it collides with Network.Id when work with associations
-	Id string `gorm:"primaryKey;column:aid"`
+	Id string `gorm:"primaryKey"`
 
 	// User.Id it was created by
 	CreatedBy              string
@@ -174,21 +174,21 @@ type Account struct {
 	DomainCategory         string
 	IsDomainPrimaryAccount bool
 	SetupKeys              map[string]*SetupKey              `gorm:"-"`
-	SetupKeysG             []SetupKey                        `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	SetupKeysG             []SetupKey                        `json:"-" gorm:"foreignKey:AccountID;references:id"`
 	Network                *Network                          `gorm:"embedded;embeddedPrefix:network_"`
 	Peers                  map[string]*Peer                  `gorm:"-"`
-	PeersG                 []Peer                            `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	PeersG                 []Peer                            `json:"-" gorm:"foreignKey:AccountID;references:id"`
 	Users                  map[string]*User                  `gorm:"-"`
-	UsersG                 []User                            `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	UsersG                 []User                            `json:"-" gorm:"foreignKey:AccountID;references:id"`
 	Groups                 map[string]*Group                 `gorm:"-"`
-	GroupsG                []Group                           `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	GroupsG                []Group                           `json:"-" gorm:"foreignKey:AccountID;references:id"`
 	Rules                  map[string]*Rule                  `gorm:"-"`
-	RulesG                 []Rule                            `json:"-" gorm:"foreignKey:AccountID;references:aid"`
-	Policies               []*Policy                         `gorm:"foreignKey:AccountID;references:aid"`
+	RulesG                 []Rule                            `json:"-" gorm:"foreignKey:AccountID;references:id"`
+	Policies               []*Policy                         `gorm:"foreignKey:AccountID;references:id"`
 	Routes                 map[string]*route.Route           `gorm:"-"`
-	RoutesG                []route.Route                     `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	RoutesG                []route.Route                     `json:"-" gorm:"foreignKey:AccountID;references:id"`
 	NameServerGroups       map[string]*nbdns.NameServerGroup `gorm:"-"`
-	NameServerGroupsG      []nbdns.NameServerGroup           `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	NameServerGroupsG      []nbdns.NameServerGroup           `json:"-" gorm:"foreignKey:AccountID;references:id"`
 	DNSSettings            DNSSettings                       `gorm:"embedded;embeddedPrefix:dns_settings_"`
 	// Settings is a dictionary of Account settings
 	Settings *Settings `gorm:"embedded;embeddedPrefix:settings_"`

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -186,9 +186,9 @@ type Account struct {
 	RulesG                 []Rule                            `json:"-" gorm:"foreignKey:AccountID;references:aid"`
 	Policies               []*Policy                         `gorm:"foreignKey:AccountID;references:aid"`
 	Routes                 map[string]*route.Route           `gorm:"-"`
-	RoutesG                []route.Route                     `gorm:"foreignKey:AccountID;references:aid"`
+	RoutesG                []route.Route                     `json:"-" gorm:"foreignKey:AccountID;references:aid"`
 	NameServerGroups       map[string]*nbdns.NameServerGroup `gorm:"-"`
-	NameServerGroupsG      []nbdns.NameServerGroup           `gorm:"foreignKey:AccountID;references:aid"`
+	NameServerGroupsG      []nbdns.NameServerGroup           `json:"-" gorm:"foreignKey:AccountID;references:aid"`
 	DNSSettings            DNSSettings                       `gorm:"embedded;embeddedPrefix:dns_settings_"`
 	// Settings is a dictionary of Account settings
 	Settings *Settings `gorm:"embedded;embeddedPrefix:settings_"`

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -165,24 +165,25 @@ func (s *Settings) Copy() *Settings {
 
 // Account represents a unique account of the system
 type Account struct {
-	Id string
+	Id string `gorm:"primaryKey"`
+
 	// User.Id it was created by
 	CreatedBy              string
-	Domain                 string
+	Domain                 string `gorm:"index"`
 	DomainCategory         string
 	IsDomainPrimaryAccount bool
-	SetupKeys              map[string]*SetupKey
-	Network                *Network
-	Peers                  map[string]*Peer
-	Users                  map[string]*User
-	Groups                 map[string]*Group
-	Rules                  map[string]*Rule
-	Policies               []*Policy
-	Routes                 map[string]*route.Route
-	NameServerGroups       map[string]*nbdns.NameServerGroup
-	DNSSettings            DNSSettings
+	SetupKeys              map[string]*SetupKey              `gorm:"serializer:json"`
+	Network                *Network                          `gorm:"embedded;embeddedPrefix:network_"`
+	Peers                  map[string]*Peer                  `gorm:"serializer:json"`
+	Users                  map[string]*User                  `gorm:"serializer:json"`
+	Groups                 map[string]*Group                 `gorm:"serializer:json"`
+	Rules                  map[string]*Rule                  `gorm:"serializer:json"`
+	Policies               []*Policy                         `gorm:"serializer:json"`
+	Routes                 map[string]*route.Route           `gorm:"serializer:json"`
+	NameServerGroups       map[string]*nbdns.NameServerGroup `gorm:"serializer:json"`
+	DNSSettings            DNSSettings                       `gorm:"embedded;embeddedPrefix:dns_settings_"`
 	// Settings is a dictionary of Account settings
-	Settings *Settings
+	Settings *Settings `gorm:"embedded;embeddedPrefix:settings_"`
 }
 
 type UserInfo struct {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -165,22 +165,30 @@ func (s *Settings) Copy() *Settings {
 
 // Account represents a unique account of the system
 type Account struct {
-	Id string `gorm:"primaryKey"`
+	// we have to name column to aid as it collides with Network.Id when work with associations
+	Id string `gorm:"primaryKey;column:aid"`
 
 	// User.Id it was created by
 	CreatedBy              string
 	Domain                 string `gorm:"index"`
 	DomainCategory         string
 	IsDomainPrimaryAccount bool
-	SetupKeys              map[string]*SetupKey              `gorm:"serializer:json"`
+	SetupKeys              map[string]*SetupKey              `gorm:"-"`
+	SetupKeysG             []SetupKey                        `json:"-" gorm:"foreignKey:AccountID;references:aid"`
 	Network                *Network                          `gorm:"embedded;embeddedPrefix:network_"`
-	Peers                  map[string]*Peer                  `gorm:"serializer:json"`
-	Users                  map[string]*User                  `gorm:"serializer:json"`
-	Groups                 map[string]*Group                 `gorm:"serializer:json"`
-	Rules                  map[string]*Rule                  `gorm:"serializer:json"`
-	Policies               []*Policy                         `gorm:"serializer:json"`
-	Routes                 map[string]*route.Route           `gorm:"serializer:json"`
-	NameServerGroups       map[string]*nbdns.NameServerGroup `gorm:"serializer:json"`
+	Peers                  map[string]*Peer                  `gorm:"-"`
+	PeersG                 []Peer                            `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	Users                  map[string]*User                  `gorm:"-"`
+	UsersG                 []User                            `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	Groups                 map[string]*Group                 `gorm:"-"`
+	GroupsG                []Group                           `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	Rules                  map[string]*Rule                  `gorm:"-"`
+	RulesG                 []Rule                            `json:"-" gorm:"foreignKey:AccountID;references:aid"`
+	Policies               []*Policy                         `gorm:"foreignKey:AccountID;references:aid"`
+	Routes                 map[string]*route.Route           `gorm:"-"`
+	RoutesG                []route.Route                     `gorm:"foreignKey:AccountID;references:aid"`
+	NameServerGroups       map[string]*nbdns.NameServerGroup `gorm:"-"`
+	NameServerGroupsG      []nbdns.NameServerGroup           `gorm:"foreignKey:AccountID;references:aid"`
 	DNSSettings            DNSSettings                       `gorm:"embedded;embeddedPrefix:dns_settings_"`
 	// Settings is a dictionary of Account settings
 	Settings *Settings `gorm:"embedded;embeddedPrefix:settings_"`

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1400,6 +1400,10 @@ func hasNilField(x interface{}) error {
 	rv := reflect.ValueOf(x)
 	rv = rv.Elem()
 	for i := 0; i < rv.NumField(); i++ {
+		// skip gorm internal fields
+		if json, ok := rv.Type().Field(i).Tag.Lookup("json"); ok && json == "-" {
+			continue
+		}
 		if f := rv.Field(i); f.IsValid() {
 			k := f.Kind()
 			switch k {

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -2048,7 +2048,7 @@ func createManager(t *testing.T) (*DefaultAccountManager, error) {
 
 func createStore(t *testing.T) (Store, error) {
 	dataDir := t.TempDir()
-	store, err := NewSqliteStore(dataDir, nil)
+	store, err := NewStoreFromJson(dataDir, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -2045,7 +2045,7 @@ func createManager(t *testing.T) (*DefaultAccountManager, error) {
 
 func createStore(t *testing.T) (Store, error) {
 	dataDir := t.TempDir()
-	store, err := NewFileStore(dataDir, nil)
+	store, err := NewSqliteStore(dataDir, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -476,7 +476,7 @@ func TestDefaultAccountManager_GetGroupsFromTheToken(t *testing.T) {
 	// as initAccount was created without account id we have to take the id after account initialization
 	// that happens inside the GetAccountByUserOrAccountID where the id is getting generated
 	// it is important to set the id as it help to avoid creating additional account with empty Id and re-pointing indices to it
-	initAccount.Id = acc.Id
+	initAccount = acc
 
 	claims := jwtclaims.AuthorizationClaims{
 		AccountId:      accountID, // is empty as it is based on accountID right after initialization of initAccount

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1025,7 +1025,6 @@ func TestAccountManager_NetworkUpdates(t *testing.T) {
 
 		wg.Wait()
 	})
-
 	t.Run("delete peer update", func(t *testing.T) {
 		wg.Add(1)
 		go func() {

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -198,11 +198,11 @@ func TestAccount_GetPeerNetworkMap(t *testing.T) {
 	netIP := net.IP{100, 64, 0, 0}
 	netMask := net.IPMask{255, 255, 0, 0}
 	network := &Network{
-		Id:     "network",
-		Net:    net.IPNet{IP: netIP, Mask: netMask},
-		Dns:    "netbird.selfhosted",
-		Serial: 0,
-		mu:     sync.Mutex{},
+		Identifier: "network",
+		Net:        net.IPNet{IP: netIP, Mask: netMask},
+		Dns:        "netbird.selfhosted",
+		Serial:     0,
+		mu:         sync.Mutex{},
 	}
 
 	for _, testCase := range tt {
@@ -1308,7 +1308,7 @@ func TestAccount_Copy(t *testing.T) {
 			},
 		},
 		Network: &Network{
-			Id: "net1",
+			Identifier: "net1",
 		},
 		Peers: map[string]*Peer{
 			"peer1": {

--- a/management/server/config.go
+++ b/management/server/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	DeviceAuthorizationFlow *DeviceAuthorizationFlow
 
 	PKCEAuthorizationFlow *PKCEAuthorizationFlow
+
+	StoreKind StoreKind
 }
 
 // GetAuthAudiences returns the audience from the http config and device authorization flow config

--- a/management/server/dns.go
+++ b/management/server/dns.go
@@ -20,7 +20,7 @@ type lookupMap map[string]struct{}
 // DNSSettings defines dns settings at the account level
 type DNSSettings struct {
 	// DisabledManagementGroups groups whose DNS management is disabled
-	DisabledManagementGroups []string
+	DisabledManagementGroups []string `gorm:"serializer:json"`
 }
 
 // Copy returns a copy of the DNS settings

--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -196,7 +196,7 @@ func createDNSManager(t *testing.T) (*DefaultAccountManager, error) {
 
 func createDNSStore(t *testing.T) (Store, error) {
 	dataDir := t.TempDir()
-	store, err := NewFileStore(dataDir, nil)
+	store, err := NewSqliteStore(dataDir, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -196,7 +196,7 @@ func createDNSManager(t *testing.T) (*DefaultAccountManager, error) {
 
 func createDNSStore(t *testing.T) (Store, error) {
 	dataDir := t.TempDir()
-	store, err := NewSqliteStore(dataDir, nil)
+	store, err := NewStoreFromJson(dataDir, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,18 +66,11 @@ func NewFilestoreFromSqliteStore(sqlitestore *SqliteStore, dataDir string, metri
 		return nil, err
 	}
 
-	l := len(sqlitestore.GetAllAccounts())
-	fmt.Print("\033[s")
-	for i, account := range sqlitestore.GetAllAccounts() {
-		fmt.Print("\033[u\033[K")
-		fmt.Printf("%d/%d", i, l)
-		err := store.SaveAccount(account)
-		if err != nil {
-			return nil, err
-		}
+	for _, account := range sqlitestore.GetAllAccounts() {
+		store.Accounts[account.Id] = account
 	}
 
-	return store, nil
+	return store, store.persist(store.storeFile)
 }
 
 // restore the state of the store from the file.

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -614,3 +614,8 @@ func (s *FileStore) Close() error {
 
 	return s.persist(s.storeFile)
 }
+
+// GetStoreKind returns FileStoreKind
+func (s *FileStore) GetStoreKind() StoreKind {
+	return FileStoreKind
+}

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -387,7 +387,7 @@ func TestFileStore_GetAccount(t *testing.T) {
 	assert.Equal(t, expected.DomainCategory, account.DomainCategory)
 	assert.Equal(t, expected.Domain, account.Domain)
 	assert.Equal(t, expected.CreatedBy, account.CreatedBy)
-	assert.Equal(t, expected.Network.Id, account.Network.Id)
+	assert.Equal(t, expected.Network.Identifier, account.Network.Identifier)
 	assert.Len(t, account.Peers, len(expected.Peers))
 	assert.Len(t, account.Users, len(expected.Users))
 	assert.Len(t, account.SetupKeys, len(expected.SetupKeys))

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -23,6 +23,9 @@ type Group struct {
 	// ID of the group
 	ID string
 
+	// AccountID is a reference to Account that this object belongs
+	AccountID string `gorm:"index"`
+
 	// Name visible in the UI
 	Name string
 
@@ -30,7 +33,7 @@ type Group struct {
 	Issued string
 
 	// Peers list of the group
-	Peers []string
+	Peers []string `gorm:"serializer:json"`
 }
 
 // EventMeta returns activity event meta related to the group

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -24,7 +24,7 @@ type Group struct {
 	ID string
 
 	// AccountID is a reference to Account that this object belongs
-	AccountID string `gorm:"index"`
+	AccountID string `json:"-" gorm:"index"`
 
 	// Name visible in the UI
 	Name string

--- a/management/server/group_test.go
+++ b/management/server/group_test.go
@@ -80,6 +80,7 @@ func initTestGroupAccount(am *DefaultAccountManager) (*Account, error) {
 
 	groupForRoute := &Group{
 		"grp-for-route",
+		"account-id",
 		"Group for route",
 		GroupIssuedAPI,
 		make([]string, 0),
@@ -87,6 +88,7 @@ func initTestGroupAccount(am *DefaultAccountManager) (*Account, error) {
 
 	groupForNameServerGroups := &Group{
 		"grp-for-name-server-grp",
+		"account-id",
 		"Group for name server groups",
 		GroupIssuedAPI,
 		make([]string, 0),
@@ -94,6 +96,7 @@ func initTestGroupAccount(am *DefaultAccountManager) (*Account, error) {
 
 	groupForPolicies := &Group{
 		"grp-for-policies",
+		"account-id",
 		"Group for policies",
 		GroupIssuedAPI,
 		make([]string, 0),
@@ -101,6 +104,7 @@ func initTestGroupAccount(am *DefaultAccountManager) (*Account, error) {
 
 	groupForSetupKeys := &Group{
 		"grp-for-keys",
+		"account-id",
 		"Group for setup keys",
 		GroupIssuedAPI,
 		make([]string, 0),
@@ -108,6 +112,7 @@ func initTestGroupAccount(am *DefaultAccountManager) (*Account, error) {
 
 	groupForUsers := &Group{
 		"grp-for-users",
+		"account-id",
 		"Group for users",
 		GroupIssuedAPI,
 		make([]string, 0),

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -405,11 +405,7 @@ func startManagement(t *testing.T, config *Config) (*grpc.Server, string, error)
 		return nil, "", err
 	}
 	s := grpc.NewServer(grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp))
-	fstore, err := NewFileStore(config.Datadir, nil)
-	if err != nil {
-		return nil, "", err
-	}
-	store, err := NewSqliteStoreFromFileStore(fstore, config.Datadir, nil)
+	store, err := NewStoreFromJson(config.Datadir, nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -405,7 +405,11 @@ func startManagement(t *testing.T, config *Config) (*grpc.Server, string, error)
 		return nil, "", err
 	}
 	s := grpc.NewServer(grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp))
-	store, err := NewFileStore(config.Datadir, nil)
+	fstore, err := NewFileStore(config.Datadir, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	store, err := NewSqliteStoreFromFileStore(fstore, config.Datadir, nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/management/server/management_test.go
+++ b/management/server/management_test.go
@@ -497,13 +497,9 @@ func startServer(config *server.Config) (*grpc.Server, net.Listener) {
 	Expect(err).NotTo(HaveOccurred())
 	s := grpc.NewServer()
 
-	fstore, err := server.NewFileStore(config.Datadir, nil)
+	store, err := server.NewStoreFromJson(config.Datadir, nil)
 	if err != nil {
-		log.Fatalf("failed creating a filestore: %s: %v", config.Datadir, err)
-	}
-	store, err := server.NewSqliteStoreFromFileStore(fstore, config.Datadir, nil)
-	if err != nil {
-		log.Fatalf("failed creating a sqlstore: %s: %v", config.Datadir, err)
+		log.Fatalf("failed creating a store: %s: %v", config.Datadir, err)
 	}
 	peersUpdateManager := server.NewPeersUpdateManager()
 	eventStore := &activity.InMemoryEventStore{}

--- a/management/server/metrics/selfhosted.go
+++ b/management/server/metrics/selfhosted.go
@@ -48,6 +48,7 @@ type properties map[string]interface{}
 // DataSource metric data source
 type DataSource interface {
 	GetAllAccounts() []*server.Account
+	GetStoreKind() server.StoreKind
 }
 
 // ConnManager peer connection manager that holds state for current active connections
@@ -295,6 +296,7 @@ func (w *Worker) generateProperties() properties {
 	metricsProperties["max_active_peer_version"] = maxActivePeerVersion
 	metricsProperties["ui_clients"] = uiClient
 	metricsProperties["idp_manager"] = w.idpManager
+	metricsProperties["store_kind"] = w.dataSource.GetStoreKind()
 
 	for protocol, count := range rulesProtocol {
 		metricsProperties["rules_protocol_"+protocol] = count

--- a/management/server/metrics/selfhosted_test.go
+++ b/management/server/metrics/selfhosted_test.go
@@ -151,6 +151,11 @@ func (mockDatasource) GetAllAccounts() []*server.Account {
 	}
 }
 
+// GetStoreKind returns FileStoreKind
+func (mockDatasource) GetStoreKind() server.StoreKind {
+	return server.FileStoreKind
+}
+
 // TestGenerateProperties tests and validate the properties generation by using the mockDatasource for the Worker.generateProperties
 func TestGenerateProperties(t *testing.T) {
 	ds := mockDatasource{}
@@ -235,5 +240,9 @@ func TestGenerateProperties(t *testing.T) {
 
 	if properties["user_peers"] != 2 {
 		t.Errorf("expected 2 user_peers, got %d", properties["user_peers"])
+	}
+
+	if properties["store_kind"] != server.FileStoreKind {
+		t.Errorf("expected JsonFile, got %s", properties["store_kind"])
 	}
 }

--- a/management/server/nameserver_test.go
+++ b/management/server/nameserver_test.go
@@ -749,7 +749,7 @@ func createNSManager(t *testing.T) (*DefaultAccountManager, error) {
 
 func createNSStore(t *testing.T) (Store, error) {
 	dataDir := t.TempDir()
-	store, err := NewSqliteStore(dataDir, nil)
+	store, err := NewStoreFromJson(dataDir, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/nameserver_test.go
+++ b/management/server/nameserver_test.go
@@ -749,7 +749,7 @@ func createNSManager(t *testing.T) (*DefaultAccountManager, error) {
 
 func createNSStore(t *testing.T) (Store, error) {
 	dataDir := t.TempDir()
-	store, err := NewFileStore(dataDir, nil)
+	store, err := NewSqliteStore(dataDir, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/network.go
+++ b/management/server/network.go
@@ -35,13 +35,13 @@ type NetworkMap struct {
 
 type Network struct {
 	Id  string
-	Net net.IPNet
+	Net net.IPNet `gorm:"serializer:gob"`
 	Dns string
 	// Serial is an ID that increments by 1 when any change to the network happened (e.g. new peer has been added).
 	// Used to synchronize state to the client apps.
 	Serial uint64
 
-	mu sync.Mutex `json:"-"`
+	mu sync.Mutex `json:"-" gorm:"-"`
 }
 
 // NewNetwork creates a new Network initializing it with a Serial=0

--- a/management/server/network.go
+++ b/management/server/network.go
@@ -34,9 +34,9 @@ type NetworkMap struct {
 }
 
 type Network struct {
-	Id  string
-	Net net.IPNet `gorm:"serializer:gob"`
-	Dns string
+	Identifier string    `json:"id"`
+	Net        net.IPNet `gorm:"serializer:gob"`
+	Dns        string
 	// Serial is an ID that increments by 1 when any change to the network happened (e.g. new peer has been added).
 	// Used to synchronize state to the client apps.
 	Serial uint64
@@ -56,10 +56,10 @@ func NewNetwork() *Network {
 	intn := r.Intn(len(sub))
 
 	return &Network{
-		Id:     xid.New().String(),
-		Net:    sub[intn].IPNet,
-		Dns:    "",
-		Serial: 0}
+		Identifier: xid.New().String(),
+		Net:        sub[intn].IPNet,
+		Dns:        "",
+		Serial:     0}
 }
 
 // IncSerial increments Serial by 1 reflecting that the network state has been changed
@@ -78,10 +78,10 @@ func (n *Network) CurrentSerial() uint64 {
 
 func (n *Network) Copy() *Network {
 	return &Network{
-		Id:     n.Id,
-		Net:    n.Net,
-		Dns:    n.Dns,
-		Serial: n.Serial,
+		Identifier: n.Identifier,
+		Net:        n.Net,
+		Dns:        n.Dns,
+		Serial:     n.Serial,
 	}
 }
 

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -74,7 +74,7 @@ type Peer struct {
 	// ID is an internal ID of the peer
 	ID string `gorm:"primaryKey"`
 	// AccountID is a reference to Account that this object belongs
-	AccountID string `gorm:"index;uniqueIndex:idx_peers_account_id_ip"`
+	AccountID string `json:"-" gorm:"index;uniqueIndex:idx_peers_account_id_ip"`
 	// WireGuard public key
 	Key string `gorm:"index"`
 	// A setup key this peer was registered with

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -74,13 +74,13 @@ type Peer struct {
 	// ID is an internal ID of the peer
 	ID string `gorm:"primaryKey"`
 	// AccountID is a reference to Account that this object belongs
-	AccountID string `gorm:"index"`
+	AccountID string `gorm:"index;uniqueIndex:idx_peers_account_id_ip"`
 	// WireGuard public key
 	Key string `gorm:"index"`
 	// A setup key this peer was registered with
 	SetupKey string
 	// IP address of the Peer
-	IP net.IP
+	IP net.IP `gorm:"uniqueIndex:idx_peers_account_id_ip"`
 	// Meta is a Peer system meta data
 	Meta PeerSystemMeta `gorm:"embedded;embeddedPrefix:meta_"`
 	// Name is peer's name (machine name)

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -72,22 +72,24 @@ type PeerLogin struct {
 // The Peer is a WireGuard peer identified by a public key
 type Peer struct {
 	// ID is an internal ID of the peer
-	ID string
+	ID string `gorm:"primaryKey"`
+	// AccountID is a reference to Account that this object belongs
+	AccountID string `gorm:"index"`
 	// WireGuard public key
-	Key string
+	Key string `gorm:"index"`
 	// A setup key this peer was registered with
 	SetupKey string
 	// IP address of the Peer
 	IP net.IP
 	// Meta is a Peer system meta data
-	Meta PeerSystemMeta
+	Meta PeerSystemMeta `gorm:"embedded;embeddedPrefix:meta_"`
 	// Name is peer's name (machine name)
 	Name string
 	// DNSLabel is the parsed peer name for domain resolution. It is used to form an FQDN by appending the account's
 	// domain to the peer label. e.g. peer-dns-label.netbird.cloud
 	DNSLabel string
 	// Status peer's management connection status
-	Status *PeerStatus
+	Status *PeerStatus `gorm:"embedded;embeddedPrefix:peer_status_"`
 	// The user ID that registered the peer
 	UserID string
 	// SSHKey is a public SSH key of the peer
@@ -116,6 +118,7 @@ func (p *Peer) Copy() *Peer {
 	}
 	return &Peer{
 		ID:                     p.ID,
+		AccountID:              p.AccountID,
 		Key:                    p.Key,
 		SetupKey:               p.SetupKey,
 		IP:                     p.IP,

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -369,8 +369,8 @@ func TestAccountManager_GetPeerNetwork(t *testing.T) {
 		return
 	}
 
-	if account.Network.Id != network.Id {
-		t.Errorf("expecting Account Networks ID to be equal, got %s expected %s", network.Id, account.Network.Id)
+	if account.Network.Identifier != network.Identifier {
+		t.Errorf("expecting Account Networks ID to be equal, got %s expected %s", network.Identifier, account.Network.Identifier)
 	}
 }
 

--- a/management/server/personal_access_token.go
+++ b/management/server/personal_access_token.go
@@ -26,7 +26,9 @@ const (
 
 // PersonalAccessToken holds all information about a PAT including a hashed version of it for verification
 type PersonalAccessToken struct {
-	ID             string
+	ID string `gorm:"primaryKey"`
+	// User is a reference to Account that this object belongs
+	UserID         string `gorm:"index"`
 	Name           string
 	HashedToken    string
 	ExpirationDate time.Time

--- a/management/server/policy.go
+++ b/management/server/policy.go
@@ -66,7 +66,7 @@ type PolicyRule struct {
 	ID string `gorm:"primaryKey"`
 
 	// PolicyID is a reference to Policy that this object belongs
-	PolicyID string `gorm:"index"`
+	PolicyID string `json:"-" gorm:"index"`
 
 	// Name of the rule visible in the UI
 	Name string
@@ -135,7 +135,7 @@ type Policy struct {
 	ID string `gorm:"primaryKey"`
 
 	// AccountID is a reference to Account that this object belongs
-	AccountID string `gorm:"index"`
+	AccountID string `json:"-" gorm:"index"`
 
 	// Name of the Policy
 	Name string

--- a/management/server/policy.go
+++ b/management/server/policy.go
@@ -65,6 +65,9 @@ type PolicyRule struct {
 	// ID of the policy rule
 	ID string
 
+	// PolicyID is a reference to Policy that this object belongs
+	PolicyID string `gorm:"index"`
+
 	// Name of the rule visible in the UI
 	Name string
 
@@ -78,10 +81,10 @@ type PolicyRule struct {
 	Action PolicyTrafficActionType
 
 	// Destinations policy destination groups
-	Destinations []string
+	Destinations []string `gorm:"serializer:json"`
 
 	// Sources policy source groups
-	Sources []string
+	Sources []string `gorm:"serializer:json"`
 
 	// Bidirectional define if the rule is applicable in both directions, sources, and destinations
 	Bidirectional bool
@@ -90,7 +93,7 @@ type PolicyRule struct {
 	Protocol PolicyRuleProtocolType
 
 	// Ports or it ranges list
-	Ports []string
+	Ports []string `gorm:"serializer:json"`
 }
 
 // Copy returns a copy of a policy rule
@@ -128,8 +131,11 @@ func (pm *PolicyRule) ToRule() *Rule {
 
 // Policy of the Rego query
 type Policy struct {
-	// ID of the policy
-	ID string
+	// ID of the policy'
+	ID string `gorm:"primaryKey"`
+
+	// AccountID is a reference to Account that this object belongs
+	AccountID string `gorm:"index"`
 
 	// Name of the Policy
 	Name string
@@ -141,7 +147,7 @@ type Policy struct {
 	Enabled bool
 
 	// Rules of the policy
-	Rules []*PolicyRule
+	Rules []*PolicyRule `gorm:"foreignKey:PolicyID;references:id"`
 }
 
 // Copy returns a copy of the policy.

--- a/management/server/policy.go
+++ b/management/server/policy.go
@@ -63,7 +63,7 @@ type PolicyUpdateOperation struct {
 // PolicyRule is the metadata of the policy
 type PolicyRule struct {
 	// ID of the policy rule
-	ID string
+	ID string `gorm:"primaryKey"`
 
 	// PolicyID is a reference to Policy that this object belongs
 	PolicyID string `gorm:"index"`
@@ -207,7 +207,6 @@ type FirewallRule struct {
 // This function returns the list of peers and firewall rules that are applicable to a given peer.
 func (a *Account) getPeerConnectionResources(peerID string) ([]*Peer, []*FirewallRule) {
 	generateResources, getAccumulatedResources := a.connResourcesGenerator()
-
 	for _, policy := range a.Policies {
 		if !policy.Enabled {
 			continue

--- a/management/server/route_test.go
+++ b/management/server/route_test.go
@@ -1017,7 +1017,7 @@ func createRouterManager(t *testing.T) (*DefaultAccountManager, error) {
 
 func createRouterStore(t *testing.T) (Store, error) {
 	dataDir := t.TempDir()
-	store, err := NewFileStore(dataDir, nil)
+	store, err := NewSqliteStore(dataDir, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/route_test.go
+++ b/management/server/route_test.go
@@ -1017,7 +1017,7 @@ func createRouterManager(t *testing.T) (*DefaultAccountManager, error) {
 
 func createRouterStore(t *testing.T) (Store, error) {
 	dataDir := t.TempDir()
-	store, err := NewSqliteStore(dataDir, nil)
+	store, err := NewStoreFromJson(dataDir, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/rule.go
+++ b/management/server/rule.go
@@ -26,7 +26,7 @@ type Rule struct {
 	ID string
 
 	// AccountID is a reference to Account that this object belongs
-	AccountID string `gorm:"index"`
+	AccountID string `json:"-" gorm:"index"`
 
 	// Name of the rule visible in the UI
 	Name string

--- a/management/server/rule.go
+++ b/management/server/rule.go
@@ -25,6 +25,9 @@ type Rule struct {
 	// ID of the rule
 	ID string
 
+	// AccountID is a reference to Account that this object belongs
+	AccountID string `gorm:"index"`
+
 	// Name of the rule visible in the UI
 	Name string
 
@@ -35,10 +38,10 @@ type Rule struct {
 	Disabled bool
 
 	// Source list of groups IDs of peers
-	Source []string
+	Source []string `gorm:"serializer:json"`
 
 	// Destination list of groups IDs of peers
-	Destination []string
+	Destination []string `gorm:"serializer:json"`
 
 	// Flow of the traffic allowed by the rule
 	Flow TrafficFlowType

--- a/management/server/setupkey.go
+++ b/management/server/setupkey.go
@@ -68,7 +68,9 @@ type SetupKeyType string
 
 // SetupKey represents a pre-authorized key used to register machines (peers)
 type SetupKey struct {
-	Id        string
+	Id string
+	// AccountID is a reference to Account that this object belongs
+	AccountID string `gorm:"index"`
 	Key       string
 	Name      string
 	Type      SetupKeyType
@@ -82,7 +84,7 @@ type SetupKey struct {
 	// LastUsed last time the key was used for peer registration
 	LastUsed time.Time
 	// AutoGroups is a list of Group IDs that are auto assigned to a Peer when it uses this key to register
-	AutoGroups []string
+	AutoGroups []string `gorm:"serializer:json"`
 	// UsageLimit indicates the number of times this key can be used to enroll a machine.
 	// The value of 0 indicates the unlimited usage.
 	UsageLimit int
@@ -99,6 +101,7 @@ func (key *SetupKey) Copy() *SetupKey {
 	}
 	return &SetupKey{
 		Id:         key.Id,
+		AccountID:  key.AccountID,
 		Key:        key.Key,
 		Name:       key.Name,
 		Type:       key.Type,

--- a/management/server/setupkey.go
+++ b/management/server/setupkey.go
@@ -76,7 +76,7 @@ type SetupKey struct {
 	Type      SetupKeyType
 	CreatedAt time.Time
 	ExpiresAt time.Time
-	UpdatedAt time.Time
+	UpdatedAt time.Time `gorm:"autoUpdateTime:false"`
 	// Revoked indicates whether the key was revoked or not (we don't remove them for tracking purposes)
 	Revoked bool
 	// UsedTimes indicates how many times the key was used

--- a/management/server/setupkey.go
+++ b/management/server/setupkey.go
@@ -70,7 +70,7 @@ type SetupKeyType string
 type SetupKey struct {
 	Id string
 	// AccountID is a reference to Account that this object belongs
-	AccountID string `gorm:"index"`
+	AccountID string `json:"-" gorm:"index"`
 	Key       string
 	Name      string
 	Type      SetupKeyType

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -128,6 +128,8 @@ func (s *SqliteStore) AcquireAccountLock(accountID string) (unlock func()) {
 }
 
 func (s *SqliteStore) SaveAccount(account *Account) error {
+	start := time.Now()
+
 	for _, key := range account.SetupKeys {
 		account.SetupKeysG = append(account.SetupKeysG, *key)
 	}
@@ -190,6 +192,12 @@ func (s *SqliteStore) SaveAccount(account *Account) error {
 		}
 		return nil
 	})
+
+	took := time.Since(start)
+	if s.metrics != nil {
+		s.metrics.StoreMetrics().CountPersistenceDuration(took)
+	}
+	log.Debugf("took %d ms to persist an account to the SQLite", took.Milliseconds())
 
 	return err
 }

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -343,7 +343,7 @@ func (s *SqliteStore) GetAccount(accountID string) (*Account, error) {
 
 	account.SetupKeys = make(map[string]*SetupKey, len(account.SetupKeysG))
 	for _, key := range account.SetupKeysG {
-		account.SetupKeys[key.Id] = key.Copy()
+		account.SetupKeys[key.Key] = key.Copy()
 	}
 	account.SetupKeysG = nil
 

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -357,7 +357,7 @@ func (s *SqliteStore) GetAccount(accountID string) (*Account, error) {
 	for _, user := range account.UsersG {
 		user.PATs = make(map[string]*PersonalAccessToken, len(user.PATs))
 		for _, pat := range user.PATsG {
-			user.PATs[pat.ID] = &pat
+			user.PATs[pat.ID] = pat.Copy()
 		}
 		account.Users[user.Id] = user.Copy()
 	}

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -290,7 +290,7 @@ func (s *SqliteStore) GetAccount(accountID string) (*Account, error) {
 	result := s.db.Model(&account).
 		Preload("UsersG.PATsG"). // have to be specifies as this is nester reference
 		Preload(clause.Associations).
-		First(&account, "aid = ?", accountID)
+		First(&account, "id = ?", accountID)
 	if result.Error != nil {
 		return nil, status.Errorf(status.NotFound, "account not found")
 	}

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -47,9 +47,6 @@ func NewSqliteStore(dataDir string, metrics telemetry.AppMetrics) (*SqliteStore,
 		return nil, err
 	}
 	conns := runtime.NumCPU()
-	if runtime.GOOS == "windows" {
-		conns = 1
-	}
 	sql.SetMaxOpenConns(conns) // TODO: make it configurable
 
 	err = db.AutoMigrate(

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -46,7 +46,11 @@ func NewSqliteStore(dataDir string, metrics telemetry.AppMetrics) (*SqliteStore,
 	if err != nil {
 		return nil, err
 	}
-	sql.SetMaxOpenConns(runtime.NumCPU()) // TODO: make it configurable
+	conns := runtime.NumCPU()
+	if runtime.GOOS == "windows" {
+		conns = 1
+	}
+	sql.SetMaxOpenConns(conns) // TODO: make it configurable
 
 	err = db.AutoMigrate(
 		&SetupKey{}, &Peer{}, &User{}, &PersonalAccessToken{}, &Group{}, &Rule{},

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -74,6 +74,11 @@ func NewSqliteStoreFromFileStore(filestore *FileStore, dataDir string, metrics t
 		return nil, err
 	}
 
+	err = store.SaveInstallationID(filestore.InstallationID)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, account := range filestore.GetAllAccounts() {
 		err := store.SaveAccount(account)
 		if err != nil {

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -33,7 +32,7 @@ type installation struct {
 
 // NewSqliteStore restores a store from the file located in the datadir
 func NewSqliteStore(dataDir string, metrics telemetry.AppMetrics) (*SqliteStore, error) {
-	file := filepath.Join(dataDir, "store.db?cache=shared")
+	file := filepath.Join(dataDir, "store.db")
 	db, err := gorm.Open(sqlite.Open(file), &gorm.Config{
 		Logger:      logger.Default.LogMode(logger.Silent),
 		PrepareStmt: true,
@@ -42,12 +41,12 @@ func NewSqliteStore(dataDir string, metrics telemetry.AppMetrics) (*SqliteStore,
 		return nil, err
 	}
 
-	sql, err := db.DB()
-	if err != nil {
-		return nil, err
-	}
-	conns := runtime.NumCPU()
-	sql.SetMaxOpenConns(conns) // TODO: make it configurable
+	//sql, err := db.DB()
+	//if err != nil {
+	//	return nil, err
+	//}
+	//conns := runtime.NumCPU()
+	//sql.SetMaxOpenConns(conns) // TODO: make it configurable
 
 	err = db.AutoMigrate(
 		&SetupKey{}, &Peer{}, &User{}, &PersonalAccessToken{}, &Group{}, &Rule{},

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -67,7 +67,7 @@ func NewSqliteStore(dataDir string, metrics telemetry.AppMetrics) (*SqliteStore,
 	return &SqliteStore{db: db, storeFile: file, installationPK: 1}, nil
 }
 
-// NewSqliteStoreFromFileStor restores a store from FileStore and stores SQLite DB in the file located in datadir
+// NewSqliteStoreFromFileStore restores a store from FileStore and stores SQLite DB in the file located in datadir
 func NewSqliteStoreFromFileStore(filestore *FileStore, dataDir string, metrics telemetry.AppMetrics) (*SqliteStore, error) {
 	store, err := NewSqliteStore(dataDir, metrics)
 	if err != nil {

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -1,0 +1,296 @@
+package server
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/netbirdio/netbird/management/server/status"
+	"github.com/netbirdio/netbird/management/server/telemetry"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/logger"
+)
+
+// SqliteStore represents an account storage backed by a Sqlite DB persisted to disk
+type SqliteStore struct {
+	db             *gorm.DB
+	storeFile      string
+	accountLocks   sync.Map
+	InstallationPK int
+}
+
+type installation struct {
+	ID                  uint `gorm:"primaryKey"`
+	InstallationIDValue string
+}
+
+type accountIndex struct {
+	ID          string `gorm:"primaryKey"`
+	Type        string `gorm:"primaryKey"`
+	SecondaryID string
+	AccountID   string  `gorm:"index"`
+	Account     Account `gorm:"foreignKey:account_id;references:id"`
+}
+
+// NewSqliteStore restores a store from the file located in the datadir
+func NewSqliteStore(dataDir string, metrics telemetry.AppMetrics) (*SqliteStore, error) {
+	file := filepath.Join(dataDir, "store.db?cache=shared")
+	db, err := gorm.Open(sqlite.Open(file), &gorm.Config{
+		Logger:                 logger.Default.LogMode(logger.Silent),
+		SkipDefaultTransaction: true,
+		PrepareStmt:            true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sql, err := db.DB()
+	if err != nil {
+		return nil, err
+	}
+	sql.SetMaxOpenConns(runtime.NumCPU()) // TODO: make it configurable
+
+	err = db.AutoMigrate(&Account{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.AutoMigrate(&accountIndex{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.AutoMigrate(&installation{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range []string{"account_indices_add", "account_indices_update", "account_indices_delete"} {
+		db.Exec("DROP TRIGGER IF EXISTS " + name)
+	}
+
+	indicesStatements := `
+	DELETE FROM account_indices where account_id = new.id;
+
+	INSERT INTO account_indices(account_id, type, id) SELECT new.id, 'user-id', j.key from json_each(new.users) as j
+		WHERE true ON CONFLICT(id, type) DO UPDATE SET account_id=excluded.account_id, type=excluded.type, id=excluded.id, secondary_id=excluded.secondary_id;
+	INSERT INTO account_indices(account_id, type, id) SELECT new.id, 'peer-id', j.key from json_each(new.peers) as j
+		WHERE true ON CONFLICT(id, type) DO UPDATE SET account_id=excluded.account_id, type=excluded.type, id=excluded.id, secondary_id=excluded.secondary_id;
+	INSERT INTO account_indices(account_id, type, id) SELECT new.id, 'setup-key', upper(j.key) from json_each(new.setup_keys) as j
+		WHERE true ON CONFLICT(id, type) DO UPDATE SET account_id=excluded.account_id, type=excluded.type, id=excluded.id, secondary_id=excluded.secondary_id;
+	INSERT INTO account_indices(account_id, type, id) SELECT new.id, 'peer-key', json_extract(j.value, '$.Key') from json_each(new.peers) as j
+		WHERE true ON CONFLICT(id, type) DO UPDATE SET account_id=excluded.account_id, type=excluded.type, id=excluded.id, secondary_id=excluded.secondary_id;
+
+	INSERT INTO account_indices(account_id, type, id, secondary_id) SELECT new.id, 'token-id', json_extract(j.value, '$.ID'), k
+		FROM (SELECT json_extract(u.value, '$.PATs') pats, t.id, u.key k 
+				FROM accounts t, json_each(t.users) u) t, json_each(t.pats) j
+		WHERE true ON CONFLICT(id, type) DO UPDATE SET account_id=excluded.account_id, type=excluded.type, id=excluded.id, secondary_id=excluded.secondary_id;
+
+	INSERT INTO account_indices(account_id, type, id, secondary_id) 
+		SELECT new.id, 'hashed-token', json_extract(j.value, '$.HashedToken'), json_extract(j.value, '$.ID')
+		FROM (SELECT json_extract(u.value, '$.PATs') pats, t.id 
+				FROM accounts t, json_each(t.users) u) t, json_each(t.pats) j
+		WHERE true ON CONFLICT(id, type) DO UPDATE SET account_id=excluded.account_id, type=excluded.type, id=excluded.id, secondary_id=excluded.secondary_id;
+	`
+	db.Exec(fmt.Sprintf("CREATE TRIGGER account_indices_add AFTER INSERT ON accounts BEGIN %s END", indicesStatements))
+	db.Exec(fmt.Sprintf("CREATE TRIGGER account_indices_update AFTER UPDATE ON accounts BEGIN %s END", indicesStatements))
+	db.Exec(`CREATE TRIGGER account_indices_delete AFTER DELETE ON accounts BEGIN
+		DELETE FROM account_indices where account_id = old.id;
+  	END;`)
+
+	return &SqliteStore{db: db, storeFile: file, InstallationPK: 1}, nil
+}
+
+// NewSqliteStoreFromFileStor restores a store from FileStore and stored SQLite DB in the file located in datadir
+func NewSqliteStoreFromFileStore(filestore *FileStore, dataDir string, metrics telemetry.AppMetrics) (*SqliteStore, error) {
+	store, err := NewSqliteStore(dataDir, metrics)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, account := range filestore.GetAllAccounts() {
+		err := store.SaveAccount(account)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return store, nil
+}
+
+// lookupIndex fetched account though lookup table using provided index
+func (s *SqliteStore) lookupIndex(t, id string) (*Account, error) {
+	var account accountIndex
+	result := s.db.Preload(clause.Associations).First(&account, "type = ? and id = ?", t, id)
+	if result.Error != nil {
+		return nil, status.Errorf(status.NotFound, "account not found: index lookup failed")
+	}
+
+	if account.Account.Id == "" {
+		return nil, status.Errorf(status.NotFound, "account not found: index lookup failed")
+	}
+
+	return &account.Account, nil
+}
+
+// AcquireGlobalLock is noop in SqliteStore
+func (s *SqliteStore) AcquireGlobalLock() (unlock func()) {
+	return func() {}
+}
+
+func (s *SqliteStore) AcquireAccountLock(accountID string) (unlock func()) {
+	log.Debugf("acquiring lock for account %s", accountID)
+
+	start := time.Now()
+	value, _ := s.accountLocks.LoadOrStore(accountID, &sync.Mutex{})
+	mtx := value.(*sync.Mutex)
+	mtx.Lock()
+
+	unlock = func() {
+		mtx.Unlock()
+		log.Debugf("released lock for account %s in %v", accountID, time.Since(start))
+	}
+
+	return unlock
+}
+
+func (s *SqliteStore) SaveAccount(account *Account) error {
+	result := s.db.Clauses(clause.OnConflict{UpdateAll: true}).Create(account)
+
+	return result.Error
+}
+
+func (s *SqliteStore) SaveInstallationID(ID string) error {
+	installation := installation{InstallationIDValue: ID}
+	installation.ID = uint(s.InstallationPK)
+
+	result := s.db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&installation)
+
+	return result.Error
+}
+
+func (s *SqliteStore) GetInstallationID() string {
+	var installation installation
+
+	result := s.db.First(&installation, "id = ?", s.InstallationPK)
+	if result.Error != nil {
+		return ""
+	}
+
+	return installation.InstallationIDValue
+}
+
+func (s *SqliteStore) SavePeerStatus(accountID, peerID string, peerStatus PeerStatus) error {
+	account, err := s.GetAccount(accountID)
+	if err != nil {
+		return err
+	}
+
+	peer := account.Peers[peerID]
+	if peer == nil {
+		return status.Errorf(status.NotFound, "peer %s not found", peerID)
+	}
+
+	peer.Status = &peerStatus
+
+	return s.SaveAccount(account)
+}
+
+// DeleteHashedPAT2TokenIDIndex is noop in Sqlite
+func (s *SqliteStore) DeleteHashedPAT2TokenIDIndex(hashedToken string) error {
+	return nil
+}
+
+// DeleteTokenID2UserIDIndex is noop in Sqlite
+func (s *SqliteStore) DeleteTokenID2UserIDIndex(tokenID string) error {
+	return nil
+}
+
+func (s *SqliteStore) GetAccountByPrivateDomain(domain string) (*Account, error) {
+	var account Account
+
+	result := s.db.First(&account, "domain = ?", strings.ToLower(domain))
+	if result.Error != nil {
+		return nil, status.Errorf(status.NotFound, "account not found: provided domain is not registered or is not private")
+	}
+
+	return &account, nil
+}
+
+func (s *SqliteStore) GetAccountBySetupKey(setupKey string) (*Account, error) {
+	return s.lookupIndex("setup-key", strings.ToUpper(setupKey))
+}
+
+func (s *SqliteStore) GetTokenIDByHashedToken(token string) (string, error) {
+	var account accountIndex
+	result := s.db.First(&account, "type = ? and id = ?", "hashed-token", token)
+	if result.Error != nil {
+		return "", status.Errorf(status.NotFound, "tokenID not found: provided token doesn't exists")
+	}
+
+	return account.SecondaryID, nil
+}
+
+func (s *SqliteStore) GetUserByTokenID(tokenID string) (*User, error) {
+	var account accountIndex
+	result := s.db.Preload(clause.Associations).First(&account, "id = ?", tokenID)
+	if result.Error != nil {
+		return nil, status.Errorf(status.NotFound, "user not found: provided token id is not found")
+	}
+
+	for _, user := range account.Account.Users {
+		if user.Id == account.SecondaryID {
+			return user, nil
+		}
+	}
+
+	return nil, status.Errorf(status.NotFound, "user not found: provided token id is not found")
+}
+
+func (s *SqliteStore) GetAllAccounts() (all []*Account) {
+	var accounts []Account
+	result := s.db.Find(&accounts)
+	if result.Error != nil {
+		return all
+	}
+
+	for _, account := range accounts {
+		all = append(all, account.Copy())
+	}
+
+	return all
+}
+
+func (s *SqliteStore) GetAccount(accountID string) (*Account, error) {
+	var account Account
+
+	result := s.db.First(&account, "id = ?", accountID)
+	if result.Error != nil {
+		return nil, status.Errorf(status.NotFound, "account not found")
+	}
+
+	return &account, nil
+}
+
+func (s *SqliteStore) GetAccountByUser(userID string) (*Account, error) {
+	return s.lookupIndex("user-id", userID)
+}
+
+func (s *SqliteStore) GetAccountByPeerID(peerID string) (*Account, error) {
+	return s.lookupIndex("peer-id", peerID)
+}
+
+func (s *SqliteStore) GetAccountByPeerPubKey(peerKey string) (*Account, error) {
+	return s.lookupIndex("peer-key", peerKey)
+}
+
+// Close is noop in Sqlite
+func (s *SqliteStore) Close() error {
+	return nil
+}

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -394,6 +394,20 @@ func (s *SqliteStore) GetAccountByPeerPubKey(peerKey string) (*Account, error) {
 	return s.GetAccount(peer.AccountID)
 }
 
+// SaveUserLastLogin stores the last login time for a user in DB.
+func (s *SqliteStore) SaveUserLastLogin(accountID, userID string, lastLogin time.Time) error {
+	var peer Peer
+
+	result := s.db.First(&peer, "account_id = ? and user_id = ?", accountID, userID)
+	if result.Error != nil {
+		return status.Errorf(status.NotFound, "user %s not found", userID)
+	}
+
+	peer.LastLogin = lastLogin
+
+	return s.db.Save(peer).Error
+}
+
 // Close is noop in Sqlite
 func (s *SqliteStore) Close() error {
 	return nil

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -33,7 +33,13 @@ type installation struct {
 
 // NewSqliteStore restores a store from the file located in the datadir
 func NewSqliteStore(dataDir string, metrics telemetry.AppMetrics) (*SqliteStore, error) {
-	file := filepath.Join(dataDir, "store.db")
+	storeStr := "store.db?cache=shared"
+	if runtime.GOOS == "windows" {
+		// Vo avoid `The process cannot access the file because it is being used by another process` on Windows
+		storeStr = "store.db"
+	}
+
+	file := filepath.Join(dataDir, storeStr)
 	db, err := gorm.Open(sqlite.Open(file), &gorm.Config{
 		Logger:      logger.Default.LogMode(logger.Silent),
 		PrepareStmt: true,

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -41,12 +42,12 @@ func NewSqliteStore(dataDir string, metrics telemetry.AppMetrics) (*SqliteStore,
 		return nil, err
 	}
 
-	//sql, err := db.DB()
-	//if err != nil {
-	//	return nil, err
-	//}
-	//conns := runtime.NumCPU()
-	//sql.SetMaxOpenConns(conns) // TODO: make it configurable
+	sql, err := db.DB()
+	if err != nil {
+		return nil, err
+	}
+	conns := runtime.NumCPU()
+	sql.SetMaxOpenConns(conns) // TODO: make it configurable
 
 	err = db.AutoMigrate(
 		&SetupKey{}, &Peer{}, &User{}, &PersonalAccessToken{}, &Group{}, &Rule{},

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -343,7 +343,7 @@ func (s *SqliteStore) GetAccount(accountID string) (*Account, error) {
 
 	account.SetupKeys = make(map[string]*SetupKey, len(account.SetupKeysG))
 	for _, key := range account.SetupKeysG {
-		account.SetupKeys[key.Key] = key.Copy()
+		account.SetupKeys[key.Id] = key.Copy()
 	}
 	account.SetupKeysG = nil
 

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -451,3 +451,8 @@ func (s *SqliteStore) SaveUserLastLogin(accountID, userID string, lastLogin time
 func (s *SqliteStore) Close() error {
 	return nil
 }
+
+// GetStoreKind returns SqliteStoreKind
+func (s *SqliteStore) GetStoreKind() StoreKind {
+	return SqliteStoreKind
+}

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -311,7 +311,6 @@ func (s *SqliteStore) GetAllAccounts() (all []*Account) {
 	}
 
 	for _, account := range accounts {
-		//all = append(all, account.Copy()) // TODO: copy and delete gorm models
 		if acc, err := s.GetAccount(account.Id); err == nil {
 			all = append(all, acc)
 		}

--- a/management/server/sqlite_store_test.go
+++ b/management/server/sqlite_store_test.go
@@ -1,0 +1,194 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/netbirdio/netbird/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSqlite_NewStore(t *testing.T) {
+	store := newSqliteStore(t)
+
+	if len(store.GetAllAccounts()) != 0 {
+		t.Errorf("expected to create a new empty Accounts map when creating a new FileStore")
+	}
+}
+
+func TestSqlite_SaveAccount(t *testing.T) {
+	store := newSqliteStore(t)
+
+	account := newAccountWithId("account_id", "testuser", "")
+	setupKey := GenerateDefaultSetupKey()
+	account.SetupKeys[setupKey.Key] = setupKey
+	account.Peers["testpeer"] = &Peer{
+		Key:      "peerkey",
+		SetupKey: "peerkeysetupkey",
+		IP:       net.IP{127, 0, 0, 1},
+		Meta:     PeerSystemMeta{},
+		Name:     "peer name",
+		Status:   &PeerStatus{Connected: true, LastSeen: time.Now().UTC()},
+	}
+
+	err := store.SaveAccount(account)
+	require.NoError(t, err)
+
+	account2 := newAccountWithId("account_id2", "testuser2", "")
+	setupKey = GenerateDefaultSetupKey()
+	account2.SetupKeys[setupKey.Key] = setupKey
+	account2.Peers["testpeer2"] = &Peer{
+		Key:      "peerkey2",
+		SetupKey: "peerkeysetupkey2",
+		IP:       net.IP{127, 0, 0, 2},
+		Meta:     PeerSystemMeta{},
+		Name:     "peer name 2",
+		Status:   &PeerStatus{Connected: true, LastSeen: time.Now().UTC()},
+	}
+
+	err = store.SaveAccount(account2)
+	require.NoError(t, err)
+
+	if len(store.GetAllAccounts()) != 2 {
+		t.Errorf("expecting 2 Accounts to be stored after SaveAccount()")
+	}
+
+	if a, err := store.GetAccount(account.Id); a == nil {
+		t.Errorf("expecting Account to be stored after SaveAccount(): %v", err)
+	}
+
+	if a, err := store.GetAccountByPeerPubKey("peerkey"); a == nil {
+		t.Errorf("expecting PeerKeyID2AccountID index updated after SaveAccount(): %v", err)
+	}
+
+	if a, err := store.GetAccountByUser("testuser"); a == nil {
+		t.Errorf("expecting UserID2AccountID index updated after SaveAccount(): %v", err)
+	}
+
+	if a, err := store.GetAccountByPeerID("testpeer"); a == nil {
+		t.Errorf("expecting PeerID2AccountID index updated after SaveAccount(): %v", err)
+	}
+
+	if a, err := store.GetAccountBySetupKey(setupKey.Key); a == nil {
+		t.Errorf("expecting SetupKeyID2AccountID index updated after SaveAccount(): %v", err)
+	}
+}
+
+func TestSqlite_SavePeerStatus(t *testing.T) {
+	store := newSqliteStoreFromFile(t, "testdata/store.json")
+
+	account, err := store.GetAccount("bf1c8084-ba50-4ce7-9439-34653001fc3b")
+	require.NoError(t, err)
+
+	// save status of non-existing peer
+	newStatus := PeerStatus{Connected: true, LastSeen: time.Now().UTC()}
+	err = store.SavePeerStatus(account.Id, "non-existing-peer", newStatus)
+	assert.Error(t, err)
+
+	// save new status of existing peer
+	account.Peers["testpeer"] = &Peer{
+		Key:      "peerkey",
+		ID:       "testpeer",
+		SetupKey: "peerkeysetupkey",
+		IP:       net.IP{127, 0, 0, 1},
+		Meta:     PeerSystemMeta{},
+		Name:     "peer name",
+		Status:   &PeerStatus{Connected: false, LastSeen: time.Now().UTC()},
+	}
+
+	err = store.SaveAccount(account)
+	require.NoError(t, err)
+
+	err = store.SavePeerStatus(account.Id, "testpeer", newStatus)
+	require.NoError(t, err)
+
+	account, err = store.GetAccount(account.Id)
+	require.NoError(t, err)
+
+	actual := account.Peers["testpeer"].Status
+	assert.Equal(t, newStatus, *actual)
+}
+
+func TestSqlite_TestGetAccountByPrivateDomain(t *testing.T) {
+	store := newSqliteStoreFromFile(t, "testdata/store.json")
+
+	existingDomain := "test.com"
+
+	account, err := store.GetAccountByPrivateDomain(existingDomain)
+	require.NoError(t, err, "should found account")
+	require.Equal(t, existingDomain, account.Domain, "domains should match")
+
+	_, err = store.GetAccountByPrivateDomain("missing-domain.com")
+	require.Error(t, err, "should return error on domain lookup")
+}
+
+func TestSqlite_GetTokenIDByHashedToken(t *testing.T) {
+	store := newSqliteStoreFromFile(t, "testdata/store.json")
+
+	hashed := "SoMeHaShEdToKeN"
+	id := "9dj38s35-63fb-11ec-90d6-0242ac120003"
+
+	token, err := store.GetTokenIDByHashedToken(hashed)
+	require.NoError(t, err)
+	require.Equal(t, id, token)
+}
+
+func TestSqlite_GetUserByTokenID(t *testing.T) {
+	store := newSqliteStoreFromFile(t, "testdata/store.json")
+
+	id := "9dj38s35-63fb-11ec-90d6-0242ac120003"
+
+	user, err := store.GetUserByTokenID(id)
+	require.NoError(t, err)
+	require.Equal(t, id, user.PATs[id].ID)
+}
+
+func newSqliteStore(t *testing.T) *SqliteStore {
+	t.Helper()
+
+	store, err := NewSqliteStore(t.TempDir(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	return store
+}
+
+func newSqliteStoreFromFile(t *testing.T, filename string) *SqliteStore {
+	t.Helper()
+
+	storeDir := t.TempDir()
+
+	err := util.CopyFileContents(filename, filepath.Join(storeDir, "store.json"))
+	require.NoError(t, err)
+
+	fStore, err := NewFileStore(storeDir, nil)
+	require.NoError(t, err)
+
+	store, err := NewSqliteStoreFromFileStore(fStore, storeDir, nil)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	return store
+}
+
+func newAccount(store Store, id int) error {
+	str := fmt.Sprintf("%s-%d", uuid.New().String(), id)
+	account := newAccountWithId(str, str+"-testuser", "example.com")
+	setupKey := GenerateDefaultSetupKey()
+	account.SetupKeys[setupKey.Key] = setupKey
+	account.Peers["p"+str] = &Peer{
+		Key:      "peerkey" + str,
+		SetupKey: "peerkeysetupkey",
+		IP:       net.IP{127, 0, 0, 1},
+		Meta:     PeerSystemMeta{},
+		Name:     "peer name",
+		Status:   &PeerStatus{Connected: true, LastSeen: time.Now().UTC()},
+	}
+
+	return store.SaveAccount(account)
+}

--- a/management/server/sqlite_store_test.go
+++ b/management/server/sqlite_store_test.go
@@ -58,8 +58,18 @@ func TestSqlite_SaveAccount(t *testing.T) {
 		t.Errorf("expecting 2 Accounts to be stored after SaveAccount()")
 	}
 
-	if a, err := store.GetAccount(account.Id); a == nil {
+	a, err := store.GetAccount(account.Id)
+	if a == nil {
 		t.Errorf("expecting Account to be stored after SaveAccount(): %v", err)
+	}
+
+	if a != nil && len(a.Policies) != 1 {
+		t.Errorf("expecting Account to have one policy stored after SaveAccount(), got %d", len(a.Policies))
+	}
+
+	if a != nil && len(a.Policies[0].Rules) != 1 {
+		t.Errorf("expecting Account to have one policy rule stored after SaveAccount(), got %d", len(a.Policies[0].Rules))
+		return
 	}
 
 	if a, err := store.GetAccountByPeerPubKey("peerkey"); a == nil {

--- a/management/server/sqlite_store_test.go
+++ b/management/server/sqlite_store_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -14,6 +15,10 @@ import (
 )
 
 func TestSqlite_NewStore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("The SQLite store is not properly supported by Windows yet")
+	}
+
 	store := newSqliteStore(t)
 
 	if len(store.GetAllAccounts()) != 0 {
@@ -22,6 +27,10 @@ func TestSqlite_NewStore(t *testing.T) {
 }
 
 func TestSqlite_SaveAccount(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("The SQLite store is not properly supported by Windows yet")
+	}
+
 	store := newSqliteStore(t)
 
 	account := newAccountWithId("account_id", "testuser", "")
@@ -90,6 +99,10 @@ func TestSqlite_SaveAccount(t *testing.T) {
 }
 
 func TestSqlite_SavePeerStatus(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("The SQLite store is not properly supported by Windows yet")
+	}
+
 	store := newSqliteStoreFromFile(t, "testdata/store.json")
 
 	account, err := store.GetAccount("bf1c8084-ba50-4ce7-9439-34653001fc3b")
@@ -125,6 +138,10 @@ func TestSqlite_SavePeerStatus(t *testing.T) {
 }
 
 func TestSqlite_TestGetAccountByPrivateDomain(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("The SQLite store is not properly supported by Windows yet")
+	}
+
 	store := newSqliteStoreFromFile(t, "testdata/store.json")
 
 	existingDomain := "test.com"
@@ -138,6 +155,10 @@ func TestSqlite_TestGetAccountByPrivateDomain(t *testing.T) {
 }
 
 func TestSqlite_GetTokenIDByHashedToken(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("The SQLite store is not properly supported by Windows yet")
+	}
+
 	store := newSqliteStoreFromFile(t, "testdata/store.json")
 
 	hashed := "SoMeHaShEdToKeN"
@@ -149,6 +170,10 @@ func TestSqlite_GetTokenIDByHashedToken(t *testing.T) {
 }
 
 func TestSqlite_GetUserByTokenID(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("The SQLite store is not properly supported by Windows yet")
+	}
+
 	store := newSqliteStoreFromFile(t, "testdata/store.json")
 
 	id := "9dj38s35-63fb-11ec-90d6-0242ac120003"

--- a/management/server/store.go
+++ b/management/server/store.go
@@ -1,6 +1,12 @@
 package server
 
-import "time"
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/netbirdio/netbird/management/server/telemetry"
+)
 
 type Store interface {
 	GetAllAccounts() []*Account
@@ -25,4 +31,60 @@ type Store interface {
 	SaveUserLastLogin(accountID, userID string, lastLogin time.Time) error
 	// Close should close the store persisting all unsaved data.
 	Close() error
+}
+
+type StoreKind string
+
+const (
+	FileStoreKind   StoreKind = "JsonFile"
+	SqliteStoreKind StoreKind = "Sqlite"
+)
+
+func GetStoreKindFromEnv() StoreKind {
+	kind, ok := os.LookupEnv("NETBIRD_STORE_KIND")
+	if !ok {
+		return FileStoreKind
+	}
+
+	value := StoreKind(kind)
+
+	if value == FileStoreKind || value == SqliteStoreKind {
+		return value
+	}
+
+	return FileStoreKind
+}
+
+func NewStore(kind StoreKind, dataDir string, metrics telemetry.AppMetrics) (Store, error) {
+	if kind == "" {
+		// fallback to env. Normally this only should be used from tests
+		kind = GetStoreKindFromEnv()
+	}
+	switch kind {
+	case FileStoreKind:
+		return NewFileStore(dataDir, metrics)
+	case SqliteStoreKind:
+		return NewSqliteStore(dataDir, metrics)
+	default:
+		return nil, fmt.Errorf("unsupported kind of store %s", kind)
+	}
+}
+
+func NewStoreFromJson(dataDir string, metrics telemetry.AppMetrics) (Store, error) {
+	fstore, err := NewFileStore(dataDir, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	kind := GetStoreKindFromEnv()
+
+	switch kind {
+	case FileStoreKind:
+		return fstore, nil
+	case SqliteStoreKind:
+		return NewSqliteStoreFromFileStore(fstore, dataDir, metrics)
+	default:
+		return nil, fmt.Errorf("unsupported kind of store %s", kind)
+	}
+
 }

--- a/management/server/store.go
+++ b/management/server/store.go
@@ -31,6 +31,9 @@ type Store interface {
 	SaveUserLastLogin(accountID, userID string, lastLogin time.Time) error
 	// Close should close the store persisting all unsaved data.
 	Close() error
+	// GetStoreKind should return StoreKind of the current store implementation.
+	// This is also a method of metrics.DataSource interface.
+	GetStoreKind() StoreKind
 }
 
 type StoreKind string

--- a/management/server/store_test.go
+++ b/management/server/store_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type benchCase struct {
+	name    string
+	storeFn func(b *testing.B) Store
+	size    int
+}
+
+var newFs = func(b *testing.B) Store {
+	store, _ := NewFileStore(b.TempDir(), nil)
+	return store
+}
+
+var newSqlite = func(b *testing.B) Store {
+	store, _ := NewSqliteStore(b.TempDir(), nil)
+	return store
+}
+
+func BenchmarkTest_StoreWrite(b *testing.B) {
+	cases := []benchCase{
+		{name: "FileStore_Write", storeFn: newFs, size: 100},
+		{name: "SqliteStore_Write", storeFn: newSqlite, size: 100},
+		{name: "FileStore_Write", storeFn: newFs, size: 500},
+		{name: "SqliteStore_Write", storeFn: newSqlite, size: 500},
+		{name: "FileStore_Write", storeFn: newFs, size: 1000},
+		{name: "SqliteStore_Write", storeFn: newSqlite, size: 1000},
+		{name: "FileStore_Write", storeFn: newFs, size: 2000},
+		{name: "SqliteStore_Write", storeFn: newSqlite, size: 2000},
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf("%s_%d", c.name, c.size)
+		store := c.storeFn(b)
+
+		for i := 0; i < c.size; i++ {
+			_ = newAccount(store, i)
+		}
+
+		b.Run(name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				i := c.size
+				for pb.Next() {
+					i++
+					err := newAccount(store, i)
+					require.NoError(b, err)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkTest_StoreRead(b *testing.B) {
+	cases := []benchCase{
+		{name: "FileStore_Read", storeFn: newFs, size: 100},
+		{name: "SqliteStore_Read", storeFn: newSqlite, size: 100},
+		{name: "FileStore_Read", storeFn: newFs, size: 500},
+		{name: "SqliteStore_Read", storeFn: newSqlite, size: 500},
+		{name: "FileStore_Read", storeFn: newFs, size: 1000},
+		{name: "SqliteStore_Read", storeFn: newSqlite, size: 1000},
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf("%s_%d", c.name, c.size)
+		store := c.storeFn(b)
+
+		for i := 0; i < c.size; i++ {
+			_ = newAccount(store, i)
+		}
+
+		accounts := store.GetAllAccounts()
+		id := accounts[c.size-1].Id
+
+		b.Run(name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_, _ = store.GetAccount(id)
+				}
+			})
+		})
+	}
+}

--- a/management/server/testdata/store.json
+++ b/management/server/testdata/store.json
@@ -2,52 +2,87 @@
     "Accounts": {
         "bf1c8084-ba50-4ce7-9439-34653001fc3b": {
             "Id": "bf1c8084-ba50-4ce7-9439-34653001fc3b",
+            "CreatedBy": "",
             "Domain": "test.com",
             "DomainCategory": "private",
             "IsDomainPrimaryAccount": true,
             "SetupKeys": {
                 "A2C8E62B-38F5-4553-B31E-DD66C696CEBB": {
+                    "Id": "",
+                    "AccountID": "",
                     "Key": "A2C8E62B-38F5-4553-B31E-DD66C696CEBB",
                     "Name": "Default key",
                     "Type": "reusable",
                     "CreatedAt": "2021-08-19T20:46:20.005936822+02:00",
                     "ExpiresAt": "2321-09-18T20:46:20.005936822+02:00",
+                    "UpdatedAt": "0001-01-01T00:00:00Z",
                     "Revoked": false,
-                    "UsedTimes": 0
-
+                    "UsedTimes": 0,
+                    "LastUsed": "0001-01-01T00:00:00Z",
+                    "AutoGroups": null,
+                    "UsageLimit": 0,
+                    "Ephemeral": false
                 }
             },
             "Network": {
-                "Id": "af1c8024-ha40-4ce2-9418-34653101fc3c",
+                "id": "af1c8024-ha40-4ce2-9418-34653101fc3c",
                 "Net": {
                     "IP": "100.64.0.0",
                     "Mask": "//8AAA=="
                 },
-                "Dns": null
+                "Dns": "",
+                "Serial": 0
             },
             "Peers": {},
             "Users": {
                 "edafee4e-63fb-11ec-90d6-0242ac120003": {
                     "Id": "edafee4e-63fb-11ec-90d6-0242ac120003",
+                    "AccountID": "",
                     "Role": "admin",
-                    "PATs": {}
+                    "IsServiceUser": false,
+                    "ServiceUserName": "",
+                    "AutoGroups": null,
+                    "PATs": {},
+                    "Blocked": false,
+                    "LastLogin": "0001-01-01T00:00:00Z"
                 },
                 "f4f6d672-63fb-11ec-90d6-0242ac120003": {
                     "Id": "f4f6d672-63fb-11ec-90d6-0242ac120003",
+                    "AccountID": "",
                     "Role": "user",
+                    "IsServiceUser": false,
+                    "ServiceUserName": "",
+                    "AutoGroups": null,
                     "PATs": {
                         "9dj38s35-63fb-11ec-90d6-0242ac120003": {
-                            "ID":"9dj38s35-63fb-11ec-90d6-0242ac120003",
-                            "Description":"some Description",
-                            "HashedToken":"SoMeHaShEdToKeN",
-                            "ExpirationDate":"2023-02-27T00:00:00Z",
-                            "CreatedBy":"user",
-                            "CreatedAt":"2023-01-01T00:00:00Z",
-                            "LastUsed":"2023-02-01T00:00:00Z"
+                            "ID": "9dj38s35-63fb-11ec-90d6-0242ac120003",
+                            "UserID": "",
+                            "Name": "",
+                            "HashedToken": "SoMeHaShEdToKeN",
+                            "ExpirationDate": "2023-02-27T00:00:00Z",
+                            "CreatedBy": "user",
+                            "CreatedAt": "2023-01-01T00:00:00Z",
+                            "LastUsed": "2023-02-01T00:00:00Z"
                         }
-                    }
+                    },
+                    "Blocked": false,
+                    "LastLogin": "0001-01-01T00:00:00Z"
                 }
+            },
+            "Groups": null,
+            "Rules": null,
+            "Policies": [],
+            "Routes": null,
+            "NameServerGroups": null,
+            "DNSSettings": null,
+            "Settings": {
+                "PeerLoginExpirationEnabled": false,
+                "PeerLoginExpiration": 86400000000000,
+                "GroupsPropagationEnabled": false,
+                "JWTGroupsEnabled": false,
+                "JWTGroupsClaimName": ""
             }
         }
-    }
+    },
+    "InstallationID": ""
 }

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -46,7 +46,7 @@ type UserRole string
 type User struct {
 	Id string `gorm:"primaryKey"`
 	// AccountID is a reference to Account that this object belongs
-	AccountID     string `gorm:"index"`
+	AccountID     string `json:"-" gorm:"index"`
 	Role          UserRole
 	IsServiceUser bool
 	// ServiceUserName is only set if IsServiceUser is true

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -127,6 +127,7 @@ func (u *User) Copy() *User {
 	}
 	return &User{
 		Id:              u.Id,
+		AccountID:       u.AccountID,
 		Role:            u.Role,
 		AutoGroups:      autoGroups,
 		IsServiceUser:   u.IsServiceUser,

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -44,14 +44,17 @@ type UserRole string
 
 // User represents a user of the system
 type User struct {
-	Id            string
+	Id string `gorm:"primaryKey"`
+	// AccountID is a reference to Account that this object belongs
+	AccountID     string `gorm:"index"`
 	Role          UserRole
 	IsServiceUser bool
 	// ServiceUserName is only set if IsServiceUser is true
 	ServiceUserName string
 	// AutoGroups is a list of Group IDs to auto-assign to peers registered by this user
-	AutoGroups []string
-	PATs       map[string]*PersonalAccessToken
+	AutoGroups []string                        `gorm:"serializer:json"`
+	PATs       map[string]*PersonalAccessToken `gorm:"-"`
+	PATsG      []PersonalAccessToken           `json:"-" gorm:"foreignKey:UserID;references:id"`
 	// Blocked indicates whether the user is blocked. Blocked users can't use the system.
 	Blocked bool
 	// LastLogin is the last time the user logged in to IdP

--- a/management/server/user_test.go
+++ b/management/server/user_test.go
@@ -251,6 +251,7 @@ func TestUser_Copy(t *testing.T) {
 	// this is an imaginary case which will never be in DB this way
 	user := User{
 		Id:              "userId",
+		AccountID:       "accountId",
 		Role:            "role",
 		IsServiceUser:   true,
 		ServiceUserName: "servicename",
@@ -290,6 +291,11 @@ func validateStruct(s interface{}) (err error) {
 	for i := 0; i < fieldNum; i++ {
 		field := structVal.Field(i)
 		fieldName := structType.Field(i).Name
+
+		// skip gorm internal fields
+		if json, ok := structType.Field(i).Tag.Lookup("json"); ok && json == "-" {
+			continue
+		}
 
 		isSet := field.IsValid() && (!field.IsZero() || field.Type().String() == "bool")
 

--- a/route/route.go
+++ b/route/route.go
@@ -72,7 +72,7 @@ type Route struct {
 	NetID       string
 	Description string
 	Peer        string
-	PeerGroups  []string
+	PeerGroups  []string `gorm:"serializer:gob"`
 	NetworkType NetworkType
 	Masquerade  bool
 	Metric      int

--- a/route/route.go
+++ b/route/route.go
@@ -65,8 +65,10 @@ func ToPrefixType(prefix string) NetworkType {
 
 // Route represents a route
 type Route struct {
-	ID          string
-	Network     netip.Prefix
+	ID string `gorm:"primaryKey"`
+	// AccountID is a reference to Account that this object belongs
+	AccountID   string       `gorm:"index"`
+	Network     netip.Prefix `gorm:"serializer:gob"`
 	NetID       string
 	Description string
 	Peer        string
@@ -75,7 +77,7 @@ type Route struct {
 	Masquerade  bool
 	Metric      int
 	Enabled     bool
-	Groups      []string
+	Groups      []string `gorm:"serializer:json"`
 }
 
 // EventMeta returns activity event meta related to the route


### PR DESCRIPTION
## Describe your changes

This approach involves loading associated tables into slices and then converting them into maps. This technique is introducing additional fields prefixed with 'G' (shows Gorm relation), allowing for granular resource management without many changes to existing structures. While this approach introduces complexities, it serves the goal of achieving a functional implementation while minimizing disruptions to the current architecture.

One significant advantage is the elimination of the complexity associated with the lookup table used in the document-oriented approach. This simplification not only enhances query performance but also contributes to improved write speed, especially as the number of accounts grows.

Another key advantage introduced by the new relational approach is the ability to operate on separated data structures, such as accounts, users, and peers, independently. This level of separation empowers more granular and focused updates, ensuring that modifications to one resource do not require loading the entire account. But this may require additional changes in the Store interface and the Account Manager.

#### Benchmark Results:

```
$ go test  ./management/server -run Benchmark_ -bench=.  -benchmem
goos: darwin
goarch: amd64
pkg: github.com/netbirdio/netbird/management/server
cpu: Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
BenchmarkTest_StoreWrite/FileStore_Write_100-8         	     146	  14532698 ns/op	 6130954 B/op	    8549 allocs/op
BenchmarkTest_StoreWrite/SqliteStore_Write_100-8       	     278	   4623969 ns/op	  210247 B/op	    2714 allocs/op
BenchmarkTest_StoreWrite/FileStore_Write_500-8         	      44	  25448032 ns/op	13313935 B/op	   15779 allocs/op
BenchmarkTest_StoreWrite/SqliteStore_Write_500-8       	     242	   5269740 ns/op	  210193 B/op	    2714 allocs/op
BenchmarkTest_StoreWrite/FileStore_Write_1000-8        	      25	  45887216 ns/op	26595502 B/op	   30004 allocs/op
BenchmarkTest_StoreWrite/SqliteStore_Write_1000-8      	     205	   5795530 ns/op	  210193 B/op	    2715 allocs/op
BenchmarkTest_StoreWrite/FileStore_Write_2000-8        	      12	 100217523 ns/op	50800290 B/op	   58819 allocs/op
BenchmarkTest_StoreWrite/SqliteStore_Write_2000-8      	     178	   6024594 ns/op	  210188 B/op	    2715 allocs/op
BenchmarkTest_StoreRead/FileStore_Read_100-8           	  434073	      2602 ns/op	    3192 B/op	      27 allocs/op
BenchmarkTest_StoreRead/SqliteStore_Read_100-8         	    1483	    694025 ns/op	  118992 B/op	    2113 allocs/op
BenchmarkTest_StoreRead/FileStore_Read_500-8           	  412197	      2588 ns/op	    3192 B/op	      27 allocs/op
BenchmarkTest_StoreRead/SqliteStore_Read_500-8         	    1731	    676320 ns/op	  118894 B/op	    2113 allocs/op
BenchmarkTest_StoreRead/FileStore_Read_1000-8          	  439562	      2681 ns/op	    3192 B/op	      27 allocs/op
BenchmarkTest_StoreRead/SqliteStore_Read_1000-8        	    1508	    708517 ns/op	  118790 B/op	    2113 allocs/op
```

We can see that the write speed of the relational approach is better compared with the result shown in #1030. 
Unfortunately, the reading speed is worse but this might be due to the amount of copying I have to do when loading an account. This can be improved.

#### ERD diagram:

![image](https://github.com/netbirdio/netbird/assets/708165/914e82ee-e7ad-43d6-a204-2575c4e81539)

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
