### PR TITLE
Add non-deletable service user

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -211,6 +211,7 @@ type UserInfo struct {
 	Status               string               `json:"-"`
 	IsServiceUser        bool                 `json:"is_service_user"`
 	IsBlocked            bool                 `json:"is_blocked"`
+	NonDeletable         bool                 `json:"non_deletable"`
 	LastLogin            time.Time            `json:"last_login"`
 	Issued               string               `json:"issued"`
 	IntegrationReference IntegrationReference `json:"-"`

--- a/management/server/http/users_handler.go
+++ b/management/server/http/users_handler.go
@@ -207,7 +207,7 @@ func (h *UsersHandler) GetAllUsers(w http.ResponseWriter, r *http.Request) {
 			util.WriteError(status.Errorf(status.InvalidArgument, "invalid service_user query parameter"), w)
 			return
 		}
-		if includeServiceUser == r.IsServiceUser {
+		if includeServiceUser == r.IsServiceUser && !r.NonDeletable {
 			users = append(users, toUserResponse(r, claims.UserId))
 		}
 	}

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -963,6 +963,7 @@ func (am *DefaultAccountManager) GetUsersFromAccount(accountID, userID string) (
 				AutoGroups:    localUser.AutoGroups,
 				Status:        string(UserStatusActive),
 				IsServiceUser: localUser.IsServiceUser,
+				NonDeletable:  localUser.NonDeletable,
 			}
 		}
 		userInfos = append(userInfos, info)


### PR DESCRIPTION
## Describe your changes

Introduce a non-deletable service user, which can only be created by invoking the AccountManager's `CreateUser` method rather than through API calls. Additionally, ensure the exclusion of these users from the list of retrieved account service users in API calls.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
