### PR TITLE
Enable netbird traffic through uspfilter on Linux systems

### DIFF
--- a/client/firewall/iptables/manager_linux.go
+++ b/client/firewall/iptables/manager_linux.go
@@ -84,6 +84,10 @@ func Create(wgIface iFaceMapper) (*Manager, error) {
 		}
 	}
 
+	if m.ipv4Client == nil && m.ipv6Client == nil {
+		return nil, fmt.Errorf("iptables is not installed in the system or not enough permissions to use it")
+	}
+
 	if err := m.Reset(); err != nil {
 		return nil, fmt.Errorf("failed to reset firewall: %v", err)
 	}

--- a/client/firewall/uspfilter/allow_netbird.go
+++ b/client/firewall/uspfilter/allow_netbird.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !linux
 
 package uspfilter
 

--- a/client/firewall/uspfilter/allow_netbird_linux.go
+++ b/client/firewall/uspfilter/allow_netbird_linux.go
@@ -1,0 +1,6 @@
+package uspfilter
+
+// AllowNetbird allows netbird interface traffic
+func (m *Manager) AllowNetbird() error {
+	return nil
+}

--- a/client/firewall/uspfilter/allow_netbird_linux.go
+++ b/client/firewall/uspfilter/allow_netbird_linux.go
@@ -4,3 +4,18 @@ package uspfilter
 func (m *Manager) AllowNetbird() error {
 	return nil
 }
+
+// Reset firewall to the default state
+func (m *Manager) Reset() error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.outgoingRules = make(map[string]RuleSet)
+	m.incomingRules = make(map[string]RuleSet)
+
+	if m.resetHook != nil {
+		return m.resetHook()
+	}
+
+	return nil
+}

--- a/client/firewall/uspfilter/uspfilter.go
+++ b/client/firewall/uspfilter/uspfilter.go
@@ -32,6 +32,7 @@ type Manager struct {
 	wgNetwork     *net.IPNet
 	decoders      sync.Pool
 	wgIface       IFaceMapper
+	resetHook func() error
 
 	mutex sync.RWMutex
 }
@@ -366,4 +367,9 @@ func (m *Manager) RemovePacketHook(hookID string) error {
 		}
 	}
 	return fmt.Errorf("hook with given id not found")
+}
+
+// SetResetHook which will be executed in the end of Reset method
+func (m *Manager) SetResetHook(hook func() error) {
+	m.resetHook = hook
 }

--- a/client/internal/acl/manager.go
+++ b/client/internal/acl/manager.go
@@ -45,9 +45,6 @@ type ipsetInfo struct {
 }
 
 func newDefaultManager(fm firewall.Manager) *DefaultManager {
-	if err := fm.AllowNetbird(); err != nil {
-		log.Errorf("failed to allow netbird interface traffic: %v", err)
-	}
 	return &DefaultManager{
 		manager:    fm,
 		rulesPairs: make(map[string][]firewall.Rule),

--- a/client/internal/acl/manager_create.go
+++ b/client/internal/acl/manager_create.go
@@ -17,6 +17,9 @@ func Create(iface IFaceMapper) (manager *DefaultManager, err error) {
 		if err != nil {
 			return nil, err
 		}
+		if err := fm.AllowNetbird(); err != nil {
+			log.Errorf("failed to allow netbird interface traffic: %v", err)
+		}
 		return newDefaultManager(fm), nil
 	}
 	return nil, fmt.Errorf("not implemented for this OS: %s", runtime.GOOS)

--- a/client/internal/acl/manager_create.go
+++ b/client/internal/acl/manager_create.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"runtime"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/netbirdio/netbird/client/firewall/uspfilter"
 )
 

--- a/client/internal/acl/manager_create_linux.go
+++ b/client/internal/acl/manager_create_linux.go
@@ -11,22 +11,42 @@ import (
 
 // Create creates a firewall manager instance for the Linux
 func Create(iface IFaceMapper) (manager *DefaultManager, err error) {
+	// on the linux system we try to user nftables or iptables
+	// in any case, because we need to allow netbird interface traffic
+	// so we use AllowNetbird traffic from these firewall managers
+	// for the userspace packet filtering firewall
 	var fm firewall.Manager
+	if fm, err = nftables.Create(iface); err != nil {
+		log.Debugf("failed to create nftables manager: %s", err)
+		// fallback to iptables
+		if fm, err = iptables.Create(iface); err != nil {
+			log.Debugf("failed to create iptables manager: %s", err)
+		}
+	}
+	if fm != nil && err == nil {
+		// err shadowing is used here, to ignore this error
+		if err := fm.AllowNetbird(); err != nil {
+			log.Errorf("failed to allow netbird interface traffic: %v", err)
+		}
+	}
+
 	if iface.IsUserspaceBind() {
 		// use userspace packet filtering firewall
 		if fm, err = uspfilter.Create(iface); err != nil {
 			log.Debugf("failed to create userspace filtering firewall: %s", err)
 			return nil, err
 		}
-	} else {
-		if fm, err = nftables.Create(iface); err != nil {
-			log.Debugf("failed to create nftables manager: %s", err)
-			// fallback to iptables
-			if fm, err = iptables.Create(iface); err != nil {
-				log.Errorf("failed to create iptables manager: %s", err)
-				return nil, err
-			}
+		// to be consistent for any future extensions.
+		// ignore this error
+		if err := fm.AllowNetbird(); err != nil {
+			log.Errorf("failed to allow netbird interface traffic: %v", err)
 		}
+	}
+
+	if fm == nil || err != nil {
+		log.Errorf("failed to create firewall manager: %s", err)
+		// no firewall manager found or initalized correctly
+		return nil, err
 	}
 
 	return newDefaultManager(fm), nil

--- a/client/internal/acl/manager_test.go
+++ b/client/internal/acl/manager_test.go
@@ -2,7 +2,6 @@ package acl
 
 import (
 	"net"
-	"runtime"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -38,18 +37,16 @@ func TestDefaultManager(t *testing.T) {
 	ifaceMock := mocks.NewMockIFaceMapper(ctrl)
 	ifaceMock.EXPECT().IsUserspaceBind().Return(true)
 	ifaceMock.EXPECT().SetFilter(gomock.Any())
-	if runtime.GOOS == "linux" {
-		ip, network, err := net.ParseCIDR("172.0.0.1/32")
-		if err != nil {
-			t.Fatalf("failed to parse IP address: %v", err)
-		}
-
-		ifaceMock.EXPECT().Name().Return("lo")
-		ifaceMock.EXPECT().Address().Return(iface.WGAddress{
-			IP:      ip,
-			Network: network,
-		})
+	ip, network, err := net.ParseCIDR("172.0.0.1/32")
+	if err != nil {
+		t.Fatalf("failed to parse IP address: %v", err)
 	}
+
+	ifaceMock.EXPECT().Name().Return("lo").AnyTimes()
+	ifaceMock.EXPECT().Address().Return(iface.WGAddress{
+		IP:      ip,
+		Network: network,
+	}).AnyTimes()
 
 	// we receive one rule from the management so for testing purposes ignore it
 	acl, err := Create(ifaceMock)
@@ -328,18 +325,16 @@ func TestDefaultManagerEnableSSHRules(t *testing.T) {
 	ifaceMock := mocks.NewMockIFaceMapper(ctrl)
 	ifaceMock.EXPECT().IsUserspaceBind().Return(true)
 	ifaceMock.EXPECT().SetFilter(gomock.Any())
-	if runtime.GOOS == "linux" {
-		ip, network, err := net.ParseCIDR("172.0.0.1/32")
-		if err != nil {
-			t.Fatalf("failed to parse IP address: %v", err)
-		}
-
-		ifaceMock.EXPECT().Name().Return("lo")
-		ifaceMock.EXPECT().Address().Return(iface.WGAddress{
-			IP:      ip,
-			Network: network,
-		})
+	ip, network, err := net.ParseCIDR("172.0.0.1/32")
+	if err != nil {
+		t.Fatalf("failed to parse IP address: %v", err)
 	}
+
+	ifaceMock.EXPECT().Name().Return("lo").AnyTimes()
+	ifaceMock.EXPECT().Address().Return(iface.WGAddress{
+		IP:      ip,
+		Network: network,
+	}).AnyTimes()
 
 	// we receive one rule from the management so for testing purposes ignore it
 	acl, err := Create(ifaceMock)


### PR DESCRIPTION
## Describe your changes
Enable netbird traffic through uspfilter on Linux systems

Issue:
While every firewall manager has an AllowNetbird method,
uspfilter doesn't utilize it on Linux due to the need
for system firewall traffic control.

Solution:
On Linux, we now attempt to initialize either nftables
or iptables within the ACL manager. We then invoke the
AllowNetbird method for the chosen firewall. If userspace
implementation is being used, the firewall manager is
subsequently recreated as a uspfilter instance.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
