### PR TITLE
Update iptables lib to v0.7.0

### DIFF
--- a/client/internal/routemanager/iptables_linux.go
+++ b/client/internal/routemanager/iptables_linux.go
@@ -395,6 +395,10 @@ func (i *iptablesManager) insertRoutingRule(keyFormat, table, chain, jump string
 		ipVersion = ipv6
 	}
 
+	if iptablesClient == nil {
+		return fmt.Errorf("unable to insert iptables routing rules. Iptables client is not initialized")
+	}
+
 	ruleKey := genKey(keyFormat, pair.ID)
 	rule := genRuleSpec(jump, ruleKey, pair.source, pair.destination)
 	existingRule, found := i.rules[ipVersion][ruleKey]
@@ -457,6 +461,10 @@ func (i *iptablesManager) removeRoutingRule(keyFormat, table, chain string, pair
 	if prefix.Addr().Unmap().Is6() {
 		iptablesClient = i.ipv6Client
 		ipVersion = ipv6
+	}
+
+	if iptablesClient == nil {
+		return fmt.Errorf("unable to remove iptables routing rules. Iptables client is not initialized")
 	}
 
 	ruleKey := genKey(keyFormat, pair.ID)

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	fyne.io/fyne/v2 v2.1.4
 	github.com/c-robinson/iplib v1.0.3
 	github.com/cilium/ebpf v0.10.0
-	github.com/coreos/go-iptables v0.6.0
+	github.com/coreos/go-iptables v0.7.0
 	github.com/creack/pty v1.1.18
 	github.com/eko/gocache/v3 v3.1.1
 	github.com/getlantern/systray v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcD
 github.com/coocood/freecache v1.2.1 h1:/v1CqMq45NFH9mp/Pt142reundeBM0dVUD3osQBeu/U=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
-github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/coreos/go-iptables v0.7.0 h1:XWM3V+MPRr5/q51NuWSgU0fqMad64Zyxs8ZUoMsamr8=
+github.com/coreos/go-iptables v0.7.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=


### PR DESCRIPTION
## Describe your changes
In Docker the old version can not determine well the path of executable file

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
