### PR TITLE
Fix Windows firewall message check

### DIFF
--- a/client/internal/acl/manager_create.go
+++ b/client/internal/acl/manager_create.go
@@ -20,7 +20,7 @@ func Create(iface IFaceMapper) (manager *DefaultManager, err error) {
 			return nil, err
 		}
 		if err := fm.AllowNetbird(); err != nil {
-			log.Errorf("failed to allow netbird interface traffic: %v", err)
+			log.Warnf("failed to allow netbird interface traffic: %v", err)
 		}
 		return newDefaultManager(fm), nil
 	}


### PR DESCRIPTION
## Describe your changes
The no rules matched message is operating system language specific, and can cause errors

Now we check if firewall is reachable by the app and then if the rule is returned or not in two different calls:

isWindowsFirewallReachable

isFirewallRuleActive

## Issue ticket number and link
Fixes # 1249

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
