### PR TITLE
Fix/key backup in config script

### DIFF
--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -175,7 +175,10 @@ fi
 # Read the encryption key
 if test -f 'management.json'; then
     encKey=$(jq -r  ".DataStoreEncryptionKey" management.json)
-    export NETBIRD_DATASTORE_ENC_KEY=$encKey
+    if [[ "$encKey" != "null" ]]; then
+        export NETBIRD_DATASTORE_ENC_KEY=$encKey
+
+    fi
 fi
 
 env | grep NETBIRD

--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -186,15 +186,15 @@ env | grep NETBIRD
 
 bkp_postfix="$(date +%s)"
 if test -f 'docker-compose.yml'; then
-    cp docker-compose.yml "docker-compose.yml.$bkp_postfix"
+    cp docker-compose.yml "docker-compose.yml.bkp.${bkp_postfix}"
 fi
 
 if test -f 'management.json'; then
-    cp management.json "management.json.$bkp_postfix"
+    cp management.json "management.json.bkp.${bkp_postfix}"
 fi
 
 if test -f 'turnserver.conf'; then
-    cp turnserver.conf "turnserver.conf.$bkp_postfix"
+    cp turnserver.conf "turnserver.conf.bpk.${bkp_postfix}"
 fi
 envsubst <docker-compose.yml.tmpl >docker-compose.yml
 envsubst <management.json.tmpl | jq . >management.json

--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -171,13 +171,25 @@ if [ "$NETBIRD_DASH_AUTH_USE_AUDIENCE" = "false" ]; then
 fi
 
 # Read the encryption key
-if test -f "management.json"; then
+if test -f 'management.json'; then
     encKey=$(jq -r  ".DataStoreEncryptionKey" management.json)
     export NETBIRD_DATASTORE_ENC_KEY=$encKey
 fi
 
 env | grep NETBIRD
 
+bkp_postfix="$(date +%s)"
+if test -f 'docker-compose.yml'; then
+    cp docker-compose.yml "docker-compose.yml.$bkp_postfix"
+fi
+
+if test -f 'management.json'; then
+    cp management.json "management.json.$bkp_postfix"
+fi
+
+if test -f 'turnserver.conf'; then
+    cp turnserver.conf "turnserver.conf.$bkp_postfix"
+fi
 envsubst <docker-compose.yml.tmpl >docker-compose.yml
 envsubst <management.json.tmpl >management.json
 envsubst <turnserver.conf.tmpl >turnserver.conf

--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -154,6 +154,8 @@ if [ -n "$NETBIRD_MGMT_IDP" ]; then
   export NETBIRD_IDP_MGMT_CLIENT_ID
   export NETBIRD_IDP_MGMT_CLIENT_SECRET
   export NETBIRD_IDP_MGMT_EXTRA_CONFIG=$EXTRA_CONFIG
+else
+  export NETBIRD_IDP_MGMT_EXTRA_CONFIG={}
 fi
 
 IFS=',' read -r -a REDIRECT_URL_PORTS <<< "$NETBIRD_AUTH_PKCE_REDIRECT_URL_PORTS"
@@ -191,5 +193,5 @@ if test -f 'turnserver.conf'; then
     cp turnserver.conf "turnserver.conf.$bkp_postfix"
 fi
 envsubst <docker-compose.yml.tmpl >docker-compose.yml
-envsubst <management.json.tmpl >management.json
+envsubst <management.json.tmpl | jq . >management.json
 envsubst <turnserver.conf.tmpl >turnserver.conf

--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -170,6 +170,12 @@ if [ "$NETBIRD_DASH_AUTH_USE_AUDIENCE" = "false" ]; then
     export NETBIRD_AUTH_PKCE_AUDIENCE=
 fi
 
+# Read the encryption key
+if test -f "management.json"; then
+    encKey=$(jq -r  ".DataStoreEncryptionKey" management.json)
+    export NETBIRD_DATASTORE_ENC_KEY=$encKey
+fi
+
 env | grep NETBIRD
 
 envsubst <docker-compose.yml.tmpl >docker-compose.yml

--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if ! which curl >/dev/null 2>&1; then
   echo "This script uses curl fetch OpenID configuration from IDP."

--- a/infrastructure_files/management.json.tmpl
+++ b/infrastructure_files/management.json.tmpl
@@ -27,6 +27,7 @@
         "Password": null
     },
     "Datadir": "",
+    "DataStoreEncryptionKey": "$NETBIRD_DATASTORE_ENC_KEY",
     "HttpConfig": {
         "Address": "0.0.0.0:$NETBIRD_MGMT_API_PORT",
         "AuthIssuer": "$NETBIRD_AUTH_AUTHORITY",

--- a/infrastructure_files/management.json.tmpl
+++ b/infrastructure_files/management.json.tmpl
@@ -47,7 +47,7 @@
             "ClientSecret": "$NETBIRD_IDP_MGMT_CLIENT_SECRET",
             "GrantType": "client_credentials"
         },
-        "ExtraConfig": "$NETBIRD_IDP_MGMT_EXTRA_CONFIG"
+        "ExtraConfig": $NETBIRD_IDP_MGMT_EXTRA_CONFIG
      },
     "DeviceAuthorizationFlow": {
         "Provider": "$NETBIRD_AUTH_DEVICE_AUTH_PROVIDER",

--- a/infrastructure_files/management.json.tmpl
+++ b/infrastructure_files/management.json.tmpl
@@ -46,7 +46,7 @@
             "ClientSecret": "$NETBIRD_IDP_MGMT_CLIENT_SECRET",
             "GrantType": "client_credentials"
         },
-        "ExtraConfig": $NETBIRD_IDP_MGMT_EXTRA_CONFIG
+        "ExtraConfig": "$NETBIRD_IDP_MGMT_EXTRA_CONFIG"
      },
     "DeviceAuthorizationFlow": {
         "Provider": "$NETBIRD_AUTH_DEVICE_AUTH_PROVIDER",


### PR DESCRIPTION
## Describe your changes

Because we provide the option to regenerate the config files, the encryption key could be lost.

- The configure.sh read the existing key and write it back during the config generation
- Backup the previously generated config files before overwrite it
- Fix invalid json output in the Extras field
- Reduce the error logs in case if the encryption key is invalid
- Response in the events API with valid user info in any cases
- Add extra error handling to the configure.sh. I.e. handle the invalid OpenID urls

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
