### PR TITLE
Fix nil pointer handling in get peers from group

### DIFF
--- a/management/server/policy.go
+++ b/management/server/policy.go
@@ -493,11 +493,7 @@ func getAllPeersFromGroups(account *Account, groups []string, peerID string) ([]
 
 		for _, p := range group.Peers {
 			peer, ok := account.Peers[p]
-			if !ok {
-				continue
-			}
-
-			if peer == nil {
+			if !ok || peer == nil {
 				continue
 			}
 

--- a/management/server/policy.go
+++ b/management/server/policy.go
@@ -493,7 +493,15 @@ func getAllPeersFromGroups(account *Account, groups []string, peerID string) ([]
 
 		for _, p := range group.Peers {
 			peer, ok := account.Peers[p]
-			if ok && peer != nil && peer.ID == peerID {
+			if !ok {
+				continue
+			}
+
+			if peer == nil {
+				continue
+			}
+
+			if peer.ID == peerID {
 				peerInGroups = true
 				continue
 			}


### PR DESCRIPTION
## Describe your changes
Fix nil handling in getAllPeersFromGroups to not include nil pointer in the output.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
