### PR TITLE
Send network update when propagate user auto-groups

### DIFF
--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1930,7 +1930,7 @@ func TestAccount_GetNextPeerExpiration(t *testing.T) {
 	}
 }
 
-func TestAccount_AddJWTGroups(t *testing.T) {
+func TestAccount_SetJWTGroups(t *testing.T) {
 	// create a new account
 	account := &Account{
 		Peers: map[string]*Peer{
@@ -1951,13 +1951,13 @@ func TestAccount_AddJWTGroups(t *testing.T) {
 	}
 
 	t.Run("api group already exists", func(t *testing.T) {
-		updated := account.AddJWTGroups("user1", []string{"group1"})
+		updated := account.SetJWTGroups("user1", []string{"group1"})
 		assert.False(t, updated, "account should not be updated")
 		assert.Empty(t, account.Users["user1"].AutoGroups, "auto groups must be empty")
 	})
 
 	t.Run("add jwt group", func(t *testing.T) {
-		updated := account.AddJWTGroups("user1", []string{"group1", "group2"})
+		updated := account.SetJWTGroups("user1", []string{"group1", "group2"})
 		assert.True(t, updated, "account should be updated")
 		assert.Len(t, account.Groups, 2, "new group should be added")
 		assert.Len(t, account.Users["user1"].AutoGroups, 1, "new group should be added")
@@ -1965,13 +1965,13 @@ func TestAccount_AddJWTGroups(t *testing.T) {
 	})
 
 	t.Run("existed group not update", func(t *testing.T) {
-		updated := account.AddJWTGroups("user1", []string{"group2"})
+		updated := account.SetJWTGroups("user1", []string{"group2"})
 		assert.False(t, updated, "account should not be updated")
 		assert.Len(t, account.Groups, 2, "groups count should not be changed")
 	})
 
 	t.Run("add new group", func(t *testing.T) {
-		updated := account.AddJWTGroups("user2", []string{"group1", "group3"})
+		updated := account.SetJWTGroups("user2", []string{"group1", "group3"})
 		assert.True(t, updated, "account should be updated")
 		assert.Len(t, account.Groups, 3, "new group should be added")
 		assert.Len(t, account.Users["user2"].AutoGroups, 1, "new group should be added")

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -604,10 +604,19 @@ func (am *DefaultAccountManager) SaveUser(accountID, initiatorUserID string, upd
 		// need force update all auto groups in any case they will not be dublicated
 		account.UserGroupsAddToPeers(oldUser.Id, update.AutoGroups...)
 		account.UserGroupsRemoveFromPeers(oldUser.Id, removedGroups...)
-	}
 
-	if err = am.Store.SaveAccount(account); err != nil {
-		return nil, err
+		account.Network.IncSerial()
+		if err = am.Store.SaveAccount(account); err != nil {
+			return nil, err
+		}
+
+		if err := am.updateAccountPeers(account); err != nil {
+			log.Errorf("failed updating account peers while updating user %s", accountID)
+		}
+	} else {
+		if err = am.Store.SaveAccount(account); err != nil {
+			return nil, err
+		}
 	}
 
 	defer func() {
@@ -635,7 +644,6 @@ func (am *DefaultAccountManager) SaveUser(accountID, initiatorUserID string, upd
 				} else {
 					log.Errorf("group %s not found while saving user activity event of account %s", g, account.Id)
 				}
-
 			}
 
 			for _, g := range addedGroups {


### PR DESCRIPTION
## Describe your changes
For peer propagation this commit triggers
network map update in two cases:
  1) peer login
  2) user AutoGroups update

Also it issues new activity message about new user group for peer login process.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
