### PR TITLE
Support pinning version during binary install

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -44,7 +44,7 @@ get_release() {
 }
 
 download_release_binary() {
-    VERSION=$(get_release $NETBIRD_RELEASE)
+    VERSION="$(get_release $NETBIRD_RELEASE)"
     BASE_URL="https://github.com/${OWNER}/${REPO}/releases/download"
     BINARY_BASE_NAME="${VERSION#v}_${OS_TYPE}_${ARCH}.tar.gz"
 

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -23,19 +23,28 @@ if command -v sudo > /dev/null && [ "$(id -u)" -ne 0 ]; then
     SUDO="sudo"
 fi
 
-get_latest_release() {
+if [ -z ${NETBIRD_RELEASE+x} ]; then 
+    NETBIRD_RELEASE=latest
+fi
+
+get_release() {
+    local RELEASE=$1
+    if [ "$RELEASE" == "latest" ]; then
+        local TAG="latest"
+    else
+        local TAG="tags/${RELEASE}"
+    fi
     if [ -n "$GITHUB_TOKEN" ]; then
-          curl -H  "Authorization: token ${GITHUB_TOKEN}" -s "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" \
+          curl -H  "Authorization: token ${GITHUB_TOKEN}" -s "https://api.github.com/repos/${OWNER}/${REPO}/releases/${TAG}" \
               | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
     else
-          curl -s "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" \
+          curl -s "https://api.github.com/repos/${OWNER}/${REPO}/releases/${TAG}" \
               | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
     fi
-
 }
 
 download_release_binary() {
-    VERSION=$(get_latest_release)
+    VERSION=$(get_release $NETBIRD_RELEASE)
     BASE_URL="https://github.com/${OWNER}/${REPO}/releases/download"
     BINARY_BASE_NAME="${VERSION#v}_${OS_TYPE}_${ARCH}.tar.gz"
 
@@ -299,7 +308,7 @@ stop_running_netbird_ui() {
 
 update_netbird() {
   if is_bin_package_manager "$CONFIG_FILE"; then
-    latest_release=$(get_latest_release)
+    latest_release=$(get_release "latest")
     latest_version=${latest_release#v}
     installed_version=$(netbird version)
 

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -23,13 +23,13 @@ if command -v sudo > /dev/null && [ "$(id -u)" -ne 0 ]; then
     SUDO="sudo"
 fi
 
-if [ -z ${NETBIRD_RELEASE+x} ]; then 
+if [ -z ${NETBIRD_RELEASE+x} ]; then
     NETBIRD_RELEASE=latest
 fi
 
 get_release() {
     local RELEASE=$1
-    if [ "$RELEASE" == "latest" ]; then
+    if [ "$RELEASE" = "latest" ]; then
         local TAG="latest"
     else
         local TAG="tags/${RELEASE}"

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -44,7 +44,7 @@ get_release() {
 }
 
 download_release_binary() {
-    VERSION="$(get_release $NETBIRD_RELEASE)"
+    VERSION=$(get_release "$NETBIRD_RELEASE")
     BASE_URL="https://github.com/${OWNER}/${REPO}/releases/download"
     BINARY_BASE_NAME="${VERSION#v}_${OS_TYPE}_${ARCH}.tar.gz"
 


### PR DESCRIPTION
## Support for specific version installation
For installations using the binary release method (using the official installer script), it would be nice to be able to define a specific version to install.

A user/developer can choose to define the `NETBIRD_RELEASE` variable during installation, to pin a specific version during installation. 
If `NETBIRD_RELEASE` is not defined, we default to the current behavior of `latest`


#### Example usage (once merged)
```
export SKIP_UI_APP=true; export NETBIRD_RELEASE=v0.23.7; curl https://pkgs.netbird.io/install.sh | sh
```


### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
