### PR TITLE
systemd units for the client, management & signal services

### DIFF
--- a/release_files/systemd/env
+++ b/release_files/systemd/env
@@ -1,0 +1,3 @@
+# Extra flags you might want to pass to the daemon
+FLAGS=""
+

--- a/release_files/systemd/netbird-management.service
+++ b/release_files/systemd/netbird-management.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=Netbird Management
+Documentation=https://netbird.io/docs
+After=network-online.target syslog.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/default/netbird-management
+ExecStart=/usr/bin/netbird-mgmt management $FLAGS
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
+CacheDirectory=netbird
+ConfigurationDirectory=netbird
+LogDirectory=netbird
+RuntimeDirectory=netbird
+StateDirectory=netbird
+
+# sandboxing
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateMounts=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+
+[Install]
+WantedBy=multi-user.target
+

--- a/release_files/systemd/netbird-signal.service
+++ b/release_files/systemd/netbird-signal.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=Netbird Signal
+Documentation=https://netbird.io/docs
+After=network-online.target syslog.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/default/netbird-signal
+ExecStart=/usr/bin/netbird-signal run $FLAGS
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
+CacheDirectory=netbird
+ConfigurationDirectory=netbird
+LogDirectory=netbird
+RuntimeDirectory=netbird
+StateDirectory=netbird
+
+# sandboxing
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateMounts=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+
+[Install]
+WantedBy=multi-user.target
+

--- a/release_files/systemd/netbird@.service
+++ b/release_files/systemd/netbird@.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=Netbird Client (%i)
+Documentation=https://netbird.io/docs
+After=network-online.target syslog.target NetworkManager.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/default/netbird
+ExecStart=/usr/bin/netbird service run --log-file /var/log/netbird/client-%i.log --config /etc/netbird/%i.json --daemon-addr unix:///var/run/netbird/%i.sock $FLAGS
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
+CacheDirectory=netbird
+ConfigurationDirectory=netbird
+LogDirectory=netbird
+RuntimeDirectory=netbird
+StateDirectory=netbird
+
+# sandboxing
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateMounts=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=no  # needed to load wg module for kernel-mode WireGuard
+ProtectKernelTunables=no
+ProtectSystem=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

---




Continuing from #1316.

### install & upgrade

I did not change `install.sh` yet as this PR uses a templated systemd unit for the client, and thus `install.sh` will need a bit of work to make it safely migrate old clients. I'd like to know first if you want this at all.

### logging

Logs get written to the console where they get picked up by journald, since this is where you would typically expect to see them on a systemd-based Linux distribution. Users get automatic compression and log rotation for free.

It's trivial to make each client use a separate log file if you'd rather keep using text logs, though.

### sanbox

Sandbox flags are quite conservative: they mostly deny access to home directories and things netbird shouldn't have to worry about (like changing mount points).

It isn't difficult to make all daemons *appear* to work with a non-root user and somewhat limited privileges (with `CAP_NET_ADMIN`), but I am not sure that it doesn't introduce some subtle breakage somewhere. It would probably make a bad default for now.

### customization

`env` should be copied into `/etc/default/netbird{,-management,-signal}` and is the same for all three. It's there to allow the user to pass additional configuration flags without overriding the unit.

### directories

These directives:

```ini
RuntimeDirectory=netbird
StateDirectory=netbird
LogDirectory=netbird
ConfigurationDirectory=netbird
```

create `/etc/netbird` and `/var/{log,lib,run}/netbird` (if necessary), make sure the daemon can access them, and only then start the daemon. This will prevent problems such as #1079 for those users who prefer and configure text logs. If someday netbird is made to run under a restricted user, you won't have to `chown -R` them in upgrade scripts since systemd will do it for you.

What do you think?
