### PR TITLE
Always call Login from UI with the desktop flag

### DIFF
--- a/client/ui/build-ui-linux.sh
+++ b/client/ui/build-ui-linux.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+sudo apt update
+sudo apt remove gir1.2-appindicator3-0.1
+sudo apt install -y libayatana-appindicator3-dev
+go build

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -234,7 +234,9 @@ func (s *serviceClient) login() error {
 		return err
 	}
 
-	loginResp, err := conn.Login(s.ctx, &proto.LoginRequest{})
+	loginResp, err := conn.Login(s.ctx, &proto.LoginRequest{
+		IsLinuxDesktopClient: runtime.GOOS == "linux",
+	})
 	if err != nil {
 		log.Errorf("login to management URL with: %v", err)
 		return err


### PR DESCRIPTION
## Describe your changes

On Linux desktops we need to pass a flag to daemon indicating 
that this is a Desktop environment.
Without it the Device flow always triggered instead of PCKE.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
