### PR TITLE
quickstart script support custom ports and ssl certificates

### DIFF
--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -506,20 +506,22 @@ initEnvironment() {
       NETBIRD_DOMAIN=$(read_nb_domain)
     fi
 
-    if ! check_nb_http_port "$NETBIRD_HTTP_PORT"; then
-      NETBIRD_HTTP_PORT=$(read_nb_http_port)
-    fi
-
-    if ! check_nb_http_port "$NETBIRD_8080_PORT"; then
-      NETBIRD_8080_PORT=$(read_nb_8080_port)
-    fi
-
-    if ! check_nb_3478_port "$TURN_LISTENING_PORT"; then
-      TURN_LISTENING_PORT=$(read_nb_3478_port)
-    fi
-    if ! check_nb_port "$NETBIRD_PORT"; then
-      NETBIRD_PORT=$(read_nb_port)
-    fi
+    if [[ "x-$NETBIRD_INTERATIVE_MODE" == "x-true" ]]; then 
+        if ! check_nb_http_port "$NETBIRD_HTTP_PORT"; then
+          NETBIRD_HTTP_PORT=$(read_nb_http_port)
+        fi
+    
+        if ! check_nb_http_port "$NETBIRD_8080_PORT"; then
+          NETBIRD_8080_PORT=$(read_nb_8080_port)
+        fi
+    
+        if ! check_nb_3478_port "$TURN_LISTENING_PORT"; then
+          TURN_LISTENING_PORT=$(read_nb_3478_port)
+        fi
+        if ! check_nb_port "$NETBIRD_PORT"; then
+          NETBIRD_PORT=$(read_nb_port)
+        fi
+    fi  
 
     CADDY_SECURE_DOMAIN=", $NETBIRD_DOMAIN:443"
     NETBIRD_HTTP_PROTOCOL="https"


### PR DESCRIPTION
## Describe your changes
Ports 80, 8080, and 443 of our self-host server have been occupied, and deployment cannot be completed through the quickstart script. 

This modification enables the script to support custom ports and SSL certificates, which solves the issue of #1408 #1267, but it feels not elegant enough. 

Hope other developers can participate and continue to improve it.

I'm very sorry, my English is poor, so I used Google Translate.

## Issue ticket number and link
#1408 
#1267 

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
