### PR TITLE
Extend linter rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,6 +34,7 @@ linters:
     - bodyclose # checks whether HTTP response body is closed successfully
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - predeclared # predeclared finds code that shadows one of Go's predeclared identifiers
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
     - thelper # thelper detects Go test helpers without t.Helper() call and checks the consistency of test helpers.
     - wastedassign # wastedassign finds wasted assignment statements

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,6 +35,7 @@ linters:
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - thelper # thelper detects Go test helpers without t.Helper() call and checks the consistency of test helpers.
     - wastedassign # wastedassign finds wasted assignment statements
 issues:
   # Maximum count of issues with the same text.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,6 +34,7 @@ linters:
     - bodyclose # checks whether HTTP response body is closed successfully
     - dupword # dupword checks for duplicate words in the source code
     - durationcheck # durationcheck checks for two durations multiplied together
+    - forbidigo # forbidigo forbids identifiers
     # - mirror # mirror reports wrong mirror patterns of bytes/strings usage
     - misspell # misspess finds commonly misspelled English words in comments
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
@@ -49,6 +50,11 @@ issues:
   max-same-issues: 5
 
   exclude-rules:
+    # allow fmt
+    - path: management/cmd/root.go
+      linters: forbidigo
+    - path: signal/cmd/root.go
+      linters: forbidigo
     - path: sharedsock/filter.go
       linters:
       - unused

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,6 +32,7 @@ linters:
     - unused # checks for unused constants, variables, functions and types
     ## disable by default but the have interesting results so lets add them
     - bodyclose # checks whether HTTP response body is closed successfully
+    - dupword # dupword checks for duplicate words in the source code
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
     - predeclared # predeclared finds code that shadows one of Go's predeclared identifiers

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,8 @@ linters:
     ## disable by default but the have interesting results so lets add them
     - bodyclose # checks whether HTTP response body is closed successfully
     - dupword # dupword checks for duplicate words in the source code
+    - durationcheck # durationcheck checks for two durations multiplied together
+    #- mirror # mirror reports wrong mirror patterns of bytes/strings usage
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
     - predeclared # predeclared finds code that shadows one of Go's predeclared identifiers

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,7 +34,8 @@ linters:
     - bodyclose # checks whether HTTP response body is closed successfully
     - dupword # dupword checks for duplicate words in the source code
     - durationcheck # durationcheck checks for two durations multiplied together
-    #- mirror # mirror reports wrong mirror patterns of bytes/strings usage
+    # - mirror # mirror reports wrong mirror patterns of bytes/strings usage
+    - misspell # misspess finds commonly misspelled English words in comments
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
     - predeclared # predeclared finds code that shadows one of Go's predeclared identifiers

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,7 +35,7 @@ linters:
     - dupword # dupword checks for duplicate words in the source code
     - durationcheck # durationcheck checks for two durations multiplied together
     - forbidigo # forbidigo forbids identifiers
-    # - mirror # mirror reports wrong mirror patterns of bytes/strings usage
+    - mirror # mirror reports wrong mirror patterns of bytes/strings usage
     - misspell # misspess finds commonly misspelled English words in comments
     - nilerr # finds the code that returns nil even if it checks that the error is not nil
     - nilnil # checks that there is no simultaneous return of nil error and an invalid value
@@ -61,6 +61,9 @@ issues:
     - path: client/firewall/iptables/rule.go
       linters:
       - unused
+    - path: test.go
+      linters:
+      - mirror
     - path: mock.go
       linters:
       - nilnil

--- a/client/android/login.go
+++ b/client/android/login.go
@@ -205,8 +205,8 @@ func (a *Auth) foregroundGetTokenInfo(urlOpener URLOpener) (*auth.TokenInfo, err
 
 	go urlOpener.Open(flowInfo.VerificationURIComplete)
 
-	waitTimeout := time.Duration(flowInfo.ExpiresIn)
-	waitCTX, cancel := context.WithTimeout(a.ctx, waitTimeout*time.Second)
+	waitTimeout := time.Duration(flowInfo.ExpiresIn) * time.Second
+	waitCTX, cancel := context.WithTimeout(a.ctx, waitTimeout)
 	defer cancel()
 	tokenInfo, err := oAuthFlow.WaitToken(waitCTX, flowInfo)
 	if err != nil {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -177,8 +177,8 @@ func foregroundGetTokenInfo(ctx context.Context, cmd *cobra.Command, config *int
 
 	openURL(cmd, flowInfo.VerificationURIComplete, flowInfo.UserCode)
 
-	waitTimeout := time.Duration(flowInfo.ExpiresIn)
-	waitCTX, c := context.WithTimeout(context.TODO(), waitTimeout*time.Second)
+	waitTimeout := time.Duration(flowInfo.ExpiresIn) * time.Second
+	waitCTX, c := context.WithTimeout(context.TODO(), waitTimeout)
 	defer c()
 
 	tokenInfo, err := oAuthFlow.WaitToken(waitCTX, flowInfo)

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -92,7 +92,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&adminURL, "admin-url", "", fmt.Sprintf("Admin Panel URL [http|https]://[host]:[port] (default \"%s\")", internal.DefaultAdminURL))
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", defaultConfigPath, "Netbird config file location")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "sets Netbird log level")
-	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the the log will be output to stdout")
+	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout")
 	rootCmd.PersistentFlags().StringVarP(&setupKey, "setup-key", "k", "", "Setup key obtained from the Management Service Dashboard (used to register peer)")
 	rootCmd.PersistentFlags().StringVar(&preSharedKey, "preshared-key", "", "Sets Wireguard PreSharedKey property. If set, then only peers that have the same key can communicate.")
 	rootCmd.PersistentFlags().StringVarP(&hostName, "hostname", "n", "", "Sets a custom hostname for the device")

--- a/client/cmd/testutil.go
+++ b/client/cmd/testutil.go
@@ -22,6 +22,7 @@ import (
 )
 
 func startTestingServices(t *testing.T) string {
+	t.Helper()
 	config := &mgmt.Config{}
 	_, err := util.ReadJson("../testdata/management.json", config)
 	if err != nil {
@@ -44,6 +45,7 @@ func startTestingServices(t *testing.T) string {
 }
 
 func startSignal(t *testing.T) (*grpc.Server, net.Listener) {
+	t.Helper()
 	lis, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatal(err)
@@ -60,6 +62,7 @@ func startSignal(t *testing.T) (*grpc.Server, net.Listener) {
 }
 
 func startManagement(t *testing.T, config *mgmt.Config) (*grpc.Server, net.Listener) {
+	t.Helper()
 	lis, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatal(err)
@@ -98,6 +101,7 @@ func startManagement(t *testing.T, config *mgmt.Config) (*grpc.Server, net.Liste
 func startClientDaemon(
 	t *testing.T, ctx context.Context, managementURL, configPath string,
 ) (*grpc.Server, net.Listener) {
+	t.Helper()
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)

--- a/client/firewall/iptables/manager_linux_test.go
+++ b/client/firewall/iptables/manager_linux_test.go
@@ -206,6 +206,7 @@ func TestIptablesManagerIPSet(t *testing.T) {
 }
 
 func checkRuleSpecs(t *testing.T, ipv4Client *iptables.IPTables, chainName string, mustExists bool, rulespec ...string) {
+    t.Helper()
 	exists, err := ipv4Client.Exists("filter", chainName, rulespec...)
 	require.NoError(t, err, "failed to check rule")
 	require.Falsef(t, !exists && mustExists, "rule '%v' does not exist", rulespec)

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -771,6 +771,7 @@ func TestDNSPermanent_matchOnly(t *testing.T) {
 }
 
 func createWgInterfaceWithBind(t *testing.T) (*iface.WGIface, error) {
+	t.Helper()
 	ov := os.Getenv("NB_WG_KERNEL_DISABLED")
 	defer os.Setenv("NB_WG_KERNEL_DISABLED", ov)
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -640,7 +640,7 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 				if config.GetSshConfig() != nil && config.GetSshConfig().GetSshPubKey() != nil {
 					err := e.sshServer.AddAuthorizedKey(config.WgPubKey, string(config.GetSshConfig().GetSshPubKey()))
 					if err != nil {
-						log.Warnf("failed adding authroized key to SSH DefaultServer %v", err)
+						log.Warnf("failed adding authorized key to SSH DefaultServer %v", err)
 					}
 				}
 			}

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -174,13 +174,13 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 	return nil
 }
 
-func shouldSkipNotify(new, curr State) bool {
+func shouldSkipNotify(received, curr State) bool {
 	switch {
-	case new.ConnStatus == StatusConnecting:
+	case received.ConnStatus == StatusConnecting:
 		return true
-	case new.ConnStatus == StatusDisconnected && curr.ConnStatus == StatusConnecting:
+	case received.ConnStatus == StatusDisconnected && curr.ConnStatus == StatusConnecting:
 		return true
-	case new.ConnStatus == StatusDisconnected && curr.ConnStatus == StatusDisconnected:
+	case received.ConnStatus == StatusDisconnected && curr.ConnStatus == StatusDisconnected:
 		return curr.IP != ""
 	default:
 		return false

--- a/client/internal/routemanager/systemops_nonandroid_test.go
+++ b/client/internal/routemanager/systemops_nonandroid_test.go
@@ -123,7 +123,7 @@ func TestGetExistingRIBRouteGateway(t *testing.T) {
 
 func TestAddExistAndRemoveRouteNonAndroid(t *testing.T) {
 	defaultGateway, err := getExistingRIBRouteGateway(netip.MustParsePrefix("0.0.0.0/0"))
-	fmt.Println("defaultGateway: ", defaultGateway)
+	t.Log("defaultGateway: ", defaultGateway)
 	if err != nil {
 		t.Fatal("shouldn't return error when fetching the gateway: ", err)
 	}
@@ -207,7 +207,7 @@ func TestAddExistAndRemoveRouteNonAndroid(t *testing.T) {
 			// route should either not have been added or should have been removed
 			// In case of already existing route, it should not have been added (but still exist)
 			ok, err := existsInRouteTable(testCase.prefix)
-			fmt.Println("Buffer string: ", buf.String())
+			t.Log("Buffer string: ", buf.String())
 			require.NoError(t, err, "should not return err")
 			if !strings.Contains(buf.String(), "because it already exists") {
 				require.False(t, ok, "route should not exist")

--- a/client/system/info_darwin.go
+++ b/client/system/info_darwin.go
@@ -3,7 +3,6 @@ package system
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -21,7 +20,7 @@ func GetInfo(ctx context.Context) *Info {
 	utsname := unix.Utsname{}
 	err := unix.Uname(&utsname)
 	if err != nil {
-		fmt.Println("getInfo:", err)
+		log.Warnf("getInfo: %s", err)
 	}
 	sysName := string(bytes.Split(utsname.Sysname[:], []byte{0})[0])
 	machine := string(bytes.Split(utsname.Machine[:], []byte{0})[0])

--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/netbirdio/netbird/version"
 )
 
@@ -67,7 +69,7 @@ func _getInfo() string {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		fmt.Println("getInfo:", err)
+		log.Warnf("getInfo: %s", err)
 	}
 	return out.String()
 }
@@ -81,7 +83,7 @@ func _getReleaseInfo() string {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		fmt.Println("getReleaseInfo:", err)
+		log.Warnf("geucwReleaseInfo: %s", err)
 	}
 	return out.String()
 }

--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -6,7 +6,6 @@ package system
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -69,7 +69,7 @@ func main() {
 		a.Run()
 	} else {
 		if err := checkPIDFile(); err != nil {
-			fmt.Println(err)
+			log.Errorf("check PID file: %v", err)
 			return
 		}
 		systray.Run(client.onTrayReady, client.onTrayExit)

--- a/iface/module_linux_test.go
+++ b/iface/module_linux_test.go
@@ -132,6 +132,7 @@ func resetGlobals() {
 }
 
 func createFiles(t *testing.T) (string, []module) {
+    t.Helper()
 	writeFile := func(path, text string) {
 		if err := os.WriteFile(path, []byte(text), 0644); err != nil {
 			t.Fatal(err)
@@ -167,6 +168,7 @@ func createFiles(t *testing.T) (string, []module) {
 }
 
 func getRandomLoadedModule(t *testing.T) (string, error) {
+    t.Helper()
 	f, err := os.Open("/proc/modules")
 	if err != nil {
 		return "", err

--- a/management/client/client_test.go
+++ b/management/client/client_test.go
@@ -31,6 +31,7 @@ import (
 const ValidKey = "A2C8E62B-38F5-4553-B31E-DD66C696CEBB"
 
 func startManagement(t *testing.T) (*grpc.Server, net.Listener) {
+	t.Helper()
 	level, _ := log.ParseLevel("debug")
 	log.SetLevel(level)
 
@@ -81,6 +82,7 @@ func startManagement(t *testing.T) (*grpc.Server, net.Listener) {
 }
 
 func startMockManagement(t *testing.T) (*grpc.Server, net.Listener, *mock_server.ManagementServiceServerMock, wgtypes.Key) {
+	t.Helper()
 	lis, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatal(err)

--- a/management/client/client_test.go
+++ b/management/client/client_test.go
@@ -170,7 +170,7 @@ func TestClient_LoginUnregistered_ShouldThrow_401(t *testing.T) {
 		t.Error("expecting err on unregistered login, got nil")
 	}
 	if s, ok := status.FromError(err); !ok || s.Code() != codes.PermissionDenied {
-		t.Errorf("expecting err code %d denied on on unregistered login got %d", codes.PermissionDenied, s.Code())
+		t.Errorf("expecting err code %d denied on unregistered login got %d", codes.PermissionDenied, s.Code())
 	}
 }
 

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -67,7 +67,7 @@ func init() {
 	rootCmd.MarkFlagRequired("config") //nolint
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "")
-	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the the log will be output to stdout")
+	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout")
 	rootCmd.AddCommand(mgmtCmd)
 
 	migrationCmd.PersistentFlags().StringVar(&mgmtDataDir, "datadir", defaultMgmtDataDir, "server data directory location")

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1574,7 +1574,7 @@ func (am *DefaultAccountManager) GetAllConnectedPeers() (map[string]struct{}, er
 
 func isDomainValid(domain string) bool {
 	re := regexp.MustCompile(`^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$`)
-	return re.Match([]byte(domain))
+	return re.MatchString(domain)
 }
 
 // GetDNSDomain returns the configured dnsDomain

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func verifyCanAddPeerToAccount(t *testing.T, manager AccountManager, account *Account, userID string) {
+	t.Helper()
 	peer := &Peer{
 		Key:  "BhRPtynAAYRDy08+q4HTMsos8fs4plTP4NOSh7C1ry8=",
 		Name: "test-host@netbird.io",
@@ -52,6 +53,7 @@ func verifyCanAddPeerToAccount(t *testing.T, manager AccountManager, account *Ac
 }
 
 func verifyNewAccountHasDefaultFields(t *testing.T, account *Account, createdBy string, domain string, expectedUsers []string) {
+	t.Helper()
 	if len(account.Peers) != 0 {
 		t.Errorf("expected account to have len(Peers) = %v, got %v", 0, len(account.Peers))
 	}
@@ -1131,6 +1133,7 @@ func TestAccountManager_DeletePeer(t *testing.T) {
 }
 
 func getEvent(t *testing.T, accountID string, manager AccountManager, eventType activity.Activity) *activity.Event {
+	t.Helper()
 	for {
 		select {
 		case <-time.After(time.Second):
@@ -2038,6 +2041,7 @@ func TestAccount_UserGroupsRemoveFromPeers(t *testing.T) {
 }
 
 func createManager(t *testing.T) (*DefaultAccountManager, error) {
+	t.Helper()
 	store, err := createStore(t)
 	if err != nil {
 		return nil, err
@@ -2047,6 +2051,7 @@ func createManager(t *testing.T) (*DefaultAccountManager, error) {
 }
 
 func createStore(t *testing.T) (Store, error) {
+	t.Helper()
 	dataDir := t.TempDir()
 	store, err := NewStoreFromJson(dataDir, nil)
 	if err != nil {

--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -186,6 +186,7 @@ func TestGetNetworkMap_DNSConfigSync(t *testing.T) {
 }
 
 func createDNSManager(t *testing.T) (*DefaultAccountManager, error) {
+	t.Helper()
 	store, err := createDNSStore(t)
 	if err != nil {
 		return nil, err
@@ -195,6 +196,7 @@ func createDNSManager(t *testing.T) (*DefaultAccountManager, error) {
 }
 
 func createDNSStore(t *testing.T) (Store, error) {
+	t.Helper()
 	dataDir := t.TempDir()
 	store, err := NewStoreFromJson(dataDir, nil)
 	if err != nil {
@@ -205,6 +207,7 @@ func createDNSStore(t *testing.T) (Store, error) {
 }
 
 func initTestDNSAccount(t *testing.T, am *DefaultAccountManager) (*Account, error) {
+	t.Helper()
 	peer1 := &Peer{
 		Key:  dnsPeer1Key,
 		Name: "test-host1@netbird.io",

--- a/management/server/event_test.go
+++ b/management/server/event_test.go
@@ -11,6 +11,7 @@ import (
 
 func generateAndStoreEvents(t *testing.T, manager *DefaultAccountManager, typ activity.Activity, initiatorID, targetID,
 	accountID string, count int) {
+	t.Helper()
 	for i := 0; i < count; i++ {
 		_, err := manager.eventStore.Save(&activity.Event{
 			Timestamp:   time.Now().UTC(),

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -580,6 +580,7 @@ func TestFileStore_SavePeerStatus(t *testing.T) {
 }
 
 func newStore(t *testing.T) *FileStore {
+	t.Helper()
 	store, err := NewFileStore(t.TempDir(), nil)
 	if err != nil {
 		t.Errorf("failed creating a new store")

--- a/management/server/http/groups_handler_test.go
+++ b/management/server/http/groups_handler_test.go
@@ -230,7 +230,7 @@ func TestWriteGroup(t *testing.T) {
 			expectedBody:   false,
 		},
 		{
-			name:        "Write Group PUT not not change Issue",
+			name:        "Write Group PUT not change Issue",
 			requestType: http.MethodPut,
 			requestPath: "/api/groups/id-jwt-group",
 			requestBody: bytes.NewBuffer(

--- a/management/server/http/peers_handler_test.go
+++ b/management/server/http/peers_handler_test.go
@@ -3,7 +3,6 @@ package http
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -232,7 +231,7 @@ func TestGetPeers(t *testing.T) {
 				}
 			}
 
-			fmt.Println(got)
+			t.Log(got)
 
 			assert.Equal(t, got.Name, tc.expectedPeer.Name)
 			assert.Equal(t, got.Version, tc.expectedPeer.Meta.WtVersion)

--- a/management/server/http/setupkeys_handler_test.go
+++ b/management/server/http/setupkeys_handler_test.go
@@ -220,6 +220,7 @@ func TestSetupKeysHandlers(t *testing.T) {
 }
 
 func assertKeys(t *testing.T, got *api.SetupKey, expected *api.SetupKey) {
+	t.Helper()
 	// this comparison is done manually because when converting to JSON dates formatted differently
 	// assert.Equal(t, got.UpdatedAt, tc.expectedSetupKey.UpdatedAt) //doesn't work
 	assert.WithinDurationf(t, got.UpdatedAt, expected.UpdatedAt, 0, "")

--- a/management/server/idp/auth0_test.go
+++ b/management/server/idp/auth0_test.go
@@ -65,6 +65,7 @@ func (mc *mockAuth0Credentials) Authenticate() (JWTToken, error) {
 }
 
 func newTestJWT(t *testing.T, expInt int) string {
+	t.Helper()
 	now := time.Now()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"iat": now.Unix(),

--- a/management/server/idp/okta.go
+++ b/management/server/idp/okta.go
@@ -256,7 +256,6 @@ func (om *OktaManager) InviteUserByID(_ string) error {
 func (om *OktaManager) DeleteUser(userID string) error {
 	resp, err := om.client.User.DeactivateOrDeleteUser(context.Background(), userID, nil)
 	if err != nil {
-		fmt.Println(err.Error())
 		return err
 	}
 

--- a/management/server/jwtclaims/extractor_test.go
+++ b/management/server/jwtclaims/extractor_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func newTestRequestWithJWT(t *testing.T, claims AuthorizationClaims, audience string) *http.Request {
+	t.Helper()
 	const layout = "2006-01-02T15:04:05.999Z"
 
 	claimMaps := jwt.MapClaims{}
@@ -143,6 +144,7 @@ func TestExtractClaimsFromRequestContext(t *testing.T) {
 }
 
 func TestExtractClaimsSetOptions(t *testing.T) {
+	t.Helper()
 	type test struct {
 		name      string
 		extractor *ClaimsExtractor
@@ -153,6 +155,7 @@ func TestExtractClaimsSetOptions(t *testing.T) {
 		name:      "No custom options",
 		extractor: NewClaimsExtractor(),
 		check: func(t *testing.T, c test) {
+			t.Helper()
 			if c.extractor.authAudience != "" {
 				t.Error("audience should be empty")
 				return
@@ -172,6 +175,7 @@ func TestExtractClaimsSetOptions(t *testing.T) {
 		name:      "Custom audience",
 		extractor: NewClaimsExtractor(WithAudience("https://login/")),
 		check: func(t *testing.T, c test) {
+			t.Helper()
 			if c.extractor.authAudience != "https://login/" {
 				t.Errorf("audience expected %s, got %s", "https://login/", c.extractor.authAudience)
 				return
@@ -183,6 +187,7 @@ func TestExtractClaimsSetOptions(t *testing.T) {
 		name:      "Custom user id claim",
 		extractor: NewClaimsExtractor(WithUserIDClaim("customUserId")),
 		check: func(t *testing.T, c test) {
+			t.Helper()
 			if c.extractor.userIDClaim != "customUserId" {
 				t.Errorf("user id claim expected %s, got %s", "customUserId", c.extractor.userIDClaim)
 				return
@@ -199,6 +204,7 @@ func TestExtractClaimsSetOptions(t *testing.T) {
 				}
 			})),
 		check: func(t *testing.T, c test) {
+			t.Helper()
 			claims := c.extractor.FromRequestContext(&http.Request{})
 			if claims.UserId != "testCustomRequest" {
 				t.Errorf("user id claim expected %s, got %s", "testCustomRequest", claims.UserId)

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -400,6 +400,7 @@ func TestServer_GetDeviceAuthorizationFlow(t *testing.T) {
 }
 
 func startManagement(t *testing.T, config *Config) (*grpc.Server, string, error) {
+	t.Helper()
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		return nil, "", err

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -355,7 +355,7 @@ func (am *MockAccountManager) UpdatePeerSSHKey(peerID string, sshKey string) err
 	if am.UpdatePeerSSHKeyFunc != nil {
 		return am.UpdatePeerSSHKeyFunc(peerID, sshKey)
 	}
-	return status.Errorf(codes.Unimplemented, "method UpdatePeerSSHKey is is not implemented")
+	return status.Errorf(codes.Unimplemented, "method UpdatePeerSSHKey is not implemented")
 }
 
 // UpdatePeer mocks UpdatePeerFunc function of the account manager
@@ -363,7 +363,7 @@ func (am *MockAccountManager) UpdatePeer(accountID, userID string, peer *server.
 	if am.UpdatePeerFunc != nil {
 		return am.UpdatePeerFunc(accountID, userID, peer)
 	}
-	return nil, status.Errorf(codes.Unimplemented, "method UpdatePeerFunc is is not implemented")
+	return nil, status.Errorf(codes.Unimplemented, "method UpdatePeerFunc is not implemented")
 }
 
 // CreateRoute mock implementation of CreateRoute from server.AccountManager interface

--- a/management/server/nameserver_test.go
+++ b/management/server/nameserver_test.go
@@ -741,6 +741,7 @@ func TestGetNameServerGroup(t *testing.T) {
 }
 
 func createNSManager(t *testing.T) (*DefaultAccountManager, error) {
+	t.Helper()
 	store, err := createNSStore(t)
 	if err != nil {
 		return nil, err
@@ -750,6 +751,7 @@ func createNSManager(t *testing.T) (*DefaultAccountManager, error) {
 }
 
 func createNSStore(t *testing.T) (Store, error) {
+	t.Helper()
 	dataDir := t.TempDir()
 	store, err := NewStoreFromJson(dataDir, nil)
 	if err != nil {
@@ -760,6 +762,7 @@ func createNSStore(t *testing.T) (Store, error) {
 }
 
 func initTestNSAccount(t *testing.T, am *DefaultAccountManager) (*Account, error) {
+	t.Helper()
 	peer1 := &Peer{
 		Key:  nsGroupPeer1Key,
 		Name: "test-host1@netbird.io",

--- a/management/server/route_test.go
+++ b/management/server/route_test.go
@@ -1007,6 +1007,7 @@ func TestGetNetworkMap_RouteSync(t *testing.T) {
 }
 
 func createRouterManager(t *testing.T) (*DefaultAccountManager, error) {
+	t.Helper()
 	store, err := createRouterStore(t)
 	if err != nil {
 		return nil, err
@@ -1016,6 +1017,7 @@ func createRouterManager(t *testing.T) (*DefaultAccountManager, error) {
 }
 
 func createRouterStore(t *testing.T) (Store, error) {
+	t.Helper()
 	dataDir := t.TempDir()
 	store, err := NewStoreFromJson(dataDir, nil)
 	if err != nil {

--- a/management/server/setupkey_test.go
+++ b/management/server/setupkey_test.go
@@ -237,6 +237,7 @@ func TestSetupKey_IsValid(t *testing.T) {
 func assertKey(t *testing.T, key *SetupKey, expectedName string, expectedRevoke bool, expectedType string,
 	expectedUsedTimes int, expectedCreatedAt time.Time, expectedExpiresAt time.Time, expectedID string,
 	expectedUpdatedAt time.Time, expectedAutoGroups []string) {
+	t.Helper()
 	if key.Name != expectedName {
 		t.Errorf("expected setup key to have Name %v, got %v", expectedName, key.Name)
 	}

--- a/management/server/store_test.go
+++ b/management/server/store_test.go
@@ -14,11 +14,13 @@ type benchCase struct {
 }
 
 var newFs = func(b *testing.B) Store {
+	b.Helper()
 	store, _ := NewFileStore(b.TempDir(), nil)
 	return store
 }
 
 var newSqlite = func(b *testing.B) Store {
+	b.Helper()
 	store, _ := NewSqliteStore(b.TempDir(), nil)
 	return store
 }

--- a/management/server/telemetry/grpc_metrics.go
+++ b/management/server/telemetry/grpc_metrics.go
@@ -116,6 +116,6 @@ func (grpcMetrics *GRPCMetrics) RegisterConnectedStreams(producer func() int64) 
 }
 
 // UpdateChannelQueueLength update the histogram that keep distribution of the update messages channel queue
-func (metrics *GRPCMetrics) UpdateChannelQueueLength(len int) {
-	metrics.channelQueueLength.Record(metrics.ctx, int64(len))
+func (metrics *GRPCMetrics) UpdateChannelQueueLength(length int) {
+	metrics.channelQueueLength.Record(metrics.ctx, int64(length))
 }

--- a/management/server/turncredentials_test.go
+++ b/management/server/turncredentials_test.go
@@ -4,9 +4,10 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
-	"github.com/netbirdio/netbird/util"
 	"testing"
 	"time"
+
+	"github.com/netbirdio/netbird/util"
 )
 
 var TurnTestHost = &Host{
@@ -36,7 +37,7 @@ func TestTimeBasedAuthSecretsManager_GenerateCredentials(t *testing.T) {
 		t.Errorf("expected generated TURN password not to be empty, got empty")
 	}
 
-	validateMAC(credentials.Username, credentials.Password, []byte(secret), t)
+	validateMAC(t, credentials.Username, credentials.Password, []byte(secret))
 
 }
 
@@ -112,7 +113,8 @@ func TestTimeBasedAuthSecretsManager_CancelRefresh(t *testing.T) {
 	}
 }
 
-func validateMAC(username string, actualMAC string, key []byte, t *testing.T) {
+func validateMAC(t *testing.T, username string, actualMAC string, key []byte) {
+	t.Helper()
 	mac := hmac.New(sha1.New, key)
 
 	_, err := mac.Write([]byte(username))

--- a/sharedsock/example/main.go
+++ b/sharedsock/example/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/netbirdio/netbird/sharedsock"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
+
+	"github.com/netbirdio/netbird/sharedsock"
+	log "github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -16,7 +17,7 @@ func main() {
 		panic(err)
 	}
 
-	log.Infof("attached to to the raw socket on port %d", port)
+	log.Infof("attached to the raw socket on port %d", port)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// read packets

--- a/signal/cmd/root.go
+++ b/signal/cmd/root.go
@@ -47,7 +47,7 @@ func init() {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "")
-	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the the log will be output to stdout")
+	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout")
 	rootCmd.AddCommand(runCmd)
 }
 


### PR DESCRIPTION
## Describe your changes

This PR adds the following linters and addresses issues raised by them:

- `dupword` checks for duplicate words in the source code
- `durationcheck` checks for two durations multiplied together
- `forbidigo` forbids identifiers
- `mirror` reports wrong mirror patterns of bytes/strings usage
- `misspell` finds commonly misspelled English words in comments
- `predeclared` finds code that shadows one of Go's predeclared identifiers
- `thelper` detects Go test helpers without t.Helper() call and checks the consistency of test helpers

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
