### PR TITLE
Update user's last login when authenticating a peer

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -442,8 +442,11 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *nbpeer.P
 	}
 
 	if addedByUser {
-		user := account.Users[userID]
-		user.LastLogin = newPeer.LastLogin
+		user, err := account.FindUser(userID)
+		if err != nil {
+			return nil, nil, status.Errorf(status.Internal, "couldn't find user")
+		}
+		user.updateLastLogin(newPeer.LastLogin)
 	}
 
 	account.Peers[newPeer.ID] = newPeer
@@ -557,8 +560,11 @@ func (am *DefaultAccountManager) LoginPeer(login PeerLogin) (*nbpeer.Peer, *Netw
 		shouldStoreAccount = true
 
 		// sync user last login with peer last login
-		user := account.Users[login.UserID]
-		user.LastLogin = peer.LastLogin
+		user, err := account.FindUser(login.UserID)
+		if err != nil {
+			return nil, nil, status.Errorf(status.Internal, "couldn't find user")
+		}
+		user.updateLastLogin(peer.LastLogin)
 
 		am.StoreEvent(login.UserID, peer.ID, account.Id, activity.UserLoggedInPeer, peer.EventMeta(am.GetDNSDomain()))
 	}

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/netbirdio/management-integrations/additions"
 	"github.com/rs/xid"
+
+	"github.com/netbirdio/management-integrations/additions"
 
 	"github.com/netbirdio/netbird/management/server/activity"
 	nbpeer "github.com/netbirdio/netbird/management/server/peer"
@@ -440,6 +441,11 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *nbpeer.P
 		}
 	}
 
+	if addedByUser {
+		user := account.Users[userID]
+		user.LastLogin = newPeer.LastLogin
+	}
+
 	account.Peers[newPeer.ID] = newPeer
 	account.Network.IncSerial()
 	err = am.Store.SaveAccount(account)
@@ -549,6 +555,10 @@ func (am *DefaultAccountManager) LoginPeer(login PeerLogin) (*nbpeer.Peer, *Netw
 		updatePeerLastLogin(peer, account)
 		updateRemotePeers = true
 		shouldStoreAccount = true
+
+		// sync user last login with peer last login
+		user := account.Users[login.UserID]
+		user.LastLogin = peer.LastLogin
 
 		am.StoreEvent(login.UserID, peer.ID, account.Id, activity.UserLoggedInPeer, peer.EventMeta(am.GetDNSDomain()))
 	}

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -101,6 +101,10 @@ func (u *User) LastDashboardLoginChanged(LastLogin time.Time) bool {
 	return LastLogin.After(u.LastLogin) && !u.LastLogin.IsZero()
 }
 
+func (u *User) updateLastLogin(login time.Time) {
+	u.LastLogin = login
+}
+
 // HasAdminPower returns true if the user has admin or owner roles, false otherwise
 func (u *User) HasAdminPower() bool {
 	return u.Role == UserRoleAdmin || u.Role == UserRoleOwner


### PR DESCRIPTION
## Describe your changes

Prior to this update, the user's last login was only updated on the dashboard authentication

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
