### PR TITLE
Adding dashboard login activity

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1350,7 +1350,8 @@ func (am *DefaultAccountManager) GetAccountFromToken(claims jwtclaims.Authorizat
 	err = am.Store.SaveUserLastLogin(account.Id, claims.UserId, claims.LastLogin)
 	unlock()
 	if newLogin {
-		am.storeEvent(claims.UserId, claims.UserId, account.Id, activity.DashboardLogin, nil)
+		meta := map[string]any{"timestamp": claims.LastLogin}
+		am.storeEvent(claims.UserId, claims.UserId, account.Id, activity.DashboardLogin, meta)
 		if err != nil {
 			log.Errorf("failed saving user last login: %v", err)
 		}

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1345,18 +1345,6 @@ func (am *DefaultAccountManager) GetAccountFromToken(claims jwtclaims.Authorizat
 		return nil, nil, status.Errorf(status.NotFound, "user %s not found", claims.UserId)
 	}
 
-	unlock := am.Store.AcquireAccountLock(account.Id)
-	newLogin := user.LastDashboardLoginChanged(claims.LastLogin)
-	err = am.Store.SaveUserLastLogin(account.Id, claims.UserId, claims.LastLogin)
-	unlock()
-	if newLogin {
-		meta := map[string]any{"timestamp": claims.LastLogin}
-		am.storeEvent(claims.UserId, claims.UserId, account.Id, activity.DashboardLogin, meta)
-		if err != nil {
-			log.Errorf("failed saving user last login: %v", err)
-		}
-	}
-
 	if !user.IsServiceUser {
 		err = am.redeemInvite(account, claims.UserId)
 		if err != nil {

--- a/management/server/activity/codes.go
+++ b/management/server/activity/codes.go
@@ -110,6 +110,8 @@ const (
 	UserLoggedInPeer
 	// PeerLoginExpired indicates that the user peer login has been expired and peer disconnected
 	PeerLoginExpired
+	// DashboardLogin indicates that the user logged in to the dashboard
+	DashboardLogin
 )
 
 var activityMap = map[Activity]Code{
@@ -163,6 +165,7 @@ var activityMap = map[Activity]Code{
 	GroupDeleted:                              {"Group deleted", "group.delete"},
 	UserLoggedInPeer:                          {"User logged in peer", "user.peer.login"},
 	PeerLoginExpired:                          {"Peer login expired", "peer.login.expire"},
+	DashboardLogin:                            {"Dashboard login", "dashboard.login"},
 }
 
 // StringCode returns a string code of the activity

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -570,6 +570,26 @@ func (s *FileStore) SavePeerStatus(accountID, peerID string, peerStatus PeerStat
 	return nil
 }
 
+// SaveUserLastLogin stores the last login time for a user in memory. It doesn't attempt to persist data to speed up things.
+func (s *FileStore) SaveUserLastLogin(accountID, userID string, lastLogin time.Time) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	account, err := s.getAccount(accountID)
+	if err != nil {
+		return err
+	}
+
+	peer := account.Users[userID]
+	if peer == nil {
+		return status.Errorf(status.NotFound, "user %s not found", userID)
+	}
+
+	peer.LastLogin = lastLogin
+
+	return nil
+}
+
 // Close the FileStore persisting data to disk
 func (s *FileStore) Close() error {
 	s.mux.Lock()

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -101,7 +101,7 @@ components:
           enum: [ "active","invited","blocked" ]
           example: active
         last_login:
-          description: Last time this user performed log in to IdP
+          description: Last time this user performed a login to the dashboard
           type: string
           format: date-time
           example: 2023-05-05T09:00:35.477782Z

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -100,6 +100,11 @@ components:
           type: string
           enum: [ "active","invited","blocked" ]
           example: active
+        last_login:
+          description: Last time this user performed log in to IdP
+          type: string
+          format: date-time
+          example: 2023-05-05T09:00:35.477782Z
         auto_groups:
           description: Groups to auto-assign to peers registered by this user
           type: array

--- a/management/server/http/api/types.gen.go
+++ b/management/server/http/api/types.gen.go
@@ -767,6 +767,9 @@ type User struct {
 	// IsServiceUser Is true if this user is a service user
 	IsServiceUser *bool `json:"is_service_user,omitempty"`
 
+	// LastLogin Last time this user performed log in to IdP
+	LastLogin *time.Time `json:"last_login,omitempty"`
+
 	// Name User's name from idp provider
 	Name string `json:"name"`
 

--- a/management/server/http/api/types.gen.go
+++ b/management/server/http/api/types.gen.go
@@ -767,7 +767,7 @@ type User struct {
 	// IsServiceUser Is true if this user is a service user
 	IsServiceUser *bool `json:"is_service_user,omitempty"`
 
-	// LastLogin Last time this user performed log in to IdP
+	// LastLogin Last time this user performed a login to the dashboard
 	LastLogin *time.Time `json:"last_login,omitempty"`
 
 	// Name User's name from idp provider

--- a/management/server/http/users_handler.go
+++ b/management/server/http/users_handler.go
@@ -270,5 +270,6 @@ func toUserResponse(user *server.UserInfo, currenUserID string) *api.User {
 		IsCurrent:     &isCurrent,
 		IsServiceUser: &user.IsServiceUser,
 		IsBlocked:     user.IsBlocked,
+		LastLogin:     &user.LastLogin,
 	}
 }

--- a/management/server/jwtclaims/claims.go
+++ b/management/server/jwtclaims/claims.go
@@ -1,6 +1,8 @@
 package jwtclaims
 
 import (
+	"time"
+
 	"github.com/golang-jwt/jwt"
 )
 
@@ -10,6 +12,7 @@ type AuthorizationClaims struct {
 	AccountId      string
 	Domain         string
 	DomainCategory string
+	LastLogin      time.Time
 
 	Raw jwt.MapClaims
 }

--- a/management/server/jwtclaims/extractor.go
+++ b/management/server/jwtclaims/extractor.go
@@ -27,9 +27,8 @@ type ExtractClaims func(r *http.Request) AuthorizationClaims
 
 // ClaimsExtractor struct that holds the extract function
 type ClaimsExtractor struct {
-	authAudience   string
-	userIDClaim    string
-	lastLoginClaim time.Time
+	authAudience string
+	userIDClaim  string
 
 	FromRequestContext ExtractClaims
 }

--- a/management/server/store.go
+++ b/management/server/store.go
@@ -1,5 +1,7 @@
 package server
 
+import "time"
+
 type Store interface {
 	GetAllAccounts() []*Account
 	GetAccount(accountID string) (*Account, error)
@@ -20,6 +22,7 @@ type Store interface {
 	// AcquireGlobalLock should attempt to acquire a global lock and return a function that releases the lock
 	AcquireGlobalLock() func()
 	SavePeerStatus(accountID, peerID string, status PeerStatus) error
+	SaveUserLastLogin(accountID, userID string, lastLogin time.Time) error
 	// Close should close the store persisting all unsaved data.
 	Close() error
 }

--- a/management/server/updatechannel.go
+++ b/management/server/updatechannel.go
@@ -1,9 +1,11 @@
 package server
 
 import (
-	"github.com/netbirdio/netbird/management/proto"
-	log "github.com/sirupsen/logrus"
 	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/management/proto"
 )
 
 const channelBufferSize = 100
@@ -33,7 +35,7 @@ func (p *PeersUpdateManager) SendUpdate(peerID string, update *UpdateMessage) er
 	if channel, ok := p.peerChannels[peerID]; ok {
 		select {
 		case channel <- update:
-			log.Infof("update was sent to channel for peer %s", peerID)
+			log.Debugf("update was sent to channel for peer %s", peerID)
 		default:
 			log.Warnf("channel for peer %s is %d full", peerID, len(channel))
 		}
@@ -52,7 +54,7 @@ func (p *PeersUpdateManager) CreateChannel(peerID string) chan *UpdateMessage {
 		delete(p.peerChannels, peerID)
 		close(channel)
 	}
-	//mbragin: todo shouldn't it be more? or configurable?
+	// mbragin: todo shouldn't it be more? or configurable?
 	channel := make(chan *UpdateMessage, channelBufferSize)
 	p.peerChannels[peerID] = channel
 

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -53,11 +54,17 @@ type User struct {
 	PATs       map[string]*PersonalAccessToken
 	// Blocked indicates whether the user is blocked. Blocked users can't use the system.
 	Blocked bool
+	// LastLogin is the last time the user logged in to IdP
+	LastLogin time.Time
 }
 
 // IsBlocked returns true if the user is blocked, false otherwise
 func (u *User) IsBlocked() bool {
 	return u.Blocked
+}
+
+func (u *User) LastDashboardLoginChanged(LastLogin time.Time) bool {
+	return LastLogin.After(u.LastLogin) && !u.LastLogin.IsZero()
 }
 
 // IsAdmin returns true if the user is an admin, false otherwise
@@ -82,6 +89,7 @@ func (u *User) ToUserInfo(userData *idp.UserData) (*UserInfo, error) {
 			Status:        string(UserStatusActive),
 			IsServiceUser: u.IsServiceUser,
 			IsBlocked:     u.Blocked,
+			LastLogin:     u.LastLogin,
 		}, nil
 	}
 	if userData.ID != u.Id {
@@ -102,6 +110,7 @@ func (u *User) ToUserInfo(userData *idp.UserData) (*UserInfo, error) {
 		Status:        string(userStatus),
 		IsServiceUser: u.IsServiceUser,
 		IsBlocked:     u.Blocked,
+		LastLogin:     u.LastLogin,
 	}, nil
 }
 
@@ -123,6 +132,7 @@ func (u *User) Copy() *User {
 		ServiceUserName: u.ServiceUserName,
 		PATs:            pats,
 		Blocked:         u.Blocked,
+		LastLogin:       u.LastLogin,
 	}
 }
 
@@ -186,6 +196,7 @@ func (am *DefaultAccountManager) createServiceUser(accountID string, initiatorUs
 		AutoGroups:    newUser.AutoGroups,
 		Status:        string(UserStatusActive),
 		IsServiceUser: true,
+		LastLogin:     time.Time{},
 	}, nil
 }
 

--- a/management/server/user_test.go
+++ b/management/server/user_test.go
@@ -266,7 +266,8 @@ func TestUser_Copy(t *testing.T) {
 				LastUsed:       time.Now(),
 			},
 		},
-		Blocked: false,
+		Blocked:   false,
+		LastLogin: time.Now(),
 	}
 
 	err := validateStruct(user)


### PR DESCRIPTION
## Describe your changes
For better auditing this PR adds a dashboard login event to the management service.

For that the user object was extended with a field for last login that is not actively saved to the database but kept in memory until next write. The information about the last login can be extracted from the JWT claims `nb_last_login`. This timestamp will be stored and compared on each API request. If the value changes we generate an event to inform about a login.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
