### PR TITLE
Avoid writing config if datastore key exists

### DIFF
--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -148,7 +148,7 @@ var (
 				return fmt.Errorf("failed to initialize database: %s", err)
 			}
 
-			if key != "" {
+			if config.DataStoreEncryptionKey != key {
 				log.Infof("update config with activity store key")
 				config.DataStoreEncryptionKey = key
 				err := updateMgmtConfig(mgmtConfig, config)


### PR DESCRIPTION
## Describe your changes
This PR aims to avoid write operations of the config file if the datastore key is already present.

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/1175

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
