### PR TITLE
Fix nil pointer exception in group delete

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -179,7 +179,7 @@ type Account struct {
 	Policies               []*Policy
 	Routes                 map[string]*route.Route
 	NameServerGroups       map[string]*nbdns.NameServerGroup
-	DNSSettings            *DNSSettings
+	DNSSettings            DNSSettings
 	// Settings is a dictionary of Account settings
 	Settings *Settings
 }
@@ -512,13 +512,11 @@ func (a *Account) getUserGroups(userID string) ([]string, error) {
 func (a *Account) getPeerDNSManagementStatus(peerID string) bool {
 	peerGroups := a.getPeerGroups(peerID)
 	enabled := true
-	if a.DNSSettings != nil {
-		for _, groupID := range a.DNSSettings.DisabledManagementGroups {
-			_, found := peerGroups[groupID]
-			if found {
-				enabled = false
-				break
-			}
+	for _, groupID := range a.DNSSettings.DisabledManagementGroups {
+		_, found := peerGroups[groupID]
+		if found {
+			enabled = false
+			break
 		}
 	}
 	return enabled
@@ -605,10 +603,7 @@ func (a *Account) Copy() *Account {
 		nsGroups[id] = nsGroup.Copy()
 	}
 
-	var dnsSettings *DNSSettings
-	if a.DNSSettings != nil {
-		dnsSettings = a.DNSSettings.Copy()
-	}
+	dnsSettings := a.DNSSettings.Copy()
 
 	var settings *Settings
 	if a.Settings != nil {
@@ -1610,7 +1605,7 @@ func newAccountWithId(accountID, userID, domain string) *Account {
 	setupKeys := map[string]*SetupKey{}
 	nameServersGroups := make(map[string]*nbdns.NameServerGroup)
 	users[userID] = NewAdminUser(userID)
-	dnsSettings := &DNSSettings{
+	dnsSettings := DNSSettings{
 		DisabledManagementGroups: make([]string, 0),
 	}
 	log.Debugf("created new account %s", accountID)

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1374,7 +1374,7 @@ func TestAccount_Copy(t *testing.T) {
 				NameServers: []nbdns.NameServer{},
 			},
 		},
-		DNSSettings: &DNSSettings{DisabledManagementGroups: []string{}},
+		DNSSettings: DNSSettings{DisabledManagementGroups: []string{}},
 		Settings:    &Settings{},
 	}
 	err := hasNilField(account)

--- a/management/server/dns.go
+++ b/management/server/dns.go
@@ -24,16 +24,12 @@ type DNSSettings struct {
 }
 
 // Copy returns a copy of the DNS settings
-func (d *DNSSettings) Copy() *DNSSettings {
-	settings := &DNSSettings{
+func (d DNSSettings) Copy() DNSSettings {
+	settings := DNSSettings{
 		DisabledManagementGroups: make([]string, 0),
 	}
 
-	if d == nil {
-		return settings
-	}
-
-	if d.DisabledManagementGroups != nil && len(d.DisabledManagementGroups) > 0 {
+	if len(d.DisabledManagementGroups) > 0 {
 		settings.DisabledManagementGroups = d.DisabledManagementGroups[:]
 	}
 
@@ -58,12 +54,8 @@ func (am *DefaultAccountManager) GetDNSSettings(accountID string, userID string)
 	if !user.IsAdmin() {
 		return nil, status.Errorf(status.PermissionDenied, "only admins are allowed to view DNS settings")
 	}
-
-	if account.DNSSettings == nil {
-		return &DNSSettings{}, nil
-	}
-
-	return account.DNSSettings.Copy(), nil
+	dnsSettings := account.DNSSettings.Copy()
+	return &dnsSettings, nil
 }
 
 // SaveDNSSettings validates a user role and updates the account's DNS settings
@@ -96,11 +88,7 @@ func (am *DefaultAccountManager) SaveDNSSettings(accountID string, userID string
 		}
 	}
 
-	oldSettings := &DNSSettings{}
-	if account.DNSSettings != nil {
-		oldSettings = account.DNSSettings.Copy()
-	}
-
+	oldSettings := account.DNSSettings.Copy()
 	account.DNSSettings = dnsSettingsToSave.Copy()
 
 	account.Network.IncSerial()

--- a/management/server/dns.go
+++ b/management/server/dns.go
@@ -26,13 +26,9 @@ type DNSSettings struct {
 // Copy returns a copy of the DNS settings
 func (d DNSSettings) Copy() DNSSettings {
 	settings := DNSSettings{
-		DisabledManagementGroups: make([]string, 0),
+		DisabledManagementGroups: make([]string, len(d.DisabledManagementGroups)),
 	}
-
-	if len(d.DisabledManagementGroups) > 0 {
-		settings.DisabledManagementGroups = d.DisabledManagementGroups[:]
-	}
-
+	copy(settings.DisabledManagementGroups, d.DisabledManagementGroups)
 	return settings
 }
 

--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -42,7 +42,7 @@ func TestGetDNSSettings(t *testing.T) {
 		t.Fatal("DNS settings for new accounts shouldn't return nil")
 	}
 
-	account.DNSSettings = &DNSSettings{
+	account.DNSSettings = DNSSettings{
 		DisabledManagementGroups: []string{group1ID},
 	}
 

--- a/management/server/http/dns_settings_handler_test.go
+++ b/management/server/http/dns_settings_handler_test.go
@@ -26,7 +26,7 @@ const (
 	testDNSSettingsUserID        = "test_user"
 )
 
-var baseExistingDNSSettings = &server.DNSSettings{
+var baseExistingDNSSettings = server.DNSSettings{
 	DisabledManagementGroups: []string{testDNSSettingsExistingGroup},
 }
 
@@ -43,7 +43,7 @@ func initDNSSettingsTestData() *DNSSettingsHandler {
 	return &DNSSettingsHandler{
 		accountManager: &mock_server.MockAccountManager{
 			GetDNSSettingsFunc: func(accountID string, userID string) (*server.DNSSettings, error) {
-				return testingDNSSettingsAccount.DNSSettings, nil
+				return &testingDNSSettingsAccount.DNSSettings, nil
 			},
 			SaveDNSSettingsFunc: func(accountID string, userID string, dnsSettingsToSave *server.DNSSettings) error {
 				if dnsSettingsToSave != nil {


### PR DESCRIPTION
## Describe your changes

Fix group delete panic

In case if in the db the DNSSettings is null then can cause panic in delete group function 
because this field is pointer and it was not checked. Because of in the future implementation 
this variable will be filled in any case then make no sense to keep the pointer type.

Fix DNSSettings copy function

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
