### PR TITLE
fix NETBIRD_SIGNAL_PORT not working with custom port

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -36,7 +36,7 @@ services:
     volumes:
       - $SIGNAL_VOLUMENAME:/var/lib/netbird
     ports:
-      - 10000:80
+      - $NETBIRD_SIGNAL_PORT:80
   #      # port and command for Let's Encrypt validation
   #      - 443:443
   #    command: ["--letsencrypt-domain", "$NETBIRD_LETSENCRYPT_DOMAIN", "--log-file", "console"]


### PR DESCRIPTION
Use NETBIRD_SIGNAL_PORT variable instead of the static port for signal container in the docker-compose template to make setting of custom signal port working

## Describe your changes
trying to use custom signal port I saw it was not working and signal container still use the default one.
after a fast look to commit that implement it and comparing with other variable for custom port working I found the missing in docker template that still have the static port to default.
This patch add the use of variable instead of the static port.
From a test seems now working correctly with custom port.

## Issue ticket number and link

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
