### PR TITLE
Add management_grpc_updatechannel_queue_bucket histogram

### DIFF
--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -159,6 +159,11 @@ func (s *GRPCServer) Sync(req *proto.EncryptedMessage, srv proto.ManagementServi
 		select {
 		// condition when there are some updates
 		case update, open := <-updates:
+
+			if s.appMetrics != nil {
+				s.appMetrics.GRPCMetrics().UpdateChannelQueueLength(len(updates) + 1)
+			}
+
 			if !open {
 				log.Debugf("updates channel for peer %s was closed", peerKey.String())
 				s.cancelPeerRoutines(peer)


### PR DESCRIPTION
This should help to find better value for `server.channelBufferSize`

## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
