### PR TITLE
Update port, ip choice logic in DNS service

### DIFF
--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -203,7 +203,7 @@ func (s *serviceViaListener) tryToUseeBPF() (ebpfMgr.Manager, uint16, bool) {
 		return nil, 0, false
 	}
 
-	port, err := s.generateFreePort()
+	port, err := s.generateFreePort() //nolint:staticcheck,unused
 	if err != nil {
 		log.Warnf("failed to generate a free port for eBPF DNS forwarder server: %s", err)
 		return nil, 0, false

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -199,7 +199,6 @@ func (s *serviceViaListener) tryToBind(ip string, port int) bool {
 // port we should fall back to the eBPF solution that will capture traffic on port 53 and forward
 // it to a local DNS server running on the chosen port.
 func (s *serviceViaListener) tryToUseeBPF() (ebpfMgr.Manager, uint16, bool) {
-	var port uint16 //nolint:golint,unused
 	if runtime.GOOS != "linux" {
 		return nil, 0, false
 	}

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -199,8 +199,9 @@ func (s *serviceViaListener) tryToBind(ip string, port int) bool {
 // port we should fall back to the eBPF solution that will capture traffic on port 53 and forward
 // it to a local DNS server running on the chosen port.
 func (s *serviceViaListener) tryToUseeBPF() (ebpfMgr.Manager, uint16, bool) {
-	var port uint16 = 0
+	var port uint16
 	if runtime.GOOS != "linux" {
+		port = 0
 		return nil, port, false
 	}
 

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -199,8 +199,9 @@ func (s *serviceViaListener) tryToBind(ip string, port int) bool {
 // port we should fall back to the eBPF solution that will capture traffic on port 53 and forward
 // it to a local DNS server running on the chosen port.
 func (s *serviceViaListener) tryToUseeBPF() (ebpfMgr.Manager, uint16, bool) {
+	var port uint16 = 0
 	if runtime.GOOS != "linux" {
-		return nil, 0, false
+		return nil, port, false
 	}
 
 	port, err := s.generateFreePort()

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -198,9 +198,8 @@ func (s *serviceViaListener) tryToBind(ip string, port int) bool {
 // the domain name  resolution won't work. So, in case we are running on Linux and picked a free
 // port we should fall back to the eBPF solution that will capture traffic on port 53 and forward
 // it to a local DNS server running on the chosen port.
-//
-//nolint:golint,unused
 func (s *serviceViaListener) tryToUseeBPF() (ebpfMgr.Manager, uint16, bool) {
+	var port uint16 //nolint:golint,unused
 	if runtime.GOOS != "linux" {
 		return nil, 0, false
 	}

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -198,11 +198,11 @@ func (s *serviceViaListener) tryToBind(ip string, port int) bool {
 // the domain name  resolution won't work. So, in case we are running on Linux and picked a free
 // port we should fall back to the eBPF solution that will capture traffic on port 53 and forward
 // it to a local DNS server running on the chosen port.
+//
+//nolint:golint,unused
 func (s *serviceViaListener) tryToUseeBPF() (ebpfMgr.Manager, uint16, bool) {
-	var port uint16
 	if runtime.GOOS != "linux" {
-		port = 0
-		return nil, port, false
+		return nil, 0, false
 	}
 
 	port, err := s.generateFreePort()

--- a/client/internal/ebpf/ebpf/dns_fwd_linux.go
+++ b/client/internal/ebpf/ebpf/dns_fwd_linux.go
@@ -13,7 +13,7 @@ const (
 )
 
 func (tf *GeneralManager) LoadDNSFwd(ip string, dnsPort int) error {
-	log.Debugf("load ebpf DNS forwarder: address: %s:%d", ip, dnsPort)
+	log.Debugf("load ebpf DNS forwarder, watching addr: %s:53, redirect to port: %d", ip, dnsPort)
 	tf.lock.Lock()
 	defer tf.lock.Unlock()
 

--- a/client/internal/ebpf/ebpf/dns_fwd_linux.go
+++ b/client/internal/ebpf/ebpf/dns_fwd_linux.go
@@ -13,7 +13,7 @@ const (
 )
 
 func (tf *GeneralManager) LoadDNSFwd(ip string, dnsPort int) error {
-	log.Debugf("load ebpf DNS forwarder, watching addr: %s:53, redirect to port: %d", ip, dnsPort)
+	log.Debugf("load eBPF DNS forwarder, watching addr: %s:53, redirect to port: %d", ip, dnsPort)
 	tf.lock.Lock()
 	defer tf.lock.Unlock()
 

--- a/client/internal/ebpf/ebpf/src/readme.md
+++ b/client/internal/ebpf/ebpf/src/readme.md
@@ -1,5 +1,10 @@
-# Debug
+# DNS forwarder
 
+The agent attach the XDP program to the lo device. We can not use fake address in eBPF because the
+traffic does not appear in the eBPF program. The program capture the traffic on wg_ip:53 and 
+overwrite in it the destination port to 5053.
+
+# Debug
 
 The CONFIG_BPF_EVENTS kernel module is required for bpf_printk.
 Apply this code to use bpf_printk


### PR DESCRIPTION
## Describe your changes

Ensure we use WG address instead of loopback addresses for eBPF.
- First try to use 53 port
- Try to use 5053 port on WG interface for eBPF
- Try to use 5053 on WG interface or loopback interface

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
