### PR TITLE
feat(Self-hosting NetBird script):support custom service port and DNS…

### DIFF
--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -312,7 +312,7 @@ delete_auto_service_user() {
 
 init_zitadel() {
   echo -e "\nInitializing Zitadel with NetBird's applications\n"
-  INSTANCE_URL="$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN"
+  INSTANCE_URL="$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT"
 
   TOKEN_PATH=./machinekey/zitadel-admin-sa.token
 
@@ -333,7 +333,7 @@ init_zitadel() {
   PROJECT_ID=$(create_new_project "$INSTANCE_URL" "$PAT")
 
   ZITADEL_DEV_MODE=false
-  BASE_REDIRECT_URL=$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN
+  BASE_REDIRECT_URL=$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT
   if [[ $NETBIRD_HTTP_PROTOCOL == "http" ]]; then
     ZITADEL_DEV_MODE=true
   fi
@@ -411,18 +411,35 @@ get_turn_external_ip() {
   echo "$TURN_EXTERNAL_IP_CONFIG"
 }
 
+init_ports(){
+  if [ -z "$NETBIRD_HTTP_PORT" ]; then
+      NETBIRD_HTTP_PORT=80
+  fi
+  if [ -z "$NETBIRD_HTTPS_PORT" ]; then
+      NETBIRD_HTTPS_PORT=443
+  fi
+  if [ -z "$TURN_MIN_PORT" ]; then
+      TURN_MIN_PORT=49152
+  fi
+  if [ -z "$TURN_MAX_PORT" ]; then
+      TURN_MAX_PORT=65535
+  fi
+  if [ -z "$TURN_LISTENING_PORT" ]; then
+      TURN_LISTENING_PORT=3478
+  fi  
+}
+
 initEnvironment() {
   CADDY_SECURE_DOMAIN=""
   ZITADEL_EXTERNALSECURE="false"
   ZITADEL_TLS_MODE="disabled"
   ZITADEL_MASTERKEY="$(openssl rand -base64 32 | head -c 32)"
-  NETBIRD_PORT=80
   NETBIRD_HTTP_PROTOCOL="http"
   TURN_USER="self"
   TURN_PASSWORD=$(openssl rand -base64 32 | sed 's/=//g')
-  TURN_MIN_PORT=49152
-  TURN_MAX_PORT=65535
   TURN_EXTERNAL_IP_CONFIG=$(get_turn_external_ip)
+
+  init_ports
 
   if ! check_nb_domain "$NETBIRD_DOMAIN"; then
     NETBIRD_DOMAIN=$(read_nb_domain)
@@ -430,11 +447,13 @@ initEnvironment() {
 
   if [ "$NETBIRD_DOMAIN" == "use-ip" ]; then
     NETBIRD_DOMAIN=$(get_main_ip_address)
+	  NETBIRD_PORT=$NETBIRD_HTTP_PORT
+	  CADDY_SECURE_DOMAIN=", $NETBIRD_DOMAIN"
   else
     ZITADEL_EXTERNALSECURE="true"
     ZITADEL_TLS_MODE="external"
-    NETBIRD_PORT=443
-    CADDY_SECURE_DOMAIN=", $NETBIRD_DOMAIN:$NETBIRD_PORT"
+    NETBIRD_PORT=$NETBIRD_HTTPS_PORT
+    CADDY_SECURE_DOMAIN=", $NETBIRD_DOMAIN:443"
     NETBIRD_HTTP_PROTOCOL="https"
   fi
 
@@ -464,6 +483,17 @@ initEnvironment() {
   echo "" > dashboard.env
   echo "" > turnserver.conf
   echo "" > management.json
+  
+  if [ "$CUSTOM_INITIAL_FILES" = "true" ]; then
+    echo "Customizing the initial profile..."
+    echo "Open a new terminal and make your changes in a new terminal."
+    echo "Please verify that the modified configuration file is correct"
+    echo "When you're done customizing the initial profile, Press any key to continue."
+
+    read -n 1 -s userInput
+
+    echo "You pressed '$userInput'. Continuing with the script."
+  fi
 
   mkdir -p machinekey
   chmod 777 machinekey
@@ -482,7 +512,7 @@ initEnvironment() {
   echo -e "\nStarting NetBird services\n"
   $DOCKER_COMPOSE_COMMAND up -d
   echo -e "\nDone!\n"
-  echo "You can access the NetBird dashboard at $NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN"
+  echo "You can access the NetBird dashboard at $NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT"
   echo "Login with the following credentials:"
   echo "Username: $ZITADEL_ADMIN_USERNAME" | tee .env
   echo "Password: $ZITADEL_ADMIN_PASSWORD" | tee -a .env
@@ -569,7 +599,7 @@ EOF
 
 renderTurnServerConf() {
   cat <<EOF
-listening-port=3478
+listening-port=$TURN_LISTENING_PORT
 $TURN_EXTERNAL_IP_CONFIG
 tls-listening-port=5349
 min-port=$TURN_MIN_PORT
@@ -593,14 +623,14 @@ renderManagementJson() {
     "Stuns": [
         {
             "Proto": "udp",
-            "URI": "stun:$NETBIRD_DOMAIN:3478"
+            "URI": "stun:$NETBIRD_DOMAIN:$TURN_LISTENING_PORT"
         }
     ],
     "TURNConfig": {
         "Turns": [
             {
                 "Proto": "udp",
-                "URI": "turn:$NETBIRD_DOMAIN:3478",
+                "URI": "turn:$NETBIRD_DOMAIN:$TURN_LISTENING_PORT",
                 "Username": "$TURN_USER",
                 "Password": "$TURN_PASSWORD"
             }
@@ -614,19 +644,19 @@ renderManagementJson() {
     "HttpConfig": {
         "AuthIssuer": "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN",
         "AuthAudience": "$NETBIRD_AUTH_CLIENT_ID",
-        "OIDCConfigEndpoint":"$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN/.well-known/openid-configuration"
+        "OIDCConfigEndpoint":"$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT/.well-known/openid-configuration"
     },
     "IdpManagerConfig": {
         "ManagerType": "zitadel",
         "ClientConfig": {
-            "Issuer": "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN",
-            "TokenEndpoint": "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN/oauth/v2/token",
+            "Issuer": "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT",
+            "TokenEndpoint": "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT/oauth/v2/token",
             "ClientID": "$NETBIRD_IDP_MGMT_CLIENT_ID",
             "ClientSecret": "$NETBIRD_IDP_MGMT_CLIENT_SECRET",
             "GrantType": "client_credentials"
         },
         "ExtraConfig": {
-            "ManagementEndpoint": "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN/management/v1"
+            "ManagementEndpoint": "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT/management/v1"
         }
      },
     "PKCEAuthorizationFlow": {
@@ -644,18 +674,18 @@ EOF
 renderDashboardEnv() {
   cat <<EOF
 # Endpoints
-NETBIRD_MGMT_API_ENDPOINT=$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN
-NETBIRD_MGMT_GRPC_API_ENDPOINT=$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN
+NETBIRD_MGMT_API_ENDPOINT=$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT
+NETBIRD_MGMT_GRPC_API_ENDPOINT=$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT
 # OIDC
 AUTH_AUDIENCE=$NETBIRD_AUTH_CLIENT_ID
 AUTH_CLIENT_ID=$NETBIRD_AUTH_CLIENT_ID
-AUTH_AUTHORITY=$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN
+AUTH_AUTHORITY=$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN:$NETBIRD_PORT
 USE_AUTH0=false
 AUTH_SUPPORTED_SCOPES="openid profile email offline_access"
 AUTH_REDIRECT_URI=/nb-auth
 AUTH_SILENT_REDIRECT_URI=/nb-silent-auth
 # SSL
-NGINX_SSL_PORT=443
+NGINX_SSL_PORT=$NETBIRD_PORT
 # Letsencrypt
 LETSENCRYPT_DOMAIN=none
 EOF
@@ -697,8 +727,8 @@ services:
     restart: unless-stopped
     networks: [ netbird ]
     ports:
-      - '443:443'
-      - '80:80'
+      - '$NETBIRD_HTTPS_PORT:443'
+      - '$NETBIRD_HTTP_PORT:80'
       - '8080:8080'
     volumes:
       - netbird_caddy_data:/data


### PR DESCRIPTION
… challenge


Adding port variable support custom service port；
Adding the CUSTOM_INITIAL_FILES variable allows you to change the configuration files to allow DNS challenge configuration or manual certificate management



Most of the people who encountered this problem were from China, so I added the description in Chinese
I didn't test the conditions for port 80 and 443 deployments, so I didn't test this case


## The following variables are added（增加了以下变量）

Custom ports（自定义端口）
```
export NETBIRD_HTTP_PORT=80;
export NETBIRD_HTTPS_PORT=443;
export TURN_MIN_PORT=49152;
export TURN_MAX_PORT=65535;
export TURN_LISTENING_PORT=3478;
```
Customize the initial configuration file（定制初始配置文件）
`export CUSTOM_INITIAL_FILES=true;`

## Certificate Settings when customizing ports（自定义端口时证书的设置）

两种设置方式：DNS challenge、Manage certificates manually（手动管理证书）

### DNS challenge

Automatically sign and renew certificates with caddy DNS challenge（通过 caddy DNS challenge自动签发、续签证书）

1. Enable the custom initial profile option（启用定制初始配置文件选项）： export CUSTOM_INITIAL_FILES=true;
2. Modify the caddy image in docker-compose.yml. Mirroring requires the addition of plugs to support the DNS challenge（修改docker-compose.yml中caddy镜像。镜像需要增加plug，以支持DNS challenge）
3. Modify Caddyfile to add DNS challenge configuration（修改Caddyfile，增加DNS challenge配置）

#### Take DNSPod as an example（以DNSPod为例）
Obtain or manually build caddy-dnspod. Modify the caddy image in docker-compose.yml.
（获取或手动构建caddy-dnspod。 修改docker-compose.yml中caddy镜像。）

<img width="405" alt="Pasted image 20240113181331" src="https://github.com/netbirdio/netbird/assets/40375067/8ebd337e-56b9-4240-b959-2a2a265976f0">

Modify Caddyfile to add DNS challenge configuration
（修改Caddyfile，增加DNS challenge配置）
```
tls youremil@icloud.com {
  dns dnspod apiTokenId,apiToken
}

```
<img width="665" alt="Pasted image 20240113181652" src="https://github.com/netbirdio/netbird/assets/40375067/87a2c633-3aa5-47a8-807b-61b45ce1c9e7">


### Manage certificates manually（手动管理证书）

Manage the certificates manually, and replace them manually when they expire
手动管理证书，到期需要手动替换证书

1. Enable the custom initial profile option（启用定制初始配置文件选项）： export CUSTOM_INITIAL_FILES=true;
2. Get the certificate and upload it to the certs folder in your installation directory.（获取证书，将证书上传到安装目录下certs文件夹中。）
3. Modify the caddy configuration in docker-compose.yml to mount the certificate file（docker-compose.yml中caddy配置，挂载证书文件）
4. Modify Caddyfile to add the certificate configuration（修改Caddyfile，增加证书配置）

Get the certificate and upload it to the certs folder in your installation directory.（获取证书，将证书上传到安装目录下certs文件夹中。）
```
~/docker-netbird# tree certs
certs
├── netbird.my-domain.com.key
└── netbird.my-domain.com.pem
```
Modify the caddy configuration in docker-compose.yml to mount the certificate file（docker-compose.yml中caddy配置，挂载证书文件）

<img width="678" alt="Pasted image 20240113182511" src="https://github.com/netbirdio/netbird/assets/40375067/8d0b2945-d8b0-42e7-8435-f1229442bdbb">

Modify Caddyfile to add the certificate configuration（修改Caddyfile，增加证书配置）

<img width="662" alt="Pasted image 20240113182955" src="https://github.com/netbirdio/netbird/assets/40375067/c7aeb737-4a7d-40f4-8650-2245bb7a8759">



## Issue ticket number and link
discussions
https://github.com/netbirdio/netbird/discussions/1406
issues
https://github.com/netbirdio/netbird/issues/1408
https://github.com/netbirdio/netbird/issues/1267


### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
