### PR TITLE
Remove the user from the cache without refreshing it

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1299,6 +1299,22 @@ func (am *DefaultAccountManager) lookupCache(accountUsers map[string]struct{}, a
 	return data, err
 }
 
+func (am *DefaultAccountManager) removeUserFromCache(accountID, userID string) error {
+	data, err := am.getAccountFromCache(accountID, false)
+	if err != nil {
+		return err
+	}
+
+	for i, datum := range data {
+		if datum.ID == userID {
+			data = append(data[:i], data[i+1:]...)
+			break
+		}
+	}
+
+	return am.cacheManager.Set(am.ctx, accountID, data, cacheStore.WithExpiration(cacheEntryExpiration()))
+}
+
 // updateAccountDomainAttributes updates the account domain attributes and then, saves the account
 func (am *DefaultAccountManager) updateAccountDomainAttributes(account *Account, claims jwtclaims.AuthorizationClaims,
 	primaryDomain bool,

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -1073,11 +1073,10 @@ func (am *DefaultAccountManager) deleteUserFromIDP(targetUserID, accountID strin
 		if err != nil {
 			return fmt.Errorf("failed to remove user %s app metadata in IdP: %s", targetUserID, err)
 		}
-
-		_, err = am.refreshCache(accountID)
-		if err != nil {
-			log.Errorf("refresh account (%q) cache: %v", accountID, err)
-		}
+	}
+	err := am.removeUserFromCache(accountID, targetUserID)
+	if err != nil {
+		log.Errorf("remove user from account (%q) cache failed with error: %v", accountID, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Describe your changes
Some IdPs might have eventual consistency for their API calls, and refreshing the cache with its data may return the deleted user as part of the account

Introduce a new account manager method, removeUserFromCache, to remove the user from the local cache without refresh

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
