### PR TITLE
Add tenv linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,12 @@ linters-settings:
     enable:
       - nilness
 
+  tenv:
+    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
+    # Default: false
+    all: true
+
 linters:
   disable-all: true
   enable:
@@ -28,6 +34,7 @@ linters:
     - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # detects when assignments to existing variables are not used
     - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - tenv # Tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17.
     - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
     - unused # checks for unused constants, variables, functions and types
     ## disable by default but the have interesting results so lets add them

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -322,9 +322,9 @@ func TestUpdateDNSServer(t *testing.T) {
 
 func TestDNSFakeResolverHandleUpdates(t *testing.T) {
 	ov := os.Getenv("NB_WG_KERNEL_DISABLED")
-	defer os.Setenv("NB_WG_KERNEL_DISABLED", ov)
+	defer t.Setenv("NB_WG_KERNEL_DISABLED", ov)
 
-	_ = os.Setenv("NB_WG_KERNEL_DISABLED", "true")
+	t.Setenv("NB_WG_KERNEL_DISABLED", "true")
 	newNet, err := stdnet.NewNet(nil)
 	if err != nil {
 		t.Errorf("create stdnet: %v", err)
@@ -771,9 +771,9 @@ func TestDNSPermanent_matchOnly(t *testing.T) {
 
 func createWgInterfaceWithBind(t *testing.T) (*iface.WGIface, error) {
 	ov := os.Getenv("NB_WG_KERNEL_DISABLED")
-	defer os.Setenv("NB_WG_KERNEL_DISABLED", ov)
+	defer t.Setenv("NB_WG_KERNEL_DISABLED", ov)
 
-	_ = os.Setenv("NB_WG_KERNEL_DISABLED", "true")
+	t.Setenv("NB_WG_KERNEL_DISABLED", "true")
 	newNet, err := stdnet.NewNet(nil)
 	if err != nil {
 		t.Fatalf("create stdnet: %v", err)


### PR DESCRIPTION
Tenv is analyzer that detects using `os.Setenv` instead of `t.Setenv` since Go 1.17.

## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
