### PR TITLE
Fix IPv6 format for DNS address received from android

### DIFF
--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -421,14 +421,7 @@ func (s *DefaultServer) updateLocalResolver(update map[string]nbdns.SimpleRecord
 }
 
 func getNSHostPort(ns nbdns.NameServer) string {
-	log.Debugf("getNSHostPort: %s : %d", ns.IP.String(), ns.Port)
-	if ns.IP.Is4() {
-		return fmt.Sprintf("%s:%d", ns.IP.String(), ns.Port)
-	}
-
-	n := fmt.Sprintf("[%s]:%d", ns.IP.String(), ns.Port)
-	log.Debugf("formated ns: %s", n)
-	return n
+	return fmt.Sprintf("%s:%d", ns.IP.String(), ns.Port)
 }
 
 // upstreamCallbacks returns two functions, the first one is used to deactivate


### PR DESCRIPTION
## Describe your changes

this adds the address in the expected format in Go [ipv6]:port

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
