### PR TITLE
Update client Dockerfile to use Alpine as base image

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,5 @@
-FROM gcr.io/distroless/base:debug
+FROM alpine:3
+RUN apk add --no-cache ca-certificates iptables ip6tables
 ENV NB_FOREGROUND_MODE=true
-ENV PATH=/sbin:/usr/sbin:/bin:/usr/bin:/busybox
-SHELL ["/busybox/sh","-c"]
-RUN sed -i -E 's/(^root:.+)\/sbin\/nologin/\1\/busybox\/sh/g' /etc/passwd
 ENTRYPOINT [ "/go/bin/netbird","up"]
 COPY netbird /go/bin/netbird


### PR DESCRIPTION
## Describe your changes

Update client Dockerfile to use Alpine as base image and install necessary packages to run iptables firewall manager

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
