### PR TITLE
Add Wix file for MSI builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
       - '**/Dockerfile.*'
 
 env:
-  SIGN_PIPE_VER: "v0.0.8"
+  SIGN_PIPE_VER: "v0.0.9"
   GORELEASER_VER: "v1.14.1"
 
 concurrency:

--- a/client/netbird.wxs
+++ b/client/netbird.wxs
@@ -1,6 +1,6 @@
 <Wix
 	xmlns="http://wixtoolset.org/schemas/v4/wxs">
-	<Package Name="Netbird" Version="$(env.NETBIRD_VERSION)" Manufacturer="Wireguard UG (haftungsbeschreankt)" Language="1033" UpgradeCode="6456ec4e-3ad6-4b9b-a2be-98e81cb21ccf"
+	<Package Name="Netbird" Version="$(env.NETBIRD_VERSION)" Manufacturer="Wiretrustee UG (haftungsbeschreankt)" Language="1033" UpgradeCode="6456ec4e-3ad6-4b9b-a2be-98e81cb21ccf"
         InstallerVersion="500" Compressed="yes"  Codepage="utf-8" >
 
 		<MediaTemplate EmbedCab="yes" />
@@ -69,7 +69,7 @@
 		</InstallExecuteSequence>
 
 		<!-- Icons -->
-		<Icon Id="NetbirdIcon" SourceFile=".\client\ui\netbird.ico" />
+		<Icon Id="NetbirdIcon" SourceFile=".\ui\netbird.ico" />
 
 	</Package>
 </Wix>

--- a/client/netbird.wxs
+++ b/client/netbird.wxs
@@ -17,6 +17,7 @@
 					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\netbird.exe" KeyPath="yes" />
 					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\netbird-ui.exe">
 						<Shortcut Id="NetbirdDesktopShortcut" Directory="DesktopFolder" Name="Netbird" WorkingDirectory="NetbirdInstallDir" Icon="NetbirdIcon" />
+						<Shortcut Id="NetbirdStartMenuShortcut" Directory="StartMenuFolder" Name="Netbird" WorkingDirectory="NetbirdInstallDir" Icon="NetbirdIcon" />
 					</File>
 					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\wintun.dll" />
 
@@ -69,7 +70,8 @@
 		</InstallExecuteSequence>
 
 		<!-- Icons -->
-		<Icon Id="NetbirdIcon" SourceFile=".\ui\netbird.ico" />
+		<Icon Id="NetbirdIcon" SourceFile=".\client\ui\netbird.ico" />
+		<Property Id="ARPPRODUCTICON" Value="NetbirdIcon" />
 
 	</Package>
 </Wix>

--- a/client/netbird.wxs
+++ b/client/netbird.wxs
@@ -1,0 +1,75 @@
+<Wix
+	xmlns="http://wixtoolset.org/schemas/v4/wxs">
+	<Package Name="Netbird" Version="$(env.NETBIRD_VERSION)" Manufacturer="Wireguard UG (haftungsbeschreankt)" Language="1033" UpgradeCode="6456ec4e-3ad6-4b9b-a2be-98e81cb21ccf"
+        InstallerVersion="500" Compressed="yes"  Codepage="utf-8" >
+
+		<MediaTemplate EmbedCab="yes" />
+
+		<Feature Id="NetbirdFeature" Title="Netbird" Level="1">
+			<ComponentGroupRef Id="NetbirdFilesComponent" />
+		</Feature>
+
+		<MajorUpgrade AllowSameVersionUpgrades='yes' DowngradeErrorMessage="A newer version of [ProductName] is already installed. Setup will now exit."/>
+
+		<StandardDirectory Id="ProgramFiles64Folder">
+			<Directory Id="NetbirdInstallDir" Name="Netbird">
+				<Component Id="NetbirdFiles" Guid="db3165de-cc6e-4922-8396-9d892950e23e" Bitness="always64">
+					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\netbird.exe" KeyPath="yes" />
+					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\netbird-ui.exe">
+						<Shortcut Id="NetbirdDesktopShortcut" Directory="DesktopFolder" Name="Netbird" WorkingDirectory="NetbirdInstallDir" Icon="NetbirdIcon" />
+					</File>
+					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\wintun.dll" />
+
+					<ServiceInstall
+                                     Id="NetBirdService"
+                                     Name="NetBird"
+                                     DisplayName="NetBird"
+                                     Description="A WireGuard-based mesh network that connects your devices into a single private network."
+                                     Start="auto" Type="ownProcess"
+                                     ErrorControl="normal"
+                                     Account="LocalSystem"
+                                     Vital="yes"
+                                     Interactive="no"
+                                     Arguments='service run config [CommonAppDataFolder]Netbird\config.json log-level info'
+                        />
+					<ServiceControl Id="NetBirdService" Name="NetBird" Start="install" Stop="both" Remove="uninstall" Wait="yes" />
+
+					<Environment Id="UpdatePath" Name="PATH" Value="[NetbirdInstallDir]" Part="last" Action="set" System="yes" />
+
+				</Component>
+			</Directory>
+		</StandardDirectory>
+
+		<ComponentGroup Id="NetbirdFilesComponent">
+			<ComponentRef Id="NetbirdFiles" />
+		</ComponentGroup>
+
+		<Property Id="cmd" Value="cmd.exe"/>
+
+		<CustomAction Id="KillDaemon"
+                      ExeCommand='/c "taskkill /im netbird.exe"'
+                      Execute="deferred"
+                      Property="cmd"
+                      Impersonate="no"
+                      Return="ignore"
+            />
+
+		<CustomAction Id="KillUI"
+                      ExeCommand='/c "taskkill /im netbird-ui.exe"'
+                      Execute="deferred"
+                      Property="cmd"
+                      Impersonate="no"
+                      Return="ignore"
+            />
+
+		<InstallExecuteSequence>
+			<!-- For Uninstallation -->
+			<Custom Action="KillDaemon" Before="RemoveFiles" Condition="Installed"/>
+			<Custom Action="KillUI" After="KillDaemon" Condition="Installed"/>
+		</InstallExecuteSequence>
+
+		<!-- Icons -->
+		<Icon Id="NetbirdIcon" SourceFile=".\client\ui\netbird.ico" />
+
+	</Package>
+</Wix>

--- a/client/netbird.wxs
+++ b/client/netbird.wxs
@@ -1,6 +1,6 @@
 <Wix
 	xmlns="http://wixtoolset.org/schemas/v4/wxs">
-	<Package Name="Netbird" Version="$(env.NETBIRD_VERSION)" Manufacturer="Wiretrustee UG (haftungsbeschreankt)" Language="1033" UpgradeCode="6456ec4e-3ad6-4b9b-a2be-98e81cb21ccf"
+	<Package Name="NetBird" Version="$(env.NETBIRD_VERSION)" Manufacturer="Wiretrustee UG (haftungsbeschreankt)" Language="1033" UpgradeCode="6456ec4e-3ad6-4b9b-a2be-98e81cb21ccf"
         InstallerVersion="500" Compressed="yes"  Codepage="utf-8" >
 
 		<MediaTemplate EmbedCab="yes" />
@@ -16,8 +16,8 @@
 				<Component Id="NetbirdFiles" Guid="db3165de-cc6e-4922-8396-9d892950e23e" Bitness="always64">
 					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\netbird.exe" KeyPath="yes" />
 					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\netbird-ui.exe">
-						<Shortcut Id="NetbirdDesktopShortcut" Directory="DesktopFolder" Name="Netbird" WorkingDirectory="NetbirdInstallDir" Icon="NetbirdIcon" />
-						<Shortcut Id="NetbirdStartMenuShortcut" Directory="StartMenuFolder" Name="Netbird" WorkingDirectory="NetbirdInstallDir" Icon="NetbirdIcon" />
+						<Shortcut Id="NetbirdDesktopShortcut" Directory="DesktopFolder" Name="NetBird" WorkingDirectory="NetbirdInstallDir" Icon="NetbirdIcon" />
+						<Shortcut Id="NetbirdStartMenuShortcut" Directory="StartMenuFolder" Name="NetBird" WorkingDirectory="NetbirdInstallDir" Icon="NetbirdIcon" />
 					</File>
 					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\wintun.dll" />
 

--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -169,7 +169,3 @@ env | grep NETBIRD
 envsubst <docker-compose.yml.tmpl >docker-compose.yml
 envsubst <management.json.tmpl >management.json
 envsubst <turnserver.conf.tmpl >turnserver.conf
-
-
-# this command will send the STUN magic cookie (0x2112A442) to a udp socket on localhost:1234 using netcat:
-# echo -ne '\x21\x12\xa4\x42' | nc -u localhost 1234

--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -169,3 +169,7 @@ env | grep NETBIRD
 envsubst <docker-compose.yml.tmpl >docker-compose.yml
 envsubst <management.json.tmpl >management.json
 envsubst <turnserver.conf.tmpl >turnserver.conf
+
+
+# this command will send the STUN magic cookie (0x2112A442) to a udp socket on localhost:1234 using netcat:
+# echo -ne '\x21\x12\xa4\x42' | nc -u localhost 1234


### PR DESCRIPTION
## Describe your changes
This adds a basic wxs file to build MSI installer

This file was created using docs from https://wixtoolset.org/docs/schema/wxs/ and examples from [gsudo](https://github.com/gerardog/gsudo/blob/eb6788844839558082bd7ebff4ea4e9cfbdb6bf6/src/gsudo.Installer/Product.wxs),  [qemu-shoggoth](https://github.com/cromulencellc/qemu-shoggoth/blob/16224789f559e98d6dc12f1b567af2f6ab29d68d/qga/installer/qemu-ga.wxs#), and many others.
## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
