### PR TITLE
Extract peer real IP from Load Balancer when possible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gopacket v1.1.19
 	github.com/google/nftables v0.0.0-20220808154552-2eca00135732
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.2-0.20240129190346-220740bc30b1
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/libp2p/go-netroute v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
 	golang.zx2c4.com/wireguard/windows v0.5.3
 	google.golang.org/grpc v1.56.3
-	google.golang.org/protobuf v1.30.0
+	google.golang.org/protobuf v1.31.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -940,8 +940,9 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,8 @@ github.com/gopherjs/gopherjs v0.0.0-20220410123724-9e86199038b0 h1:fWY+zXdWhvWnd
 github.com/gopherjs/gopherjs v0.0.0-20220410123724-9e86199038b0/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.2-0.20240129190346-220740bc30b1 h1:AKSzml3dShaejT9YPRSjPmtx9i1FsevIxUll3vyitDo=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.2-0.20240129190346-220740bc30b1/go.mod h1:w9Y7gY31krpLmrVU5ZPG9H7l9fZuRu5/3R3S3FMtVQ4=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 h1:ET4pqyjiGmY09R5y+rSd70J2w45CtbWDNvGqWp/R3Ng=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -11,7 +11,6 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
-	"net/netip"
 	"net/url"
 	"os"
 	"path"
@@ -170,7 +169,7 @@ var (
 
 			turnManager := server.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig)
 
-			trustedPeers := []netip.Prefix{}
+			trustedPeers := config.TrustedHTTPProxies
 			headers := []string{realip.XForwardedFor, realip.XRealIp}
 			gRPCOpts := []grpc.ServerOption{
 				grpc.KeepaliveEnforcementPolicy(kaep),

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"path"
@@ -170,6 +171,9 @@ var (
 			turnManager := server.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig)
 
 			trustedPeers := config.TrustedHTTPProxies
+			if len(trustedPeers) == 0 {
+				trustedPeers = []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+			}
 			headers := []string{realip.XForwardedFor, realip.XRealIp}
 			gRPCOpts := []grpc.ServerOption{
 				grpc.KeepaliveEnforcementPolicy(kaep),

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"path"
@@ -30,6 +31,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/realip"
 	"github.com/netbirdio/netbird/encryption"
 	mgmtProto "github.com/netbirdio/netbird/management/proto"
 	"github.com/netbirdio/netbird/management/server"
@@ -168,7 +170,18 @@ var (
 
 			turnManager := server.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig)
 
-			gRPCOpts := []grpc.ServerOption{grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp)}
+			trustedPeers := []netip.Prefix{}
+			headers := []string{realip.XForwardedFor, realip.XRealIp}
+			gRPCOpts := []grpc.ServerOption{
+				grpc.KeepaliveEnforcementPolicy(kaep),
+				grpc.KeepaliveParams(kasp),
+				grpc.ChainUnaryInterceptor(
+					realip.UnaryServerInterceptor(trustedPeers, headers),
+				),
+				grpc.ChainStreamInterceptor(
+					realip.StreamServerInterceptor(trustedPeers, headers),
+				),
+			}
 			var certManager *autocert.Manager
 			var tlsConfig *tls.Config
 			tlsEnabled := false

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -172,7 +172,7 @@ var (
 
 			trustedPeers := config.TrustedHTTPProxies
 			if len(trustedPeers) == 0 {
-				trustedPeers = []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+				trustedPeers = []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0")}
 			}
 			headers := []string{realip.XForwardedFor, realip.XRealIp}
 			gRPCOpts := []grpc.ServerOption{

--- a/management/server/config.go
+++ b/management/server/config.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net/netip"
 	"net/url"
 
 	"github.com/netbirdio/netbird/management/server/idp"
@@ -39,6 +40,8 @@ type Config struct {
 	DataStoreEncryptionKey string
 
 	HttpConfig *HttpServerConfig
+
+	TrustedHTTPProxies []netip.Prefix
 
 	IdpManagerConfig *idp.Config
 

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/netip"
 	"strings"
 	"time"
@@ -136,9 +135,9 @@ func extractIps(ctx context.Context) (string, string) {
 		}
 
 		if grcpPeerExtracted {
-			ip, err := net.ResolveTCPAddr("", grpcPeer.Addr.String())
+			addrPort, err := netip.ParseAddrPort(grpcPeer.Addr.String())
 			if err == nil {
-				return ip.IP.String(), peerAddr
+				return addrPort.Addr().String(), peerAddr
 			}
 			log.Errorf("when resolve ip address %s", err)
 		}


### PR DESCRIPTION
Otherwise, get it from the GRPC peer address.

This PR extends management config with a new `TrustedHTTPProxies` option that accepts a list of network prefixes ex: `"192.168.1.1/32", "10.0.0.0/16"` that is used for evaluation of client real ip according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#selecting_an_ip_address

## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
