### PR TITLE
Use email address for iphone name generation

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rs/xid"
 
 	"github.com/netbirdio/netbird/management/server/activity"
-	"github.com/netbirdio/netbird/management/server/idp"
 	"github.com/netbirdio/netbird/management/server/status"
 
 	log "github.com/sirupsen/logrus"
@@ -487,9 +486,11 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 	}
 
 	if strings.ToLower(peer.Meta.Hostname) == "iphone" || strings.ToLower(peer.Meta.Hostname) == "ipad" && userID != "" {
-		userdata, err := am.idpManager.GetUserDataByID(userID, idp.AppMetadata{})
-		if err == nil {
-			peer.Meta.Hostname = fmt.Sprintf("%s-%s", peer.Meta.Hostname, strings.Split(userdata.Email, "@")[0])
+		if am.idpManager != nil {
+			userdata, err := am.lookupUserInCache(userID, account)
+			if err == nil {
+				peer.Meta.Hostname = fmt.Sprintf("%s-%s", peer.Meta.Hostname, strings.Split(userdata.Email, "@")[0])
+			}
 		}
 	}
 

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -486,10 +486,10 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 		return nil, nil, err
 	}
 
-	if peer.Meta.Hostname == "iPhone" && userID != "" {
+	if strings.ToLower(peer.Meta.Hostname) == "iphone" || strings.ToLower(peer.Meta.Hostname) == "ipad" && userID != "" {
 		userdata, err := am.idpManager.GetUserDataByID(userID, idp.AppMetadata{})
 		if err == nil {
-			peer.Meta.Hostname = fmt.Sprintf("iPhone-%s", strings.Split(userdata.Email, "@")[0])
+			peer.Meta.Hostname = fmt.Sprintf("%s-%s", peer.Meta.Hostname, strings.Split(userdata.Email, "@")[0])
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes
Starting from iOS 16, it is not possible, to get the hostname from the device and only returns "iPhone". Therefore all devices will have the same name and the dns will be counted upwards (e.g. iphone-3.netbird.cloud). This PR adds a lookup on peer registration to get the email address of a user registering that device and adds it to the device name to allow easier differentiation. If the lookup fails or the device was added via setup key it will fall back to the default "iPhone" name.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
