### PR TITLE
Restore dns on unclean shutdown

### DIFF
--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -11,11 +11,12 @@ import (
 	"github.com/kardianos/service"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
 	"github.com/netbirdio/netbird/client/proto"
 	"github.com/netbirdio/netbird/client/server"
 	"github.com/netbirdio/netbird/util"
-	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
 )
 
 func (p *program) Start(svc service.Service) error {
@@ -109,7 +110,6 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		cmd.Printf("Netbird service is running")
 		return nil
 	},
 }

--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -88,7 +88,7 @@ func (f *fileConfigurator) applyDNSConfig(config HostDNSConfig) error {
 	log.Infof("created a NetBird managed %s file with the DNS settings. Added %d search domains. Search list: %s", defaultResolvConfPath, len(searchDomainList), searchDomainList)
 
 	// create another backup for unclean shutdown detection right after overwriting the original resolv.conf
-	if err := createUncleanShutdownBackup(fileDefaultResolvConfBackupLocation, fileManager); err != nil {
+	if err := createUncleanShutdownIndicator(fileDefaultResolvConfBackupLocation, fileManager); err != nil {
 		log.Errorf("failed to create unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -120,19 +120,19 @@ func (f *fileConfigurator) restore() error {
 		return fmt.Errorf("restoring %s from %s: %w", defaultResolvConfPath, fileDefaultResolvConfBackupLocation, err)
 	}
 
-	if err := removeUncleanShutdownBackup(); err != nil {
+	if err := removeUncleanShutdownIndicator(); err != nil {
 		log.Errorf("failed to remove unclean shutdown resolv.conf backup: %s", err)
 	}
 
 	return os.RemoveAll(fileDefaultResolvConfBackupLocation)
 }
 
-func (f *fileConfigurator) restoreUncleanShutdownBackup() error {
+func (f *fileConfigurator) restoreUncleanShutdownDNS() error {
 	if err := copyFile(fileUncleanShutdownResolvConfLocation, defaultResolvConfPath); err != nil {
 		return fmt.Errorf("restoring %s from %s: %w", defaultResolvConfPath, fileUncleanShutdownResolvConfLocation, err)
 	}
 
-	if err := removeUncleanShutdownBackup(); err != nil {
+	if err := removeUncleanShutdownIndicator(); err != nil {
 		log.Errorf("failed to remove unclean shutdown resolv.conf backup: %s", err)
 	}
 

--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -131,6 +131,11 @@ func (f *fileConfigurator) restoreUncleanShutdownBackup() error {
 	if err := copyFile(fileUncleanShutdownResolvConfLocation, defaultResolvConfPath); err != nil {
 		return fmt.Errorf("restoring %s from %s: %w", defaultResolvConfPath, fileUncleanShutdownResolvConfLocation, err)
 	}
+
+	if err := removeUncleanShutdownBackup(); err != nil {
+		log.Errorf("failed to remove unclean shutdown resolv.conf backup: %s", err)
+	}
+
 	return nil
 }
 

--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -96,7 +96,7 @@ func (f *fileConfigurator) updateConfig(nbSearchDomains []string, nbNameserverIP
 		if restoreErr != nil {
 			log.Errorf("attempt to restore default file failed with error: %s", err)
 		}
-		return fmt.Errorf("got an error creating resolver file %s. Error: %w", defaultResolvConfPath, err)
+		return fmt.Errorf("creating resolver file %s. Error: %w", defaultResolvConfPath, err)
 	}
 
 	log.Infof("created a NetBird managed %s file with the DNS settings. Added %d search domains. Search list: %s", defaultResolvConfPath, len(searchDomainList), searchDomainList)

--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -21,9 +21,6 @@ const (
 
 	fileDefaultResolvConfBackupLocation = defaultResolvConfPath + ".original.netbird"
 
-	fileUncleanShutdownResolvConfLocation  = "/var/lib/netbird/resolv.conf"
-	fileUncleanShutdownManagerTypeLocation = "/var/lib/netbird/manager-type"
-
 	fileMaxLineCharsLimit        = 256
 	fileMaxNumberOfSearchDomains = 6
 )

--- a/client/internal/dns/file_linux.go
+++ b/client/internal/dns/file_linux.go
@@ -143,7 +143,7 @@ func (f *fileConfigurator) restore() error {
 	return os.RemoveAll(fileDefaultResolvConfBackupLocation)
 }
 
-func (f *fileConfigurator) restoreUncleanShutdownDNS(storedDNSAddress netip.Addr) error {
+func (f *fileConfigurator) restoreUncleanShutdownDNS(storedDNSAddress *netip.Addr) error {
 	resolvConf, err := parseDefaultResolvConf()
 	if err != nil {
 		return fmt.Errorf("parse current resolv.conf: %w", err)

--- a/client/internal/dns/host.go
+++ b/client/internal/dns/host.go
@@ -11,7 +11,7 @@ type hostManager interface {
 	applyDNSConfig(config HostDNSConfig) error
 	restoreHostDNS() error
 	supportCustomPort() bool
-	restoreUncleanShutdownBackup() error
+	restoreUncleanShutdownDNS() error
 }
 
 type HostDNSConfig struct {
@@ -31,7 +31,7 @@ type mockHostConfigurator struct {
 	applyDNSConfigFunc               func(config HostDNSConfig) error
 	restoreHostDNSFunc               func() error
 	supportCustomPortFunc            func() bool
-	restoreUncleanShutdownBackupFunc func() error
+	restoreUncleanShutdownDNSFunc func() error
 }
 
 func (m *mockHostConfigurator) applyDNSConfig(config HostDNSConfig) error {
@@ -55,11 +55,11 @@ func (m *mockHostConfigurator) supportCustomPort() bool {
 	return false
 }
 
-func (m *mockHostConfigurator) restoreUncleanShutdownBackup() error {
-	if m.restoreUncleanShutdownBackupFunc != nil {
-		return m.restoreUncleanShutdownBackupFunc()
+func (m *mockHostConfigurator) restoreUncleanShutdownDNS() error {
+	if m.restoreUncleanShutdownDNSFunc != nil {
+		return m.restoreUncleanShutdownDNSFunc()
 	}
-	return fmt.Errorf("method restoreUncleanShutdownBackup is not implemented")
+	return fmt.Errorf("method restoreUncleanShutdownDNS is not implemented")
 }
 
 func newNoopHostMocker() hostManager {
@@ -67,7 +67,7 @@ func newNoopHostMocker() hostManager {
 		applyDNSConfigFunc:               func(config HostDNSConfig) error { return nil },
 		restoreHostDNSFunc:               func() error { return nil },
 		supportCustomPortFunc:            func() bool { return true },
-		restoreUncleanShutdownBackupFunc: func() error { return nil },
+		restoreUncleanShutdownDNSFunc: func() error { return nil },
 	}
 }
 

--- a/client/internal/dns/host.go
+++ b/client/internal/dns/host.go
@@ -11,6 +11,7 @@ type hostManager interface {
 	applyDNSConfig(config HostDNSConfig) error
 	restoreHostDNS() error
 	supportCustomPort() bool
+	restoreUncleanShutdownBackup() error
 }
 
 type HostDNSConfig struct {
@@ -27,9 +28,10 @@ type DomainConfig struct {
 }
 
 type mockHostConfigurator struct {
-	applyDNSConfigFunc    func(config HostDNSConfig) error
-	restoreHostDNSFunc    func() error
-	supportCustomPortFunc func() bool
+	applyDNSConfigFunc               func(config HostDNSConfig) error
+	restoreHostDNSFunc               func() error
+	supportCustomPortFunc            func() bool
+	restoreUncleanShutdownBackupFunc func() error
 }
 
 func (m *mockHostConfigurator) applyDNSConfig(config HostDNSConfig) error {
@@ -53,11 +55,19 @@ func (m *mockHostConfigurator) supportCustomPort() bool {
 	return false
 }
 
+func (m *mockHostConfigurator) restoreUncleanShutdownBackup() error {
+	if m.restoreUncleanShutdownBackupFunc != nil {
+		return m.restoreUncleanShutdownBackupFunc()
+	}
+	return fmt.Errorf("method restoreUncleanShutdownBackup is not implemented")
+}
+
 func newNoopHostMocker() hostManager {
 	return &mockHostConfigurator{
-		applyDNSConfigFunc:    func(config HostDNSConfig) error { return nil },
-		restoreHostDNSFunc:    func() error { return nil },
-		supportCustomPortFunc: func() bool { return true },
+		applyDNSConfigFunc:               func(config HostDNSConfig) error { return nil },
+		restoreHostDNSFunc:               func() error { return nil },
+		supportCustomPortFunc:            func() bool { return true },
+		restoreUncleanShutdownBackupFunc: func() error { return nil },
 	}
 }
 

--- a/client/internal/dns/host.go
+++ b/client/internal/dns/host.go
@@ -12,7 +12,7 @@ type hostManager interface {
 	applyDNSConfig(config HostDNSConfig) error
 	restoreHostDNS() error
 	supportCustomPort() bool
-	restoreUncleanShutdownDNS(storedDNSAddress netip.Addr) error
+	restoreUncleanShutdownDNS(storedDNSAddress *netip.Addr) error
 }
 
 type HostDNSConfig struct {
@@ -32,7 +32,7 @@ type mockHostConfigurator struct {
 	applyDNSConfigFunc            func(config HostDNSConfig) error
 	restoreHostDNSFunc            func() error
 	supportCustomPortFunc         func() bool
-	restoreUncleanShutdownDNSFunc func(netip.Addr) error
+	restoreUncleanShutdownDNSFunc func(*netip.Addr) error
 }
 
 func (m *mockHostConfigurator) applyDNSConfig(config HostDNSConfig) error {
@@ -56,7 +56,7 @@ func (m *mockHostConfigurator) supportCustomPort() bool {
 	return false
 }
 
-func (m *mockHostConfigurator) restoreUncleanShutdownDNS(storedDNSAddress netip.Addr) error {
+func (m *mockHostConfigurator) restoreUncleanShutdownDNS(storedDNSAddress *netip.Addr) error {
 	if m.restoreUncleanShutdownDNSFunc != nil {
 		return m.restoreUncleanShutdownDNSFunc(storedDNSAddress)
 	}
@@ -68,7 +68,7 @@ func newNoopHostMocker() hostManager {
 		applyDNSConfigFunc:            func(config HostDNSConfig) error { return nil },
 		restoreHostDNSFunc:            func() error { return nil },
 		supportCustomPortFunc:         func() bool { return true },
-		restoreUncleanShutdownDNSFunc: func(netip.Addr) error { return nil },
+		restoreUncleanShutdownDNSFunc: func(*netip.Addr) error { return nil },
 	}
 }
 

--- a/client/internal/dns/host.go
+++ b/client/internal/dns/host.go
@@ -28,9 +28,9 @@ type DomainConfig struct {
 }
 
 type mockHostConfigurator struct {
-	applyDNSConfigFunc               func(config HostDNSConfig) error
-	restoreHostDNSFunc               func() error
-	supportCustomPortFunc            func() bool
+	applyDNSConfigFunc            func(config HostDNSConfig) error
+	restoreHostDNSFunc            func() error
+	supportCustomPortFunc         func() bool
 	restoreUncleanShutdownDNSFunc func() error
 }
 
@@ -64,9 +64,9 @@ func (m *mockHostConfigurator) restoreUncleanShutdownDNS() error {
 
 func newNoopHostMocker() hostManager {
 	return &mockHostConfigurator{
-		applyDNSConfigFunc:               func(config HostDNSConfig) error { return nil },
-		restoreHostDNSFunc:               func() error { return nil },
-		supportCustomPortFunc:            func() bool { return true },
+		applyDNSConfigFunc:            func(config HostDNSConfig) error { return nil },
+		restoreHostDNSFunc:            func() error { return nil },
+		supportCustomPortFunc:         func() bool { return true },
 		restoreUncleanShutdownDNSFunc: func() error { return nil },
 	}
 }

--- a/client/internal/dns/host.go
+++ b/client/internal/dns/host.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"fmt"
+	"net/netip"
 	"strings"
 
 	nbdns "github.com/netbirdio/netbird/dns"
@@ -11,7 +12,7 @@ type hostManager interface {
 	applyDNSConfig(config HostDNSConfig) error
 	restoreHostDNS() error
 	supportCustomPort() bool
-	restoreUncleanShutdownDNS() error
+	restoreUncleanShutdownDNS(storedDNSAddress netip.Addr) error
 }
 
 type HostDNSConfig struct {
@@ -31,7 +32,7 @@ type mockHostConfigurator struct {
 	applyDNSConfigFunc            func(config HostDNSConfig) error
 	restoreHostDNSFunc            func() error
 	supportCustomPortFunc         func() bool
-	restoreUncleanShutdownDNSFunc func() error
+	restoreUncleanShutdownDNSFunc func(netip.Addr) error
 }
 
 func (m *mockHostConfigurator) applyDNSConfig(config HostDNSConfig) error {
@@ -55,9 +56,9 @@ func (m *mockHostConfigurator) supportCustomPort() bool {
 	return false
 }
 
-func (m *mockHostConfigurator) restoreUncleanShutdownDNS() error {
+func (m *mockHostConfigurator) restoreUncleanShutdownDNS(storedDNSAddress netip.Addr) error {
 	if m.restoreUncleanShutdownDNSFunc != nil {
-		return m.restoreUncleanShutdownDNSFunc()
+		return m.restoreUncleanShutdownDNSFunc(storedDNSAddress)
 	}
 	return fmt.Errorf("method restoreUncleanShutdownDNS is not implemented")
 }
@@ -67,7 +68,7 @@ func newNoopHostMocker() hostManager {
 		applyDNSConfigFunc:            func(config HostDNSConfig) error { return nil },
 		restoreHostDNSFunc:            func() error { return nil },
 		supportCustomPortFunc:         func() bool { return true },
-		restoreUncleanShutdownDNSFunc: func() error { return nil },
+		restoreUncleanShutdownDNSFunc: func(netip.Addr) error { return nil },
 	}
 }
 

--- a/client/internal/dns/host_android.go
+++ b/client/internal/dns/host_android.go
@@ -1,5 +1,7 @@
 package dns
 
+import "net/netip"
+
 type androidHostManager struct {
 }
 
@@ -19,10 +21,10 @@ func (a androidHostManager) supportCustomPort() bool {
 	return false
 }
 
-func (a androidHostManager) restoreUncleanShutdownDNS() error {
+func (a androidHostManager) restoreUncleanShutdownDNS(netip.Addr) error {
 	return nil
 }
 
-func CheckUncleanShutdown(_ string) error {
+func CheckUncleanShutdown(string) error {
 	return nil
 }

--- a/client/internal/dns/host_android.go
+++ b/client/internal/dns/host_android.go
@@ -5,7 +5,7 @@ import "net/netip"
 type androidHostManager struct {
 }
 
-func newHostManager(wgInterface WGIface) (hostManager, error) {
+func newHostManager() (hostManager, error) {
 	return &androidHostManager{}, nil
 }
 

--- a/client/internal/dns/host_android.go
+++ b/client/internal/dns/host_android.go
@@ -21,7 +21,7 @@ func (a androidHostManager) supportCustomPort() bool {
 	return false
 }
 
-func (a androidHostManager) restoreUncleanShutdownDNS(netip.Addr) error {
+func (a androidHostManager) restoreUncleanShutdownDNS(*netip.Addr) error {
 	return nil
 }
 

--- a/client/internal/dns/host_android.go
+++ b/client/internal/dns/host_android.go
@@ -18,3 +18,11 @@ func (a androidHostManager) restoreHostDNS() error {
 func (a androidHostManager) supportCustomPort() bool {
 	return false
 }
+
+func (a androidHostManager) restoreUncleanShutdownBackup() error {
+	return nil
+}
+
+func CheckUncleanShutdown(_ string) error {
+	return nil
+}

--- a/client/internal/dns/host_android.go
+++ b/client/internal/dns/host_android.go
@@ -19,7 +19,7 @@ func (a androidHostManager) supportCustomPort() bool {
 	return false
 }
 
-func (a androidHostManager) restoreUncleanShutdownBackup() error {
+func (a androidHostManager) restoreUncleanShutdownDNS() error {
 	return nil
 }
 

--- a/client/internal/dns/host_android.go
+++ b/client/internal/dns/host_android.go
@@ -24,7 +24,3 @@ func (a androidHostManager) supportCustomPort() bool {
 func (a androidHostManager) restoreUncleanShutdownDNS(*netip.Addr) error {
 	return nil
 }
-
-func CheckUncleanShutdown(string) error {
-	return nil
-}

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -5,14 +5,10 @@ package dns
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"net/netip"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -32,8 +28,6 @@ const (
 	scutilPath                          = "/usr/sbin/scutil"
 	searchSuffix                        = "Search"
 	matchSuffix                         = "Match"
-
-	fileUncleanShutdownFileLocation = "/var/lib/netbird/unclean_shutdown_dns"
 )
 
 type systemConfigurator struct {
@@ -301,48 +295,4 @@ func runSystemConfigCommand(command string) ([]byte, error) {
 		return nil, fmt.Errorf("running system configuration command: \"%s\", error: %w", command, err)
 	}
 	return out, nil
-}
-
-func CheckUncleanShutdown(string) error {
-	if _, err := os.Stat(fileUncleanShutdownFileLocation); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			// no file -> clean shutdown
-			return nil
-		} else {
-			return fmt.Errorf("state: %w", err)
-		}
-	}
-
-	log.Warnf("detected unclean shutdown, file %s exists. Restoring unclean shutdown dns settings.", fileUncleanShutdownFileLocation)
-
-	manager, err := newHostManager(nil)
-	if err != nil {
-		return fmt.Errorf("create host manager: %w", err)
-	}
-
-	if err := manager.restoreUncleanShutdownDNS(nil); err != nil {
-		return fmt.Errorf("restore unclean shutdown backup: %w", err)
-	}
-
-	return nil
-}
-
-func createUncleanShutdownIndicator() error {
-	dir := filepath.Dir(fileUncleanShutdownFileLocation)
-	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
-		return fmt.Errorf("create dir %s: %w", dir, err)
-	}
-
-	if err := os.WriteFile(fileUncleanShutdownFileLocation, nil, 0644); err != nil { //nolint:gosec
-		return fmt.Errorf("create %s: %w", fileUncleanShutdownFileLocation, err)
-	}
-
-	return nil
-}
-
-func removeUncleanShutdownIndicator() error {
-	if err := os.Remove(fileUncleanShutdownFileLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("remove %s: %w", fileUncleanShutdownFileLocation, err)
-	}
-	return nil
 }

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -50,12 +51,12 @@ func (s *systemConfigurator) applyDNSConfig(config HostDNSConfig) error {
 	if config.RouteAll {
 		err = s.addDNSSetupForAll(config.ServerIP, config.ServerPort)
 		if err != nil {
-			return err
+			return fmt.Errorf("add dns setup for all: %w", err)
 		}
 	} else if s.primaryServiceID != "" {
 		err = s.removeKeyFromSystemConfig(getKeyWithInput(primaryServiceSetupKeyFormat, s.primaryServiceID))
 		if err != nil {
-			return err
+			return fmt.Errorf("remote key from system config: %w", err)
 		}
 		s.primaryServiceID = ""
 		log.Infof("removed %s:%d as main DNS resolver for this peer", config.ServerIP, config.ServerPort)
@@ -85,7 +86,7 @@ func (s *systemConfigurator) applyDNSConfig(config HostDNSConfig) error {
 		err = s.removeKeyFromSystemConfig(matchKey)
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("add match domains: %w", err)
 	}
 
 	searchKey := getKeyWithInput(netbirdDNSStateKeyFormat, searchSuffix)
@@ -96,7 +97,7 @@ func (s *systemConfigurator) applyDNSConfig(config HostDNSConfig) error {
 		err = s.removeKeyFromSystemConfig(searchKey)
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("add search domains: %w", err)
 	}
 
 	return nil
@@ -119,7 +120,7 @@ func (s *systemConfigurator) restoreHostDNS() error {
 	_, err := runSystemConfigCommand(wrapCommand(lines))
 	if err != nil {
 		log.Errorf("got an error while cleaning the system configuration: %s", err)
-		return err
+		return fmt.Errorf("clean system: %w", err)
 	}
 
 	return nil
@@ -129,7 +130,7 @@ func (s *systemConfigurator) removeKeyFromSystemConfig(key string) error {
 	line := buildRemoveKeyOperation(key)
 	_, err := runSystemConfigCommand(wrapCommand(line))
 	if err != nil {
-		return err
+		return fmt.Errorf("remove key: %w", err)
 	}
 
 	delete(s.createdKeys, key)
@@ -140,7 +141,7 @@ func (s *systemConfigurator) removeKeyFromSystemConfig(key string) error {
 func (s *systemConfigurator) addSearchDomains(key, domains string, ip string, port int) error {
 	err := s.addDNSState(key, domains, ip, port, true)
 	if err != nil {
-		return err
+		return fmt.Errorf("add dns state: %w", err)
 	}
 
 	log.Infof("added %d search domains to the state. Domain list: %s", len(strings.Split(domains, " ")), domains)
@@ -153,7 +154,7 @@ func (s *systemConfigurator) addSearchDomains(key, domains string, ip string, po
 func (s *systemConfigurator) addMatchDomains(key, domains, dnsServer string, port int) error {
 	err := s.addDNSState(key, domains, dnsServer, port, false)
 	if err != nil {
-		return err
+		return fmt.Errorf("add dns state: %w", err)
 	}
 
 	log.Infof("added %d match domains to the state. Domain list: %s", len(strings.Split(domains, " ")), domains)
@@ -178,33 +179,37 @@ func (s *systemConfigurator) addDNSState(state, domains, dnsServer string, port 
 
 	_, err := runSystemConfigCommand(stdinCommands)
 	if err != nil {
-		return fmt.Errorf("got error while applying state for domains %s, error: %s", domains, err)
+		return fmt.Errorf("applying state for domains %s, error: %w", domains, err)
 	}
 	return nil
 }
 
 func (s *systemConfigurator) addDNSSetupForAll(dnsServer string, port int) error {
-	primaryServiceKey, existingNameserver := s.getPrimaryService()
-	if primaryServiceKey == "" {
-		return fmt.Errorf("couldn't find the primary service key")
+	primaryServiceKey, existingNameserver, err := s.getPrimaryService()
+	if err != nil || primaryServiceKey == "" {
+		return fmt.Errorf("couldn't find the primary service key: %w", err)
 	}
-	err := s.addDNSSetup(getKeyWithInput(primaryServiceSetupKeyFormat, primaryServiceKey), dnsServer, port, existingNameserver)
+
+	err = s.addDNSSetup(getKeyWithInput(primaryServiceSetupKeyFormat, primaryServiceKey), dnsServer, port, existingNameserver)
 	if err != nil {
-		return err
+		return fmt.Errorf("add dns setup: %w", err)
 	}
+
 	log.Infof("configured %s:%d as main DNS resolver for this peer", dnsServer, port)
 	s.primaryServiceID = primaryServiceKey
+
 	return nil
 }
 
-func (s *systemConfigurator) getPrimaryService() (string, string) {
+func (s *systemConfigurator) getPrimaryService() (string, string, error) {
 	line := buildCommandLine("show", globalIPv4State, "")
 	stdinCommands := wrapCommand(line)
+
 	b, err := runSystemConfigCommand(stdinCommands)
 	if err != nil {
-		log.Error("got error while sending the command: ", err)
-		return "", ""
+		return "", "", fmt.Errorf("sending the command: %w", err)
 	}
+
 	scanner := bufio.NewScanner(bytes.NewReader(b))
 	primaryService := ""
 	router := ""
@@ -217,7 +222,11 @@ func (s *systemConfigurator) getPrimaryService() (string, string) {
 			router = strings.TrimSpace(strings.Split(text, ":")[1])
 		}
 	}
-	return primaryService, router
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return primaryService, router, fmt.Errorf("scan: %w", err)
+	}
+
+	return primaryService, router, nil
 }
 
 func (s *systemConfigurator) addDNSSetup(setupKey, dnsServer string, port int, existingDNSServer string) error {
@@ -228,7 +237,7 @@ func (s *systemConfigurator) addDNSSetup(setupKey, dnsServer string, port int, e
 	stdinCommands := wrapCommand(addDomainCommand)
 	_, err := runSystemConfigCommand(stdinCommands)
 	if err != nil {
-		return fmt.Errorf("got error while applying dns setup, error: %s", err)
+		return fmt.Errorf("applying dns setup, error: %w", err)
 	}
 	return nil
 }
@@ -266,7 +275,7 @@ func runSystemConfigCommand(command string) ([]byte, error) {
 	cmd.Stdin = strings.NewReader(command)
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("got error while running system configuration command: \"%s\", error: %s", command, err)
+		return nil, fmt.Errorf("running system configuration command: \"%s\", error: %w", command, err)
 	}
 	return out, nil
 }

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -332,7 +332,7 @@ func createUncleanShutdownIndicator() error {
 		return fmt.Errorf("create dir %s: %w", dir, err)
 	}
 
-	if err := os.WriteFile(fileUncleanShutdownFileLocation, nil, 0644); err != nil {
+	if err := os.WriteFile(fileUncleanShutdownFileLocation, nil, 0644); err != nil { //nolint:gosec
 		return fmt.Errorf("create %s: %w", fileUncleanShutdownFileLocation, err)
 	}
 

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -36,7 +36,7 @@ type systemConfigurator struct {
 	createdKeys      map[string]struct{}
 }
 
-func newHostManager(_ WGIface) (hostManager, error) {
+func newHostManager() (hostManager, error) {
 	return &systemConfigurator{
 		createdKeys: make(map[string]struct{}),
 	}, nil

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -258,7 +258,7 @@ func (s *systemConfigurator) addDNSSetup(setupKey, dnsServer string, port int, e
 	return nil
 }
 
-func (s *systemConfigurator) restoreUncleanShutdownDNS(netip.Addr) error {
+func (s *systemConfigurator) restoreUncleanShutdownDNS(*netip.Addr) error {
 	if err := s.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via scutil: %w", err)
 	}

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -303,7 +303,7 @@ func runSystemConfigCommand(command string) ([]byte, error) {
 	return out, nil
 }
 
-func CheckUncleanShutdown(_ string) error {
+func CheckUncleanShutdown(string) error {
 	if _, err := os.Stat(fileUncleanShutdownFileLocation); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			// no file -> clean shutdown

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -270,3 +270,11 @@ func runSystemConfigCommand(command string) ([]byte, error) {
 	}
 	return out, nil
 }
+
+func (s *systemConfigurator) restoreUncleanShutdownBackup() error {
+	return nil
+}
+
+func CheckUncleanShutdown(wgIface string) error {
+	return nil
+}

--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -69,7 +69,7 @@ func (s *systemConfigurator) applyDNSConfig(config HostDNSConfig) error {
 	}
 
 	// create a file for unclean shutdown detection
-	if err := createUncleanShutdownBackup(); err != nil {
+	if err := createUncleanShutdownIndicator(); err != nil {
 		log.Errorf("failed to create unclean shutdown file: %s", err)
 	}
 
@@ -134,7 +134,7 @@ func (s *systemConfigurator) restoreHostDNS() error {
 		return fmt.Errorf("clean system: %w", err)
 	}
 
-	if err := removeUncleanShutdownBackup(); err != nil {
+	if err := removeUncleanShutdownIndicator(); err != nil {
 		log.Errorf("failed to remove unclean shutdown file: %s", err)
 	}
 
@@ -295,7 +295,7 @@ func runSystemConfigCommand(command string) ([]byte, error) {
 	return out, nil
 }
 
-func (s *systemConfigurator) restoreUncleanShutdownBackup() error {
+func (s *systemConfigurator) restoreUncleanShutdownDNS() error {
 	if err := s.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via scutil: %w", err)
 	}
@@ -319,14 +319,14 @@ func CheckUncleanShutdown(_ string) error {
 		return fmt.Errorf("create host manager: %w", err)
 	}
 
-	if err := manager.restoreUncleanShutdownBackup(); err != nil {
+	if err := manager.restoreUncleanShutdownDNS(); err != nil {
 		return fmt.Errorf("restore unclean shutdown backup: %w", err)
 	}
 
 	return nil
 }
 
-func createUncleanShutdownBackup() error {
+func createUncleanShutdownIndicator() error {
 	dir := filepath.Dir(fileUncleanShutdownFileLocation)
 	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 		return fmt.Errorf("create dir %s: %w", dir, err)
@@ -339,7 +339,7 @@ func createUncleanShutdownBackup() error {
 	return nil
 }
 
-func removeUncleanShutdownBackup() error {
+func removeUncleanShutdownIndicator() error {
 	if err := os.Remove(fileUncleanShutdownFileLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove %s: %w", fileUncleanShutdownFileLocation, err)
 	}

--- a/client/internal/dns/host_ios.go
+++ b/client/internal/dns/host_ios.go
@@ -37,7 +37,7 @@ func (a iosHostManager) supportCustomPort() bool {
 	return false
 }
 
-func (a iosHostManager) restoreUncleanShutdownBackup() error {
+func (a iosHostManager) restoreUncleanShutdownDNS() error {
 	return nil
 }
 

--- a/client/internal/dns/host_ios.go
+++ b/client/internal/dns/host_ios.go
@@ -38,7 +38,7 @@ func (a iosHostManager) supportCustomPort() bool {
 	return false
 }
 
-func (a iosHostManager) restoreUncleanShutdownDNS(netip.Addr) error {
+func (a iosHostManager) restoreUncleanShutdownDNS(*netip.Addr) error {
 	return nil
 }
 

--- a/client/internal/dns/host_ios.go
+++ b/client/internal/dns/host_ios.go
@@ -35,3 +35,11 @@ func (a iosHostManager) restoreHostDNS() error {
 func (a iosHostManager) supportCustomPort() bool {
 	return false
 }
+
+func (a iosHostManager) restoreUncleanShutdownBackup() error {
+	return nil
+}
+
+func CheckUncleanShutdown(_ string) error {
+	return nil
+}

--- a/client/internal/dns/host_ios.go
+++ b/client/internal/dns/host_ios.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"encoding/json"
 	"fmt"
+	"net/netip"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -37,10 +38,10 @@ func (a iosHostManager) supportCustomPort() bool {
 	return false
 }
 
-func (a iosHostManager) restoreUncleanShutdownDNS() error {
+func (a iosHostManager) restoreUncleanShutdownDNS(netip.Addr) error {
 	return nil
 }
 
-func CheckUncleanShutdown(_ string) error {
+func CheckUncleanShutdown(string) error {
 	return nil
 }

--- a/client/internal/dns/host_ios.go
+++ b/client/internal/dns/host_ios.go
@@ -41,7 +41,3 @@ func (a iosHostManager) supportCustomPort() bool {
 func (a iosHostManager) restoreUncleanShutdownDNS(*netip.Addr) error {
 	return nil
 }
-
-func CheckUncleanShutdown(string) error {
-	return nil
-}

--- a/client/internal/dns/host_ios.go
+++ b/client/internal/dns/host_ios.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"encoding/json"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -20,7 +21,7 @@ func newHostManager(dnsManager IosDnsManager) (hostManager, error) {
 func (a iosHostManager) applyDNSConfig(config HostDNSConfig) error {
 	jsonData, err := json.Marshal(config)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal: %w", err)
 	}
 	jsonString := string(jsonData)
 	log.Debugf("Applying DNS settings: %s", jsonString)

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -135,7 +135,7 @@ func getOSDNSManagerType() (osManagerType, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil && err != io.EOF {
-		fmt.Errorf("scan: %w", err)
+		return 0, fmt.Errorf("scan: %w", err)
 	}
 
 	return fileManager, nil

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -184,7 +184,7 @@ func CheckUncleanShutdown(wgIface string) error {
 		return fmt.Errorf("restore unclean shutdown backup: %w", err)
 	}
 
-	return removeUncleanShutdownBackup()
+	return nil
 }
 
 func createUncleanShutdownBackup(sourcePath string, managerType osManagerType) error {

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -59,7 +59,7 @@ func (t osManagerType) String() string {
 	}
 }
 
-func newHostManager(wgInterface WGIface) (hostManager, error) {
+func newHostManager(wgInterface string) (hostManager, error) {
 	osManager, err := getOSDNSManagerType()
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func newHostManager(wgInterface WGIface) (hostManager, error) {
 	return newHostManagerFromType(wgInterface, osManager)
 }
 
-func newHostManagerFromType(wgInterface WGIface, osManager osManagerType) (hostManager, error) {
+func newHostManagerFromType(wgInterface string, osManager osManagerType) (hostManager, error) {
 	switch osManager {
 	case networkManager:
 		return newNetworkManagerDbusConfigurator(wgInterface)

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -211,7 +211,7 @@ func CheckUncleanShutdown(wgIface string) error {
 		return fmt.Errorf("create previous host manager: %w", err)
 	}
 
-	if err := manager.restoreUncleanShutdownDNS(dnsAddress); err != nil {
+	if err := manager.restoreUncleanShutdownDNS(&dnsAddress); err != nil {
 		return fmt.Errorf("restore unclean shutdown backup: %w", err)
 	}
 

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -133,7 +134,9 @@ func getOSDNSManagerType() (osManagerType, error) {
 			return resolvConfManager, nil
 		}
 	}
-	// TODO: check err
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		fmt.Errorf("scan: %w", err)
+	}
 
 	return fileManager, nil
 }

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -97,7 +97,7 @@ func newHostManagerFromType(wgInterface WGIface, osManager osManagerType) (hostM
 func getOSDNSManagerType() (osManagerType, error) {
 	file, err := os.Open(defaultResolvConfPath)
 	if err != nil {
-		return 0, fmt.Errorf("unable to open %s for checking owner, got error: %s", defaultResolvConfPath, err)
+		return 0, fmt.Errorf("unable to open %s for checking owner, got error: %w", defaultResolvConfPath, err)
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
@@ -205,10 +205,10 @@ func createUncleanShutdownBackup(sourcePath string, managerType osManagerType) e
 
 func removeUncleanShutdownBackup() error {
 	if err := os.Remove(fileUncleanShutdownResolvConfLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("remove %s: %s", fileUncleanShutdownResolvConfLocation, err)
+		return fmt.Errorf("remove %s: %w", fileUncleanShutdownResolvConfLocation, err)
 	}
 	if err := os.Remove(fileUncleanShutdownManagerTypeLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("remove %s: %s", fileUncleanShutdownManagerTypeLocation, err)
+		return fmt.Errorf("remove %s: %w", fileUncleanShutdownManagerTypeLocation, err)
 	}
 	return nil
 }

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -7,21 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
-	"net/netip"
 	"os"
-	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/netbirdio/netbird/client/internal/stdnet"
-	"github.com/netbirdio/netbird/iface"
-)
-
-const (
-	fileUncleanShutdownResolvConfLocation  = "/var/lib/netbird/resolv.conf"
-	fileUncleanShutdownManagerTypeLocation = "/var/lib/netbird/manager"
 )
 
 const (
@@ -162,86 +151,4 @@ func checkStub() bool {
 	}
 
 	return false
-}
-
-func CheckUncleanShutdown(wgIface string) error {
-	if _, err := os.Stat(fileUncleanShutdownResolvConfLocation); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			// no file -> clean shutdown
-			return nil
-		} else {
-			return fmt.Errorf("state: %w", err)
-		}
-	}
-
-	log.Warnf("detected unclean shutdown, file %s exists", fileUncleanShutdownResolvConfLocation)
-
-	managerData, err := os.ReadFile(fileUncleanShutdownManagerTypeLocation)
-	if err != nil {
-		return fmt.Errorf("read %s: %w", fileUncleanShutdownManagerTypeLocation, err)
-	}
-
-	managerFields := strings.Split(string(managerData), ",")
-	if len(managerFields) < 2 {
-		return errors.New("split manager data: insufficient number of fields")
-	}
-	osManagerTypeStr, dnsAddressStr := managerFields[0], managerFields[1]
-
-	dnsAddress, err := netip.ParseAddr(dnsAddressStr)
-	if err != nil {
-		return fmt.Errorf("parse dns address %s failed: %w", dnsAddressStr, err)
-	}
-
-	log.Warnf("restoring unclean shutdown dns settings via previously detected manager: %s", osManagerTypeStr)
-
-	// determine os manager type, so we can invoke the respective restore action
-	osManagerType, err := newOsManagerType(osManagerTypeStr)
-	if err != nil {
-		return fmt.Errorf("detect previous host manager: %w", err)
-	}
-
-	// the only real thing we need is the interface name
-	dummyInt, err := iface.NewWGIFace(wgIface, "0.0.0.0/32", 0, "", iface.DefaultMTU, &stdnet.Net{}, nil)
-	if err != nil {
-		return fmt.Errorf("create dummy int: %w", err)
-	}
-
-	manager, err := newHostManagerFromType(dummyInt, osManagerType)
-	if err != nil {
-		return fmt.Errorf("create previous host manager: %w", err)
-	}
-
-	if err := manager.restoreUncleanShutdownDNS(&dnsAddress); err != nil {
-		return fmt.Errorf("restore unclean shutdown backup: %w", err)
-	}
-
-	return nil
-}
-
-func createUncleanShutdownIndicator(sourcePath string, managerType osManagerType, dnsAddress string) error {
-	dir := filepath.Dir(fileUncleanShutdownResolvConfLocation)
-	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
-		return fmt.Errorf("create dir %s: %w", dir, err)
-	}
-
-	if err := copyFile(sourcePath, fileUncleanShutdownResolvConfLocation); err != nil {
-		return fmt.Errorf("create %s: %w", sourcePath, err)
-	}
-
-	managerData := fmt.Sprintf("%s,%s", managerType, dnsAddress)
-
-	if err := os.WriteFile(fileUncleanShutdownManagerTypeLocation, []byte(managerData), 0644); err != nil { //nolint:gosec
-		return fmt.Errorf("create %s: %w", fileUncleanShutdownManagerTypeLocation, err)
-	}
-	return nil
-}
-
-func removeUncleanShutdownIndicator() error {
-	if err := os.Remove(fileUncleanShutdownResolvConfLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("remove %s: %w", fileUncleanShutdownResolvConfLocation, err)
-	}
-	if err := os.Remove(fileUncleanShutdownManagerTypeLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("remove %s: %w", fileUncleanShutdownManagerTypeLocation, err)
-	}
-	return nil
 }

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -95,7 +95,11 @@ func getOSDNSManagerType() (osManagerType, error) {
 	if err != nil {
 		return 0, fmt.Errorf("unable to open %s for checking owner, got error: %s", defaultResolvConfPath, err)
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Errorf("close file %s: %s", defaultResolvConfPath, err)
+		}
+	}()
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +21,7 @@ import (
 
 const (
 	fileUncleanShutdownResolvConfLocation  = "/var/lib/netbird/resolv.conf"
-	fileUncleanShutdownManagerTypeLocation = "/var/lib/netbird/manager-type"
+	fileUncleanShutdownManagerTypeLocation = "/var/lib/netbird/manager"
 )
 
 const (
@@ -175,15 +176,26 @@ func CheckUncleanShutdown(wgIface string) error {
 
 	log.Warnf("detected unclean shutdown, file %s exists", fileUncleanShutdownResolvConfLocation)
 
-	osManagerTypeStr, err := os.ReadFile(fileUncleanShutdownManagerTypeLocation)
+	managerData, err := os.ReadFile(fileUncleanShutdownManagerTypeLocation)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", fileUncleanShutdownManagerTypeLocation, err)
+	}
+
+	managerFields := strings.Split(string(managerData), ",")
+	if len(managerFields) < 2 {
+		return errors.New("split manager data: insufficient number of fields")
+	}
+	osManagerTypeStr, dnsAddressStr := managerFields[0], managerFields[1]
+
+	dnsAddress, err := netip.ParseAddr(dnsAddressStr)
+	if err != nil {
+		return fmt.Errorf("parse dns address %s failed: %w", dnsAddressStr, err)
 	}
 
 	log.Warnf("restoring unclean shutdown dns settings via previously detected manager: %s", osManagerTypeStr)
 
 	// determine os manager type, so we can invoke the respective restore action
-	osManagerType, err := newOsManagerType(string(osManagerTypeStr))
+	osManagerType, err := newOsManagerType(osManagerTypeStr)
 	if err != nil {
 		return fmt.Errorf("detect previous host manager: %w", err)
 	}
@@ -199,14 +211,14 @@ func CheckUncleanShutdown(wgIface string) error {
 		return fmt.Errorf("create previous host manager: %w", err)
 	}
 
-	if err := manager.restoreUncleanShutdownDNS(); err != nil {
+	if err := manager.restoreUncleanShutdownDNS(dnsAddress); err != nil {
 		return fmt.Errorf("restore unclean shutdown backup: %w", err)
 	}
 
 	return nil
 }
 
-func createUncleanShutdownIndicator(sourcePath string, managerType osManagerType) error {
+func createUncleanShutdownIndicator(sourcePath string, managerType osManagerType, dnsAddress string) error {
 	dir := filepath.Dir(fileUncleanShutdownResolvConfLocation)
 	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 		return fmt.Errorf("create dir %s: %w", dir, err)
@@ -216,7 +228,9 @@ func createUncleanShutdownIndicator(sourcePath string, managerType osManagerType
 		return fmt.Errorf("create %s: %w", sourcePath, err)
 	}
 
-	if err := os.WriteFile(fileUncleanShutdownManagerTypeLocation, []byte(managerType.String()), 0644); err != nil { //nolint:gosec
+	managerData := fmt.Sprintf("%s,%s", managerType, dnsAddress)
+
+	if err := os.WriteFile(fileUncleanShutdownManagerTypeLocation, []byte(managerData), 0644); err != nil { //nolint:gosec
 		return fmt.Errorf("create %s: %w", fileUncleanShutdownManagerTypeLocation, err)
 	}
 	return nil

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -180,14 +180,14 @@ func CheckUncleanShutdown(wgIface string) error {
 		return fmt.Errorf("create previous host manager: %w", err)
 	}
 
-	if err := manager.restoreUncleanShutdownBackup(); err != nil {
+	if err := manager.restoreUncleanShutdownDNS(); err != nil {
 		return fmt.Errorf("restore unclean shutdown backup: %w", err)
 	}
 
 	return nil
 }
 
-func createUncleanShutdownBackup(sourcePath string, managerType osManagerType) error {
+func createUncleanShutdownIndicator(sourcePath string, managerType osManagerType) error {
 	dir := filepath.Dir(fileUncleanShutdownResolvConfLocation)
 	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 		return fmt.Errorf("create dir %s: %w", dir, err)
@@ -203,7 +203,7 @@ func createUncleanShutdownBackup(sourcePath string, managerType osManagerType) e
 	return nil
 }
 
-func removeUncleanShutdownBackup() error {
+func removeUncleanShutdownIndicator() error {
 	if err := os.Remove(fileUncleanShutdownResolvConfLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove %s: %w", fileUncleanShutdownResolvConfLocation, err)
 	}

--- a/client/internal/dns/host_linux.go
+++ b/client/internal/dns/host_linux.go
@@ -20,6 +20,9 @@ import (
 
 const (
 	defaultResolvConfPath = "/etc/resolv.conf"
+
+	fileUncleanShutdownResolvConfLocation  = "/var/lib/netbird/resolv.conf"
+	fileUncleanShutdownManagerTypeLocation = "/var/lib/netbird/manager-type"
 )
 
 const (
@@ -166,6 +169,7 @@ func CheckUncleanShutdown(wgIface string) error {
 		return fmt.Errorf("detect previous host manager: %w", err)
 	}
 
+	// the only real thing we need is the interface name
 	dummyInt, err := iface.NewWGIFace(wgIface, "0.0.0.0/32", 0, "", iface.DefaultMTU, &stdnet.Net{}, nil)
 	if err != nil {
 		return fmt.Errorf("create dummy int: %w", err)

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -62,12 +62,12 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig) error {
 	if config.RouteAll {
 		err = r.addDNSSetupForAll(config.ServerIP)
 		if err != nil {
-			return err
+			return fmt.Errorf("add dns setup: %w", err)
 		}
 	} else if r.routingAll {
 		err = r.deleteInterfaceRegistryKeyProperty(interfaceConfigNameServerKey)
 		if err != nil {
-			return err
+			return fmt.Errorf("delete interface registry key property: %w", err)
 		}
 		r.routingAll = false
 		log.Infof("removed %s as main DNS forwarder for this peer", config.ServerIP)
@@ -94,12 +94,12 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig) error {
 		err = removeRegistryKeyFromDNSPolicyConfig(dnsPolicyConfigMatchPath)
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("add dns match policy: %w", err)
 	}
 
 	err = r.updateSearchDomains(searchDomains)
 	if err != nil {
-		return err
+		return fmt.Errorf("update search domains: %w", err)
 	}
 
 	// create a file for unclean shutdown detection
@@ -189,7 +189,7 @@ func (r *registryConfigurator) updateSearchDomains(domains []string) error {
 func (r *registryConfigurator) setInterfaceRegistryKeyStringValue(key, value string) error {
 	regKey, err := r.getInterfaceRegistryKey()
 	if err != nil {
-		return err
+		return fmt.Errorf("get interface registry key: %w", err)
 	}
 	defer close(regKey)
 
@@ -204,7 +204,7 @@ func (r *registryConfigurator) setInterfaceRegistryKeyStringValue(key, value str
 func (r *registryConfigurator) deleteInterfaceRegistryKeyProperty(propertyKey string) error {
 	regKey, err := r.getInterfaceRegistryKey()
 	if err != nil {
-		return err
+		return fmt.Errorf("get interface registry key: %w", err)
 	}
 	defer close(regKey)
 

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -39,7 +39,7 @@ func newHostManager(wgInterface WGIface) (hostManager, error) {
 	}, nil
 }
 
-func (s *registryConfigurator) supportCustomPort() bool {
+func (r *registryConfigurator) supportCustomPort() bool {
 	return false
 }
 
@@ -203,6 +203,10 @@ func (r *registryConfigurator) getInterfaceRegistryKey() (registry.Key, error) {
 	return regKey, nil
 }
 
+func (r *registryConfigurator) restoreUncleanShutdownBackup() error {
+	return nil
+}
+
 func removeRegistryKeyFromDNSPolicyConfig(regKeyPath string) error {
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, regKeyPath, registry.QUERY_VALUE)
 	if err == nil {
@@ -212,5 +216,9 @@ func removeRegistryKeyFromDNSPolicyConfig(regKeyPath string) error {
 			return fmt.Errorf("unable to remove existing key from registry, key: HKEY_LOCAL_MACHINE\\%s, error: %s", regKeyPath, err)
 		}
 	}
+	return nil
+}
+
+func CheckUncleanShutdown(wgIface string) error {
 	return nil
 }

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -249,7 +249,7 @@ func removeRegistryKeyFromDNSPolicyConfig(regKeyPath string) error {
 	return nil
 }
 
-func CheckUncleanShutdown(_ string) error {
+func CheckUncleanShutdown(string) error {
 	file := getUncleanShutdownFile()
 
 	if _, err := os.Stat(file); err != nil {

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -73,6 +73,11 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig) error {
 		log.Infof("removed %s as main DNS forwarder for this peer", config.ServerIP)
 	}
 
+	// create a file for unclean shutdown detection
+	if err := createUncleanShutdownBackup(r.guid); err != nil {
+		log.Errorf("failed to create unclean shutdown file: %s", err)
+	}
+
 	var (
 		searchDomains []string
 		matchDomains  []string
@@ -100,11 +105,6 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig) error {
 	err = r.updateSearchDomains(searchDomains)
 	if err != nil {
 		return fmt.Errorf("update search domains: %w", err)
-	}
-
-	// create a file for unclean shutdown detection
-	if err := createUncleanShutdownBackup(r.guid); err != nil {
-		log.Errorf("failed to create unclean shutdown file: %s", err)
 	}
 
 	return nil
@@ -287,7 +287,7 @@ func createUncleanShutdownBackup(guid string) error {
 		return fmt.Errorf("create dir %s: %w", dir, err)
 	}
 
-	if err := os.WriteFile(file, []byte(guid), 0700); err != nil {
+	if err := os.WriteFile(file, []byte(guid), 0600); err != nil {
 		return fmt.Errorf("create %s: %w", file, err)
 	}
 

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -1,7 +1,12 @@
 package dns
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -24,6 +29,11 @@ const (
 	interfaceConfigSearchListKey = "SearchList"
 )
 
+const (
+	netbirdProgramDataLocation = "Netbird"
+	fileUncleanShutdownFile    = "unclean_shutdown_dns.txt"
+)
+
 type registryConfigurator struct {
 	guid       string
 	routingAll bool
@@ -34,6 +44,10 @@ func newHostManager(wgInterface WGIface) (hostManager, error) {
 	if err != nil {
 		return nil, err
 	}
+	return newHostManagerWithGuid(guid)
+}
+
+func newHostManagerWithGuid(guid string) (hostManager, error) {
 	return &registryConfigurator{
 		guid: guid,
 	}, nil
@@ -88,13 +102,18 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig) error {
 		return err
 	}
 
+	// create a file for unclean shutdown detection
+	if err := createUncleanShutdownBackup(r.guid); err != nil {
+		log.Errorf("failed to create unclean shutdown file: %s", err)
+	}
+
 	return nil
 }
 
 func (r *registryConfigurator) addDNSSetupForAll(ip string) error {
 	err := r.setInterfaceRegistryKeyStringValue(interfaceConfigNameServerKey, ip)
 	if err != nil {
-		return fmt.Errorf("adding dns setup for all failed with error: %s", err)
+		return fmt.Errorf("adding dns setup for all failed with error: %w", err)
 	}
 	r.routingAll = true
 	log.Infof("configured %s:53 as main DNS forwarder for this peer", ip)
@@ -106,33 +125,33 @@ func (r *registryConfigurator) addDNSMatchPolicy(domains []string, ip string) er
 	if err == nil {
 		err = registry.DeleteKey(registry.LOCAL_MACHINE, dnsPolicyConfigMatchPath)
 		if err != nil {
-			return fmt.Errorf("unable to remove existing key from registry, key: HKEY_LOCAL_MACHINE\\%s, error: %s", dnsPolicyConfigMatchPath, err)
+			return fmt.Errorf("unable to remove existing key from registry, key: HKEY_LOCAL_MACHINE\\%s, error: %w", dnsPolicyConfigMatchPath, err)
 		}
 	}
 
 	regKey, _, err := registry.CreateKey(registry.LOCAL_MACHINE, dnsPolicyConfigMatchPath, registry.SET_VALUE)
 	if err != nil {
-		return fmt.Errorf("unable to create registry key, key: HKEY_LOCAL_MACHINE\\%s, error: %s", dnsPolicyConfigMatchPath, err)
+		return fmt.Errorf("unable to create registry key, key: HKEY_LOCAL_MACHINE\\%s, error: %w", dnsPolicyConfigMatchPath, err)
 	}
 
 	err = regKey.SetDWordValue(dnsPolicyConfigVersionKey, dnsPolicyConfigVersionValue)
 	if err != nil {
-		return fmt.Errorf("unable to set registry value for %s, error: %s", dnsPolicyConfigVersionKey, err)
+		return fmt.Errorf("unable to set registry value for %s, error: %w", dnsPolicyConfigVersionKey, err)
 	}
 
 	err = regKey.SetStringsValue(dnsPolicyConfigNameKey, domains)
 	if err != nil {
-		return fmt.Errorf("unable to set registry value for %s, error: %s", dnsPolicyConfigNameKey, err)
+		return fmt.Errorf("unable to set registry value for %s, error: %w", dnsPolicyConfigNameKey, err)
 	}
 
 	err = regKey.SetStringValue(dnsPolicyConfigGenericDNSServersKey, ip)
 	if err != nil {
-		return fmt.Errorf("unable to set registry value for %s, error: %s", dnsPolicyConfigGenericDNSServersKey, err)
+		return fmt.Errorf("unable to set registry value for %s, error: %w", dnsPolicyConfigGenericDNSServersKey, err)
 	}
 
 	err = regKey.SetDWordValue(dnsPolicyConfigConfigOptionsKey, dnsPolicyConfigConfigOptionsValue)
 	if err != nil {
-		return fmt.Errorf("unable to set registry value for %s, error: %s", dnsPolicyConfigConfigOptionsKey, err)
+		return fmt.Errorf("unable to set registry value for %s, error: %w", dnsPolicyConfigConfigOptionsKey, err)
 	}
 
 	log.Infof("added %d match domains to the state. Domain list: %s", len(domains), domains)
@@ -141,18 +160,25 @@ func (r *registryConfigurator) addDNSMatchPolicy(domains []string, ip string) er
 }
 
 func (r *registryConfigurator) restoreHostDNS() error {
-	err := removeRegistryKeyFromDNSPolicyConfig(dnsPolicyConfigMatchPath)
-	if err != nil {
-		log.Error(err)
+	if err := removeRegistryKeyFromDNSPolicyConfig(dnsPolicyConfigMatchPath); err != nil {
+		log.Errorf("remove registry key from dns policy config: %s", err)
 	}
 
-	return r.deleteInterfaceRegistryKeyProperty(interfaceConfigSearchListKey)
+	if err := r.deleteInterfaceRegistryKeyProperty(interfaceConfigSearchListKey); err != nil {
+		return fmt.Errorf("remove interface registry key: %w", err)
+	}
+
+	if err := removeUncleanShutdownBackup(); err != nil {
+		log.Errorf("failed to remove unclean shutdown file: %s", err)
+	}
+
+	return nil
 }
 
 func (r *registryConfigurator) updateSearchDomains(domains []string) error {
 	err := r.setInterfaceRegistryKeyStringValue(interfaceConfigSearchListKey, strings.Join(domains, ","))
 	if err != nil {
-		return fmt.Errorf("adding search domain failed with error: %s", err)
+		return fmt.Errorf("adding search domain failed with error: %w", err)
 	}
 
 	log.Infof("updated the search domains in the registry with %d domains. Domain list: %s", len(domains), domains)
@@ -165,11 +191,11 @@ func (r *registryConfigurator) setInterfaceRegistryKeyStringValue(key, value str
 	if err != nil {
 		return err
 	}
-	defer regKey.Close()
+	defer close(regKey)
 
 	err = regKey.SetStringValue(key, value)
 	if err != nil {
-		return fmt.Errorf("applying key %s with value \"%s\" for interface failed with error: %s", key, value, err)
+		return fmt.Errorf("applying key %s with value \"%s\" for interface failed with error: %w", key, value, err)
 	}
 
 	return nil
@@ -180,11 +206,11 @@ func (r *registryConfigurator) deleteInterfaceRegistryKeyProperty(propertyKey st
 	if err != nil {
 		return err
 	}
-	defer regKey.Close()
+	defer close(regKey)
 
 	err = regKey.DeleteValue(propertyKey)
 	if err != nil {
-		return fmt.Errorf("deleting registry key %s for interface failed with error: %s", propertyKey, err)
+		return fmt.Errorf("deleting registry key %s for interface failed with error: %w", propertyKey, err)
 	}
 
 	return nil
@@ -197,28 +223,92 @@ func (r *registryConfigurator) getInterfaceRegistryKey() (registry.Key, error) {
 
 	regKey, err := registry.OpenKey(registry.LOCAL_MACHINE, regKeyPath, registry.SET_VALUE)
 	if err != nil {
-		return regKey, fmt.Errorf("unable to open the interface registry key, key: HKEY_LOCAL_MACHINE\\%s, error: %s", regKeyPath, err)
+		return regKey, fmt.Errorf("unable to open the interface registry key, key: HKEY_LOCAL_MACHINE\\%s, error: %w", regKeyPath, err)
 	}
 
 	return regKey, nil
 }
 
 func (r *registryConfigurator) restoreUncleanShutdownBackup() error {
+	if err := r.restoreHostDNS(); err != nil {
+		return fmt.Errorf("restoring dns via registry: %w", err)
+	}
 	return nil
 }
 
 func removeRegistryKeyFromDNSPolicyConfig(regKeyPath string) error {
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, regKeyPath, registry.QUERY_VALUE)
 	if err == nil {
-		k.Close()
+		defer close(k)
 		err = registry.DeleteKey(registry.LOCAL_MACHINE, regKeyPath)
 		if err != nil {
-			return fmt.Errorf("unable to remove existing key from registry, key: HKEY_LOCAL_MACHINE\\%s, error: %s", regKeyPath, err)
+			return fmt.Errorf("unable to remove existing key from registry, key: HKEY_LOCAL_MACHINE\\%s, error: %w", regKeyPath, err)
 		}
 	}
 	return nil
 }
 
-func CheckUncleanShutdown(wgIface string) error {
+func CheckUncleanShutdown(_ string) error {
+	file := getUncleanShutdownFile()
+
+	if _, err := os.Stat(file); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// no file -> clean shutdown
+			return nil
+		} else {
+			return fmt.Errorf("state: %w", err)
+		}
+	}
+
+	log.Warnf("detected unclean shutdown, file %s exists. Restoring unclean shutdown dns settings.", file)
+
+	guid, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", file, err)
+	}
+
+	manager, err := newHostManagerWithGuid(string(guid))
+	if err != nil {
+		return fmt.Errorf("create host manager: %w", err)
+	}
+
+	if err := manager.restoreUncleanShutdownBackup(); err != nil {
+		return fmt.Errorf("restore unclean shutdown backup: %w", err)
+	}
+
+	return removeUncleanShutdownBackup()
+}
+
+func createUncleanShutdownBackup(guid string) error {
+	file := getUncleanShutdownFile()
+
+	dir := filepath.Dir(file)
+	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
+		return fmt.Errorf("create dir %s: %w", dir, err)
+	}
+
+	if err := os.WriteFile(file, []byte(guid), 0700); err != nil {
+		return fmt.Errorf("create %s: %w", file, err)
+	}
+
 	return nil
+}
+
+func removeUncleanShutdownBackup() error {
+	file := getUncleanShutdownFile()
+
+	if err := os.Remove(file); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", file, err)
+	}
+	return nil
+}
+
+func getUncleanShutdownFile() string {
+	return filepath.Join(os.Getenv("PROGRAMDATA"), netbirdProgramDataLocation, fileUncleanShutdownFile)
+}
+
+func close(closer io.Closer) {
+	if err := closer.Close(); err != nil {
+		log.Errorf("failed to close: %s", err)
+	}
 }

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -230,7 +230,7 @@ func (r *registryConfigurator) getInterfaceRegistryKey() (registry.Key, error) {
 	return regKey, nil
 }
 
-func (r *registryConfigurator) restoreUncleanShutdownDNS(netip.Addr) error {
+func (r *registryConfigurator) restoreUncleanShutdownDNS(*netip.Addr) error {
 	if err := r.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via registry: %w", err)
 	}

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -276,7 +276,7 @@ func CheckUncleanShutdown(_ string) error {
 		return fmt.Errorf("restore unclean shutdown backup: %w", err)
 	}
 
-	return removeUncleanShutdownBackup()
+	return nil
 }
 
 func createUncleanShutdownBackup(guid string) error {

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -229,7 +230,7 @@ func (r *registryConfigurator) getInterfaceRegistryKey() (registry.Key, error) {
 	return regKey, nil
 }
 
-func (r *registryConfigurator) restoreUncleanShutdownDNS() error {
+func (r *registryConfigurator) restoreUncleanShutdownDNS(netip.Addr) error {
 	if err := r.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via registry: %w", err)
 	}
@@ -272,7 +273,7 @@ func CheckUncleanShutdown(_ string) error {
 		return fmt.Errorf("create host manager: %w", err)
 	}
 
-	if err := manager.restoreUncleanShutdownDNS(); err != nil {
+	if err := manager.restoreUncleanShutdownDNS(nil); err != nil {
 		return fmt.Errorf("restore unclean shutdown backup: %w", err)
 	}
 

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -74,7 +74,7 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig) error {
 	}
 
 	// create a file for unclean shutdown detection
-	if err := createUncleanShutdownBackup(r.guid); err != nil {
+	if err := createUncleanShutdownIndicator(r.guid); err != nil {
 		log.Errorf("failed to create unclean shutdown file: %s", err)
 	}
 
@@ -168,7 +168,7 @@ func (r *registryConfigurator) restoreHostDNS() error {
 		return fmt.Errorf("remove interface registry key: %w", err)
 	}
 
-	if err := removeUncleanShutdownBackup(); err != nil {
+	if err := removeUncleanShutdownIndicator(); err != nil {
 		log.Errorf("failed to remove unclean shutdown file: %s", err)
 	}
 
@@ -229,7 +229,7 @@ func (r *registryConfigurator) getInterfaceRegistryKey() (registry.Key, error) {
 	return regKey, nil
 }
 
-func (r *registryConfigurator) restoreUncleanShutdownBackup() error {
+func (r *registryConfigurator) restoreUncleanShutdownDNS() error {
 	if err := r.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via registry: %w", err)
 	}
@@ -272,14 +272,14 @@ func CheckUncleanShutdown(_ string) error {
 		return fmt.Errorf("create host manager: %w", err)
 	}
 
-	if err := manager.restoreUncleanShutdownBackup(); err != nil {
+	if err := manager.restoreUncleanShutdownDNS(); err != nil {
 		return fmt.Errorf("restore unclean shutdown backup: %w", err)
 	}
 
 	return nil
 }
 
-func createUncleanShutdownBackup(guid string) error {
+func createUncleanShutdownIndicator(guid string) error {
 	file := getUncleanShutdownFile()
 
 	dir := filepath.Dir(file)
@@ -294,7 +294,7 @@ func createUncleanShutdownBackup(guid string) error {
 	return nil
 }
 
-func removeUncleanShutdownBackup() error {
+func removeUncleanShutdownIndicator() error {
 	file := getUncleanShutdownFile()
 
 	if err := os.Remove(file); err != nil && !errors.Is(err, fs.ErrNotExist) {

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -191,7 +191,7 @@ func (r *registryConfigurator) setInterfaceRegistryKeyStringValue(key, value str
 	if err != nil {
 		return fmt.Errorf("get interface registry key: %w", err)
 	}
-	defer close(regKey)
+	defer closer(regKey)
 
 	err = regKey.SetStringValue(key, value)
 	if err != nil {
@@ -206,7 +206,7 @@ func (r *registryConfigurator) deleteInterfaceRegistryKeyProperty(propertyKey st
 	if err != nil {
 		return fmt.Errorf("get interface registry key: %w", err)
 	}
-	defer close(regKey)
+	defer closer(regKey)
 
 	err = regKey.DeleteValue(propertyKey)
 	if err != nil {
@@ -239,7 +239,7 @@ func (r *registryConfigurator) restoreUncleanShutdownDNS() error {
 func removeRegistryKeyFromDNSPolicyConfig(regKeyPath string) error {
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, regKeyPath, registry.QUERY_VALUE)
 	if err == nil {
-		defer close(k)
+		defer closer(k)
 		err = registry.DeleteKey(registry.LOCAL_MACHINE, regKeyPath)
 		if err != nil {
 			return fmt.Errorf("unable to remove existing key from registry, key: HKEY_LOCAL_MACHINE\\%s, error: %w", regKeyPath, err)
@@ -307,7 +307,7 @@ func getUncleanShutdownFile() string {
 	return filepath.Join(os.Getenv("PROGRAMDATA"), netbirdProgramDataLocation, fileUncleanShutdownFile)
 }
 
-func close(closer io.Closer) {
+func closer(closer io.Closer) {
 	if err := closer.Close(); err != nil {
 		log.Errorf("failed to close: %s", err)
 	}

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	dnsPolicyConfigMatchPath            = "SYSTEM\\CurrentControlSet\\Services\\Dnscache\\Parameters\\DnsPolicyConfig\\NetBird-Match"
+	dnsPolicyConfigMatchPath            = `SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\DnsPolicyConfig\NetBird-Match`
 	dnsPolicyConfigVersionKey           = "Version"
 	dnsPolicyConfigVersionValue         = 2
 	dnsPolicyConfigNameKey              = "Name"
@@ -19,7 +19,7 @@ const (
 )
 
 const (
-	interfaceConfigPath          = "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces"
+	interfaceConfigPath          = `SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces`
 	interfaceConfigNameServerKey = "NameServer"
 	interfaceConfigSearchListKey = "SearchList"
 )

--- a/client/internal/dns/local.go
+++ b/client/internal/dns/local.go
@@ -52,7 +52,7 @@ func (d *localResolver) lookupRecord(r *dns.Msg) dns.RR {
 func (d *localResolver) registerRecord(record nbdns.SimpleRecord) error {
 	fullRecord, err := dns.NewRR(record.String())
 	if err != nil {
-		return err
+		return fmt.Errorf("register record: %w", err)
 	}
 
 	fullRecord.Header().Rdlength = record.Len()

--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -153,7 +153,7 @@ func (n *networkManagerDbusConfigurator) applyDNSConfig(config HostDNSConfig) er
 
 	// create a backup for unclean shutdown detection before adding domains, as these might end up in the resolv.conf file.
 	// The file content itself is not important for network-manager restoration
-	if err := createUncleanShutdownIndicator(defaultResolvConfPath, networkManager); err != nil {
+	if err := createUncleanShutdownIndicator(defaultResolvConfPath, networkManager, dnsIP.String()); err != nil {
 		log.Errorf("failed to create unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -245,7 +245,7 @@ func (n *networkManagerDbusConfigurator) deleteConnectionSettings() error {
 	return nil
 }
 
-func (n *networkManagerDbusConfigurator) restoreUncleanShutdownDNS() error {
+func (n *networkManagerDbusConfigurator) restoreUncleanShutdownDNS(netip.Addr) error {
 	if err := n.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via network-manager: %w", err)
 	}

--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -77,19 +77,19 @@ func (s networkManagerConnSettings) cleanDeprecatedSettings() {
 	}
 }
 
-func newNetworkManagerDbusConfigurator(wgInterface WGIface) (hostManager, error) {
+func newNetworkManagerDbusConfigurator(wgInterface string) (hostManager, error) {
 	obj, closeConn, err := getDbusObject(networkManagerDest, networkManagerDbusObjectNode)
 	if err != nil {
 		return nil, fmt.Errorf("get nm dbus: %w", err)
 	}
 	defer closeConn()
 	var s string
-	err = obj.Call(networkManagerDbusGetDeviceByIPIfaceMethod, dbusDefaultFlag, wgInterface.Name()).Store(&s)
+	err = obj.Call(networkManagerDbusGetDeviceByIPIfaceMethod, dbusDefaultFlag, wgInterface).Store(&s)
 	if err != nil {
 		return nil, fmt.Errorf("call: %w", err)
 	}
 
-	log.Debugf("got network manager dbus Link Object: %s from net interface %s", s, wgInterface.Name())
+	log.Debugf("got network manager dbus Link Object: %s from net interface %s", s, wgInterface)
 
 	return &networkManagerDbusConfigurator{
 		dbusLinkObject: dbus.ObjectPath(s),

--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -44,9 +44,9 @@ const (
 	networkManagerDbusSearchDomainOnlyPriority int32 = 50
 )
 
-var supportedNetworkManagerVersionConstraint = []string{
+var supportedNetworkManagerVersionConstraints = []string{
 	">= 1.16, < 1.27",
-	">=1.44, <1.45",
+	">= 1.44, < 1.45",
 }
 
 type networkManagerDbusConfigurator struct {
@@ -309,7 +309,7 @@ func isNetworkManagerSupportedVersion() bool {
 	}
 
 	var supported bool
-	for _, constraint := range supportedNetworkManagerVersionConstraint {
+	for _, constraint := range supportedNetworkManagerVersionConstraints {
 		constr, err := version.NewConstraint(constraint)
 		if err != nil {
 			log.Errorf("nm: create constraint: %s", err)
@@ -322,7 +322,7 @@ func isNetworkManagerSupportedVersion() bool {
 		}
 	}
 
-	log.Debugf("network manager constraints [%s] met: %t", strings.Join(supportedNetworkManagerVersionConstraint, " | "), supported)
+	log.Debugf("network manager constraints [%s] met: %t", strings.Join(supportedNetworkManagerVersionConstraints, " | "), supported)
 	return supported
 }
 

--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -219,6 +219,10 @@ func (n *networkManagerDbusConfigurator) deleteConnectionSettings() error {
 	return nil
 }
 
+func (n *networkManagerDbusConfigurator) restoreUncleanShutdownBackup() error {
+	return nil
+}
+
 func isNetworkManagerSupported() bool {
 	return isNetworkManagerSupportedVersion() && isNetworkManagerSupportedMode()
 }

--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -245,7 +245,7 @@ func (n *networkManagerDbusConfigurator) deleteConnectionSettings() error {
 	return nil
 }
 
-func (n *networkManagerDbusConfigurator) restoreUncleanShutdownDNS(netip.Addr) error {
+func (n *networkManagerDbusConfigurator) restoreUncleanShutdownDNS(*netip.Addr) error {
 	if err := n.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via network-manager: %w", err)
 	}

--- a/client/internal/dns/network_manager_linux.go
+++ b/client/internal/dns/network_manager_linux.go
@@ -153,7 +153,7 @@ func (n *networkManagerDbusConfigurator) applyDNSConfig(config HostDNSConfig) er
 
 	// create a backup for unclean shutdown detection before adding domains, as these might end up in the resolv.conf file.
 	// The file content itself is not important for network-manager restoration
-	if err := createUncleanShutdownBackup(defaultResolvConfPath, networkManager); err != nil {
+	if err := createUncleanShutdownIndicator(defaultResolvConfPath, networkManager); err != nil {
 		log.Errorf("failed to create unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -171,7 +171,7 @@ func (n *networkManagerDbusConfigurator) restoreHostDNS() error {
 		return fmt.Errorf("delete connection settings: %w", err)
 	}
 
-	if err := removeUncleanShutdownBackup(); err != nil {
+	if err := removeUncleanShutdownIndicator(); err != nil {
 		log.Errorf("failed to remove unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -245,7 +245,7 @@ func (n *networkManagerDbusConfigurator) deleteConnectionSettings() error {
 	return nil
 }
 
-func (n *networkManagerDbusConfigurator) restoreUncleanShutdownBackup() error {
+func (n *networkManagerDbusConfigurator) restoreUncleanShutdownDNS() error {
 	if err := n.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via network-manager: %w", err)
 	}

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -22,14 +22,14 @@ type resolvconf struct {
 }
 
 // supported "openresolv" only
-func newResolvConfConfigurator(wgInterface WGIface) (hostManager, error) {
+func newResolvConfConfigurator(wgInterface string) (hostManager, error) {
 	resolvConfEntries, err := parseDefaultResolvConf()
 	if err != nil {
 		log.Errorf("could not read original search domains from %s: %s", defaultResolvConfPath, err)
 	}
 
 	return &resolvconf{
-		ifaceName:             wgInterface.Name(),
+		ifaceName:             wgInterface,
 		originalSearchDomains: resolvConfEntries.searchDomains,
 		originalNameServers:   resolvConfEntries.nameServers,
 		othersConfigs:         resolvConfEntries.others,

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -98,7 +98,7 @@ func (r *resolvconf) applyConfig(content bytes.Buffer) error {
 	return nil
 }
 
-func (r *resolvconf) restoreUncleanShutdownDNS(netip.Addr) error {
+func (r *resolvconf) restoreUncleanShutdownDNS(*netip.Addr) error {
 	if err := r.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns for interface %s: %w", r.ifaceName, err)
 	}

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -58,7 +58,7 @@ func (r *resolvconf) applyDNSConfig(config HostDNSConfig) error {
 		r.othersConfigs)
 
 	// create a backup for unclean shutdown detection before the resolv.conf is changed
-	if err := createUncleanShutdownBackup(defaultResolvConfPath, resolvConfManager); err != nil {
+	if err := createUncleanShutdownIndicator(defaultResolvConfPath, resolvConfManager); err != nil {
 		log.Errorf("failed to create unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -79,7 +79,7 @@ func (r *resolvconf) restoreHostDNS() error {
 		return fmt.Errorf("got an error while removing resolvconf configuration for %s interface, error: %w", r.ifaceName, err)
 	}
 
-	if err := removeUncleanShutdownBackup(); err != nil {
+	if err := removeUncleanShutdownIndicator(); err != nil {
 		log.Errorf("failed to remove unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -97,7 +97,7 @@ func (r *resolvconf) applyConfig(content bytes.Buffer) error {
 	return nil
 }
 
-func (r *resolvconf) restoreUncleanShutdownBackup() error {
+func (r *resolvconf) restoreUncleanShutdownDNS() error {
 	if err := r.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns for interface %s: %w", r.ifaceName, err)
 	}

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -5,6 +5,7 @@ package dns
 import (
 	"bytes"
 	"fmt"
+	"net/netip"
 	"os/exec"
 
 	log "github.com/sirupsen/logrus"
@@ -58,7 +59,7 @@ func (r *resolvconf) applyDNSConfig(config HostDNSConfig) error {
 		r.othersConfigs)
 
 	// create a backup for unclean shutdown detection before the resolv.conf is changed
-	if err := createUncleanShutdownIndicator(defaultResolvConfPath, resolvConfManager); err != nil {
+	if err := createUncleanShutdownIndicator(defaultResolvConfPath, resolvConfManager, config.ServerIP); err != nil {
 		log.Errorf("failed to create unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -97,7 +98,7 @@ func (r *resolvconf) applyConfig(content bytes.Buffer) error {
 	return nil
 }
 
-func (r *resolvconf) restoreUncleanShutdownDNS() error {
+func (r *resolvconf) restoreUncleanShutdownDNS(netip.Addr) error {
 	if err := r.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns for interface %s: %w", r.ifaceName, err)
 	}

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -10,10 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	resolvconfCommand = "resolvconf"
-	resolvconfFile    = "/etc/resolv.conf"
-)
+const resolvconfCommand = "resolvconf"
 
 type resolvconf struct {
 	ifaceName string
@@ -25,9 +22,9 @@ type resolvconf struct {
 
 // supported "openresolv" only
 func newResolvConfConfigurator(wgInterface WGIface) (hostManager, error) {
-	originalSearchDomains, nameServers, others, err := originalDNSConfigs(resolvconfFile)
+	originalSearchDomains, nameServers, others, err := originalDNSConfigs(defaultResolvConfPath)
 	if err != nil {
-		log.Errorf("could not read original search domains from %s: %s", resolvconfFile, err)
+		log.Errorf("could not read original search domains from %s: %s", defaultResolvConfPath, err)
 	}
 
 	return &resolvconf{
@@ -61,7 +58,7 @@ func (r *resolvconf) applyDNSConfig(config HostDNSConfig) error {
 		r.othersConfigs)
 
 	// create a backup for unclean shutdown detection before the resolv.conf is changed
-	if err := createUncleanShutdownBackup(resolvconfFile, resolvConfManager); err != nil {
+	if err := createUncleanShutdownBackup(defaultResolvConfPath, resolvConfManager); err != nil {
 		log.Errorf("failed to create unclean shutdown resolv.conf backup: %s", err)
 	}
 

--- a/client/internal/dns/resolvconf_linux.go
+++ b/client/internal/dns/resolvconf_linux.go
@@ -76,7 +76,7 @@ func (r *resolvconf) restoreHostDNS() error {
 	cmd := exec.Command(resolvconfCommand, "-f", "-d", r.ifaceName)
 	_, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("got an error while removing resolvconf configuration for %s interface, error: %w", r.ifaceName, err)
+		return fmt.Errorf("removing resolvconf configuration for %s interface, error: %w", r.ifaceName, err)
 	}
 
 	if err := removeUncleanShutdownIndicator(); err != nil {
@@ -92,7 +92,7 @@ func (r *resolvconf) applyConfig(content bytes.Buffer) error {
 	cmd.Stdin = &content
 	_, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("got an error while applying resolvconf configuration for %s interface, error: %w", r.ifaceName, err)
+		return fmt.Errorf("applying resolvconf configuration for %s interface, error: %w", r.ifaceName, err)
 	}
 	return nil
 }

--- a/client/internal/dns/response_writer.go
+++ b/client/internal/dns/response_writer.go
@@ -31,10 +31,13 @@ func (r *responseWriter) RemoteAddr() net.Addr {
 func (r *responseWriter) WriteMsg(msg *dns.Msg) error {
 	buff, err := msg.Pack()
 	if err != nil {
-		return err
+		return fmt.Errorf("pack: %w", err)
 	}
-	_, err = r.Write(buff)
-	return err
+
+	if _, err := r.Write(buff); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	return nil
 }
 
 // Write writes a raw buffer back to the client.

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -140,12 +140,15 @@ func (s *DefaultServer) Initialize() (err error) {
 	if s.permanent {
 		err = s.service.Listen()
 		if err != nil {
-			return err
+			return fmt.Errorf("service listen: %w", err)
 		}
 	}
 
 	s.hostManager, err = s.initialize()
-	return err
+	if err != nil {
+		return fmt.Errorf("initialize: %w", err)
+	}
+	return nil
 }
 
 // DnsIP returns the DNS resolver server IP address
@@ -223,7 +226,7 @@ func (s *DefaultServer) UpdateDNSServer(serial uint64, update nbdns.Config) erro
 		}
 
 		if err := s.applyConfiguration(update); err != nil {
-			return err
+			return fmt.Errorf("apply configuration: %w", err)
 		}
 
 		s.updateSerial = serial

--- a/client/internal/dns/server_android.go
+++ b/client/internal/dns/server_android.go
@@ -1,5 +1,5 @@
 package dns
 
 func (s *DefaultServer) initialize() (manager hostManager, err error) {
-	return newHostManager(s.wgInterface)
+	return newHostManager()
 }

--- a/client/internal/dns/server_darwin.go
+++ b/client/internal/dns/server_darwin.go
@@ -3,5 +3,5 @@
 package dns
 
 func (s *DefaultServer) initialize() (manager hostManager, err error) {
-	return newHostManager(s.wgInterface)
+	return newHostManager()
 }

--- a/client/internal/dns/server_linux.go
+++ b/client/internal/dns/server_linux.go
@@ -3,5 +3,5 @@
 package dns
 
 func (s *DefaultServer) initialize() (manager hostManager, err error) {
-	return newHostManager(s.wgInterface)
+	return newHostManager(s.wgInterface.Name())
 }

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -63,7 +63,7 @@ func (s *serviceViaListener) Listen() error {
 	s.listenIP, s.listenPort, err = s.evalListenAddress()
 	if err != nil {
 		log.Errorf("failed to eval runtime address: %s", err)
-		return err
+		return fmt.Errorf("eval listen address: %w", err)
 	}
 	s.server.Addr = fmt.Sprintf("%s:%d", s.listenIP, s.listenPort)
 

--- a/client/internal/dns/service_memory.go
+++ b/client/internal/dns/service_memory.go
@@ -44,7 +44,7 @@ func (s *serviceViaMemory) Listen() error {
 	var err error
 	s.udpFilterHookID, err = s.filterDNSTraffic()
 	if err != nil {
-		return err
+		return fmt.Errorf("filter dns traffice: %w", err)
 	}
 	s.listenerIsRunning = true
 

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -200,6 +200,10 @@ func (s *systemdDbusConfigurator) callLinkMethod(method string, value any) error
 	return nil
 }
 
+func (s *systemdDbusConfigurator) restoreUncleanShutdownBackup() error {
+	return nil
+}
+
 func getSystemdDbusProperty(property string, store any) error {
 	obj, closeConn, err := getDbusObject(systemdResolvedDest, systemdDbusObjectNode)
 	if err != nil {

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -134,7 +134,7 @@ func (s *systemdDbusConfigurator) applyDNSConfig(config HostDNSConfig) error {
 
 	// create a backup for unclean shutdown detection before adding domains, as these might end up in the resolv.conf file.
 	// The file content itself is not important for systemd restoration
-	if err := createUncleanShutdownBackup(resolvconfFile, systemdManager); err != nil {
+	if err := createUncleanShutdownBackup(defaultResolvConfPath, systemdManager); err != nil {
 		log.Errorf("failed to create unclean shutdown resolv.conf backup: %s", err)
 	}
 

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -58,19 +58,19 @@ type systemdDbusLinkDomainsInput struct {
 func newSystemdDbusConfigurator(wgInterface WGIface) (hostManager, error) {
 	iface, err := net.InterfaceByName(wgInterface.Name())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get interface: %w", err)
 	}
 
 	obj, closeConn, err := getDbusObject(systemdResolvedDest, systemdDbusObjectNode)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get dbus resolved dest: %w", err)
 	}
 	defer closeConn()
 
 	var s string
 	err = obj.Call(systemdDbusGetLinkMethod, dbusDefaultFlag, iface.Index).Store(&s)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get dbus link method: %w", err)
 	}
 
 	log.Debugf("got dbus Link interface: %s from net interface %s and index %d", s, iface.Name, iface.Index)

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -55,8 +55,8 @@ type systemdDbusLinkDomainsInput struct {
 	MatchOnly bool
 }
 
-func newSystemdDbusConfigurator(wgInterface WGIface) (hostManager, error) {
-	iface, err := net.InterfaceByName(wgInterface.Name())
+func newSystemdDbusConfigurator(wgInterface string) (hostManager, error) {
+	iface, err := net.InterfaceByName(wgInterface)
 	if err != nil {
 		return nil, fmt.Errorf("get interface: %w", err)
 	}

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -221,7 +221,7 @@ func (s *systemdDbusConfigurator) callLinkMethod(method string, value any) error
 	return nil
 }
 
-func (s *systemdDbusConfigurator) restoreUncleanShutdownDNS(netip.Addr) error {
+func (s *systemdDbusConfigurator) restoreUncleanShutdownDNS(*netip.Addr) error {
 	if err := s.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via systemd: %w", err)
 	}

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -137,7 +137,7 @@ func (s *systemdDbusConfigurator) applyDNSConfig(config HostDNSConfig) error {
 
 	// create a backup for unclean shutdown detection before adding domains, as these might end up in the resolv.conf file.
 	// The file content itself is not important for systemd restoration
-	if err := createUncleanShutdownIndicator(defaultResolvConfPath, systemdManager); err != nil {
+	if err := createUncleanShutdownIndicator(defaultResolvConfPath, systemdManager, parsedIP.String()); err != nil {
 		log.Errorf("failed to create unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -221,7 +221,7 @@ func (s *systemdDbusConfigurator) callLinkMethod(method string, value any) error
 	return nil
 }
 
-func (s *systemdDbusConfigurator) restoreUncleanShutdownDNS() error {
+func (s *systemdDbusConfigurator) restoreUncleanShutdownDNS(netip.Addr) error {
 	if err := s.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via systemd: %w", err)
 	}

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -137,7 +137,7 @@ func (s *systemdDbusConfigurator) applyDNSConfig(config HostDNSConfig) error {
 
 	// create a backup for unclean shutdown detection before adding domains, as these might end up in the resolv.conf file.
 	// The file content itself is not important for systemd restoration
-	if err := createUncleanShutdownBackup(defaultResolvConfPath, systemdManager); err != nil {
+	if err := createUncleanShutdownIndicator(defaultResolvConfPath, systemdManager); err != nil {
 		log.Errorf("failed to create unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -174,7 +174,7 @@ func (s *systemdDbusConfigurator) restoreHostDNS() error {
 		return fmt.Errorf("unable to revert link configuration, got error: %w", err)
 	}
 
-	if err := removeUncleanShutdownBackup(); err != nil {
+	if err := removeUncleanShutdownIndicator(); err != nil {
 		log.Errorf("failed to remove unclean shutdown resolv.conf backup: %s", err)
 	}
 
@@ -221,7 +221,7 @@ func (s *systemdDbusConfigurator) callLinkMethod(method string, value any) error
 	return nil
 }
 
-func (s *systemdDbusConfigurator) restoreUncleanShutdownBackup() error {
+func (s *systemdDbusConfigurator) restoreUncleanShutdownDNS() error {
 	if err := s.restoreHostDNS(); err != nil {
 		return fmt.Errorf("restoring dns via systemd: %w", err)
 	}

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -237,7 +237,7 @@ func getSystemdDbusProperty(property string, store any) error {
 
 	v, e := obj.GetProperty(property)
 	if e != nil {
-		return fmt.Errorf("got an error getting property %s: %w", property, e)
+		return fmt.Errorf("getting property %s: %w", property, e)
 	}
 
 	return v.Store(store)

--- a/client/internal/dns/unclean_shutdown_android.go
+++ b/client/internal/dns/unclean_shutdown_android.go
@@ -1,0 +1,5 @@
+package dns
+
+func CheckUncleanShutdown(string) error {
+	return nil
+}

--- a/client/internal/dns/unclean_shutdown_darwin.go
+++ b/client/internal/dns/unclean_shutdown_darwin.go
@@ -1,0 +1,59 @@
+//go:build !ios
+
+package dns
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const fileUncleanShutdownFileLocation = "/var/lib/netbird/unclean_shutdown_dns"
+
+func CheckUncleanShutdown(string) error {
+	if _, err := os.Stat(fileUncleanShutdownFileLocation); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// no file -> clean shutdown
+			return nil
+		} else {
+			return fmt.Errorf("state: %w", err)
+		}
+	}
+
+	log.Warnf("detected unclean shutdown, file %s exists. Restoring unclean shutdown dns settings.", fileUncleanShutdownFileLocation)
+
+	manager, err := newHostManager(nil)
+	if err != nil {
+		return fmt.Errorf("create host manager: %w", err)
+	}
+
+	if err := manager.restoreUncleanShutdownDNS(nil); err != nil {
+		return fmt.Errorf("restore unclean shutdown backup: %w", err)
+	}
+
+	return nil
+}
+
+func createUncleanShutdownIndicator() error {
+	dir := filepath.Dir(fileUncleanShutdownFileLocation)
+	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
+		return fmt.Errorf("create dir %s: %w", dir, err)
+	}
+
+	if err := os.WriteFile(fileUncleanShutdownFileLocation, nil, 0644); err != nil { //nolint:gosec
+		return fmt.Errorf("create %s: %w", fileUncleanShutdownFileLocation, err)
+	}
+
+	return nil
+}
+
+func removeUncleanShutdownIndicator() error {
+	if err := os.Remove(fileUncleanShutdownFileLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", fileUncleanShutdownFileLocation, err)
+	}
+	return nil
+}

--- a/client/internal/dns/unclean_shutdown_darwin.go
+++ b/client/internal/dns/unclean_shutdown_darwin.go
@@ -26,7 +26,7 @@ func CheckUncleanShutdown(string) error {
 
 	log.Warnf("detected unclean shutdown, file %s exists. Restoring unclean shutdown dns settings.", fileUncleanShutdownFileLocation)
 
-	manager, err := newHostManager(nil)
+	manager, err := newHostManager()
 	if err != nil {
 		return fmt.Errorf("create host manager: %w", err)
 	}

--- a/client/internal/dns/unclean_shutdown_ios.go
+++ b/client/internal/dns/unclean_shutdown_ios.go
@@ -1,0 +1,5 @@
+package dns
+
+func CheckUncleanShutdown(string) error {
+	return nil
+}

--- a/client/internal/dns/unclean_shutdown_linux.go
+++ b/client/internal/dns/unclean_shutdown_linux.go
@@ -1,0 +1,105 @@
+//go:build !android
+
+package dns
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/client/internal/stdnet"
+	"github.com/netbirdio/netbird/iface"
+)
+
+const (
+	fileUncleanShutdownResolvConfLocation  = "/var/lib/netbird/resolv.conf"
+	fileUncleanShutdownManagerTypeLocation = "/var/lib/netbird/manager"
+)
+
+func CheckUncleanShutdown(wgIface string) error {
+	if _, err := os.Stat(fileUncleanShutdownResolvConfLocation); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// no file -> clean shutdown
+			return nil
+		} else {
+			return fmt.Errorf("state: %w", err)
+		}
+	}
+
+	log.Warnf("detected unclean shutdown, file %s exists", fileUncleanShutdownResolvConfLocation)
+
+	managerData, err := os.ReadFile(fileUncleanShutdownManagerTypeLocation)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", fileUncleanShutdownManagerTypeLocation, err)
+	}
+
+	managerFields := strings.Split(string(managerData), ",")
+	if len(managerFields) < 2 {
+		return errors.New("split manager data: insufficient number of fields")
+	}
+	osManagerTypeStr, dnsAddressStr := managerFields[0], managerFields[1]
+
+	dnsAddress, err := netip.ParseAddr(dnsAddressStr)
+	if err != nil {
+		return fmt.Errorf("parse dns address %s failed: %w", dnsAddressStr, err)
+	}
+
+	log.Warnf("restoring unclean shutdown dns settings via previously detected manager: %s", osManagerTypeStr)
+
+	// determine os manager type, so we can invoke the respective restore action
+	osManagerType, err := newOsManagerType(osManagerTypeStr)
+	if err != nil {
+		return fmt.Errorf("detect previous host manager: %w", err)
+	}
+
+	// the only real thing we need is the interface name
+	dummyInt, err := iface.NewWGIFace(wgIface, "0.0.0.0/32", 0, "", iface.DefaultMTU, &stdnet.Net{}, nil)
+	if err != nil {
+		return fmt.Errorf("create dummy int: %w", err)
+	}
+
+	manager, err := newHostManagerFromType(dummyInt, osManagerType)
+	if err != nil {
+		return fmt.Errorf("create previous host manager: %w", err)
+	}
+
+	if err := manager.restoreUncleanShutdownDNS(&dnsAddress); err != nil {
+		return fmt.Errorf("restore unclean shutdown backup: %w", err)
+	}
+
+	return nil
+}
+
+func createUncleanShutdownIndicator(sourcePath string, managerType osManagerType, dnsAddress string) error {
+	dir := filepath.Dir(fileUncleanShutdownResolvConfLocation)
+	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
+		return fmt.Errorf("create dir %s: %w", dir, err)
+	}
+
+	if err := copyFile(sourcePath, fileUncleanShutdownResolvConfLocation); err != nil {
+		return fmt.Errorf("create %s: %w", sourcePath, err)
+	}
+
+	managerData := fmt.Sprintf("%s,%s", managerType, dnsAddress)
+
+	if err := os.WriteFile(fileUncleanShutdownManagerTypeLocation, []byte(managerData), 0644); err != nil { //nolint:gosec
+		return fmt.Errorf("create %s: %w", fileUncleanShutdownManagerTypeLocation, err)
+	}
+	return nil
+}
+
+func removeUncleanShutdownIndicator() error {
+	if err := os.Remove(fileUncleanShutdownResolvConfLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", fileUncleanShutdownResolvConfLocation, err)
+	}
+	if err := os.Remove(fileUncleanShutdownManagerTypeLocation); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", fileUncleanShutdownManagerTypeLocation, err)
+	}
+	return nil
+}

--- a/client/internal/dns/unclean_shutdown_linux.go
+++ b/client/internal/dns/unclean_shutdown_linux.go
@@ -12,9 +12,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/netbirdio/netbird/client/internal/stdnet"
-	"github.com/netbirdio/netbird/iface"
 )
 
 const (
@@ -58,13 +55,7 @@ func CheckUncleanShutdown(wgIface string) error {
 		return fmt.Errorf("detect previous host manager: %w", err)
 	}
 
-	// the only real thing we need is the interface name
-	dummyInt, err := iface.NewWGIFace(wgIface, "0.0.0.0/32", 0, "", iface.DefaultMTU, &stdnet.Net{}, nil)
-	if err != nil {
-		return fmt.Errorf("create dummy int: %w", err)
-	}
-
-	manager, err := newHostManagerFromType(dummyInt, osManagerType)
+	manager, err := newHostManagerFromType(wgIface, osManagerType)
 	if err != nil {
 		return fmt.Errorf("create previous host manager: %w", err)
 	}

--- a/client/internal/dns/unclean_shutdown_windows.go
+++ b/client/internal/dns/unclean_shutdown_windows.go
@@ -1,0 +1,75 @@
+package dns
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	netbirdProgramDataLocation = "Netbird"
+	fileUncleanShutdownFile    = "unclean_shutdown_dns.txt"
+)
+
+func CheckUncleanShutdown(string) error {
+	file := getUncleanShutdownFile()
+
+	if _, err := os.Stat(file); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// no file -> clean shutdown
+			return nil
+		} else {
+			return fmt.Errorf("state: %w", err)
+		}
+	}
+
+	logrus.Warnf("detected unclean shutdown, file %s exists. Restoring unclean shutdown dns settings.", file)
+
+	guid, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", file, err)
+	}
+
+	manager, err := newHostManagerWithGuid(string(guid))
+	if err != nil {
+		return fmt.Errorf("create host manager: %w", err)
+	}
+
+	if err := manager.restoreUncleanShutdownDNS(nil); err != nil {
+		return fmt.Errorf("restore unclean shutdown backup: %w", err)
+	}
+
+	return nil
+}
+
+func createUncleanShutdownIndicator(guid string) error {
+	file := getUncleanShutdownFile()
+
+	dir := filepath.Dir(file)
+	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
+		return fmt.Errorf("create dir %s: %w", dir, err)
+	}
+
+	if err := os.WriteFile(file, []byte(guid), 0600); err != nil {
+		return fmt.Errorf("create %s: %w", file, err)
+	}
+
+	return nil
+}
+
+func removeUncleanShutdownIndicator() error {
+	file := getUncleanShutdownFile()
+
+	if err := os.Remove(file); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", file, err)
+	}
+	return nil
+}
+
+func getUncleanShutdownFile() string {
+	return filepath.Join(os.Getenv("PROGRAMDATA"), netbirdProgramDataLocation, fileUncleanShutdownFile)
+}

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -213,7 +213,7 @@ func (u *upstreamResolverBase) waitUntilResponse() {
 		}
 
 		log.Tracef("checking connectivity with upstreams %s failed. Retrying in %s", u.upstreamServers, exponentialBackOff.NextBackOff())
-		return fmt.Errorf("got an error from upstream check call")
+		return fmt.Errorf("upstream check call error")
 	}
 
 	err := backoff.Retry(operation, exponentialBackOff)

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1076,6 +1076,11 @@ func (e *Engine) close() {
 		log.Errorf("failed closing ebpf proxy: %s", err)
 	}
 
+	// stop/restore DNS first so dbus and friends don't complain because of a missing interface
+	if e.dnsServer != nil {
+		e.dnsServer.Stop()
+	}
+
 	log.Debugf("removing Netbird interface %s", e.config.WgIfaceName)
 	if e.wgInterface != nil {
 		if err := e.wgInterface.Close(); err != nil {
@@ -1092,10 +1097,6 @@ func (e *Engine) close() {
 
 	if e.routeManager != nil {
 		e.routeManager.Stop()
-	}
-
-	if e.dnsServer != nil {
-		e.dnsServer.Stop()
 	}
 
 	if e.firewall != nil {

--- a/iface/iface_linux.go
+++ b/iface/iface_linux.go
@@ -39,7 +39,6 @@ func NewWGIFace(iFaceName string, address string, wgPort int, wgPrivKey string, 
 	wgIFace.tun = newTunUSPDevice(iFaceName, wgAddress, wgPort, wgPrivKey, mtu, transportNet)
 	wgIFace.userspaceBind = true
 	return wgIFace, nil
-
 }
 
 // CreateOnAndroid this function make sense on mobile only


### PR DESCRIPTION
## Describe your changes

1. When the Netbird agent terminates ungracefully (kill, power outage, panic, etc.), the system DNS settings are not restored.

    This can result in broken DNS resolution (e.g. a DNS server provided by a peer), in which case the agent won't be able to connect to the management server.
    
    To fix this issue we create an indicator file after adjusting the system DNS settings.
    This file is deleted once the settings are restored.
    
    If the agent terminates ungracefully it won't be able to delete this file. Therefore when it is started again it will detect the existence of this file and restore the previous DNS state.
    
    
    - On Linux
    
      `/var/lib/netbird/resolv.conf`, contains the old `/etc/resolv.conf`
      `/var/lib/netbird/manager`, contains the name of the previous host manager and last netbird IP address
      
      - manager `file`
      
          DNS settings are restored by copying the `/var/lib/netbird/resolv.conf` back to `/etc/resolv.conf`

           Test:
          - Uninstall `systemd-resolved`, `openresolv`/`resolvconf`
          - `echo nameserver 9.9.9.9 | sudo tee /etc/resolv.conf`
          - Watch `/var/log/netbird/client.log` for restore message and `/etc/resolv.conf`
          - Start agent
          - `killall -9 netbird`
          - Start agent

     
       - manager `resolvconf`
      
           DNS settings are restored by running `restoreHostDNS()` (runs `resolvconf -d <interface>`)

           Test:
            - Uninstall `systemd-resolved`
            - Install `openresolv` package
            - `echo "nameserver 9.9.9.9" | sudo resolvconf -x -a <physical int>`
            - Watch `/var/log/netbird/client.log` for restore message and `/etc/resolv.conf`
            - Start agent
            - `killall -9 netbird`
            - Start agent

       - manager `systemd`
      
           DNS settings are restored by running `restoreHostDNS()` (runs dbus methods`)
        
          Test:
            - Watch `/var/log/netbird/client.log` for restore message and `resolvectl status`
            - Start agent
            - `killall -9 netbird`
            - Start agent

        - manager `networkManager`
      
           DNS settings are restored by running `restoreHostDNS()` (runs dbus methods`)
        
          Test:
            - Uninstall `systemd-resolved`
            - Edit `/etc/NetworkManager/NetworkManager.conf`, add `dns=dnsmasq` in the main section
            - `sudo nmcli general reload` or `sudo nmcli networking off; sudo nmcli networking on` 
            - Watch `/var/log/netbird/client.log` for restore message and `nmcli device show | grep -i dns`  
            - Start agent
            - `killall -9 netbird`
            - Start agent


    - On Windows
    
      `%PROGRAMDATA%\Netbird\unclean_shutdown_dns.txt`, contains the interface `guid` that is required to set up the host manager.
      
      DNS settings are restored by running `restoreHostDNS()` (removes registry keys)

      Test:
        - Watch `%PROGRAMDATA%\Netbird\client.log` for restore message and `SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\DnsPolicyConfig\NetBird-Match` registry
        - Start agent
        - Start PowerShell as admin
        - `Get-Process -Name netbird | Stop-Process -Force`
        - (Re)start agent
    
    - On macOS
    
      `/var/lib/netbird/unclean_shutdown_dns`, empty
      
      DNS settings are restored by running `restoreHostDNS()` (runs `scutil remove`).

      Test:
        - Watch `/var/log/netbird/client.log` for restore message and `scutil --dns` for DNS settings
        - Start agent
        - `sudo killall -9 netbird`
        - Start agent


    - mobile should not be affected
        

2. Moves the `restore DNS` logic before the `remove interface` logic so we don't get errors for missing interfaces 

3. Improves error handling and error messages for debugging

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
