### PR TITLE
Enable group propagation by default

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1814,6 +1814,7 @@ func newAccountWithId(accountID, userID, domain string) *Account {
 		Settings: &Settings{
 			PeerLoginExpirationEnabled: true,
 			PeerLoginExpiration:        DefaultPeerLoginExpiration,
+			GroupsPropagationEnabled:   true,
 		},
 	}
 


### PR DESCRIPTION
## Describe your changes

Group updates to user auto groups will propagate by default for new accounts

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
