### PR TITLE
feat: start daemon on demand (fixes #444 partially)

### DIFF
--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -110,8 +110,8 @@ func init() {
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(sshCmd)
-	serviceCmd.AddCommand(runCmd, startCmd, stopCmd, restartCmd) // service control commands are subcommands of service
-	serviceCmd.AddCommand(installCmd, uninstallCmd)              // service installer commands are subcommands of service
+	serviceCmd.AddCommand(runCmd, startCmd, stopCmd, restartCmd, enableCmd, disableCmd) // service control commands are subcommands of service
+	serviceCmd.AddCommand(installCmd, uninstallCmd)                                     // service installer commands are subcommands of service
 	upCmd.PersistentFlags().StringSliceVar(&natExternalIPs, externalIPMapFlag, nil,
 		`Sets external IPs maps between local addresses and interfaces.`+
 			`You can specify a comma-separated list with a single IP and IP/IP or IP/Interface Name. `+

--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/netbirdio/netbird/client/internal"
 	"net"
 	"os"
 	"strings"
@@ -212,5 +213,56 @@ var restartCmd = &cobra.Command{
 		}
 		cmd.Println("Netbird service has been restarted")
 		return nil
+	},
+}
+
+func toggleAutostart(cmd *cobra.Command, args []string, toggle bool) error {
+	config, err := internal.ReadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	if config.Autostart == toggle {
+		if toggle {
+			cmd.Println("Automatically connecting is already enabled")
+			return nil
+		}
+
+		cmd.Println("Automatically connecting is already disabled")
+		return nil
+	}
+
+	updatedConfig, err := internal.UpdateConfig(internal.ConfigInput{Autostart: toggle})
+	if err != nil {
+		return err
+	}
+
+	err = internal.WriteOutConfig(configPath, updatedConfig)
+	if err != nil {
+		return err
+	}
+
+	if toggle {
+		cmd.Println("Automatically connecting has been enabled")
+		return nil
+	}
+
+	cmd.Println("Automatically connecting has been disabled")
+	return nil
+}
+
+var disableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "disable automatically connecting when the Netbird service starts",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return toggleAutostart(cmd, args, false)
+	},
+}
+
+var enableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "enable automatically connecting when the Netbird service starts",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return toggleAutostart(cmd, args, true)
 	},
 }

--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -216,53 +216,42 @@ var restartCmd = &cobra.Command{
 	},
 }
 
-func toggleAutostart(cmd *cobra.Command, args []string, toggle bool) error {
-	config, err := internal.ReadConfig(configPath)
-	if err != nil {
-		return err
-	}
-
-	if config.Autostart == toggle {
-		if toggle {
-			cmd.Println("Automatically connecting is already enabled")
-			return nil
-		}
-
-		cmd.Println("Automatically connecting is already disabled")
-		return nil
-	}
-
-	updatedConfig, err := internal.UpdateConfig(internal.ConfigInput{Autostart: toggle})
-	if err != nil {
-		return err
-	}
-
-	err = internal.WriteOutConfig(configPath, updatedConfig)
-	if err != nil {
-		return err
-	}
-
-	if toggle {
-		cmd.Println("Automatically connecting has been enabled")
-		return nil
-	}
-
-	cmd.Println("Automatically connecting has been disabled")
-	return nil
-}
-
 var disableCmd = &cobra.Command{
 	Use:   "disable",
-	Short: "disable automatically connecting when the Netbird service starts",
+	Short: "disable connecting automatically when the Netbird service starts",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return toggleAutostart(cmd, args, false)
+		toggle := false
+
+		_, err := internal.UpdateOrCreateConfig(internal.ConfigInput{
+			ConfigPath: configPath,
+			Autostart:  &toggle,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		cmd.Println("Connecting automatically on daemon start has been disabled")
+		return nil
 	},
 }
 
 var enableCmd = &cobra.Command{
 	Use:   "enable",
-	Short: "enable automatically connecting when the Netbird service starts",
+	Short: "enable connecting automatically when the Netbird service starts",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return toggleAutostart(cmd, args, true)
+		toggle := true
+
+		_, err := internal.UpdateOrCreateConfig(internal.ConfigInput{
+			ConfigPath: configPath,
+			Autostart:  &toggle,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		cmd.Println("Connecting automatically on daemon start has been enabled")
+		return nil
 	},
 }

--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -44,7 +44,7 @@ type ConfigInput struct {
 	RosenpassEnabled *bool
 	InterfaceName    *string
 	WireguardPort    *int
-	Autostart        bool
+	Autostart        *bool
 }
 
 // Config Configuration type
@@ -281,17 +281,12 @@ func update(input ConfigInput) (*Config, error) {
 		refresh = true
 	}
 
-<<<<<<< Updated upstream
 	if input.RosenpassEnabled != nil {
 		config.RosenpassEnabled = *input.RosenpassEnabled
-=======
-	if config.Autostart == false {
-		refresh = true
 	}
 
-	if input.Autostart != config.Autostart {
-		config.Autostart = input.Autostart
->>>>>>> Stashed changes
+	if input.Autostart != nil {
+		config.Autostart = *input.Autostart
 		refresh = true
 	}
 

--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -44,6 +44,7 @@ type ConfigInput struct {
 	RosenpassEnabled *bool
 	InterfaceName    *string
 	WireguardPort    *int
+	Autostart        bool
 }
 
 // Config Configuration type
@@ -79,6 +80,10 @@ type Config struct {
 	NATExternalIPs []string
 	// CustomDNSAddress sets the DNS resolver listening address in format ip:port
 	CustomDNSAddress string
+
+	// Autostart determines whether the client should start with the service
+	// it's set to true by default due to backwards compatibility
+	Autostart bool
 }
 
 // ReadConfig read config file and return with Config. If it is not exists create a new with default values
@@ -152,6 +157,7 @@ func createNewConfig(input ConfigInput) (*Config, error) {
 		DisableIPv6Discovery: false,
 		NATExternalIPs:       input.NATExternalIPs,
 		CustomDNSAddress:     string(input.CustomDNSAddress),
+		Autostart:            true,
 	}
 
 	defaultManagementURL, err := parseURL("Management URL", DefaultManagementURL)
@@ -275,8 +281,17 @@ func update(input ConfigInput) (*Config, error) {
 		refresh = true
 	}
 
+<<<<<<< Updated upstream
 	if input.RosenpassEnabled != nil {
 		config.RosenpassEnabled = *input.RosenpassEnabled
+=======
+	if config.Autostart == false {
+		refresh = true
+	}
+
+	if input.Autostart != config.Autostart {
+		config.Autostart = input.Autostart
+>>>>>>> Stashed changes
 		refresh = true
 	}
 

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -116,11 +116,13 @@ func (s *Server) Start() error {
 		s.statusRecorder.UpdateManagementAddress(config.ManagementURL.String())
 	}
 
-	go func() {
-		if err := internal.RunClientWithProbes(ctx, config, s.statusRecorder, s.mgmProbe, s.signalProbe, s.relayProbe, s.wgProbe); err != nil {
-			log.Errorf("init connections: %v", err)
-		}
-	}()
+	if config.Autostart {
+		go func() {
+			if err := internal.RunClientWithProbes(ctx, config, s.statusRecorder, s.mgmProbe, s.signalProbe, s.relayProbe, s.wgProbe); err != nil {
+				log.Errorf("init connections: %v", err)
+			}
+		}()
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Describe your changes
This is still a WIP, but it is a proposal to fix the auto-start problem by allowing users to opt-out out of automatically starting netbird on boot.
I do this by trying to start the daemon whenever you try to connect. This at least allows users to manually disable auto-start if required.

## Issue ticket number and link
[#444](https://github.com/netbirdio/netbird/issues/444)

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
