### PR TITLE
Validate upstream reachability on first DNS configuration

### DIFF
--- a/client/internal/dns/local.go
+++ b/client/internal/dns/local.go
@@ -71,3 +71,5 @@ func buildRecordKey(name string, class, qType uint16) string {
 	key := fmt.Sprintf("%s_%d_%d", name, class, qType)
 	return key
 }
+
+func (d *localResolver) probeAvailability() {}

--- a/client/internal/dns/mock_server.go
+++ b/client/internal/dns/mock_server.go
@@ -48,3 +48,7 @@ func (m *MockServer) UpdateDNSServer(serial uint64, update nbdns.Config) error {
 func (m *MockServer) SearchDomains() []string {
 	return make([]string, 0)
 }
+
+// ProbeAvailability mocks implementation of ProbeAvailability from the Server interface
+func (m *MockServer) ProbeAvailability() {
+}

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -19,10 +19,14 @@ const (
 	failsTillDeact   = int32(5)
 	reactivatePeriod = 30 * time.Second
 	upstreamTimeout  = 15 * time.Second
+	probeTimeout     = 2 * time.Second
 )
+
+const testRecord = "netbird.io."
 
 type upstreamClient interface {
 	exchange(upstream string, r *dns.Msg) (*dns.Msg, time.Duration, error)
+	exchangeContext(ctx context.Context, upstream string, r *dns.Msg) (*dns.Msg, time.Duration, error)
 }
 
 type UpstreamResolver interface {
@@ -80,7 +84,7 @@ func (u *upstreamResolverBase) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		rm, t, err := u.upstreamClient.exchange(upstream, r)
 
 		if err != nil {
-			if err == context.DeadlineExceeded || isTimeout(err) {
+			if errors.Is(err, context.DeadlineExceeded) || isTimeout(err) {
 				log.WithError(err).WithField("upstream", upstream).
 					Warn("got an error while connecting to upstream")
 				continue
@@ -134,13 +138,49 @@ func (u *upstreamResolverBase) checkUpstreamFails() {
 	case <-u.ctx.Done():
 		return
 	default:
-		// todo test the deactivation logic, it seems to affect the client
-		if runtime.GOOS != "ios" {
-			log.Warnf("upstream resolving is Disabled for %v", reactivatePeriod)
-			u.deactivate()
-			u.disabled = true
-			go u.waitUntilResponse()
-		}
+	}
+
+	u.disable()
+}
+
+// probeAvailability tests all upstream servers simultaneously and
+// disables the resolver if none work
+func (u *upstreamResolverBase) probeAvailability() {
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
+
+	select {
+	case <-u.ctx.Done():
+		return
+	default:
+	}
+
+	var success bool
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, upstream := range u.upstreamServers {
+		upstream := upstream
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := u.testNameserver(upstream); err != nil {
+				log.Warnf("probing upstream nameserver %s: %s", upstream, err)
+				return
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			success = true
+		}()
+	}
+
+	wg.Wait()
+
+	// didn't find a working upstream server, let's disable and try later
+	if !success {
+		u.disable()
 	}
 }
 
@@ -156,7 +196,7 @@ func (u *upstreamResolverBase) waitUntilResponse() {
 		Clock:               backoff.SystemClock,
 	}
 
-	r := new(dns.Msg).SetQuestion("netbird.io.", dns.TypeA)
+	r := new(dns.Msg).SetQuestion(testRecord, dns.TypeA)
 
 	operation := func() error {
 		select {
@@ -165,16 +205,16 @@ func (u *upstreamResolverBase) waitUntilResponse() {
 		default:
 		}
 
-		var err error
 		for _, upstream := range u.upstreamServers {
-			_, _, err = u.upstreamClient.exchange(upstream, r)
-
-			if err == nil {
+			if _, _, err := u.upstreamClient.exchange(upstream, r); err != nil {
+				log.Tracef("upstream check for %s: %s", upstream, err)
+			} else {
+				// at least one upstream server is available, stop probing
 				return nil
 			}
 		}
 
-		log.Tracef("checking connectivity with upstreams %s failed with error: %s. Retrying in %s", err, u.upstreamServers, exponentialBackOff.NextBackOff())
+		log.Tracef("checking connectivity with upstreams %s failed. Retrying in %s", u.upstreamServers, exponentialBackOff.NextBackOff())
 		return fmt.Errorf("got an error from upstream check call")
 	}
 
@@ -199,4 +239,28 @@ func isTimeout(err error) bool {
 		return neterr != nil && neterr.Timeout()
 	}
 	return false
+}
+
+func (u *upstreamResolverBase) disable() {
+	if u.disabled {
+		return
+	}
+
+	// todo test the deactivation logic, it seems to affect the client
+	if runtime.GOOS != "ios" {
+		log.Warnf("upstream resolving is Disabled for %v", reactivatePeriod)
+		u.deactivate()
+		u.disabled = true
+		go u.waitUntilResponse()
+	}
+}
+
+func (u *upstreamResolverBase) testNameserver(server string) error {
+	ctx, cancel := context.WithTimeout(u.ctx, probeTimeout)
+	defer cancel()
+
+	r := new(dns.Msg).SetQuestion(".", dns.TypeSOA)
+
+	_, _, err := u.upstreamClient.exchangeContext(ctx, server, r)
+	return err
 }

--- a/client/internal/dns/upstream_ios.go
+++ b/client/internal/dns/upstream_ios.go
@@ -41,6 +41,10 @@ func newUpstreamResolver(parentCTX context.Context, interfaceName string, ip net
 }
 
 func (u *upstreamResolverIOS) exchange(upstream string, r *dns.Msg) (rm *dns.Msg, t time.Duration, err error) {
+	return u.exchangeContext(context.Background(), upstream, r)
+}
+
+func (u *upstreamResolverIOS) exchangeContext(ctx context.Context, upstream string, r *dns.Msg) (rm *dns.Msg, t time.Duration, err error) {
 	client := &dns.Client{}
 	upstreamHost, _, err := net.SplitHostPort(upstream)
 	if err != nil {
@@ -52,7 +56,7 @@ func (u *upstreamResolverIOS) exchange(upstream string, r *dns.Msg) (rm *dns.Msg
 		client = u.getClientPrivate()
 	}
 
-	return client.Exchange(r, upstream)
+	return client.ExchangeContext(ctx, r, upstream)
 }
 
 // getClientPrivate returns a new DNS client bound to the local IP address of the Netbird interface

--- a/client/internal/dns/upstream_nonios.go
+++ b/client/internal/dns/upstream_nonios.go
@@ -24,9 +24,13 @@ func newUpstreamResolver(parentCTX context.Context, interfaceName string, ip net
 }
 
 func (u *upstreamResolverNonIOS) exchange(upstream string, r *dns.Msg) (rm *dns.Msg, t time.Duration, err error) {
-	upstreamExchangeClient := &dns.Client{}
+	// default upstream timeout
 	ctx, cancel := context.WithTimeout(u.ctx, u.upstreamTimeout)
-	rm, t, err = upstreamExchangeClient.ExchangeContext(ctx, r, upstream)
-	cancel()
-	return rm, t, err
+	defer cancel()
+	return u.exchangeContext(ctx, upstream, r)
+}
+
+func (u *upstreamResolverNonIOS) exchangeContext(ctx context.Context, upstream string, r *dns.Msg) (rm *dns.Msg, t time.Duration, err error) {
+	upstreamExchangeClient := &dns.Client{}
+	return upstreamExchangeClient.ExchangeContext(ctx, r, upstream)
 }

--- a/client/internal/dns/upstream_test.go
+++ b/client/internal/dns/upstream_test.go
@@ -105,8 +105,13 @@ type mockUpstreamResolver struct {
 	err error
 }
 
-// ExchangeContext mock implementation of ExchangeContext from upstreamResolver
+// Exchange mock implementation of Exchangefrom upstreamResolver
 func (c mockUpstreamResolver) exchange(upstream string, r *dns.Msg) (*dns.Msg, time.Duration, error) {
+	return c.exchangeContext(context.Background(), upstream, r)
+}
+
+// ExchangeContext mock implementation of ExchangeContext from upstreamResolver
+func (c mockUpstreamResolver) exchangeContext(_ context.Context, _ string, _ *dns.Msg) (*dns.Msg, time.Duration, error) {
 	return c.r, c.rtt, c.err
 }
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -641,6 +641,10 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 		log.Errorf("failed to update dns server, err: %v", err)
 	}
 
+	// Test received (upstream) servers for availability right away instead of upon usage.
+	// If no server of a server group responds this will disable the respective handler and retry later.
+	e.dnsServer.ProbeAvailability()
+
 	if e.acl != nil {
 		e.acl.ApplyFiltering(networkMap)
 	}


### PR DESCRIPTION
## Describe your changes

This adds an availability check for each DNS server group right after receiving DNS updates from management. 
If no servers of a group are available the group will be disabled.

## Issue ticket number and link

When we receive an upstream DNS server, we add the address in the system without checking if the address is reachable; this may cause issues as some queries will fail and may delay peer connection if the domains served by the upstream might contain our management layer.

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
