### PR TITLE
Extend peer meta with location information

### DIFF
--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -179,7 +179,7 @@ var (
 
 			trustedPeers := config.TrustedHTTPProxies
 			if len(trustedPeers) == 0 {
-				trustedPeers = []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0")}
+				trustedPeers = []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0"), netip.MustParsePrefix("::/0")}
 			}
 			headers := []string{realip.XForwardedFor, realip.XRealIp}
 			gRPCOpts := []grpc.ServerOption{

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -76,7 +76,7 @@ type AccountManager interface {
 	GetUser(claims jwtclaims.AuthorizationClaims) (*User, error)
 	ListUsers(accountID string) ([]*User, error)
 	GetPeers(accountID, userID string) ([]*nbpeer.Peer, error)
-	MarkPeerConnected(peerKey string, connected bool, realIP string) error
+	MarkPeerConnected(peerKey string, connected bool, realIP net.IP) error
 	DeletePeer(accountID, peerID, userID string) error
 	UpdatePeer(accountID, userID string, peer *nbpeer.Peer) (*nbpeer.Peer, error)
 	GetNetworkMap(peerID string) (*NetworkMap, error)

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -76,7 +76,7 @@ type AccountManager interface {
 	GetUser(claims jwtclaims.AuthorizationClaims) (*User, error)
 	ListUsers(accountID string) ([]*User, error)
 	GetPeers(accountID, userID string) ([]*nbpeer.Peer, error)
-	MarkPeerConnected(peerKey string, connected bool) error
+	MarkPeerConnected(peerKey string, connected bool, realIP string) error
 	DeletePeer(accountID, peerID, userID string) error
 	UpdatePeer(accountID, userID string, peer *nbpeer.Peer) (*nbpeer.Peer, error)
 	GetNetworkMap(peerID string) (*NetworkMap, error)

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1638,7 +1638,7 @@ func TestDefaultAccountManager_UpdatePeer_PeerLoginExpiration(t *testing.T) {
 		LoginExpirationEnabled: true,
 	})
 	require.NoError(t, err, "unable to add peer")
-	err = manager.MarkPeerConnected(key.PublicKey().String(), true, "")
+	err = manager.MarkPeerConnected(key.PublicKey().String(), true, nil)
 	require.NoError(t, err, "unable to mark peer connected")
 	account, err = manager.UpdateAccountSettings(account.Id, userID, &Settings{
 		PeerLoginExpiration:        time.Hour,
@@ -1705,7 +1705,7 @@ func TestDefaultAccountManager_MarkPeerConnected_PeerLoginExpiration(t *testing.
 	}
 
 	// when we mark peer as connected, the peer login expiration routine should trigger
-	err = manager.MarkPeerConnected(key.PublicKey().String(), true, "")
+	err = manager.MarkPeerConnected(key.PublicKey().String(), true, nil)
 	require.NoError(t, err, "unable to mark peer connected")
 
 	failed := waitTimeout(wg, time.Second)
@@ -1728,7 +1728,7 @@ func TestDefaultAccountManager_UpdateAccountSettings_PeerLoginExpiration(t *test
 		LoginExpirationEnabled: true,
 	})
 	require.NoError(t, err, "unable to add peer")
-	err = manager.MarkPeerConnected(key.PublicKey().String(), true, "")
+	err = manager.MarkPeerConnected(key.PublicKey().String(), true, nil)
 	require.NoError(t, err, "unable to mark peer connected")
 
 	wg := &sync.WaitGroup{}

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1638,7 +1638,7 @@ func TestDefaultAccountManager_UpdatePeer_PeerLoginExpiration(t *testing.T) {
 		LoginExpirationEnabled: true,
 	})
 	require.NoError(t, err, "unable to add peer")
-	err = manager.MarkPeerConnected(key.PublicKey().String(), true)
+	err = manager.MarkPeerConnected(key.PublicKey().String(), true, "")
 	require.NoError(t, err, "unable to mark peer connected")
 	account, err = manager.UpdateAccountSettings(account.Id, userID, &Settings{
 		PeerLoginExpiration:        time.Hour,
@@ -1705,7 +1705,7 @@ func TestDefaultAccountManager_MarkPeerConnected_PeerLoginExpiration(t *testing.
 	}
 
 	// when we mark peer as connected, the peer login expiration routine should trigger
-	err = manager.MarkPeerConnected(key.PublicKey().String(), true)
+	err = manager.MarkPeerConnected(key.PublicKey().String(), true, "")
 	require.NoError(t, err, "unable to mark peer connected")
 
 	failed := waitTimeout(wg, time.Second)
@@ -1728,7 +1728,7 @@ func TestDefaultAccountManager_UpdateAccountSettings_PeerLoginExpiration(t *test
 		LoginExpirationEnabled: true,
 	})
 	require.NoError(t, err, "unable to add peer")
-	err = manager.MarkPeerConnected(key.PublicKey().String(), true)
+	err = manager.MarkPeerConnected(key.PublicKey().String(), true, "")
 	require.NoError(t, err, "unable to mark peer connected")
 
 	wg := &sync.WaitGroup{}

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -626,6 +626,27 @@ func (s *FileStore) SavePeerStatus(accountID, peerID string, peerStatus nbpeer.P
 	return nil
 }
 
+// SavePeerLocation stores the PeerStatus in memory. It doesn't attempt to persist data to speed up things.
+// Peer.Location will be saved eventually when some other changes occur.
+func (s *FileStore) SavePeerLocation(accountID string, peerWithLocation *nbpeer.Peer) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	account, err := s.getAccount(accountID)
+	if err != nil {
+		return err
+	}
+
+	peer := account.Peers[peerWithLocation.ID]
+	if peer == nil {
+		return status.Errorf(status.NotFound, "peer %s not found", peerWithLocation.ID)
+	}
+
+	peer.Meta.Location = peerWithLocation.Meta.Location
+
+	return nil
+}
+
 // SaveUserLastLogin stores the last login time for a user in memory. It doesn't attempt to persist data to speed up things.
 func (s *FileStore) SaveUserLastLogin(accountID, userID string, lastLogin time.Time) error {
 	s.mux.Lock()

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -642,7 +642,7 @@ func (s *FileStore) SavePeerLocation(accountID string, peerWithLocation *nbpeer.
 		return status.Errorf(status.NotFound, "peer %s not found", peerWithLocation.ID)
 	}
 
-	peer.Meta.Location = peerWithLocation.Meta.Location
+	peer.Location = peerWithLocation.Location
 
 	return nil
 }

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -654,12 +654,12 @@ func TestFileStore_SavePeerLocation(t *testing.T) {
 		ID:        "testpeer",
 		Meta: nbpeer.PeerSystemMeta{
 			Location: struct {
-				RealIP      string
+				RealIP      net.IP
 				CountryCode string
 				CityName    string
 				GeoNameID   uint
 			}{
-				RealIP:      "0.0.0.0",
+				RealIP:      net.ParseIP("10.0.0.0"),
 				CountryCode: "YY",
 				CityName:    "City",
 				GeoNameID:   1,
@@ -674,7 +674,7 @@ func TestFileStore_SavePeerLocation(t *testing.T) {
 	err = store.SaveAccount(account)
 	require.NoError(t, err)
 
-	peer.Meta.Location.RealIP = "35.1.1.1"
+	peer.Meta.Location.RealIP = net.ParseIP("35.1.1.1")
 	peer.Meta.Location.CountryCode = "DE"
 	peer.Meta.Location.CityName = "Berlin"
 	peer.Meta.Location.GeoNameID = 2950159

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -652,14 +652,13 @@ func TestFileStore_SavePeerLocation(t *testing.T) {
 	peer := &nbpeer.Peer{
 		AccountID: account.Id,
 		ID:        "testpeer",
-		Meta: nbpeer.PeerSystemMeta{
-			Location: nbpeer.Location{
-				RealIP:      net.ParseIP("10.0.0.0"),
-				CountryCode: "YY",
-				CityName:    "City",
-				GeoNameID:   1,
-			},
+		Location: nbpeer.Location{
+			ConnectionIP: net.ParseIP("10.0.0.0"),
+			CountryCode:  "YY",
+			CityName:     "City",
+			GeoNameID:    1,
 		},
+		Meta: nbpeer.PeerSystemMeta{},
 	}
 	// error is expected as peer is not in store yet
 	err = store.SavePeerLocation(account.Id, peer)
@@ -669,10 +668,10 @@ func TestFileStore_SavePeerLocation(t *testing.T) {
 	err = store.SaveAccount(account)
 	require.NoError(t, err)
 
-	peer.Meta.Location.RealIP = net.ParseIP("35.1.1.1")
-	peer.Meta.Location.CountryCode = "DE"
-	peer.Meta.Location.CityName = "Berlin"
-	peer.Meta.Location.GeoNameID = 2950159
+	peer.Location.ConnectionIP = net.ParseIP("35.1.1.1")
+	peer.Location.CountryCode = "DE"
+	peer.Location.CityName = "Berlin"
+	peer.Location.GeoNameID = 2950159
 
 	err = store.SavePeerLocation(account.Id, account.Peers[peer.ID])
 	assert.NoError(t, err)
@@ -680,8 +679,8 @@ func TestFileStore_SavePeerLocation(t *testing.T) {
 	account, err = store.GetAccount(account.Id)
 	require.NoError(t, err)
 
-	actual := account.Peers[peer.ID].Meta.Location
-	assert.Equal(t, peer.Meta.Location, actual)
+	actual := account.Peers[peer.ID].Location
+	assert.Equal(t, peer.Location, actual)
 }
 
 func newStore(t *testing.T) *FileStore {

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -653,12 +653,7 @@ func TestFileStore_SavePeerLocation(t *testing.T) {
 		AccountID: account.Id,
 		ID:        "testpeer",
 		Meta: nbpeer.PeerSystemMeta{
-			Location: struct {
-				RealIP      net.IP
-				CountryCode string
-				CityName    string
-				GeoNameID   uint
-			}{
+			Location: nbpeer.Location{
 				RealIP:      net.ParseIP("10.0.0.0"),
 				CountryCode: "YY",
 				CityName:    "City",

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -634,6 +634,61 @@ func TestFileStore_SavePeerStatus(t *testing.T) {
 	assert.Equal(t, newStatus, *actual)
 }
 
+func TestFileStore_SavePeerLocation(t *testing.T) {
+	storeDir := t.TempDir()
+
+	err := util.CopyFileContents("testdata/store.json", filepath.Join(storeDir, "store.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewFileStore(storeDir, nil)
+	if err != nil {
+		return
+	}
+	account, err := store.GetAccount("bf1c8084-ba50-4ce7-9439-34653001fc3b")
+	require.NoError(t, err)
+
+	peer := &nbpeer.Peer{
+		AccountID: account.Id,
+		ID:        "testpeer",
+		Meta: nbpeer.PeerSystemMeta{
+			Location: struct {
+				RealIP      string
+				CountryCode string
+				CityName    string
+				GeoNameID   uint
+			}{
+				RealIP:      "0.0.0.0",
+				CountryCode: "YY",
+				CityName:    "City",
+				GeoNameID:   1,
+			},
+		},
+	}
+	// error is expected as peer is not in store yet
+	err = store.SavePeerLocation(account.Id, peer)
+	assert.Error(t, err)
+
+	account.Peers[peer.ID] = peer
+	err = store.SaveAccount(account)
+	require.NoError(t, err)
+
+	peer.Meta.Location.RealIP = "35.1.1.1"
+	peer.Meta.Location.CountryCode = "DE"
+	peer.Meta.Location.CityName = "Berlin"
+	peer.Meta.Location.GeoNameID = 2950159
+
+	err = store.SavePeerLocation(account.Id, account.Peers[peer.ID])
+	assert.NoError(t, err)
+
+	account, err = store.GetAccount(account.Id)
+	require.NoError(t, err)
+
+	actual := account.Peers[peer.ID].Meta.Location
+	assert.Equal(t, peer.Meta.Location, actual)
+}
+
 func newStore(t *testing.T) *FileStore {
 	t.Helper()
 	store, err := NewFileStore(t.TempDir(), nil)

--- a/management/server/geolocation/geolocation.go
+++ b/management/server/geolocation/geolocation.go
@@ -102,17 +102,12 @@ func getSha256sum(mmdbPath string) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-func (gl *Geolocation) Lookup(ip string) (*Record, error) {
+func (gl *Geolocation) Lookup(ip net.IP) (*Record, error) {
 	gl.mux.RLock()
 	defer gl.mux.RUnlock()
 
-	parsedIp := net.ParseIP(ip)
-	if parsedIp == nil {
-		return nil, fmt.Errorf("could not parse IP %s", ip)
-	}
-
 	var record Record
-	err := gl.db.Lookup(parsedIp, &record)
+	err := gl.db.Lookup(ip, &record)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/geolocation/geolocation_test.go
+++ b/management/server/geolocation/geolocation_test.go
@@ -1,6 +1,7 @@
 package geolocation
 
 import (
+	"net"
 	"os"
 	"path"
 	"testing"
@@ -34,7 +35,7 @@ func TestGeoLite_Lookup(t *testing.T) {
 		}
 	}()
 
-	record, err := geo.Lookup("89.160.20.128")
+	record, err := geo.Lookup(net.ParseIP("89.160.20.128"))
 	assert.NoError(t, err)
 	assert.NotNil(t, record)
 	assert.Equal(t, "SE", record.Country.ISOCode)
@@ -43,7 +44,4 @@ func TestGeoLite_Lookup(t *testing.T) {
 	assert.Equal(t, uint(2694762), record.City.GeonameID)
 	assert.Equal(t, "EU", record.Continent.Code)
 	assert.Equal(t, uint(6255148), record.Continent.GeonameID)
-
-	_, err = geo.Lookup("589.160.20.128")
-	assert.Error(t, err)
 }

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -109,11 +110,11 @@ func (s *GRPCServer) GetServerKey(ctx context.Context, req *proto.Empty) (*proto
 	}, nil
 }
 
-func getRealIP(ctx context.Context) string {
-	if ip, ok := realip.FromContext(ctx); ok {
-		return ip.String()
+func getRealIP(ctx context.Context) net.IP {
+	if addr, ok := realip.FromContext(ctx); ok {
+		return net.IP(addr.AsSlice())
 	}
-	return ""
+	return nil
 }
 
 // Sync validates the existence of a connecting peer, sends an initial state (all available for the connecting peers) and
@@ -124,7 +125,7 @@ func (s *GRPCServer) Sync(req *proto.EncryptedMessage, srv proto.ManagementServi
 		s.appMetrics.GRPCMetrics().CountSyncRequest()
 	}
 	realIP := getRealIP(srv.Context())
-	log.Debugf("Sync request from peer [%s] [%s]", req.WgPubKey, realIP)
+	log.Debugf("Sync request from peer [%s] [%s]", req.WgPubKey, realIP.String())
 
 	syncReq := &proto.SyncRequest{}
 	peerKey, err := s.parseRequest(req, syncReq)
@@ -205,7 +206,7 @@ func (s *GRPCServer) Sync(req *proto.EncryptedMessage, srv proto.ManagementServi
 func (s *GRPCServer) cancelPeerRoutines(peer *nbpeer.Peer) {
 	s.peersUpdateManager.CloseChannel(peer.ID)
 	s.turnCredentialsManager.CancelRefresh(peer.ID)
-	_ = s.accountManager.MarkPeerConnected(peer.Key, false, "")
+	_ = s.accountManager.MarkPeerConnected(peer.Key, false, nil)
 	s.ephemeralManager.OnPeerDisconnected(peer)
 }
 
@@ -303,7 +304,7 @@ func (s *GRPCServer) Login(ctx context.Context, req *proto.EncryptedMessage) (*p
 		s.appMetrics.GRPCMetrics().CountLoginRequest()
 	}
 	realIP := getRealIP(ctx)
-	log.Debugf("Login request from peer [%s] [%s]", req.WgPubKey, realIP)
+	log.Debugf("Login request from peer [%s] [%s]", req.WgPubKey, realIP.String())
 
 	loginReq := &proto.LoginRequest{}
 	peerKey, err := s.parseRequest(req, loginReq)

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -147,7 +147,7 @@ func (s *GRPCServer) Sync(req *proto.EncryptedMessage, srv proto.ManagementServi
 
 	s.ephemeralManager.OnPeerConnected(peer)
 
-	err = s.accountManager.MarkPeerConnected(peerKey.String(), true)
+	err = s.accountManager.MarkPeerConnected(peerKey.String(), true, realIP)
 	if err != nil {
 		log.Warnf("failed marking peer as connected %s %v", peerKey, err)
 	}
@@ -205,7 +205,7 @@ func (s *GRPCServer) Sync(req *proto.EncryptedMessage, srv proto.ManagementServi
 func (s *GRPCServer) cancelPeerRoutines(peer *nbpeer.Peer) {
 	s.peersUpdateManager.CloseChannel(peer.ID)
 	s.turnCredentialsManager.CancelRefresh(peer.ID)
-	_ = s.accountManager.MarkPeerConnected(peer.Key, false)
+	_ = s.accountManager.MarkPeerConnected(peer.Key, false, "")
 	s.ephemeralManager.OnPeerDisconnected(peer)
 }
 

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -247,6 +247,10 @@ components:
               description: Peer's IP address
               type: string
               example: 10.64.0.1
+            public_ip:
+              description: Peer's public IP address
+              type: string
+              example: 10.64.0.1
             connected:
               description: Peer to Management connection status
               type: boolean
@@ -260,6 +264,14 @@ components:
               description: Peer's operating system and version
               type: string
               example: Darwin 13.2.1
+            kernel_version:
+              description: Peer's operating system kernel version
+              type: string
+              example: 23.2.0
+            geoname_id:
+              description: Unique identifier from the GeoNames database for a specific geographical location.
+              type: integer
+              example: 2643743
             version:
               description: Peer's daemon or cli version
               type: string

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -247,10 +247,10 @@ components:
               description: Peer's IP address
               type: string
               example: 10.64.0.1
-            public_ip:
-              description: Peer's public IP address
+            connection_ip:
+              description: Peer's public connection IP address
               type: string
-              example: 10.64.0.1
+              example: 35.64.0.1
             connected:
               description: Peer to Management connection status
               type: boolean

--- a/management/server/http/api/types.gen.go
+++ b/management/server/http/api/types.gen.go
@@ -415,6 +415,9 @@ type Peer struct {
 	// DnsLabel Peer's DNS label is the parsed peer name for domain resolution. It is used to form an FQDN by appending the account's domain to the peer label. e.g. peer-dns-label.netbird.cloud
 	DnsLabel string `json:"dns_label"`
 
+	// GeonameId Unique identifier from the GeoNames database for a specific geographical location.
+	GeonameId *int `json:"geoname_id,omitempty"`
+
 	// Groups Groups that the peer belongs to
 	Groups []GroupMinimum `json:"groups"`
 
@@ -426,6 +429,9 @@ type Peer struct {
 
 	// Ip Peer's IP address
 	Ip string `json:"ip"`
+
+	// KernelVersion Peer's operating system kernel version
+	KernelVersion *string `json:"kernel_version,omitempty"`
 
 	// LastLogin Last time this peer performed log in (authentication). E.g., user authenticated.
 	LastLogin time.Time `json:"last_login"`
@@ -444,6 +450,9 @@ type Peer struct {
 
 	// Os Peer's operating system and version
 	Os string `json:"os"`
+
+	// PublicIp Peer's public IP address
+	PublicIp *string `json:"public_ip,omitempty"`
 
 	// SshEnabled Indicates whether SSH server is enabled on this peer
 	SshEnabled bool `json:"ssh_enabled"`
@@ -469,6 +478,9 @@ type PeerBase struct {
 	// DnsLabel Peer's DNS label is the parsed peer name for domain resolution. It is used to form an FQDN by appending the account's domain to the peer label. e.g. peer-dns-label.netbird.cloud
 	DnsLabel string `json:"dns_label"`
 
+	// GeonameId Unique identifier from the GeoNames database for a specific geographical location.
+	GeonameId *int `json:"geoname_id,omitempty"`
+
 	// Groups Groups that the peer belongs to
 	Groups []GroupMinimum `json:"groups"`
 
@@ -480,6 +492,9 @@ type PeerBase struct {
 
 	// Ip Peer's IP address
 	Ip string `json:"ip"`
+
+	// KernelVersion Peer's operating system kernel version
+	KernelVersion *string `json:"kernel_version,omitempty"`
 
 	// LastLogin Last time this peer performed log in (authentication). E.g., user authenticated.
 	LastLogin time.Time `json:"last_login"`
@@ -498,6 +513,9 @@ type PeerBase struct {
 
 	// Os Peer's operating system and version
 	Os string `json:"os"`
+
+	// PublicIp Peer's public IP address
+	PublicIp *string `json:"public_ip,omitempty"`
 
 	// SshEnabled Indicates whether SSH server is enabled on this peer
 	SshEnabled bool `json:"ssh_enabled"`
@@ -526,6 +544,9 @@ type PeerBatch struct {
 	// DnsLabel Peer's DNS label is the parsed peer name for domain resolution. It is used to form an FQDN by appending the account's domain to the peer label. e.g. peer-dns-label.netbird.cloud
 	DnsLabel string `json:"dns_label"`
 
+	// GeonameId Unique identifier from the GeoNames database for a specific geographical location.
+	GeonameId *int `json:"geoname_id,omitempty"`
+
 	// Groups Groups that the peer belongs to
 	Groups []GroupMinimum `json:"groups"`
 
@@ -537,6 +558,9 @@ type PeerBatch struct {
 
 	// Ip Peer's IP address
 	Ip string `json:"ip"`
+
+	// KernelVersion Peer's operating system kernel version
+	KernelVersion *string `json:"kernel_version,omitempty"`
 
 	// LastLogin Last time this peer performed log in (authentication). E.g., user authenticated.
 	LastLogin time.Time `json:"last_login"`
@@ -555,6 +579,9 @@ type PeerBatch struct {
 
 	// Os Peer's operating system and version
 	Os string `json:"os"`
+
+	// PublicIp Peer's public IP address
+	PublicIp *string `json:"public_ip,omitempty"`
 
 	// SshEnabled Indicates whether SSH server is enabled on this peer
 	SshEnabled bool `json:"ssh_enabled"`

--- a/management/server/http/api/types.gen.go
+++ b/management/server/http/api/types.gen.go
@@ -412,6 +412,9 @@ type Peer struct {
 	// Connected Peer to Management connection status
 	Connected bool `json:"connected"`
 
+	// ConnectionIp Peer's public connection IP address
+	ConnectionIp *string `json:"connection_ip,omitempty"`
+
 	// DnsLabel Peer's DNS label is the parsed peer name for domain resolution. It is used to form an FQDN by appending the account's domain to the peer label. e.g. peer-dns-label.netbird.cloud
 	DnsLabel string `json:"dns_label"`
 
@@ -450,9 +453,6 @@ type Peer struct {
 
 	// Os Peer's operating system and version
 	Os string `json:"os"`
-
-	// PublicIp Peer's public IP address
-	PublicIp *string `json:"public_ip,omitempty"`
 
 	// SshEnabled Indicates whether SSH server is enabled on this peer
 	SshEnabled bool `json:"ssh_enabled"`
@@ -475,6 +475,9 @@ type PeerBase struct {
 	// Connected Peer to Management connection status
 	Connected bool `json:"connected"`
 
+	// ConnectionIp Peer's public connection IP address
+	ConnectionIp *string `json:"connection_ip,omitempty"`
+
 	// DnsLabel Peer's DNS label is the parsed peer name for domain resolution. It is used to form an FQDN by appending the account's domain to the peer label. e.g. peer-dns-label.netbird.cloud
 	DnsLabel string `json:"dns_label"`
 
@@ -513,9 +516,6 @@ type PeerBase struct {
 
 	// Os Peer's operating system and version
 	Os string `json:"os"`
-
-	// PublicIp Peer's public IP address
-	PublicIp *string `json:"public_ip,omitempty"`
 
 	// SshEnabled Indicates whether SSH server is enabled on this peer
 	SshEnabled bool `json:"ssh_enabled"`
@@ -541,6 +541,9 @@ type PeerBatch struct {
 	// Connected Peer to Management connection status
 	Connected bool `json:"connected"`
 
+	// ConnectionIp Peer's public connection IP address
+	ConnectionIp *string `json:"connection_ip,omitempty"`
+
 	// DnsLabel Peer's DNS label is the parsed peer name for domain resolution. It is used to form an FQDN by appending the account's domain to the peer label. e.g. peer-dns-label.netbird.cloud
 	DnsLabel string `json:"dns_label"`
 
@@ -579,9 +582,6 @@ type PeerBatch struct {
 
 	// Os Peer's operating system and version
 	Os string `json:"os"`
-
-	// PublicIp Peer's public IP address
-	PublicIp *string `json:"public_ip,omitempty"`
 
 	// SshEnabled Indicates whether SSH server is enabled on this peer
 	SshEnabled bool `json:"ssh_enabled"`

--- a/management/server/http/peers_handler.go
+++ b/management/server/http/peers_handler.go
@@ -231,7 +231,7 @@ func toGroupsInfo(groups map[string]*server.Group, peerID string) []api.GroupMin
 	return groupsInfo
 }
 
-func publicIPToString(ip net.IP) *string {
+func connectionIPoString(ip net.IP) *string {
 	publicIP := ""
 	if ip != nil {
 		publicIP = ip.String()
@@ -244,12 +244,12 @@ func toSinglePeerResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dnsD
 	if osVersion == "" {
 		osVersion = peer.Meta.Core
 	}
-	geonameID := int(peer.Meta.Location.GeoNameID)
+	geonameID := int(peer.Location.GeoNameID)
 	return &api.Peer{
 		Id:                     peer.ID,
 		Name:                   peer.Name,
 		Ip:                     peer.IP.String(),
-		PublicIp:               publicIPToString(peer.Meta.Location.RealIP),
+		ConnectionIp:           connectionIPoString(peer.Location.ConnectionIP),
 		Connected:              peer.Status.Connected,
 		LastSeen:               peer.Status.LastSeen,
 		Os:                     fmt.Sprintf("%s %s", peer.Meta.OS, osVersion),
@@ -275,12 +275,12 @@ func toPeerListItemResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dn
 	if osVersion == "" {
 		osVersion = peer.Meta.Core
 	}
-	geonameID := int(peer.Meta.Location.GeoNameID)
+	geonameID := int(peer.Location.GeoNameID)
 	return &api.PeerBatch{
 		Id:                     peer.ID,
 		Name:                   peer.Name,
 		Ip:                     peer.IP.String(),
-		PublicIp:               publicIPToString(peer.Meta.Location.RealIP),
+		ConnectionIp:           connectionIPoString(peer.Location.ConnectionIP),
 		Connected:              peer.Status.Connected,
 		LastSeen:               peer.Status.LastSeen,
 		Os:                     fmt.Sprintf("%s %s", peer.Meta.OS, osVersion),

--- a/management/server/http/peers_handler.go
+++ b/management/server/http/peers_handler.go
@@ -3,6 +3,7 @@ package http
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -230,18 +231,30 @@ func toGroupsInfo(groups map[string]*server.Group, peerID string) []api.GroupMin
 	return groupsInfo
 }
 
+func publicIPToString(ip net.IP) *string {
+	publicIP := ""
+	if ip != nil {
+		publicIP = ip.String()
+	}
+	return &publicIP
+}
+
 func toSinglePeerResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dnsDomain string, accessiblePeer []api.AccessiblePeer) *api.Peer {
 	osVersion := peer.Meta.OSVersion
 	if osVersion == "" {
 		osVersion = peer.Meta.Core
 	}
+	geonameID := int(peer.Meta.Location.GeoNameID)
 	return &api.Peer{
 		Id:                     peer.ID,
 		Name:                   peer.Name,
 		Ip:                     peer.IP.String(),
+		PublicIp:               publicIPToString(peer.Meta.Location.RealIP),
 		Connected:              peer.Status.Connected,
 		LastSeen:               peer.Status.LastSeen,
 		Os:                     fmt.Sprintf("%s %s", peer.Meta.OS, osVersion),
+		KernelVersion:          &peer.Meta.KernelVersion,
+		GeonameId:              &geonameID,
 		Version:                peer.Meta.WtVersion,
 		Groups:                 groupsInfo,
 		SshEnabled:             peer.SSHEnabled,
@@ -262,13 +275,17 @@ func toPeerListItemResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dn
 	if osVersion == "" {
 		osVersion = peer.Meta.Core
 	}
+	geonameID := int(peer.Meta.Location.GeoNameID)
 	return &api.PeerBatch{
 		Id:                     peer.ID,
 		Name:                   peer.Name,
 		Ip:                     peer.IP.String(),
+		PublicIp:               publicIPToString(peer.Meta.Location.RealIP),
 		Connected:              peer.Status.Connected,
 		LastSeen:               peer.Status.LastSeen,
 		Os:                     fmt.Sprintf("%s %s", peer.Meta.OS, osVersion),
+		KernelVersion:          &peer.Meta.KernelVersion,
+		GeonameId:              &geonameID,
 		Version:                peer.Meta.WtVersion,
 		Groups:                 groupsInfo,
 		SshEnabled:             peer.SSHEnabled,

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -1,6 +1,7 @@
 package mock_server
 
 import (
+	"net"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -24,7 +25,7 @@ type MockAccountManager struct {
 	GetUserFunc                     func(claims jwtclaims.AuthorizationClaims) (*server.User, error)
 	ListUsersFunc                   func(accountID string) ([]*server.User, error)
 	GetPeersFunc                    func(accountID, userID string) ([]*nbpeer.Peer, error)
-	MarkPeerConnectedFunc           func(peerKey string, connected bool, realIP string) error
+	MarkPeerConnectedFunc           func(peerKey string, connected bool, realIP net.IP) error
 	DeletePeerFunc                  func(accountID, peerKey, userID string) error
 	GetNetworkMapFunc               func(peerKey string) (*server.NetworkMap, error)
 	GetPeerNetworkFunc              func(peerKey string) (*server.Network, error)
@@ -152,7 +153,7 @@ func (am *MockAccountManager) GetAccountByUserOrAccountID(
 }
 
 // MarkPeerConnected mock implementation of MarkPeerConnected from server.AccountManager interface
-func (am *MockAccountManager) MarkPeerConnected(peerKey string, connected bool, realIP string) error {
+func (am *MockAccountManager) MarkPeerConnected(peerKey string, connected bool, realIP net.IP) error {
 	if am.MarkPeerConnectedFunc != nil {
 		return am.MarkPeerConnectedFunc(peerKey, connected, realIP)
 	}

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -24,7 +24,7 @@ type MockAccountManager struct {
 	GetUserFunc                     func(claims jwtclaims.AuthorizationClaims) (*server.User, error)
 	ListUsersFunc                   func(accountID string) ([]*server.User, error)
 	GetPeersFunc                    func(accountID, userID string) ([]*nbpeer.Peer, error)
-	MarkPeerConnectedFunc           func(peerKey string, connected bool) error
+	MarkPeerConnectedFunc           func(peerKey string, connected bool, realIP string) error
 	DeletePeerFunc                  func(accountID, peerKey, userID string) error
 	GetNetworkMapFunc               func(peerKey string) (*server.NetworkMap, error)
 	GetPeerNetworkFunc              func(peerKey string) (*server.Network, error)
@@ -152,9 +152,9 @@ func (am *MockAccountManager) GetAccountByUserOrAccountID(
 }
 
 // MarkPeerConnected mock implementation of MarkPeerConnected from server.AccountManager interface
-func (am *MockAccountManager) MarkPeerConnected(peerKey string, connected bool) error {
+func (am *MockAccountManager) MarkPeerConnected(peerKey string, connected bool, realIP string) error {
 	if am.MarkPeerConnectedFunc != nil {
-		return am.MarkPeerConnectedFunc(peerKey, connected)
+		return am.MarkPeerConnectedFunc(peerKey, connected, realIP)
 	}
 	return status.Errorf(codes.Unimplemented, "method MarkPeerConnected is not implemented")
 }

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -116,10 +116,10 @@ func (am *DefaultAccountManager) MarkPeerConnected(peerPubKey string, connected 
 		if err != nil {
 			log.Warnf("failed to get location for peer %s realip: [%s]: %v", peer.ID, realIP.String(), err)
 		} else {
-			peer.Meta.Location.RealIP = realIP
-			peer.Meta.Location.CountryCode = location.Country.ISOCode
-			peer.Meta.Location.CityName = location.City.Names.En
-			peer.Meta.Location.GeoNameID = location.City.GeonameID
+			peer.Location.ConnectionIP = realIP
+			peer.Location.CountryCode = location.Country.ISOCode
+			peer.Location.CityName = location.City.Names.En
+			peer.Location.GeoNameID = location.City.GeonameID
 			err = am.Store.SavePeerLocation(account.Id, peer)
 			if err != nil {
 				log.Warnf("could not store location for peer %s: %s", peer.ID, err)

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -80,7 +81,7 @@ func (am *DefaultAccountManager) GetPeers(accountID, userID string) ([]*nbpeer.P
 }
 
 // MarkPeerConnected marks peer as connected (true) or disconnected (false)
-func (am *DefaultAccountManager) MarkPeerConnected(peerPubKey string, connected bool, realIP string) error {
+func (am *DefaultAccountManager) MarkPeerConnected(peerPubKey string, connected bool, realIP net.IP) error {
 	account, err := am.Store.GetAccountByPeerPubKey(peerPubKey)
 	if err != nil {
 		return err
@@ -110,10 +111,10 @@ func (am *DefaultAccountManager) MarkPeerConnected(peerPubKey string, connected 
 	}
 	peer.Status = newStatus
 
-	if am.geo != nil && realIP != "" {
+	if am.geo != nil && realIP != nil {
 		location, err := am.geo.Lookup(realIP)
 		if err != nil {
-			log.Warnf("failed to get location for peer %s realip: [%s]: %v", peer.ID, realIP, err)
+			log.Warnf("failed to get location for peer %s realip: [%s]: %v", peer.ID, realIP.String(), err)
 		} else {
 			peer.Meta.Location.RealIP = realIP
 			peer.Meta.Location.CountryCode = location.Country.ISOCode

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -113,11 +113,16 @@ func (am *DefaultAccountManager) MarkPeerConnected(peerPubKey string, connected 
 	if am.geo != nil && realIP != "" {
 		location, err := am.geo.Lookup(realIP)
 		if err != nil {
-			log.Errorf("failed to get location for peer %s realip: [%s]: %v", peer.ID, realIP, err)
+			log.Warnf("failed to get location for peer %s realip: [%s]: %v", peer.ID, realIP, err)
 		} else {
+			peer.Meta.Location.RealIP = realIP
 			peer.Meta.Location.CountryCode = location.Country.ISOCode
 			peer.Meta.Location.CityName = location.City.Names.En
-			// TODO: save peer location
+			peer.Meta.Location.GeoNameID = location.City.GeonameID
+			err = am.Store.SavePeerLocation(account.Id, peer)
+			if err != nil {
+				log.Warnf("could not store location for peer %s: %s", peer.ID, err)
+			}
 		}
 	}
 

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -66,9 +66,7 @@ type PeerSystemMeta struct {
 	WtVersion     string
 	UIVersion     string
 	KernelVersion string
-	// Location mock location for peer
-	// TODO: Add actual implementation based on peer IP
-	Location struct {
+	Location      struct {
 		RealIP      net.IP // from grpc peer or reverse proxy headers depends on setup
 		CountryCode string
 		CityName    string

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -66,12 +66,13 @@ type PeerSystemMeta struct {
 	WtVersion     string
 	UIVersion     string
 	KernelVersion string
-	Location      struct {
-		RealIP      net.IP // from grpc peer or reverse proxy headers depends on setup
-		CountryCode string
-		CityName    string
-		GeoNameID   uint // city level geoname id
-	} `gorm:"embedded;embeddedPrefix:location_"`
+	Location      Location `gorm:"embedded;embeddedPrefix:location_"`
+}
+type Location struct {
+	RealIP      net.IP // from grpc peer or reverse proxy headers depends on setup
+	CountryCode string
+	CityName    string
+	GeoNameID   uint // city level geoname id
 }
 
 func (p PeerSystemMeta) isEqual(other PeerSystemMeta) bool {

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -41,6 +41,8 @@ type Peer struct {
 	LastLogin time.Time
 	// Indicate ephemeral peer attribute
 	Ephemeral bool
+	// Geo location based on connection IP
+	Location Location `gorm:"embedded;embeddedPrefix:location_"`
 }
 
 type PeerStatus struct {
@@ -52,6 +54,14 @@ type PeerStatus struct {
 	LoginExpired bool
 	// RequiresApproval indicates whether peer requires approval or not
 	RequiresApproval bool
+}
+
+// Location is a geo location information of a Peer based on public connection IP
+type Location struct {
+	ConnectionIP net.IP // from grpc peer or reverse proxy headers depends on setup
+	CountryCode  string
+	CityName     string
+	GeoNameID    uint // city level geoname id
 }
 
 // PeerSystemMeta is a metadata of a Peer machine system
@@ -66,13 +76,6 @@ type PeerSystemMeta struct {
 	WtVersion     string
 	UIVersion     string
 	KernelVersion string
-	Location      Location `gorm:"embedded;embeddedPrefix:location_"`
-}
-type Location struct {
-	RealIP      net.IP // from grpc peer or reverse proxy headers depends on setup
-	CountryCode string
-	CityName    string
-	GeoNameID   uint // city level geoname id
 }
 
 func (p PeerSystemMeta) isEqual(other PeerSystemMeta) bool {
@@ -85,11 +88,7 @@ func (p PeerSystemMeta) isEqual(other PeerSystemMeta) bool {
 		p.OS == other.OS &&
 		p.OSVersion == other.OSVersion &&
 		p.WtVersion == other.WtVersion &&
-		p.UIVersion == other.UIVersion &&
-		p.Location.RealIP.Equal(other.Location.RealIP) &&
-		p.Location.CountryCode == other.Location.CountryCode &&
-		p.Location.CityName == other.Location.CityName &&
-		p.Location.GeoNameID == other.Location.GeoNameID
+		p.UIVersion == other.UIVersion
 }
 
 // AddedWithSSOLogin indicates whether this peer has been added with an SSO login by a user.
@@ -119,6 +118,7 @@ func (p *Peer) Copy() *Peer {
 		LoginExpirationEnabled: p.LoginExpirationEnabled,
 		LastLogin:              p.LastLogin,
 		Ephemeral:              p.Ephemeral,
+		Location:               p.Location,
 	}
 }
 

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -69,8 +69,10 @@ type PeerSystemMeta struct {
 	// Location mock location for peer
 	// TODO: Add actual implementation based on peer IP
 	Location struct {
+		RealIP      string // from grpc peer or reverse proxy headers depends on setup
 		CountryCode string
 		CityName    string
+		GeoNameID   uint // city level geoname id
 	} `gorm:"embedded;embeddedPrefix:location_"`
 }
 
@@ -84,7 +86,11 @@ func (p PeerSystemMeta) isEqual(other PeerSystemMeta) bool {
 		p.OS == other.OS &&
 		p.OSVersion == other.OSVersion &&
 		p.WtVersion == other.WtVersion &&
-		p.UIVersion == other.UIVersion
+		p.UIVersion == other.UIVersion &&
+		p.Location.RealIP == other.Location.RealIP &&
+		p.Location.CountryCode == other.Location.CountryCode &&
+		p.Location.CityName == other.Location.CityName &&
+		p.Location.GeoNameID == other.Location.GeoNameID
 }
 
 // AddedWithSSOLogin indicates whether this peer has been added with an SSO login by a user.

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -69,7 +69,7 @@ type PeerSystemMeta struct {
 	// Location mock location for peer
 	// TODO: Add actual implementation based on peer IP
 	Location struct {
-		RealIP      string // from grpc peer or reverse proxy headers depends on setup
+		RealIP      net.IP // from grpc peer or reverse proxy headers depends on setup
 		CountryCode string
 		CityName    string
 		GeoNameID   uint // city level geoname id
@@ -87,7 +87,7 @@ func (p PeerSystemMeta) isEqual(other PeerSystemMeta) bool {
 		p.OSVersion == other.OSVersion &&
 		p.WtVersion == other.WtVersion &&
 		p.UIVersion == other.UIVersion &&
-		p.Location.RealIP == other.Location.RealIP &&
+		p.Location.RealIP.Equal(other.Location.RealIP) &&
 		p.Location.CountryCode == other.Location.CountryCode &&
 		p.Location.CityName == other.Location.CityName &&
 		p.Location.GeoNameID == other.Location.GeoNameID

--- a/management/server/posture/geo_location.go
+++ b/management/server/posture/geo_location.go
@@ -31,8 +31,8 @@ type GeoLocationCheck struct {
 
 func (g *GeoLocationCheck) Check(peer nbpeer.Peer) (bool, error) {
 	for _, loc := range g.Locations {
-		if loc.CountryCode == peer.Meta.Location.CountryCode {
-			if loc.CityName == "" || loc.CityName == peer.Meta.Location.CityName {
+		if loc.CountryCode == peer.Location.CountryCode {
+			if loc.CityName == "" || loc.CityName == peer.Location.CityName {
 				switch g.Action {
 				case GeoLocationActionDeny:
 					return false, nil

--- a/management/server/posture/geo_location_test.go
+++ b/management/server/posture/geo_location_test.go
@@ -19,11 +19,9 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 		{
 			name: "Peer location matches the location in the allow sets",
 			input: peer.Peer{
-				Meta: peer.PeerSystemMeta{
-					Location: peer.Location{
-						CountryCode: "DE",
-						CityName:    "Berlin",
-					},
+				Location: peer.Location{
+					CountryCode: "DE",
+					CityName:    "Berlin",
 				},
 			},
 			check: GeoLocationCheck{
@@ -45,11 +43,9 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 		{
 			name: "Peer location matches the location in the allow country only",
 			input: peer.Peer{
-				Meta: peer.PeerSystemMeta{
-					Location: peer.Location{
-						CountryCode: "DE",
-						CityName:    "Berlin",
-					},
+				Location: peer.Location{
+					CountryCode: "DE",
+					CityName:    "Berlin",
 				},
 			},
 			check: GeoLocationCheck{
@@ -66,11 +62,9 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 		{
 			name: "Peer location doesn't match the location in the allow sets",
 			input: peer.Peer{
-				Meta: peer.PeerSystemMeta{
-					Location: peer.Location{
-						CountryCode: "DE",
-						CityName:    "Frankfurt am Main",
-					},
+				Location: peer.Location{
+					CountryCode: "DE",
+					CityName:    "Frankfurt am Main",
 				},
 			},
 			check: GeoLocationCheck{
@@ -92,11 +86,9 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 		{
 			name: "Peer location doesn't match the location in the allow country only",
 			input: peer.Peer{
-				Meta: peer.PeerSystemMeta{
-					Location: peer.Location{
-						CountryCode: "DE",
-						CityName:    "Frankfurt am Main",
-					},
+				Location: peer.Location{
+					CountryCode: "DE",
+					CityName:    "Frankfurt am Main",
 				},
 			},
 			check: GeoLocationCheck{
@@ -113,11 +105,9 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 		{
 			name: "Peer location matches the location in the deny sets",
 			input: peer.Peer{
-				Meta: peer.PeerSystemMeta{
-					Location: peer.Location{
-						CountryCode: "DE",
-						CityName:    "Berlin",
-					},
+				Location: peer.Location{
+					CountryCode: "DE",
+					CityName:    "Berlin",
 				},
 			},
 			check: GeoLocationCheck{
@@ -139,11 +129,9 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 		{
 			name: "Peer location matches the location in the deny country only",
 			input: peer.Peer{
-				Meta: peer.PeerSystemMeta{
-					Location: peer.Location{
-						CountryCode: "DE",
-						CityName:    "Berlin",
-					},
+				Location: peer.Location{
+					CountryCode: "DE",
+					CityName:    "Berlin",
 				},
 			},
 			check: GeoLocationCheck{
@@ -163,11 +151,9 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 		{
 			name: "Peer location doesn't match the location in the deny sets",
 			input: peer.Peer{
-				Meta: peer.PeerSystemMeta{
-					Location: peer.Location{
-						CountryCode: "DE",
-						CityName:    "Frankfurt am Main",
-					},
+				Location: peer.Location{
+					CountryCode: "DE",
+					CityName:    "Frankfurt am Main",
 				},
 			},
 			check: GeoLocationCheck{
@@ -189,11 +175,9 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 		{
 			name: "Peer location doesn't match the location in the deny country only",
 			input: peer.Peer{
-				Meta: peer.PeerSystemMeta{
-					Location: peer.Location{
-						CountryCode: "DE",
-						CityName:    "Frankfurt am Main",
-					},
+				Location: peer.Location{
+					CountryCode: "DE",
+					CityName:    "Frankfurt am Main",
 				},
 			},
 			check: GeoLocationCheck{

--- a/management/server/posture/geo_location_test.go
+++ b/management/server/posture/geo_location_test.go
@@ -20,7 +20,7 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 			name: "Peer location matches the location in the allow sets",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
-					Location: Location{
+					Location: peer.Location{
 						CountryCode: "DE",
 						CityName:    "Berlin",
 					},
@@ -46,7 +46,7 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 			name: "Peer location matches the location in the allow country only",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
-					Location: Location{
+					Location: peer.Location{
 						CountryCode: "DE",
 						CityName:    "Berlin",
 					},
@@ -67,7 +67,7 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 			name: "Peer location doesn't match the location in the allow sets",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
-					Location: Location{
+					Location: peer.Location{
 						CountryCode: "DE",
 						CityName:    "Frankfurt am Main",
 					},
@@ -93,7 +93,7 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 			name: "Peer location doesn't match the location in the allow country only",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
-					Location: Location{
+					Location: peer.Location{
 						CountryCode: "DE",
 						CityName:    "Frankfurt am Main",
 					},
@@ -114,7 +114,7 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 			name: "Peer location matches the location in the deny sets",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
-					Location: Location{
+					Location: peer.Location{
 						CountryCode: "DE",
 						CityName:    "Berlin",
 					},
@@ -140,7 +140,7 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 			name: "Peer location matches the location in the deny country only",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
-					Location: Location{
+					Location: peer.Location{
 						CountryCode: "DE",
 						CityName:    "Berlin",
 					},
@@ -164,7 +164,7 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 			name: "Peer location doesn't match the location in the deny sets",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
-					Location: Location{
+					Location: peer.Location{
 						CountryCode: "DE",
 						CityName:    "Frankfurt am Main",
 					},
@@ -190,7 +190,7 @@ func TestGeoLocationCheck_Check(t *testing.T) {
 			name: "Peer location doesn't match the location in the deny country only",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
-					Location: Location{
+					Location: peer.Location{
 						CountryCode: "DE",
 						CityName:    "Frankfurt am Main",
 					},

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -274,7 +274,7 @@ func (s *SqliteStore) SavePeerLocation(accountID string, peerWithLocation *nbpee
 		return status.Errorf(status.NotFound, "peer %s not found", peer.ID)
 	}
 
-	peer.Meta.Location = peerWithLocation.Meta.Location
+	peer.Location = peerWithLocation.Location
 
 	return s.db.Save(peer).Error
 }

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -267,6 +267,18 @@ func (s *SqliteStore) SavePeerStatus(accountID, peerID string, peerStatus nbpeer
 	return s.db.Save(peer).Error
 }
 
+func (s *SqliteStore) SavePeerLocation(accountID string, peerWithLocation *nbpeer.Peer) error {
+	var peer nbpeer.Peer
+	result := s.db.First(&peer, "account_id = ? and id = ?", accountID, peer.ID)
+	if result.Error != nil {
+		return status.Errorf(status.NotFound, "peer %s not found", peer.ID)
+	}
+
+	peer.Meta.Location = peerWithLocation.Meta.Location
+
+	return s.db.Save(peer).Error
+}
+
 // DeleteHashedPAT2TokenIDIndex is noop in Sqlite
 func (s *SqliteStore) DeleteHashedPAT2TokenIDIndex(hashedToken string) error {
 	return nil

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -269,7 +269,7 @@ func (s *SqliteStore) SavePeerStatus(accountID, peerID string, peerStatus nbpeer
 
 func (s *SqliteStore) SavePeerLocation(accountID string, peerWithLocation *nbpeer.Peer) error {
 	var peer nbpeer.Peer
-	result := s.db.First(&peer, "account_id = ? and id = ?", accountID, peer.ID)
+	result := s.db.First(&peer, "account_id = ? and id = ?", accountID, peerWithLocation.ID)
 	if result.Error != nil {
 		return status.Errorf(status.NotFound, "peer %s not found", peer.ID)
 	}

--- a/management/server/sqlite_store_test.go
+++ b/management/server/sqlite_store_test.go
@@ -225,14 +225,13 @@ func TestSqlite_SavePeerLocation(t *testing.T) {
 	peer := &nbpeer.Peer{
 		AccountID: account.Id,
 		ID:        "testpeer",
-		Meta: nbpeer.PeerSystemMeta{
-			Location: nbpeer.Location{
-				RealIP:      net.ParseIP("0.0.0.0"),
-				CountryCode: "YY",
-				CityName:    "City",
-				GeoNameID:   1,
-			},
+		Location: nbpeer.Location{
+			ConnectionIP: net.ParseIP("0.0.0.0"),
+			CountryCode:  "YY",
+			CityName:     "City",
+			GeoNameID:    1,
 		},
+		Meta: nbpeer.PeerSystemMeta{},
 	}
 	// error is expected as peer is not in store yet
 	err = store.SavePeerLocation(account.Id, peer)
@@ -242,10 +241,10 @@ func TestSqlite_SavePeerLocation(t *testing.T) {
 	err = store.SaveAccount(account)
 	require.NoError(t, err)
 
-	peer.Meta.Location.RealIP = net.ParseIP("35.1.1.1")
-	peer.Meta.Location.CountryCode = "DE"
-	peer.Meta.Location.CityName = "Berlin"
-	peer.Meta.Location.GeoNameID = 2950159
+	peer.Location.ConnectionIP = net.ParseIP("35.1.1.1")
+	peer.Location.CountryCode = "DE"
+	peer.Location.CityName = "Berlin"
+	peer.Location.GeoNameID = 2950159
 
 	err = store.SavePeerLocation(account.Id, account.Peers[peer.ID])
 	assert.NoError(t, err)
@@ -253,8 +252,8 @@ func TestSqlite_SavePeerLocation(t *testing.T) {
 	account, err = store.GetAccount(account.Id)
 	require.NoError(t, err)
 
-	actual := account.Peers[peer.ID].Meta.Location
-	assert.Equal(t, peer.Meta.Location, actual)
+	actual := account.Peers[peer.ID].Location
+	assert.Equal(t, peer.Location, actual)
 }
 
 func TestSqlite_TestGetAccountByPrivateDomain(t *testing.T) {

--- a/management/server/sqlite_store_test.go
+++ b/management/server/sqlite_store_test.go
@@ -227,12 +227,12 @@ func TestSqlite_SavePeerLocation(t *testing.T) {
 		ID:        "testpeer",
 		Meta: nbpeer.PeerSystemMeta{
 			Location: struct {
-				RealIP      string
+				RealIP      net.IP
 				CountryCode string
 				CityName    string
 				GeoNameID   uint
 			}{
-				RealIP:      "0.0.0.0",
+				RealIP:      net.ParseIP("0.0.0.0"),
 				CountryCode: "YY",
 				CityName:    "City",
 				GeoNameID:   1,
@@ -247,7 +247,7 @@ func TestSqlite_SavePeerLocation(t *testing.T) {
 	err = store.SaveAccount(account)
 	require.NoError(t, err)
 
-	peer.Meta.Location.RealIP = "35.1.1.1"
+	peer.Meta.Location.RealIP = net.ParseIP("35.1.1.1")
 	peer.Meta.Location.CountryCode = "DE"
 	peer.Meta.Location.CityName = "Berlin"
 	peer.Meta.Location.GeoNameID = 2950159

--- a/management/server/sqlite_store_test.go
+++ b/management/server/sqlite_store_test.go
@@ -212,6 +212,55 @@ func TestSqlite_SavePeerStatus(t *testing.T) {
 	actual := account.Peers["testpeer"].Status
 	assert.Equal(t, newStatus, *actual)
 }
+func TestSqlite_SavePeerLocation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("The SQLite store is not properly supported by Windows yet")
+	}
+
+	store := newSqliteStoreFromFile(t, "testdata/store.json")
+
+	account, err := store.GetAccount("bf1c8084-ba50-4ce7-9439-34653001fc3b")
+	require.NoError(t, err)
+
+	peer := &nbpeer.Peer{
+		AccountID: account.Id,
+		ID:        "testpeer",
+		Meta: nbpeer.PeerSystemMeta{
+			Location: struct {
+				RealIP      string
+				CountryCode string
+				CityName    string
+				GeoNameID   uint
+			}{
+				RealIP:      "0.0.0.0",
+				CountryCode: "YY",
+				CityName:    "City",
+				GeoNameID:   1,
+			},
+		},
+	}
+	// error is expected as peer is not in store yet
+	err = store.SavePeerLocation(account.Id, peer)
+	assert.Error(t, err)
+
+	account.Peers[peer.ID] = peer
+	err = store.SaveAccount(account)
+	require.NoError(t, err)
+
+	peer.Meta.Location.RealIP = "35.1.1.1"
+	peer.Meta.Location.CountryCode = "DE"
+	peer.Meta.Location.CityName = "Berlin"
+	peer.Meta.Location.GeoNameID = 2950159
+
+	err = store.SavePeerLocation(account.Id, account.Peers[peer.ID])
+	assert.NoError(t, err)
+
+	account, err = store.GetAccount(account.Id)
+	require.NoError(t, err)
+
+	actual := account.Peers[peer.ID].Meta.Location
+	assert.Equal(t, peer.Meta.Location, actual)
+}
 
 func TestSqlite_TestGetAccountByPrivateDomain(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/management/server/sqlite_store_test.go
+++ b/management/server/sqlite_store_test.go
@@ -226,12 +226,7 @@ func TestSqlite_SavePeerLocation(t *testing.T) {
 		AccountID: account.Id,
 		ID:        "testpeer",
 		Meta: nbpeer.PeerSystemMeta{
-			Location: struct {
-				RealIP      net.IP
-				CountryCode string
-				CityName    string
-				GeoNameID   uint
-			}{
+			Location: nbpeer.Location{
 				RealIP:      net.ParseIP("0.0.0.0"),
 				CountryCode: "YY",
 				CityName:    "City",

--- a/management/server/store.go
+++ b/management/server/store.go
@@ -33,6 +33,7 @@ type Store interface {
 	// AcquireGlobalLock should attempt to acquire a global lock and return a function that releases the lock
 	AcquireGlobalLock() func()
 	SavePeerStatus(accountID, peerID string, status nbpeer.PeerStatus) error
+	SavePeerLocation(accountID string, peer *nbpeer.Peer) error
 	SaveUserLastLogin(accountID, userID string, lastLogin time.Time) error
 	// Close should close the store persisting all unsaved data.
 	Close() error


### PR DESCRIPTION
## Describe your changes

This PR uses the geolocation service to resolve IP to location. The lookup happens once on the first connection - when a client calls the Sync procedure.
The location is stored as part of the peer:

```go
type Location struct {
	ConnectionIP net.IP 
	CountryCode  string
	CityName     string
	GeoNameID    uint 
}
```

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
