### PR TITLE
Revert zitadel update parameters endpoint

### DIFF
--- a/management/server/http/util/util.go
+++ b/management/server/http/util/util.go
@@ -77,6 +77,7 @@ func WriteErrorResponse(errMsg string, httpStatus int, w http.ResponseWriter) {
 // WriteError converts an error to an JSON error response.
 // If it is known internal error of type server.Error then it sets the messages from the error, a generic message otherwise
 func WriteError(err error, w http.ResponseWriter) {
+	log.Errorf("got a handler error: %s", err.Error())
 	errStatus, ok := status.FromError(err)
 	httpStatus := http.StatusInternalServerError
 	msg := "internal server error"

--- a/management/server/idp/zitadel.go
+++ b/management/server/idp/zitadel.go
@@ -13,8 +13,9 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt"
-	"github.com/netbirdio/netbird/management/server/telemetry"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/management/server/telemetry"
 )
 
 // ZitadelManager zitadel manager client instance.
@@ -428,7 +429,7 @@ func (zm *ZitadelManager) UpdateUserAppMetadata(userID string, appMetadata AppMe
 		return err
 	}
 
-	resource := fmt.Sprintf("users/%s", userID)
+	resource := fmt.Sprintf("users/%s/metadata/_bulk", userID)
 	_, err = zm.post(resource, string(payload))
 	if err != nil {
 		return err


### PR DESCRIPTION
## Describe your changes

With previous release we broke the parameters' endpoint. This Pr reverses that

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
