### PR TITLE
getFirstListenerAvailable(): adjust logging levels and add success message

### DIFF
--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -156,9 +156,10 @@ func (s *serviceViaListener) getFirstListenerAvailable() (string, int, error) {
 				if err != nil {
 					log.Errorf("got an error closing the probe listener, error: %s", err)
 				}
+				log.Infof("successfully found dns binding candidate at %s", addrString)
 				return ip, port, nil
 			}
-			log.Warnf("binding dns on %s is not available, error: %s", addrString, err)
+			log.Debugf("binding dns on %s is not available, error: %s", addrString, err)
 		}
 	}
 	return "", 0, fmt.Errorf("unable to find an unused ip and port combination. IPs tested: %v and ports %v", ips, ports)

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -140,7 +140,7 @@ func (s *serviceViaListener) setListenerStatus(running bool) {
 	s.listenerIsRunning = running
 }
 
-func (s *serviceViaListener) getFirstListenerAvailable() (string, int, error) {
+func (s *serviceViaListener) getFirstDNSListenerAvailable() (string, int, error) {
 	ips := []string{defaultIP, customIP}
 	if runtime.GOOS != "darwin" {
 		ips = append([]string{s.wgInterface.Address().IP.String()}, ips...)
@@ -170,7 +170,7 @@ func (s *serviceViaListener) evalListenAddress() (string, int, error) {
 		return s.customAddr.Addr().String(), int(s.customAddr.Port()), nil
 	}
 
-	return s.getFirstListenerAvailable()
+	return s.getFirstDNSListenerAvailable()
 }
 
 // shouldApplyPortFwd decides whether to apply eBPF program to capture DNS traffic on port 53.


### PR DESCRIPTION
## Describe your changes

it was worrying to see multiple warnings and no success message when lacking CAP_NET_BIND_SERVICE

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
