### PR TITLE
Extend add peer event meta with setup key name

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -525,6 +525,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 		opEvent.InitiatorID = sk.Id
 		opEvent.Activity = activity.PeerAddedWithSetupKey
 		ephemeral = sk.Ephemeral
+		opEvent.Meta["setup_key_name"] = sk.Name
 	} else {
 		opEvent.InitiatorID = userID
 		opEvent.Activity = activity.PeerAddedByUser
@@ -598,7 +599,11 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *Peer) (*
 	}
 
 	opEvent.TargetID = newPeer.ID
-	opEvent.Meta = newPeer.EventMeta(am.GetDNSDomain())
+	peerMeta := newPeer.EventMeta(am.GetDNSDomain())
+	for k, v := range peerMeta {
+		opEvent.Meta[k] = v
+	}
+
 	am.StoreEvent(opEvent.InitiatorID, opEvent.TargetID, opEvent.AccountID, opEvent.Activity, opEvent.Meta)
 
 	am.updateAccountPeers(account)


### PR DESCRIPTION
## Describe your changes
We want to show the user the name of the setup key instead of the key ID. This PR adds the name of a setup key to the event on peer add.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
