### PR TITLE
Add domain validation for nameserver groups

### DIFF
--- a/management/server/nameserver.go
+++ b/management/server/nameserver.go
@@ -32,7 +32,7 @@ const (
 	// UpdateNameServerGroupDomains indicates a nameserver group' domains update operation
 	UpdateNameServerGroupDomains
 
-	domainPattern = `^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,}$`
+	domainPattern = `^(?i)[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,}$`
 )
 
 // NameServerGroupUpdateOperationType operation type

--- a/management/server/nameserver.go
+++ b/management/server/nameserver.go
@@ -2,12 +2,11 @@ package server
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"unicode/utf8"
 
+	"github.com/miekg/dns"
 	"github.com/rs/xid"
 	log "github.com/sirupsen/logrus"
 
@@ -430,15 +429,13 @@ func validateDomain(domain string) error {
 		return errors.New("domain should consists of only letters, numbers, and hyphens with no leading, trailing hyphens, or spaces")
 	}
 
-	labels := strings.Split(domain, ".")
-	if len(labels) < 2 {
-		return errors.New("domain should consists of a minimum of two labels")
+	labels, valid := dns.IsDomainName(domain)
+	if !valid {
+		return errors.New("invalid domain name")
 	}
 
-	for _, label := range labels {
-		if len(label) < 2 || len(label) > 63 {
-			return fmt.Errorf("domain label: %s length should be ranging from 2 to 63 characters", label)
-		}
+	if labels < 2 {
+		return errors.New("domain should consists of a minimum of two labels")
 	}
 
 	return nil

--- a/management/server/nameserver_test.go
+++ b/management/server/nameserver_test.go
@@ -1160,3 +1160,69 @@ func initTestNSAccount(t *testing.T, am *DefaultAccountManager) (*Account, error
 
 	return account, nil
 }
+
+func TestValidateDomain(t *testing.T) {
+	testCases := []struct {
+		name    string
+		domain  string
+		errFunc require.ErrorAssertionFunc
+	}{
+		{
+			name:    "Valid domain name with multiple labels",
+			domain:  "123.example.com",
+			errFunc: require.NoError,
+		},
+		{
+			name:    "Valid domain name with hyphen",
+			domain:  "test-example.com",
+			errFunc: require.NoError,
+		},
+		{
+			name:    "Invalid domain name with double hyphen",
+			domain:  "test--example.com",
+			errFunc: require.Error,
+		},
+		{
+			name:    "Invalid domain name with only one label",
+			domain:  "com",
+			errFunc: require.Error,
+		},
+		{
+			name:    "Invalid domain name with a label exceeding 63 characters",
+			domain:  "dnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdnsdns.com",
+			errFunc: require.Error,
+		},
+		{
+			name:    "Invalid domain name starting with a hyphen",
+			domain:  "-example.com",
+			errFunc: require.Error,
+		},
+		{
+			name:    "Invalid domain name ending with a hyphen",
+			domain:  "example.com-",
+			errFunc: require.Error,
+		},
+		{
+			name:    "Invalid domain with unicode",
+			domain:  "example?,.com",
+			errFunc: require.Error,
+		},
+		{
+			name:    "Invalid domain with space before top-level domain",
+			domain:  "space .example.com",
+			errFunc: require.Error,
+		},
+		{
+			name:    "Invalid domain with trailing space",
+			domain:  "example.com ",
+			errFunc: require.Error,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.errFunc(t, validateDomain(testCase.domain))
+		})
+	}
+
+}


### PR DESCRIPTION
## Describe your changes

Add domain validation for nameserver groups.

## Issue ticket number and link

* Validate match domains input  ([#245][i245])


[i245]: https://github.com/netbirdio/dashboard/issues/245

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
