### PR TITLE
Fix Windows settings popup with mesa 3d openGL emulator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
       - 'client/ui/**'
 
 env:
-  SIGN_PIPE_VER: "v0.0.10"
+  SIGN_PIPE_VER: "v0.0.11"
   GORELEASER_VER: "v1.14.1"
 
 concurrency:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,8 @@ CGO_ENABLED=0 go build .
 
 > Windows clients have a Wireguard driver requirement. You can download the wintun driver from https://www.wintun.net/builds/wintun-0.14.1.zip, after decompressing, you can copy the file `windtun\bin\ARCH\wintun.dll` to the same path as your binary file or to `C:\Windows\System32\wintun.dll`.
 
+> To test the client GUI application on Windows machines with RDP or vituralized environments (e.g. virtualbox or cloud), you need to download and extract the opengl32.dll from https://fdossena.com/?p=mesa/index.frag next to the built application.
+
 To start NetBird the client in the foreground:
 
 ```

--- a/client/installer.nsis
+++ b/client/installer.nsis
@@ -193,6 +193,7 @@ Sleep 3000
 Delete "$INSTDIR\${UI_APP_EXE}"
 Delete "$INSTDIR\${MAIN_APP_EXE}"
 Delete "$INSTDIR\wintun.dll"
+Delete "$INSTDIR\opengl32.dll"
 RmDir /r "$INSTDIR"
 
 SetShellVarContext all

--- a/client/netbird.wxs
+++ b/client/netbird.wxs
@@ -20,6 +20,7 @@
 						<Shortcut Id="NetbirdStartMenuShortcut" Directory="StartMenuFolder" Name="NetBird" WorkingDirectory="NetbirdInstallDir" Icon="NetbirdIcon" />
 					</File>
 					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\wintun.dll" />
+					<File ProcessorArchitecture="x64" Source=".\dist\netbird_windows_amd64\opengl32.dll" />
 
 					<ServiceInstall
                                      Id="NetBirdService"


### PR DESCRIPTION
## Describe your changes
By copying the emulator driver next to our binary, our GUI setting popup works on remote desktop connections

the dll is added as part of our sign pipelines workflow

## Issue ticket number and link
#986 #1189
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
