### PR TITLE
Fix data dir creation permissions

### DIFF
--- a/encryption/letsencrypt.go
+++ b/encryption/letsencrypt.go
@@ -1,10 +1,11 @@
 package encryption
 
 import (
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/acme/autocert"
 	"os"
 	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/acme/autocert"
 )
 
 // CreateCertManager wraps common logic of generating Let's encrypt certificate.
@@ -12,7 +13,7 @@ func CreateCertManager(datadir string, letsencryptDomain string) (*autocert.Mana
 	certDir := filepath.Join(datadir, "letsencrypt")
 
 	if _, err := os.Stat(certDir); os.IsNotExist(err) {
-		err = os.MkdirAll(certDir, os.ModeDir)
+		err = os.MkdirAll(certDir, 0755)
 		if err != nil {
 			return nil, err
 		}

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/netbirdio/management-integrations/integrations"
 	"io"
 	"io/fs"
 	"net"
@@ -17,6 +16,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/netbirdio/management-integrations/integrations"
 
 	"github.com/google/uuid"
 	"github.com/miekg/dns"
@@ -115,7 +116,7 @@ var (
 			}
 
 			if _, err = os.Stat(config.Datadir); os.IsNotExist(err) {
-				err = os.MkdirAll(config.Datadir, os.ModeDir)
+				err = os.MkdirAll(config.Datadir, 0755)
 				if err != nil {
 					return fmt.Errorf("failed creating datadir: %s: %v", config.Datadir, err)
 				}


### PR DESCRIPTION
## Describe your changes

Uses proper permissions to create dirs. `os.ModeDir` creates a directory with no bits set

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
