### PR TITLE
Allow removal of preshared keys

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -51,7 +51,7 @@ var loginCmd = &cobra.Command{
 				AdminURL:      adminURL,
 				ConfigPath:    configPath,
 			}
-			if preSharedKey != "" {
+			if rootCmd.PersistentFlags().Changed(preSharedKeyFlag) {
 				ic.PreSharedKey = &preSharedKey
 			}
 

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	externalIPMapFlag  = "external-ip-map"
+	preSharedKeyFlag   = "preshared-key"
 	dnsResolverAddress = "dns-resolver-address"
 )
 
@@ -94,7 +95,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "sets Netbird log level")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout")
 	rootCmd.PersistentFlags().StringVarP(&setupKey, "setup-key", "k", "", "Setup key obtained from the Management Service Dashboard (used to register peer)")
-	rootCmd.PersistentFlags().StringVar(&preSharedKey, "preshared-key", "", "Sets Wireguard PreSharedKey property. If set, then only peers that have the same key can communicate.")
+	rootCmd.PersistentFlags().StringVar(&preSharedKey, preSharedKeyFlag, "", "Sets Wireguard PreSharedKey property. If set, then only peers that have the same key can communicate.")
 	rootCmd.PersistentFlags().StringVarP(&hostName, "hostname", "n", "", "Sets a custom hostname for the device")
 	rootCmd.AddCommand(serviceCmd)
 	rootCmd.AddCommand(upCmd)

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -85,7 +85,8 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command) error {
 		NATExternalIPs:   natExternalIPs,
 		CustomDNSAddress: customDNSAddressConverted,
 	}
-	if preSharedKey != "" {
+
+	if rootCmd.PersistentFlags().Changed(preSharedKeyFlag) {
 		ic.PreSharedKey = &preSharedKey
 	}
 

--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -215,12 +215,10 @@ func update(input ConfigInput) (*Config, error) {
 	}
 
 	if input.PreSharedKey != nil && config.PreSharedKey != *input.PreSharedKey {
-		if *input.PreSharedKey != "" {
-			log.Infof("new pre-shared key provides, updated to %s (old value %s)",
-				*input.PreSharedKey, config.PreSharedKey)
-			config.PreSharedKey = *input.PreSharedKey
-			refresh = true
-		}
+		log.Infof("new pre-shared key provides, updated to %s (old value %s)",
+			*input.PreSharedKey, config.PreSharedKey)
+		config.PreSharedKey = *input.PreSharedKey
+		refresh = true
 	}
 
 	if config.SSHKey == "" {

--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -215,8 +215,7 @@ func update(input ConfigInput) (*Config, error) {
 	}
 
 	if input.PreSharedKey != nil && config.PreSharedKey != *input.PreSharedKey {
-		log.Infof("new pre-shared key provides, updated to %s (old value %s)",
-			*input.PreSharedKey, config.PreSharedKey)
+		log.Infof("new pre-shared key provided, replacing old key")
 		config.PreSharedKey = *input.PreSharedKey
 		refresh = true
 	}

--- a/client/internal/config_test.go
+++ b/client/internal/config_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/netbirdio/netbird/util"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netbirdio/netbird/util"
 )
 
 func TestGetConfig(t *testing.T) {
@@ -60,22 +61,7 @@ func TestGetConfig(t *testing.T) {
 	assert.Equal(t, config.ManagementURL.String(), managementURL)
 	assert.Equal(t, config.PreSharedKey, preSharedKey)
 
-	// case 4: new empty pre-shared key config -> fetch it
-	newPreSharedKey := ""
-	config, err = UpdateOrCreateConfig(ConfigInput{
-		ManagementURL: managementURL,
-		AdminURL:      adminURL,
-		ConfigPath:    path,
-		PreSharedKey:  &newPreSharedKey,
-	})
-	if err != nil {
-		return
-	}
-
-	assert.Equal(t, config.ManagementURL.String(), managementURL)
-	assert.Equal(t, config.PreSharedKey, preSharedKey)
-
-	// case 5: existing config, but new managementURL has been provided -> update config
+	// case 4: existing config, but new managementURL has been provided -> update config
 	newManagementURL := "https://test.newManagement.url:33071"
 	config, err = UpdateOrCreateConfig(ConfigInput{
 		ManagementURL: newManagementURL,


### PR DESCRIPTION
## Describe your changes
The goal was to be able to remove a preshared key by setting it to empty string.

The changes needed to be able to hande the usecase described in https://github.com/netbirdio/netbird/issues/887.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
