### PR TITLE
Fix/events key handling

### DIFF
--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -170,6 +170,10 @@ if [ "$NETBIRD_DASH_AUTH_USE_AUDIENCE" = "false" ]; then
     export NETBIRD_AUTH_PKCE_AUDIENCE=
 fi
 
+# Read the encryption key
+encKey=$(grep DataStoreEncryptionKey management.json | awk -F'"' '{$0=$4}1')
+export NETBIRD_DATASTORE_ENC_KEY=$encKey
+
 env | grep NETBIRD
 
 envsubst <docker-compose.yml.tmpl >docker-compose.yml

--- a/infrastructure_files/management.json.tmpl
+++ b/infrastructure_files/management.json.tmpl
@@ -27,6 +27,7 @@
         "Password": null
     },
     "Datadir": "",
+    "DataStoreEncryptionKey": "$NETBIRD_DATASTORE_ENC_KEY",
     "HttpConfig": {
         "Address": "0.0.0.0:$NETBIRD_MGMT_API_PORT",
         "AuthIssuer": "$NETBIRD_AUTH_AUTHORITY",

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -301,15 +301,23 @@ var (
 func initEventStore(dataDir string, key string) (activity.Store, string, error) {
 	var err error
 	if key == "" {
-		log.Debugf("generate new activity store encryption key")
-		key, err = sqlite.GenerateKey()
+		log.Debugf("restore or generate new activity store encryption key")
+		key, err = sqlite.RestoreKey(dataDir)
+		if err == nil {
+			goto CreateStore
+		} else {
+			log.Debugf("failed to restore encryption key for activity store: %s", err)
+		}
+
+		log.Infof("generate new encryption key for activity store")
+		key, err = sqlite.GenerateKey(dataDir)
 		if err != nil {
 			return nil, "", err
 		}
 	}
+CreateStore:
 	store, err := sqlite.NewSQLiteStore(dataDir, key)
 	return store, key, err
-
 }
 
 func notifyStop(msg string) {

--- a/management/server/activity/sqlite/crypt_test.go
+++ b/management/server/activity/sqlite/crypt_test.go
@@ -2,11 +2,20 @@ package sqlite
 
 import (
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 )
+
+func TestRestoreKey(t *testing.T) {
+	_, err := RestoreKey(t.TempDir())
+	if err != nil {
+		log.Infof("err: %s", err)
+	}
+}
 
 func TestGenerateKey(t *testing.T) {
 	testData := "exampl@netbird.io"
-	key, err := GenerateKey()
+	key, err := GenerateKey(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to generate key: %s", err)
 	}
@@ -32,7 +41,7 @@ func TestGenerateKey(t *testing.T) {
 
 func TestCorruptKey(t *testing.T) {
 	testData := "exampl@netbird.io"
-	key, err := GenerateKey()
+	key, err := GenerateKey(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to generate key: %s", err)
 	}
@@ -46,7 +55,7 @@ func TestCorruptKey(t *testing.T) {
 		t.Fatalf("invalid encrypted text")
 	}
 
-	newKey, err := GenerateKey()
+	newKey, err := GenerateKey(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to generate key: %s", err)
 	}

--- a/management/server/activity/sqlite/sqlite_test.go
+++ b/management/server/activity/sqlite/sqlite_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewSQLiteStore(t *testing.T) {
 	dataDir := t.TempDir()
-	key, _ := GenerateKey()
+	key, _ := GenerateKey(dataDir)
 	store, err := NewSQLiteStore(dataDir, key)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Describe your changes

Because of we provide option to regenerate the config file the encryption key could be lost.
- The configure.sh read the existing key and write it back during the config generation
- If config file does not contains key then the service try to read the key from backup file
- During the key generation the service write out the key into a file and after save it to config file
- Refactor the logging logic in case the key is invalid for the encrypted data 
## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
