### PR TITLE
Expose store metrics with milliseconds bucketing

### DIFF
--- a/management/server/telemetry/store_metrics.go
+++ b/management/server/telemetry/store_metrics.go
@@ -26,8 +26,7 @@ func NewStoreMetrics(ctx context.Context, meter metric.Meter) (*StoreMetrics, er
 		return nil, err
 	}
 
-	globalLockAcquisitionDurationMs, err := meter.SyncInt64().Histogram("management.store.global.lock.acquisition.duration.ms",
-		instrument.WithUnit("ms"))
+	globalLockAcquisitionDurationMs, err := meter.SyncInt64().Histogram("management.store.global.lock.acquisition.duration.ms")
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +37,7 @@ func NewStoreMetrics(ctx context.Context, meter metric.Meter) (*StoreMetrics, er
 		return nil, err
 	}
 
-	persistenceDurationMs, err := meter.SyncInt64().Histogram("management.store.persistence.duration.ms",
-		instrument.WithUnit("ms"))
+	persistenceDurationMs, err := meter.SyncInt64().Histogram("management.store.persistence.duration.ms")
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/telemetry/store_metrics.go
+++ b/management/server/telemetry/store_metrics.go
@@ -11,37 +11,56 @@ import (
 
 // StoreMetrics represents all metrics related to the FileStore
 type StoreMetrics struct {
-	globalLockAcquisitionDuration syncint64.Histogram
-	persistenceDuration           syncint64.Histogram
-	ctx                           context.Context
+	globalLockAcquisitionDurationMicro syncint64.Histogram
+	globalLockAcquisitionDurationMs    syncint64.Histogram
+	persistenceDurationMicro           syncint64.Histogram
+	persistenceDurationMs              syncint64.Histogram
+	ctx                                context.Context
 }
 
 // NewStoreMetrics creates an instance of StoreMetrics
 func NewStoreMetrics(ctx context.Context, meter metric.Meter) (*StoreMetrics, error) {
-	globalLockAcquisitionDuration, err := meter.SyncInt64().Histogram("management.store.global.lock.acquisition.duration.micro",
+	globalLockAcquisitionDurationMicro, err := meter.SyncInt64().Histogram("management.store.global.lock.acquisition.duration.micro",
 		instrument.WithUnit("microseconds"))
 	if err != nil {
 		return nil, err
 	}
-	persistenceDuration, err := meter.SyncInt64().Histogram("management.store.persistence.duration.micro",
+
+	globalLockAcquisitionDurationMs, err := meter.SyncInt64().Histogram("management.store.global.lock.acquisition.duration.ms",
+		instrument.WithUnit("ms"))
+	if err != nil {
+		return nil, err
+	}
+
+	persistenceDurationMicro, err := meter.SyncInt64().Histogram("management.store.persistence.duration.micro",
 		instrument.WithUnit("microseconds"))
+	if err != nil {
+		return nil, err
+	}
+
+	persistenceDurationMs, err := meter.SyncInt64().Histogram("management.store.persistence.duration.ms",
+		instrument.WithUnit("ms"))
 	if err != nil {
 		return nil, err
 	}
 
 	return &StoreMetrics{
-		globalLockAcquisitionDuration: globalLockAcquisitionDuration,
-		persistenceDuration:           persistenceDuration,
-		ctx:                           ctx,
+		globalLockAcquisitionDurationMicro: globalLockAcquisitionDurationMicro,
+		globalLockAcquisitionDurationMs:    globalLockAcquisitionDurationMs,
+		persistenceDurationMicro:           persistenceDurationMicro,
+		persistenceDurationMs:              persistenceDurationMs,
+		ctx:                                ctx,
 	}, nil
 }
 
 // CountGlobalLockAcquisitionDuration counts the duration of the global lock acquisition
 func (metrics *StoreMetrics) CountGlobalLockAcquisitionDuration(duration time.Duration) {
-	metrics.globalLockAcquisitionDuration.Record(metrics.ctx, duration.Microseconds())
+	metrics.globalLockAcquisitionDurationMicro.Record(metrics.ctx, duration.Microseconds())
+	metrics.globalLockAcquisitionDurationMs.Record(metrics.ctx, duration.Milliseconds())
 }
 
 // CountPersistenceDuration counts the duration of a store persistence operation
 func (metrics *StoreMetrics) CountPersistenceDuration(duration time.Duration) {
-	metrics.persistenceDuration.Record(metrics.ctx, duration.Microseconds())
+	metrics.persistenceDurationMicro.Record(metrics.ctx, duration.Microseconds())
+	metrics.persistenceDurationMs.Record(metrics.ctx, duration.Milliseconds())
 }


### PR DESCRIPTION
As the current upper 10000 microseconds(10ms) bucket may be to low for `management.store.persistence.duration` metric

## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
