### PR TITLE
Support status filter by names

### DIFF
--- a/client/cmd/status.go
+++ b/client/cmd/status.go
@@ -176,8 +176,12 @@ func getStatus(ctx context.Context, cmd *cobra.Command) (*proto.StatusResponse, 
 }
 
 func parseFilters() error {
+
 	switch strings.ToLower(statusFilter) {
 	case "", "disconnected", "connected":
+		if strings.ToLower(statusFilter) != "" {
+			enableDetailFlagWhenFilterFlag()
+		}
 	default:
 		return fmt.Errorf("wrong status filter, should be one of connected|disconnected, got: %s", statusFilter)
 	}
@@ -189,6 +193,7 @@ func parseFilters() error {
 				return fmt.Errorf("got an invalid IP address in the filter: address %s, error %s", addr, err)
 			}
 			ipsFilterMap[addr] = struct{}{}
+			enableDetailFlagWhenFilterFlag()
 		}
 	}
 
@@ -196,9 +201,16 @@ func parseFilters() error {
 		for _, name := range namesFilter {
 			namesFilterMap[name] = struct{}{}
 		}
+		enableDetailFlagWhenFilterFlag()
 	}
 
 	return nil
+}
+
+func enableDetailFlagWhenFilterFlag() {
+	if !detailFlag && !jsonFlag && !yamlFlag {
+		detailFlag = true
+	}
 }
 
 func convertToStatusOutputOverview(resp *proto.StatusResponse) statusOutputOverview {


### PR DESCRIPTION
## Describe your changes

users can filter status based on peer fully qualified names.

e.g., netbird status -d --filter-by-names peer-a.netbird.cloud,peer-b.netbird.cloud

Enable detailed information when using just filter flags.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
