### PR TITLE
Close PKCE Listening Port After Authorization

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -204,6 +204,7 @@ func openURL(cmd *cobra.Command, verificationURIComplete, userCode string) {
 
 	authenticateUsingBrowser := func() {
 		cmd.Println(browserAuthMsg)
+		cmd.Println("")
 		if err := open.Run(verificationURIComplete); err != nil {
 			cmd.Println(setupKeyAuthMsg)
 		}


### PR DESCRIPTION
## Describe your changes

Addresses the issue of an open listening port persisting after the PKCE authorization flow is completed.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
