### PR TITLE
Support disabled resolved stub server mode

### DIFF
--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -30,7 +30,7 @@ type fileConfigurator struct {
 
 func newFileConfigurator() (hostManager, error) {
 	fc := &fileConfigurator{}
-	fc.repair = newRepair(fc.updateConfig)
+	fc.repair = newRepair(defaultResolvConfPath, fc.updateConfig)
 	return fc, nil
 }
 

--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -3,7 +3,6 @@
 package dns
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"os"
@@ -61,7 +60,7 @@ func (f *fileConfigurator) applyDNSConfig(config HostDNSConfig) error {
 
 	searchDomainList := searchDomains(config)
 
-	originalSearchDomains, nameServers, others, err := originalDNSConfigs(fileDefaultResolvConfBackupLocation)
+	originalSearchDomains, nameServers, others, err := parseResolvConf(fileDefaultResolvConfBackupLocation)
 	if err != nil {
 		log.Error(err)
 	}
@@ -148,70 +147,6 @@ func searchDomains(config HostDNSConfig) []string {
 		listOfDomains = append(listOfDomains, dConf.Domain)
 	}
 	return listOfDomains
-}
-
-func originalDNSConfigs(resolvconfFile string) (searchDomains, nameServers, others []string, err error) {
-	file, err := os.Open(resolvconfFile)
-	if err != nil {
-		err = fmt.Errorf(`could not read existing resolv.conf`)
-		return
-	}
-	defer file.Close()
-
-	reader := bufio.NewReader(file)
-
-	for {
-		lineBytes, isPrefix, readErr := reader.ReadLine()
-		if readErr != nil {
-			break
-		}
-
-		if isPrefix {
-			err = fmt.Errorf(`resolv.conf line too long`)
-			return
-		}
-
-		line := strings.TrimSpace(string(lineBytes))
-
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		if strings.HasPrefix(line, "domain") {
-			continue
-		}
-
-		if strings.HasPrefix(line, "options") && strings.Contains(line, "rotate") {
-			line = strings.ReplaceAll(line, "rotate", "")
-			splitLines := strings.Fields(line)
-			if len(splitLines) == 1 {
-				continue
-			}
-			line = strings.Join(splitLines, " ")
-		}
-
-		if strings.HasPrefix(line, "search") {
-			splitLines := strings.Fields(line)
-			if len(splitLines) < 2 {
-				continue
-			}
-
-			searchDomains = splitLines[1:]
-			continue
-		}
-
-		if strings.HasPrefix(line, "nameserver") {
-			splitLines := strings.Fields(line)
-			if len(splitLines) != 2 {
-				continue
-			}
-			nameServers = append(nameServers, splitLines[1])
-			continue
-		}
-
-		others = append(others, line)
-	}
-	return
 }
 
 // merge search Domains lists and cut off the list if it is too long

--- a/client/internal/dns/file_linux_test.go
+++ b/client/internal/dns/file_linux_test.go
@@ -1,3 +1,5 @@
+//go:build !android
+
 package dns
 
 import (

--- a/client/internal/dns/file_linux_test.go
+++ b/client/internal/dns/file_linux_test.go
@@ -88,6 +88,20 @@ func Test_isContains(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			args: args{
+				subList: []string{},
+				list:    []string{"b"},
+			},
+			want: true,
+		},
+		{
+			args: args{
+				subList: []string{},
+				list:    []string{},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run("list check test", func(t *testing.T) {

--- a/client/internal/dns/file_linux_test.go
+++ b/client/internal/dns/file_linux_test.go
@@ -7,7 +7,7 @@ import (
 
 func Test_mergeSearchDomains(t *testing.T) {
 	searchDomains := []string{"a", "b"}
-	originDomains := []string{"a", "b"}
+	originDomains := []string{"c", "d"}
 	mergedDomains := mergeSearchDomains(searchDomains, originDomains)
 	if len(mergedDomains) != 4 {
 		t.Errorf("invalid len of result domains: %d, want: %d", len(mergedDomains), 4)

--- a/client/internal/dns/file_linux_test.go
+++ b/client/internal/dns/file_linux_test.go
@@ -49,6 +49,53 @@ func Test_mergeSearchTooLongDomain(t *testing.T) {
 	}
 }
 
+func Test_isContains(t *testing.T) {
+	type args struct {
+		subList []string
+		list    []string
+	}
+	tests := []struct {
+		args args
+		want bool
+	}{
+		{
+			args: args{
+				subList: []string{"a", "b", "c"},
+				list:    []string{"a", "b", "c"},
+			},
+			want: true,
+		},
+		{
+			args: args{
+				subList: []string{"a"},
+				list:    []string{"a", "b", "c"},
+			},
+			want: true,
+		},
+		{
+			args: args{
+				subList: []string{"d"},
+				list:    []string{"a", "b", "c"},
+			},
+			want: false,
+		},
+		{
+			args: args{
+				subList: []string{"a"},
+				list:    []string{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run("list check test", func(t *testing.T) {
+			if got := isContains(tt.args.subList, tt.args.list); got != tt.want {
+				t.Errorf("isContains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func getLongLine() string {
 	x := "search "
 	for {

--- a/client/internal/dns/file_parser_linux.go
+++ b/client/internal/dns/file_parser_linux.go
@@ -1,3 +1,5 @@
+//go:build !android
+
 package dns
 
 import (

--- a/client/internal/dns/file_parser_linux.go
+++ b/client/internal/dns/file_parser_linux.go
@@ -53,8 +53,9 @@ func parseResolvConfFile(resolvConfFile string) (*resolvConf, error) {
 	}
 
 	rconf := &resolvConf{
-		nameServers: make([]string, 0),
-		others:      make([]string, 0),
+		searchDomains: make([]string, 0),
+		nameServers:   make([]string, 0),
+		others:        make([]string, 0),
 	}
 
 	for _, line := range strings.Split(string(cur), "\n") {

--- a/client/internal/dns/file_parser_linux.go
+++ b/client/internal/dns/file_parser_linux.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -16,6 +14,10 @@ type resolvConf struct {
 	nameServers   []string
 	searchDomains []string
 	others        []string
+}
+
+func (r *resolvConf) String() string {
+	return fmt.Sprintf("search domains: %v, name servers: %v, others: %s", r.searchDomains, r.nameServers, r.others)
 }
 
 func parseDefaultResolvConf() (*resolvConf, error) {
@@ -68,14 +70,12 @@ func parseResolvConfFile(resolvConfFile string) (*resolvConf, error) {
 		}
 
 		if strings.HasPrefix(line, "search") {
-			log.Debugf("found search domains: %s", line)
 			splitLines := strings.Fields(line)
 			if len(splitLines) < 2 {
 				continue
 			}
 
 			rconf.searchDomains = splitLines[1:]
-			log.Debugf("search domains: %s", rconf.searchDomains)
 			continue
 		}
 

--- a/client/internal/dns/file_parser_linux.go
+++ b/client/internal/dns/file_parser_linux.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -33,13 +35,17 @@ func parseBackupResolvConf() (*resolvConf, error) {
 func parseResolvConfFile(resolvConfFile string) (*resolvConf, error) {
 	file, err := os.Open(resolvConfFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open %s file: %w", resolvConfFile, err)
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Errorf("failed closing %s: %s", resolvConfFile, err)
+		}
+	}()
 
 	cur, err := os.ReadFile(resolvConfFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read %s file: %w", resolvConfFile, err)
 	}
 
 	if len(cur) == 0 {

--- a/client/internal/dns/file_parser_linux.go
+++ b/client/internal/dns/file_parser_linux.go
@@ -1,0 +1,82 @@
+package dns
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	defaultResolvConfPath = "/etc/resolv.conf"
+)
+
+func resolvConfEntries() (searchDomains, nameServers, others []string, err error) {
+	return parseResolvConf(defaultResolvConfPath)
+}
+
+func parseResolvConf(resolvconfFile string) (searchDomains, nameServers, others []string, err error) {
+	file, err := os.Open(resolvconfFile)
+	if err != nil {
+		err = fmt.Errorf(`could not read existing resolv.conf`)
+		return
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+
+	for {
+		lineBytes, isPrefix, readErr := reader.ReadLine()
+		if readErr != nil {
+			break
+		}
+
+		if isPrefix {
+			err = fmt.Errorf(`resolv.conf line too long`)
+			return
+		}
+
+		line := strings.TrimSpace(string(lineBytes))
+
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "domain") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "options") && strings.Contains(line, "rotate") {
+			line = strings.ReplaceAll(line, "rotate", "")
+			splitLines := strings.Fields(line)
+			if len(splitLines) == 1 {
+				continue
+			}
+			line = strings.Join(splitLines, " ")
+		}
+
+		if strings.HasPrefix(line, "search") {
+			splitLines := strings.Fields(line)
+			if len(splitLines) < 2 {
+				continue
+			}
+
+			searchDomains = splitLines[1:]
+			continue
+		}
+
+		if strings.HasPrefix(line, "nameserver") {
+			splitLines := strings.Fields(line)
+			if len(splitLines) != 2 {
+				continue
+			}
+			nameServers = append(nameServers, splitLines[1])
+			continue
+		}
+
+		if line != "" {
+			others = append(others, line)
+		}
+	}
+	return
+}

--- a/client/internal/dns/file_parser_linux_test.go
+++ b/client/internal/dns/file_parser_linux_test.go
@@ -1,3 +1,5 @@
+//go:build !android
+
 package dns
 
 import (

--- a/client/internal/dns/file_parser_linux_test.go
+++ b/client/internal/dns/file_parser_linux_test.go
@@ -52,6 +52,7 @@ search netbird.cloud
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run("test", func(t *testing.T) {
 			t.Parallel()
 			tmpResolvConf := fmt.Sprintf("%s/%s", t.TempDir(), "resolv.conf")

--- a/client/internal/dns/file_parser_linux_test.go
+++ b/client/internal/dns/file_parser_linux_test.go
@@ -1,0 +1,90 @@
+package dns
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func Test_parseResolvConf(t *testing.T) {
+	testCases := []struct {
+		input          string
+		expectedSearch []string
+		expectedNS     []string
+		expectedOther  []string
+	}{
+		{
+			input: `domain chello.hu
+search chello.hu
+nameserver 192.168.0.1
+`,
+			expectedSearch: []string{"chello.hu"},
+			expectedNS:     []string{"192.168.0.1"},
+			expectedOther:  []string{},
+		},
+		{
+			input: `# This is /run/systemd/resolve/resolv.conf managed by man:systemd-resolved(8).
+# Do not edit.
+#
+# This file might be symlinked as /etc/resolv.conf. If you're looking at
+# /etc/resolv.conf and seeing this text, you have followed the symlink.
+#
+# This is a dynamic resolv.conf file for connecting local clients directly to
+# all known uplink DNS servers. This file lists all configured search domains.
+#
+# Third party programs should typically not access this file directly, but only
+# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
+# different way, replace this symlink by a static file or a different symlink.
+#
+# See man:systemd-resolved.service(8) for details about the supported modes of
+# operation for /etc/resolv.conf.
+
+nameserver 192.168.2.1
+nameserver 100.81.99.197
+search netbird.cloud
+`,
+			expectedSearch: []string{"netbird.cloud"},
+			expectedNS:     []string{"192.168.2.1", "100.81.99.197"},
+			expectedOther:  []string{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		tmpResolvConf := fmt.Sprintf("%s/%s", os.TempDir(), "resolv.conf")
+		err := os.WriteFile(tmpResolvConf, []byte(testCase.input), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		search, ns, other, err := parseResolvConf(tmpResolvConf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ok := compareLists(search, testCase.expectedSearch)
+		if !ok {
+			t.Errorf("invalid parse result for search domains, expected: %v, got: %v", testCase.expectedSearch, search)
+		}
+
+		ok = compareLists(ns, testCase.expectedNS)
+		if !ok {
+			t.Errorf("invalid parse result for ns domains, expected: %v, got: %v", testCase.expectedNS, ns)
+		}
+
+		ok = compareLists(other, testCase.expectedOther)
+		if !ok {
+			t.Errorf("invalid parse result for others, expected: %v, got: %v", testCase.expectedOther, other)
+		}
+	}
+
+}
+
+func compareLists(search []string, search2 []string) bool {
+	if len(search) != len(search2) {
+		return false
+	}
+	for i, v := range search {
+		if v != search2[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/client/internal/dns/file_parser_linux_test.go
+++ b/client/internal/dns/file_parser_linux_test.go
@@ -54,7 +54,7 @@ search netbird.cloud
 	for _, testCase := range testCases {
 		t.Run("test", func(t *testing.T) {
 			t.Parallel()
-			tmpResolvConf := fmt.Sprintf("%s/%s", os.TempDir(), "resolv.conf")
+			tmpResolvConf := fmt.Sprintf("%s/%s", t.TempDir(), "resolv.conf")
 			err := os.WriteFile(tmpResolvConf, []byte(testCase.input), 0644)
 			if err != nil {
 				t.Fatal(err)

--- a/client/internal/dns/file_parser_linux_test.go
+++ b/client/internal/dns/file_parser_linux_test.go
@@ -49,6 +49,59 @@ search netbird.cloud
 			expectedNS:     []string{"192.168.2.1", "100.81.99.197"},
 			expectedOther:  []string{},
 		},
+		{
+			input: `# This is /run/systemd/resolve/resolv.conf managed by man:systemd-resolved(8).
+# Do not edit.
+#
+# This file might be symlinked as /etc/resolv.conf. If you're looking at
+# /etc/resolv.conf and seeing this text, you have followed the symlink.
+#
+# This is a dynamic resolv.conf file for connecting local clients directly to
+# all known uplink DNS servers. This file lists all configured search domains.
+#
+# Third party programs should typically not access this file directly, but only
+# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
+# different way, replace this symlink by a static file or a different symlink.
+#
+# See man:systemd-resolved.service(8) for details about the supported modes of
+# operation for /etc/resolv.conf.
+
+nameserver 192.168.2.1
+nameserver 100.81.99.197
+search netbird.cloud
+options debug
+`,
+			expectedSearch: []string{"netbird.cloud"},
+			expectedNS:     []string{"192.168.2.1", "100.81.99.197"},
+			expectedOther:  []string{"options debug"},
+		},
+		{
+			input: `# This is /run/systemd/resolve/resolv.conf managed by man:systemd-resolved(8).
+# Do not edit.
+#
+# This file might be symlinked as /etc/resolv.conf. If you're looking at
+# /etc/resolv.conf and seeing this text, you have followed the symlink.
+#
+# This is a dynamic resolv.conf file for connecting local clients directly to
+# all known uplink DNS servers. This file lists all configured search domains.
+#
+# Third party programs should typically not access this file directly, but only
+# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
+# different way, replace this symlink by a static file or a different symlink.
+#
+# See man:systemd-resolved.service(8) for details about the supported modes of
+# operation for /etc/resolv.conf.
+
+nameserver 192.168.2.1
+nameserver 100.81.99.197
+search netbird.cloud
+options debug
+options edns0 trust-ad
+`,
+			expectedSearch: []string{"netbird.cloud"},
+			expectedNS:     []string{"192.168.2.1", "100.81.99.197"},
+			expectedOther:  []string{"options debug", "options edns0 trust-ad"},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/client/internal/dns/file_parser_linux_test.go
+++ b/client/internal/dns/file_parser_linux_test.go
@@ -52,29 +52,32 @@ search netbird.cloud
 	}
 
 	for _, testCase := range testCases {
-		tmpResolvConf := fmt.Sprintf("%s/%s", os.TempDir(), "resolv.conf")
-		err := os.WriteFile(tmpResolvConf, []byte(testCase.input), 0644)
-		if err != nil {
-			t.Fatal(err)
-		}
-		cfg, err := parseResolvConfFile(tmpResolvConf)
-		if err != nil {
-			t.Fatal(err)
-		}
-		ok := compareLists(cfg.searchDomains, testCase.expectedSearch)
-		if !ok {
-			t.Errorf("invalid parse result for search domains, expected: %v, got: %v", testCase.expectedSearch, cfg.searchDomains)
-		}
+		t.Run("test", func(t *testing.T) {
+			t.Parallel()
+			tmpResolvConf := fmt.Sprintf("%s/%s", os.TempDir(), "resolv.conf")
+			err := os.WriteFile(tmpResolvConf, []byte(testCase.input), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := parseResolvConfFile(tmpResolvConf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ok := compareLists(cfg.searchDomains, testCase.expectedSearch)
+			if !ok {
+				t.Errorf("invalid parse result for search domains, expected: %v, got: %v", testCase.expectedSearch, cfg.searchDomains)
+			}
 
-		ok = compareLists(cfg.nameServers, testCase.expectedNS)
-		if !ok {
-			t.Errorf("invalid parse result for ns domains, expected: %v, got: %v", testCase.expectedNS, cfg.nameServers)
-		}
+			ok = compareLists(cfg.nameServers, testCase.expectedNS)
+			if !ok {
+				t.Errorf("invalid parse result for ns domains, expected: %v, got: %v", testCase.expectedNS, cfg.nameServers)
+			}
 
-		ok = compareLists(cfg.others, testCase.expectedOther)
-		if !ok {
-			t.Errorf("invalid parse result for others, expected: %v, got: %v", testCase.expectedOther, cfg.others)
-		}
+			ok = compareLists(cfg.others, testCase.expectedOther)
+			if !ok {
+				t.Errorf("invalid parse result for others, expected: %v, got: %v", testCase.expectedOther, cfg.others)
+			}
+		})
 	}
 
 }

--- a/client/internal/dns/file_parser_linux_test.go
+++ b/client/internal/dns/file_parser_linux_test.go
@@ -55,23 +55,23 @@ search netbird.cloud
 		if err != nil {
 			t.Fatal(err)
 		}
-		search, ns, other, err := parseResolvConf(tmpResolvConf)
+		cfg, err := parseResolvConfFile(tmpResolvConf)
 		if err != nil {
 			t.Fatal(err)
 		}
-		ok := compareLists(search, testCase.expectedSearch)
+		ok := compareLists(cfg.searchDomains, testCase.expectedSearch)
 		if !ok {
-			t.Errorf("invalid parse result for search domains, expected: %v, got: %v", testCase.expectedSearch, search)
+			t.Errorf("invalid parse result for search domains, expected: %v, got: %v", testCase.expectedSearch, cfg.searchDomains)
 		}
 
-		ok = compareLists(ns, testCase.expectedNS)
+		ok = compareLists(cfg.nameServers, testCase.expectedNS)
 		if !ok {
-			t.Errorf("invalid parse result for ns domains, expected: %v, got: %v", testCase.expectedNS, ns)
+			t.Errorf("invalid parse result for ns domains, expected: %v, got: %v", testCase.expectedNS, cfg.nameServers)
 		}
 
-		ok = compareLists(other, testCase.expectedOther)
+		ok = compareLists(cfg.others, testCase.expectedOther)
 		if !ok {
-			t.Errorf("invalid parse result for others, expected: %v, got: %v", testCase.expectedOther, other)
+			t.Errorf("invalid parse result for others, expected: %v, got: %v", testCase.expectedOther, cfg.others)
 		}
 	}
 

--- a/client/internal/dns/file_repair_linux.go
+++ b/client/internal/dns/file_repair_linux.go
@@ -1,3 +1,5 @@
+//go:build !android
+
 package dns
 
 import (

--- a/client/internal/dns/file_repair_linux.go
+++ b/client/internal/dns/file_repair_linux.go
@@ -73,7 +73,7 @@ func (f *repair) watchFileChanges(nbSearchDomains []string, nbNameserverIP strin
 				log.Tracef("resolv.conf still correct, skip the update")
 				continue
 			}
-			log.Info("broken params in resolv.conf, repair it...")
+			log.Info("broken params in resolv.conf, repairing it...")
 
 			err = f.inotify.Remove(f.watchDir)
 			if err != nil {
@@ -124,8 +124,8 @@ func (f *repair) isEventRelevant(event fsnotify.Event) bool {
 		return false
 	}
 
-	operatioFileSymlink := fmt.Sprintf("%s~", f.operationFile)
-	if event.Name == f.operationFile || event.Name == operatioFileSymlink {
+	operationFileSymlink := fmt.Sprintf("%s~", f.operationFile)
+	if event.Name == f.operationFile || event.Name == operationFileSymlink {
 		return true
 	}
 	return false

--- a/client/internal/dns/file_repair_linux.go
+++ b/client/internal/dns/file_repair_linux.go
@@ -130,7 +130,6 @@ func (f *repair) isEventRelevant(event fsnotify.Event) bool {
 		return false
 	}
 
-	//todo validate this
 	operatioFileSymlink := fmt.Sprintf("%s~", f.operationFile)
 	if event.Name == f.operationFile || event.Name == operatioFileSymlink {
 		return true

--- a/client/internal/dns/file_repair_linux.go
+++ b/client/internal/dns/file_repair_linux.go
@@ -1,0 +1,146 @@
+package dns
+
+import (
+	"errors"
+	"os"
+	"sync"
+
+	"github.com/illarion/gonotify"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	eventTypes = gonotify.IN_CREATE |
+		gonotify.IN_MODIFY |
+		gonotify.IN_MOVE |
+		gonotify.IN_CLOSE_WRITE |
+		gonotify.IN_DELETE
+
+	watchDir = "/etc"
+)
+
+type repairConfFn func([]string, string, *resolvConf) error
+
+type repair struct {
+	updateFn repairConfFn
+
+	inotify   *gonotify.Inotify
+	inotifyWg sync.WaitGroup
+}
+
+func newRepair(updateFn repairConfFn) *repair {
+	return &repair{
+		updateFn: updateFn,
+	}
+}
+
+func (f *repair) watchFileChanges(nbSearchDomains []string, nbNameserverIP string) {
+	if f.inotify != nil {
+		return
+	}
+
+	inotify, err := gonotify.NewInotify()
+	if err != nil {
+		log.Errorf("failed to start inotify watcher for resolv.conf: %s", err)
+		return
+	}
+	f.inotify = inotify
+
+	err = f.inotify.AddWatch(watchDir, eventTypes)
+	if err != nil {
+		log.Errorf("failed to add inotify watch for resolv.conf: %s", err)
+		return
+	}
+	f.inotifyWg.Add(1)
+	go func() {
+		defer f.inotifyWg.Done()
+		for {
+			events, err := f.inotify.Read()
+			if err != nil {
+				if errors.Is(err, os.ErrClosed) {
+					log.Infof("inotify closed")
+					return
+				}
+
+				log.Errorf("failed to read inotify %v", err)
+				return
+			}
+
+			if !isEventRelevant(events) {
+				continue
+			}
+
+			log.Debugf("resolv.conf changed, check if it is broken")
+
+			rConf, err := parseDefaultResolvConf()
+			if err != nil {
+				log.Warnf("failed to parse resolv conf: %s", err)
+				continue
+			}
+
+			log.Debugf("check resolv.conf parameters: %s", rConf)
+			if !isNbParamsMissing(nbSearchDomains, nbNameserverIP, rConf) {
+				log.Debugf("resolv.conf still correct, skip the update")
+				continue
+			}
+			log.Info("broken params in resolv.conf, repair it...")
+
+			err = f.inotify.RmWatch(watchDir)
+			if err != nil {
+				log.Errorf("failed to rm inotify watch for resolv.conf: %s", err)
+			}
+
+			err = f.updateFn(nbSearchDomains, nbNameserverIP, rConf)
+			if err != nil {
+				log.Errorf("failed to repair resolv.conf: %v", err)
+			}
+
+			err = f.inotify.AddWatch(watchDir, eventTypes)
+			if err != nil {
+				log.Errorf("failed to readd inotify watch for resolv.conf: %s", err)
+				return
+			}
+		}
+	}()
+	return
+}
+
+func (f *repair) stopWatchFileChanges() {
+	if f.inotify == nil {
+		return
+	}
+	err := f.inotify.Close()
+	if err != nil {
+		log.Warnf("failed to close resolv.conf inotify: %v", err)
+	}
+	f.inotifyWg.Wait()
+	f.inotify = nil
+}
+
+// nbParamsAreMissing checks if the resolv.conf file contains all the parameters that NetBird needs
+// check the NetBird related nameserver IP at the first place
+// check the NetBird related search domains in the search domains list
+func isNbParamsMissing(nbSearchDomains []string, nbNameserverIP string, rConf *resolvConf) bool {
+	if !isContains(nbSearchDomains, rConf.searchDomains) {
+		return true
+	}
+
+	if len(rConf.nameServers) == 0 {
+		return true
+	}
+
+	if rConf.nameServers[0] != nbNameserverIP {
+		return true
+	}
+
+	return false
+}
+
+func isEventRelevant(events []gonotify.InotifyEvent) bool {
+	for _, ev := range events {
+		if ev.Name == defaultResolvConfPath {
+			return true
+		}
+	}
+	return false
+}

--- a/client/internal/dns/file_repair_linux_test.go
+++ b/client/internal/dns/file_repair_linux_test.go
@@ -1,0 +1,127 @@
+//go:build !android
+
+package dns
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/netbirdio/netbird/util"
+)
+
+func TestMain(m *testing.M) {
+	util.InitLog("debug", "console")
+	code := m.Run()
+	os.Exit(code)
+}
+
+func Test_newRepairtmp(t *testing.T) {
+	type args struct {
+		resolvConfContent  string
+		touchedConfContent string
+		wantChange         bool
+	}
+	tests := []args{
+		{
+			resolvConfContent: `
+nameserver 10.0.0.1
+nameserver 8.8.8.8
+searchdomain netbird.cloud something`,
+
+			touchedConfContent: `
+nameserver 8.8.8.8
+searchdomain netbird.cloud something`,
+			wantChange: true,
+		},
+		{
+			resolvConfContent: `
+nameserver 10.0.0.1
+nameserver 8.8.8.8
+searchdomain netbird.cloud something`,
+
+			touchedConfContent: `
+nameserver 10.0.0.1
+nameserver 8.8.8.8
+searchdomain netbird.cloud something somethingelse`,
+			wantChange: false,
+		},
+		{
+			resolvConfContent: `
+nameserver 10.0.0.1
+nameserver 8.8.8.8
+searchdomain netbird.cloud something`,
+
+			touchedConfContent: `
+nameserver 10.0.0.1
+searchdomain netbird.cloud something`,
+			wantChange: false,
+		},
+		{
+			resolvConfContent: `
+nameserver 10.0.0.1
+nameserver 8.8.8.8
+searchdomain netbird.cloud something`,
+
+			touchedConfContent: `
+searchdomain something`,
+			wantChange: true,
+		},
+		{
+			resolvConfContent: `
+nameserver 10.0.0.1
+nameserver 8.8.8.8
+searchdomain netbird.cloud something`,
+
+			touchedConfContent: `
+nameserver 10.0.0.1`,
+			wantChange: true,
+		},
+		{
+			resolvConfContent: `
+nameserver 10.0.0.1
+nameserver 8.8.8.8
+searchdomain netbird.cloud something`,
+
+			touchedConfContent: `
+nameserver 8.8.8.8`,
+			wantChange: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run("test", func(t *testing.T) {
+			workDir := t.TempDir()
+			operationFile := workDir + "/resolv.conf"
+			err := os.WriteFile(operationFile, []byte(tt.resolvConfContent), 0755)
+			if err != nil {
+				t.Fatalf("failed to wrtie out resolv.conf: %s", err)
+			}
+
+			var changed bool
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			updateFn := func([]string, string, *resolvConf) error {
+				changed = true
+				cancel()
+				return nil
+			}
+
+			r := newRepair(operationFile, updateFn)
+			r.watchFileChanges([]string{"netbird.cloud"}, "10.0.0.1")
+
+			err = os.WriteFile(operationFile, []byte(tt.touchedConfContent), 0755)
+			if err != nil {
+				t.Fatalf("failed to wrtie out resolv.conf: %s", err)
+			}
+
+			<-ctx.Done()
+
+			r.stopWatchFileChanges()
+
+			if changed != tt.wantChange {
+				t.Errorf("unexpected result: want: %v, get: %v", tt.wantChange, changed)
+			}
+		})
+	}
+
+}

--- a/client/internal/dns/file_repair_linux_test.go
+++ b/client/internal/dns/file_repair_linux_test.go
@@ -98,7 +98,7 @@ nameserver 8.8.8.8`,
 			operationFile := workDir + "/resolv.conf"
 			err := os.WriteFile(operationFile, []byte(tt.resolvConfContent), 0755)
 			if err != nil {
-				t.Fatalf("failed to wrtie out resolv.conf: %s", err)
+				t.Fatalf("failed to write out resolv.conf: %s", err)
 			}
 
 			var changed bool
@@ -114,7 +114,7 @@ nameserver 8.8.8.8`,
 
 			err = os.WriteFile(operationFile, []byte(tt.touchedConfContent), 0755)
 			if err != nil {
-				t.Fatalf("failed to wrtie out resolv.conf: %s", err)
+				t.Fatalf("failed to write out resolv.conf: %s", err)
 			}
 
 			<-ctx.Done()
@@ -122,7 +122,7 @@ nameserver 8.8.8.8`,
 			r.stopWatchFileChanges()
 
 			if changed != tt.wantChange {
-				t.Errorf("unexpected result: want: %v, get: %v", tt.wantChange, changed)
+				t.Errorf("unexpected result: want: %v, got: %v", tt.wantChange, changed)
 			}
 		})
 	}

--- a/client/internal/dns/file_repair_linux_test.go
+++ b/client/internal/dns/file_repair_linux_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	util.InitLog("debug", "console")
+	_ = util.InitLog("debug", "console")
 	code := m.Run()
 	os.Exit(code)
 }
@@ -89,8 +89,10 @@ nameserver 8.8.8.8`,
 			wantChange: true,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
+			t.Parallel()
 			workDir := t.TempDir()
 			operationFile := workDir + "/resolv.conf"
 			err := os.WriteFile(operationFile, []byte(tt.resolvConfContent), 0755)

--- a/client/internal/dns/file_repair_linux_test.go
+++ b/client/internal/dns/file_repair_linux_test.go
@@ -91,6 +91,7 @@ nameserver 8.8.8.8`,
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run("test", func(t *testing.T) {
 			t.Parallel()
 			workDir := t.TempDir()

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -106,13 +106,13 @@ func getOSDNSManagerType() (osManagerType, error) {
 
 // checkStub checks if the stub resolver is disabled in systemd-resolved. If it is disabled, we fallback to file manager.
 func checkStub() bool {
-	_, nameServers, _, err := resolvConfEntries()
+	rConf, err := parseDefaultResolvConf()
 	if err != nil {
 		log.Warnf("failed to parse resolv conf: %s", err)
 		return true
 	}
 
-	for _, ns := range nameServers {
+	for _, ns := range rConf.nameServers {
 		if ns == "127.0.0.53" {
 			return true
 		}

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -104,7 +104,7 @@ func getOSDNSManagerType() (osManagerType, error) {
 	return fileManager, nil
 }
 
-// checkStub checks if the stub resolver is disabled in systemd-resolved. If it is disabled, we fallback to file manager.
+// checkStub checks if the stub resolver is disabled in systemd-resolved. If it is disabled, we fall back to file manager.
 func checkStub() bool {
 	rConf, err := parseDefaultResolvConf()
 	if err != nil {

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -12,10 +12,6 @@ import (
 )
 
 const (
-	defaultResolvConfPath = "/etc/resolv.conf"
-)
-
-const (
 	netbirdManager osManagerType = iota
 	fileManager
 	networkManager
@@ -85,7 +81,11 @@ func getOSDNSManagerType() (osManagerType, error) {
 			return networkManager, nil
 		}
 		if strings.Contains(text, "systemd-resolved") && isDbusListenerRunning(systemdResolvedDest, systemdDbusObjectNode) {
-			return systemdManager, nil
+			if checkStub() {
+				return systemdManager, nil
+			} else {
+				return fileManager, nil
+			}
 		}
 		if strings.Contains(text, "resolvconf") {
 			if isDbusListenerRunning(systemdResolvedDest, systemdDbusObjectNode) {
@@ -102,4 +102,21 @@ func getOSDNSManagerType() (osManagerType, error) {
 		}
 	}
 	return fileManager, nil
+}
+
+// checkStub checks if the stub resolver is disabled in systemd-resolved. If it is disabled, we fallback to file manager.
+func checkStub() bool {
+	_, nameServers, _, err := resolvConfEntries()
+	if err != nil {
+		log.Warnf("failed to parse resolv conf: %s", err)
+		return true
+	}
+
+	for _, ns := range nameServers {
+		if ns == "127.0.0.53" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -22,16 +22,16 @@ type resolvconf struct {
 
 // supported "openresolv" only
 func newResolvConfConfigurator(wgInterface WGIface) (hostManager, error) {
-	originalSearchDomains, nameServers, others, err := resolvConfEntries()
+	resolvConfEntries, err := parseDefaultResolvConf()
 	if err != nil {
 		log.Error(err)
 	}
 
 	return &resolvconf{
 		ifaceName:             wgInterface.Name(),
-		originalSearchDomains: originalSearchDomains,
-		originalNameServers:   nameServers,
-		othersConfigs:         others,
+		originalSearchDomains: resolvConfEntries.searchDomains,
+		originalNameServers:   resolvConfEntries.nameServers,
+		othersConfigs:         resolvConfEntries.others,
 	}, nil
 }
 

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -22,7 +22,7 @@ type resolvconf struct {
 
 // supported "openresolv" only
 func newResolvConfConfigurator(wgInterface WGIface) (hostManager, error) {
-	originalSearchDomains, nameServers, others, err := originalDNSConfigs("/etc/resolv.conf")
+	originalSearchDomains, nameServers, others, err := resolvConfEntries()
 	if err != nil {
 		log.Error(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/google/nftables v0.0.0-20220808154552-2eca00135732
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2
 	github.com/hashicorp/go-version v1.6.0
+	github.com/illarion/gonotify v1.0.1
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/magiconair/properties v1.8.5
 	github.com/mattn/go-sqlite3 v1.14.17

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/coreos/go-iptables v0.7.0
 	github.com/creack/pty v1.1.18
 	github.com/eko/gocache/v3 v3.1.1
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/getlantern/systray v1.2.1
 	github.com/gliderlabs/ssh v0.3.4
 	github.com/godbus/dbus/v5 v5.1.0
@@ -48,7 +49,6 @@ require (
 	github.com/google/nftables v0.0.0-20220808154552-2eca00135732
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2
 	github.com/hashicorp/go-version v1.6.0
-	github.com/illarion/gonotify v1.0.1
 	github.com/libp2p/go-netroute v0.2.0
 	github.com/magiconair/properties v1.8.5
 	github.com/mattn/go-sqlite3 v1.14.17
@@ -99,7 +99,6 @@ require (
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fredbi/uri v0.0.0-20181227131451-3dcfdacbaaf3 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/getlantern/context v0.0.0-20190109183933-c447772a6520 // indirect
 	github.com/getlantern/errors v0.0.0-20190325191628-abdb3e3e36f7 // indirect
 	github.com/getlantern/golog v0.0.0-20190830074920-4ef2e798c2d7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/illarion/gonotify v1.0.1 h1:F1d+0Fgbq/sDWjj/r66ekjDG+IDeecQKUFH4wNwsoio=
-github.com/illarion/gonotify v1.0.1/go.mod h1:zt5pmDofZpU1f8aqlK0+95eQhoEAn/d4G4B/FjVW4jE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackmordaunt/icns v0.0.0-20181231085925-4f16af745526/go.mod h1:UQkeMHVoNcyXYq9otUupF7/h/2tmHlhrS2zw7ZVvUqc=

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/illarion/gonotify v1.0.1 h1:F1d+0Fgbq/sDWjj/r66ekjDG+IDeecQKUFH4wNwsoio=
+github.com/illarion/gonotify v1.0.1/go.mod h1:zt5pmDofZpU1f8aqlK0+95eQhoEAn/d4G4B/FjVW4jE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackmordaunt/icns v0.0.0-20181231085925-4f16af745526/go.mod h1:UQkeMHVoNcyXYq9otUupF7/h/2tmHlhrS2zw7ZVvUqc=


### PR DESCRIPTION
## Describe your changes
In the case of disabled stub listeren the list of name servers is unordered. The solution is to configure the resolv.conf file directly instead of dbus API.
Because third-party services also can manipulate the DNS settings the agent watch the resolv.conf file and keep it up to date.

- apply file type DNS manager if in the name server list does not exist the 127.0.0.53 address
- watching the resolv.conf file with inotify service and overwrite all the time if the configuration has changed and it invalid
- fix resolv.conf generation algorithm

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
