### PR TITLE
Reimplement isValidAccessToken without reflect package

### DIFF
--- a/client/internal/auth/util.go
+++ b/client/internal/auth/util.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
 )
 
@@ -44,15 +43,14 @@ func isValidAccessToken(token string, audience string) error {
 	}
 
 	// Audience claim of JWT can be a string or an array of strings
-	typ := reflect.TypeOf(claims.Audience)
-	switch typ.Kind() {
-	case reflect.String:
-		if claims.Audience == audience {
+	switch aud := claims.Audience.(type) {
+	case string:
+		if aud == audience {
 			return nil
 		}
-	case reflect.Slice:
-		for _, aud := range claims.Audience.([]interface{}) {
-			if audience == aud {
+	case []interface{}:
+		for _, audItem := range aud {
+			if audStr, ok := audItem.(string); ok && audStr == audience {
 				return nil
 			}
 		}


### PR DESCRIPTION
The use of reflection should generally be minimized in Go code because it can make the code less readable, less type-safe, and potentially slower.

In this particular case we can simply rely on type switch.

## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
