### PR TITLE
Fix Windows name on WMI error

### DIFF
--- a/client/system/info_windows.go
+++ b/client/system/info_windows.go
@@ -36,7 +36,8 @@ func getOSNameAndVersion() (string, string) {
 	query := wmi.CreateQuery(&dst, "")
 	err := wmi.Query(query, &dst)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		return "Windows", getBuildVersion()
 	}
 
 	if len(dst) == 0 {


### PR DESCRIPTION
## Describe your changes
Before, netbird would exit and prevent the agent from starting if getting the system name using WMI was an issue.

This change returns a default value in this case

## Issue ticket number and link
#1418
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
