### PR TITLE
Add account deletion endpoint

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -64,6 +64,7 @@ type AccountManager interface {
 	GetAccountByUserOrAccountID(userID, accountID, domain string) (*Account, error)
 	GetAccountFromToken(claims jwtclaims.AuthorizationClaims) (*Account, *User, error)
 	GetAccountFromPAT(pat string) (*Account, *User, *PersonalAccessToken, error)
+	DeleteAccount(accountID, userID string) error
 	MarkPATUsed(tokenID string) error
 	GetUser(claims jwtclaims.AuthorizationClaims) (*User, error)
 	ListUsers(accountID string) ([]*User, error)
@@ -1000,6 +1001,57 @@ func (am *DefaultAccountManager) warmupIDPCache() error {
 		}
 	}
 	log.Infof("warmed up IDP cache with %d entries", len(userData))
+	return nil
+}
+
+// DeleteAccount deletes an account and all its users from local store and from the remote IDP if the requester is an admin and account owner
+func (am *DefaultAccountManager) DeleteAccount(accountID, userID string) error {
+	unlock := am.Store.AcquireGlobalLock()
+	defer unlock()
+	account, err := am.Store.GetAccount(accountID)
+	if err != nil {
+		return err
+	}
+
+	user, err := account.FindUser(userID)
+	if err != nil {
+		return err
+	}
+
+	if !user.IsAdmin() {
+		return status.Errorf(status.PermissionDenied, "user is not allowed to delete account")
+	}
+
+	if user.Id != account.CreatedBy {
+		return status.Errorf(status.PermissionDenied, "user is not allowed to delete account. Only account owner can delete account")
+	}
+	for _, otherUser := range account.Users {
+		if otherUser.IsServiceUser {
+			continue
+		}
+
+		if otherUser.Id == userID {
+			continue
+		}
+
+		deleteUserErr := am.deleteRegularUser(account, userID, otherUser.Id)
+		if deleteUserErr != nil {
+			return deleteUserErr
+		}
+	}
+
+	err = am.deleteRegularUser(account, userID, userID)
+	if err != nil {
+		log.Errorf("failed deleting user %s. error: %s", userID, err)
+		return err
+	}
+
+	err = am.Store.DeleteAccount(account)
+	if err != nil {
+		log.Errorf("failed deleting account %s. error: %s", accountID, err)
+		return err
+	}
+	log.Debugf("account %s deleted", accountID)
 	return nil
 }
 

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -351,6 +351,41 @@ func (s *FileStore) SaveAccount(account *Account) error {
 	return s.persist(s.storeFile)
 }
 
+func (s *FileStore) DeleteAccount(account *Account) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	if account.Id == "" {
+		return status.Errorf(status.InvalidArgument, "account id should not be empty")
+	}
+
+	for keyID := range account.SetupKeys {
+		delete(s.SetupKeyID2AccountID, strings.ToUpper(keyID))
+	}
+
+	// enforce peer to account index and delete peer to route indexes for rebuild
+	for _, peer := range account.Peers {
+		delete(s.PeerKeyID2AccountID, peer.Key)
+		delete(s.PeerID2AccountID, peer.ID)
+	}
+
+	for _, user := range account.Users {
+		for _, pat := range user.PATs {
+			delete(s.TokenID2UserID, pat.ID)
+			delete(s.HashedPAT2TokenID, pat.HashedToken)
+		}
+		delete(s.UserID2AccountID, user.Id)
+	}
+
+	if account.DomainCategory == PrivateCategory && account.IsDomainPrimaryAccount {
+		delete(s.PrivateDomain2AccountID, account.Domain)
+	}
+
+	delete(s.Accounts, account.Id)
+
+	return s.persist(s.storeFile)
+}
+
 // DeleteHashedPAT2TokenIDIndex removes an entry from the indexing map HashedPAT2TokenID
 func (s *FileStore) DeleteHashedPAT2TokenIDIndex(hashedToken string) error {
 	s.mux.Lock()

--- a/management/server/http/accounts_handler.go
+++ b/management/server/http/accounts_handler.go
@@ -98,6 +98,30 @@ func (h *AccountsHandler) UpdateAccount(w http.ResponseWriter, r *http.Request) 
 	util.WriteJSONObject(w, &resp)
 }
 
+// DeleteAccount is a DELETE request to delete an account
+func (h *AccountsHandler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		util.WriteErrorResponse("wrong HTTP method", http.StatusMethodNotAllowed, w)
+		return
+	}
+
+	claims := h.claimsExtractor.FromRequestContext(r)
+	vars := mux.Vars(r)
+	targetAccountID := vars["accountId"]
+	if len(targetAccountID) == 0 {
+		util.WriteError(status.Errorf(status.InvalidArgument, "invalid account ID"), w)
+		return
+	}
+
+	err := h.accountManager.DeleteAccount(targetAccountID, claims.UserId)
+	if err != nil {
+		util.WriteError(err, w)
+		return
+	}
+
+	util.WriteJSONObject(w, emptyObject{})
+}
+
 func toAccountResponse(account *server.Account) *api.Account {
 	return &api.Account{
 		Id: account.Id,

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -1074,6 +1074,32 @@ paths:
         '500':
           "$ref": "#/components/responses/internal_error"
   /api/accounts/{accountId}:
+    delete:
+      summary: Delete an Account
+      description: Deletes an account and all its resources. Only administrators and account owners can delete accounts.
+      tags: [ Accounts ]
+      security:
+        - BearerAuth: [ ]
+        - TokenAuth: [ ]
+      parameters:
+        - in: path
+          name: accountId
+          required: true
+          schema:
+            type: string
+          description: The unique identifier of an account
+      responses:
+        '200':
+          description: Delete account status code
+          content: { }
+        '400':
+          "$ref": "#/components/responses/bad_request"
+        '401':
+          "$ref": "#/components/responses/requires_authentication"
+        '403':
+          "$ref": "#/components/responses/forbidden"
+        '500':
+          "$ref": "#/components/responses/internal_error"
     put:
       summary: Update an Account
       description: Update information about an account

--- a/management/server/http/handler.go
+++ b/management/server/http/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/cors"
 
 	"github.com/netbirdio/management-integrations/integrations"
+
 	s "github.com/netbirdio/netbird/management/server"
 	"github.com/netbirdio/netbird/management/server/http/middleware"
 	"github.com/netbirdio/netbird/management/server/jwtclaims"
@@ -105,6 +106,7 @@ func APIHandler(accountManager s.AccountManager, jwtValidator jwtclaims.JWTValid
 func (apiHandler *apiHandler) addAccountsEndpoint() {
 	accountsHandler := NewAccountsHandler(apiHandler.AccountManager, apiHandler.AuthCfg)
 	apiHandler.Router.HandleFunc("/accounts/{accountId}", accountsHandler.UpdateAccount).Methods("PUT", "OPTIONS")
+	apiHandler.Router.HandleFunc("/accounts/{accountId}", accountsHandler.DeleteAccount).Methods("DELETE", "OPTIONS")
 	apiHandler.Router.HandleFunc("/accounts", accountsHandler.GetAllAccounts).Methods("GET", "OPTIONS")
 }
 

--- a/management/server/http/users_handler.go
+++ b/management/server/http/users_handler.go
@@ -94,7 +94,7 @@ func (h *UsersHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	util.WriteJSONObject(w, toUserResponse(newUser, claims.UserId))
 }
 
-// DeleteUser is a DELETE request to delete a user (only works for service users right now)
+// DeleteUser is a DELETE request to delete a user
 func (h *UsersHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		util.WriteErrorResponse("wrong HTTP method", http.StatusMethodNotAllowed, w)

--- a/management/server/store.go
+++ b/management/server/store.go
@@ -14,6 +14,7 @@ import (
 type Store interface {
 	GetAllAccounts() []*Account
 	GetAccount(accountID string) (*Account, error)
+	DeleteAccount(account *Account) error
 	GetAccountByUser(userID string) (*Account, error)
 	GetAccountByPeerPubKey(peerKey string) (*Account, error)
 	GetAccountByPeerID(peerID string) (*Account, error)


### PR DESCRIPTION
## Describe your changes
Adding support to account owners to delete an account

This will remove all users from local, and if `--user-delete-from-idp` is set it will remove from the remote IDP

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
