### PR TITLE
Fix jwks validation and flag/config overriding

### DIFF
--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -83,7 +83,10 @@ var (
 			if err != nil {
 				return fmt.Errorf("failed reading provided config file: %s: %v", mgmtConfig, err)
 			}
-			config.HttpConfig.IdpSignKeyRefreshEnabled = idpSignKeyRefreshEnabled
+
+			if cmd.Flag(idpSignKeyRefreshEnabledFlagName).Changed {
+				config.HttpConfig.IdpSignKeyRefreshEnabled = idpSignKeyRefreshEnabled
+			}
 
 			tlsEnabled := false
 			if mgmtLetsencryptDomain != "" || (config.HttpConfig.CertFile != "" && config.HttpConfig.CertKey != "") {

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	// ExitSetupFailed defines exit code
-	ExitSetupFailed = 1
+	ExitSetupFailed                  = 1
+	idpSignKeyRefreshEnabledFlagName = "idp-sign-key-refresh-enabled"
 )
 
 var (
@@ -62,7 +63,7 @@ func init() {
 	mgmtCmd.Flags().StringVar(&certKey, "cert-key", "", "Location of your SSL certificate private key. Can be used when you have an existing certificate and don't want a new certificate be generated automatically. If letsencrypt-domain is specified this property has no effect")
 	mgmtCmd.Flags().BoolVar(&disableMetrics, "disable-anonymous-metrics", false, "disables push of anonymous usage metrics to NetBird")
 	mgmtCmd.Flags().StringVar(&dnsDomain, "dns-domain", defaultSingleAccModeDomain, fmt.Sprintf("Domain used for peer resolution. This is appended to the peer's name, e.g. pi-server. %s. Max length is 192 characters to allow appending to a peer name with up to 63 characters.", defaultSingleAccModeDomain))
-	mgmtCmd.Flags().BoolVar(&idpSignKeyRefreshEnabled, "idp-sign-key-refresh-enabled", false, "Enable cache headers evaluation to determine signing key rotation period. This will refresh the signing key upon expiry.")
+	mgmtCmd.Flags().BoolVar(&idpSignKeyRefreshEnabled, idpSignKeyRefreshEnabledFlagName, false, "Enable cache headers evaluation to determine signing key rotation period. This will refresh the signing key upon expiry.")
 	mgmtCmd.Flags().BoolVar(&userDeleteFromIDPEnabled, "user-delete-from-idp", false, "Allows to delete user from IDP when user is deleted from account")
 	rootCmd.MarkFlagRequired("config") //nolint
 

--- a/management/server/jwtclaims/jwtValidator.go
+++ b/management/server/jwtclaims/jwtValidator.go
@@ -108,6 +108,8 @@ func NewJWTValidator(issuer string, audienceList []string, keysLocation string, 
 						refreshedKeys = keys
 					}
 
+					log.Debugf("keys refreshed, new UTC expiration time: %s", refreshedKeys.expiresInTime.UTC())
+
 					keys = refreshedKeys
 				}
 			}
@@ -179,7 +181,7 @@ func (m *JWTValidator) ValidateAndParse(token string) (*jwt.Token, error) {
 
 // stillValid returns true if the JSONWebKey still valid and have enough time to be used
 func (jwks *Jwks) stillValid() bool {
-	return jwks.expiresInTime.IsZero() && time.Now().Add(5*time.Second).Before(jwks.expiresInTime)
+	return !jwks.expiresInTime.IsZero() && time.Now().Add(5*time.Second).Before(jwks.expiresInTime)
 }
 
 func getPemKeys(keysLocation string) (*Jwks, error) {


### PR DESCRIPTION
## Describe your changes
Ensure the jwks expiresInTime is not zero and add a log indicating the new expiration time

Replace the configuration property only when the flag is being used
## Issue ticket number and link
fixes #1379
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
