### PR TITLE
Remove Account.Rules from Store engines

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -209,8 +209,8 @@ type Account struct {
 	UsersG                 []User                            `json:"-" gorm:"foreignKey:AccountID;references:id"`
 	Groups                 map[string]*Group                 `gorm:"-"`
 	GroupsG                []Group                           `json:"-" gorm:"foreignKey:AccountID;references:id"`
-	Rules                  map[string]*Rule                  `gorm:"-"`
-	RulesG                 []Rule                            `json:"-" gorm:"foreignKey:AccountID;references:id"`
+	Rules                  map[string]*Rule                  `json:"-" gorm:"-"`
+	RulesG                 []Rule                            `json:"-" gorm:"-"`
 	Policies               []*Policy                         `gorm:"foreignKey:AccountID;references:id"`
 	Routes                 map[string]*route.Route           `gorm:"-"`
 	RoutesG                []route.Route                     `json:"-" gorm:"foreignKey:AccountID;references:id"`
@@ -635,11 +635,6 @@ func (a *Account) Copy() *Account {
 		groups[id] = group.Copy()
 	}
 
-	rules := map[string]*Rule{}
-	for id, rule := range a.Rules {
-		rules[id] = rule.Copy()
-	}
-
 	policies := []*Policy{}
 	for _, policy := range a.Policies {
 		policies = append(policies, policy.Copy())
@@ -673,7 +668,6 @@ func (a *Account) Copy() *Account {
 		Peers:                  peers,
 		Users:                  users,
 		Groups:                 groups,
-		Rules:                  rules,
 		Policies:               policies,
 		Routes:                 routes,
 		NameServerGroups:       nsGroups,
@@ -1787,7 +1781,6 @@ func addAllGroup(account *Account) error {
 			Source:      []string{allGroup.ID},
 			Destination: []string{allGroup.ID},
 		}
-		account.Rules = map[string]*Rule{defaultRule.ID: defaultRule}
 
 		// TODO: after migration we need to drop rule and create policy directly
 		defaultPolicy, err := RuleToPolicy(defaultRule)

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -96,16 +96,6 @@ func verifyNewAccountHasDefaultFields(t *testing.T, account *Account, createdBy 
 	if account.Domain != domain {
 		t.Errorf("expecting newly created account to have domain %s, got %s", domain, account.Domain)
 	}
-
-	if len(account.Rules) != 1 {
-		t.Errorf("expecting newly created account to have 1 rule, got %d", len(account.Rules))
-	}
-
-	for _, rule := range account.Rules {
-		if rule.Name != "Default" {
-			t.Errorf("expecting newly created account to have Default rule, got %s", rule.Name)
-		}
-	}
 }
 
 func TestAccount_GetPeerNetworkMap(t *testing.T) {
@@ -1528,13 +1518,7 @@ func TestAccount_Copy(t *testing.T) {
 				Peers: []string{"peer1"},
 			},
 		},
-		Rules: map[string]*Rule{
-			"rule1": {
-				ID:          "rule1",
-				Destination: []string{},
-				Source:      []string{},
-			},
-		},
+		Rules: map[string]*Rule{},
 		Policies: []*Policy{
 			{
 				ID:      "policy1",

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1518,7 +1518,6 @@ func TestAccount_Copy(t *testing.T) {
 				Peers: []string{"peer1"},
 			},
 		},
-		Rules: map[string]*Rule{},
 		Policies: []*Policy{
 			{
 				ID:      "policy1",

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -159,18 +159,6 @@ func restore(file string) (*FileStore, error) {
 		if account.Policies == nil {
 			account.Policies = make([]*Policy, 0)
 		}
-		for _, rule := range account.Rules {
-			policy, err := RuleToPolicy(rule)
-			if err != nil {
-				log.Errorf("unable to migrate rule to policy: %v", err)
-				continue
-			}
-			// don't update policies from rules, rules deprecated,
-			// only append not existed rules as part of the migration process
-			if _, ok := policies[policy.ID]; !ok {
-				account.Policies = append(account.Policies, policy)
-			}
-		}
 
 		// for data migration. Can be removed once most base will be with labels
 		existingLabels := account.getPeerDNSLabels()
@@ -340,13 +328,6 @@ func (s *FileStore) SaveAccount(account *Account) error {
 
 	if accountCopy.DomainCategory == PrivateCategory && accountCopy.IsDomainPrimaryAccount {
 		s.PrivateDomain2AccountID[accountCopy.Domain] = accountCopy.Id
-	}
-
-	accountCopy.Rules = make(map[string]*Rule)
-	for _, policy := range accountCopy.Policies {
-		for _, rule := range policy.Rules {
-			accountCopy.Rules[rule.ID] = rule.ToRule()
-		}
 	}
 
 	return s.persist(s.storeFile)

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -193,18 +193,18 @@ func TestStore(t *testing.T) {
 		Name:  "all",
 		Peers: []string{"testpeer"},
 	}
-	allRule := &Rule{
-		ID:          "all",
-		Name:        "all",
-		Source:      []string{"all"},
-		Destination: []string{"all"},
-		Flow:        TrafficFlowBidirect,
-	}
 	account.Policies = append(account.Policies, &Policy{
 		ID:      "all",
 		Name:    "all",
 		Enabled: true,
-		Rules:   []*PolicyRule{allRule.ToPolicyRule()},
+		Rules: []*PolicyRule{
+			{
+				ID:           "all",
+				Name:         "all",
+				Sources:      []string{"all"},
+				Destinations: []string{"all"},
+			},
+		},
 	})
 	account.Policies = append(account.Policies, &Policy{
 		ID:      "dmz",

--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -193,7 +193,7 @@ func TestStore(t *testing.T) {
 		Name:  "all",
 		Peers: []string{"testpeer"},
 	}
-	account.Rules["all"] = &Rule{
+	allRule := &Rule{
 		ID:          "all",
 		Name:        "all",
 		Source:      []string{"all"},
@@ -204,7 +204,7 @@ func TestStore(t *testing.T) {
 		ID:      "all",
 		Name:    "all",
 		Enabled: true,
-		Rules:   []*PolicyRule{account.Rules["all"].ToPolicyRule()},
+		Rules:   []*PolicyRule{allRule.ToPolicyRule()},
 	})
 	account.Policies = append(account.Policies, &Policy{
 		ID:      "dmz",
@@ -315,41 +315,6 @@ func TestRestore(t *testing.T) {
 	require.Len(t, store.HashedPAT2TokenID, 1, "failed to restore a FileStore wrong HashedPAT2TokenID mapping length")
 
 	require.Len(t, store.TokenID2UserID, 1, "failed to restore a FileStore wrong TokenID2UserID mapping length")
-}
-
-// TODO: outdated, delete this
-func TestRestorePolicies_Migration(t *testing.T) {
-	storeDir := t.TempDir()
-
-	err := util.CopyFileContents("testdata/store_policy_migrate.json", filepath.Join(storeDir, "store.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	store, err := NewFileStore(storeDir, nil)
-	if err != nil {
-		return
-	}
-
-	account := store.Accounts["bf1c8084-ba50-4ce7-9439-34653001fc3b"]
-	require.Len(t, account.Groups, 1, "failed to restore a FileStore file - missing Account Groups")
-	require.Len(t, account.Rules, 1, "failed to restore a FileStore file - missing Account Rules")
-	require.Len(t, account.Policies, 1, "failed to restore a FileStore file - missing Account Policies")
-
-	policy := account.Policies[0]
-	require.Equal(t, policy.Name, "Default", "failed to restore a FileStore file - missing Account Policies Name")
-	require.Equal(t, policy.Description,
-		"This is a default rule that allows connections between all the resources",
-		"failed to restore a FileStore file - missing Account Policies Description")
-	require.NoError(t, err, "failed to upldate query")
-	require.Len(t, policy.Rules, 1, "failed to restore a FileStore file - missing Account Policy Rules")
-	require.Equal(t, policy.Rules[0].Action, PolicyTrafficActionAccept, "failed to restore a FileStore file - missing Account Policies Action")
-	require.Equal(t, policy.Rules[0].Destinations,
-		[]string{"cfefqs706sqkneg59g3g"},
-		"failed to restore a FileStore file - missing Account Policies Destinations")
-	require.Equal(t, policy.Rules[0].Sources,
-		[]string{"cfefqs706sqkneg59g3g"},
-		"failed to restore a FileStore file - missing Account Policies Sources")
 }
 
 func TestRestoreGroups_Migration(t *testing.T) {

--- a/management/server/policy_test.go
+++ b/management/server/policy_test.go
@@ -83,40 +83,56 @@ func TestAccount_getPeersByPolicy(t *testing.T) {
 				},
 			},
 		},
-		Rules: map[string]*Rule{
-			"RuleDefault": {
+		Policies: []*Policy{
+			{
 				ID:          "RuleDefault",
 				Name:        "Default",
 				Description: "This is a default rule that allows connections between all the resources",
-				Source: []string{
-					"GroupAll",
-				},
-				Destination: []string{
-					"GroupAll",
+				Enabled:     true,
+				Rules: []*PolicyRule{
+					{
+						ID:            "RuleDefault",
+						Name:          "Default",
+						Description:   "This is a default rule that allows connections between all the resources",
+						Bidirectional: true,
+						Enabled:       true,
+						Protocol:      PolicyRuleProtocolALL,
+						Action:        PolicyTrafficActionAccept,
+						Sources: []string{
+							"GroupAll",
+						},
+						Destinations: []string{
+							"GroupAll",
+						},
+					},
 				},
 			},
-			"RuleSwarm": {
+			{
 				ID:          "RuleSwarm",
 				Name:        "Swarm",
-				Description: "",
-				Source: []string{
-					"GroupSwarm",
-					"GroupAll",
-				},
-				Destination: []string{
-					"GroupSwarm",
+				Description: "No description",
+				Enabled:     true,
+				Rules: []*PolicyRule{
+					{
+						ID:            "RuleSwarm",
+						Name:          "Swarm",
+						Description:   "No description",
+						Bidirectional: true,
+						Enabled:       true,
+						Protocol:      PolicyRuleProtocolALL,
+						Action:        PolicyTrafficActionAccept,
+						Sources: []string{
+							"GroupSwarm",
+							"GroupAll",
+						},
+						Destinations: []string{
+							"GroupSwarm",
+						},
+					},
 				},
 			},
 		},
 	}
-
-	rule1, err := RuleToPolicy(account.Rules["RuleDefault"])
-	assert.NoError(t, err)
-
-	rule2, err := RuleToPolicy(account.Rules["RuleSwarm"])
-	assert.NoError(t, err)
-
-	account.Policies = append(account.Policies, rule1, rule2)
 
 	t.Run("check that all peers get map", func(t *testing.T) {
 		for _, p := range account.Peers {
@@ -307,40 +323,55 @@ func TestAccount_getPeersByPolicyDirect(t *testing.T) {
 				},
 			},
 		},
-		Rules: map[string]*Rule{
-			"RuleDefault": {
+		Policies: []*Policy{
+			{
 				ID:          "RuleDefault",
 				Name:        "Default",
-				Disabled:    true,
 				Description: "This is a default rule that allows connections between all the resources",
-				Source: []string{
-					"GroupAll",
-				},
-				Destination: []string{
-					"GroupAll",
+				Enabled:     false,
+				Rules: []*PolicyRule{
+					{
+						ID:            "RuleDefault",
+						Name:          "Default",
+						Description:   "This is a default rule that allows connections between all the resources",
+						Bidirectional: true,
+						Enabled:       false,
+						Protocol:      PolicyRuleProtocolALL,
+						Action:        PolicyTrafficActionAccept,
+						Sources: []string{
+							"GroupAll",
+						},
+						Destinations: []string{
+							"GroupAll",
+						},
+					},
 				},
 			},
-			"RuleSwarm": {
+			{
 				ID:          "RuleSwarm",
 				Name:        "Swarm",
-				Description: "",
-				Source: []string{
-					"GroupSwarm",
-				},
-				Destination: []string{
-					"peerF",
+				Description: "No description",
+				Enabled:     true,
+				Rules: []*PolicyRule{
+					{
+						ID:            "RuleSwarm",
+						Name:          "Swarm",
+						Description:   "No description",
+						Bidirectional: true,
+						Enabled:       true,
+						Protocol:      PolicyRuleProtocolALL,
+						Action:        PolicyTrafficActionAccept,
+						Sources: []string{
+							"GroupSwarm",
+						},
+						Destinations: []string{
+							"peerF",
+						},
+					},
 				},
 			},
 		},
 	}
-
-	rule1, err := RuleToPolicy(account.Rules["RuleDefault"])
-	assert.NoError(t, err)
-
-	rule2, err := RuleToPolicy(account.Rules["RuleSwarm"])
-	assert.NoError(t, err)
-
-	account.Policies = append(account.Policies, rule1, rule2)
 
 	t.Run("check first peer map", func(t *testing.T) {
 		peers, firewallRules := account.getPeerConnectionResources("peerB")

--- a/management/server/rule.go
+++ b/management/server/rule.go
@@ -1,7 +1,5 @@
 package server
 
-import "fmt"
-
 // TrafficFlowType defines allowed direction of the traffic in the rule
 type TrafficFlowType int
 
@@ -65,36 +63,4 @@ func (r *Rule) Copy() *Rule {
 // EventMeta returns activity event meta related to this rule
 func (r *Rule) EventMeta() map[string]any {
 	return map[string]any{"name": r.Name}
-}
-
-// ToPolicyRule converts a Rule to a PolicyRule object
-func (r *Rule) ToPolicyRule() *PolicyRule {
-	if r == nil {
-		return nil
-	}
-	return &PolicyRule{
-		ID:            r.ID,
-		Name:          r.Name,
-		Enabled:       !r.Disabled,
-		Description:   r.Description,
-		Destinations:  r.Destination,
-		Sources:       r.Source,
-		Bidirectional: true,
-		Protocol:      PolicyRuleProtocolALL,
-		Action:        PolicyTrafficActionAccept,
-	}
-}
-
-// RuleToPolicy converts a Rule to a Policy query object
-func RuleToPolicy(rule *Rule) (*Policy, error) {
-	if rule == nil {
-		return nil, fmt.Errorf("rule is empty")
-	}
-	return &Policy{
-		ID:          rule.ID,
-		Name:        rule.Name,
-		Description: rule.Description,
-		Enabled:     !rule.Disabled,
-		Rules:       []*PolicyRule{rule.ToPolicyRule()},
-	}, nil
 }

--- a/management/server/rule.go
+++ b/management/server/rule.go
@@ -1,5 +1,7 @@
 package server
 
+import "fmt"
+
 // TrafficFlowType defines allowed direction of the traffic in the rule
 type TrafficFlowType int
 
@@ -63,4 +65,36 @@ func (r *Rule) Copy() *Rule {
 // EventMeta returns activity event meta related to this rule
 func (r *Rule) EventMeta() map[string]any {
 	return map[string]any{"name": r.Name}
+}
+
+// ToPolicyRule converts a Rule to a PolicyRule object
+func (r *Rule) ToPolicyRule() *PolicyRule {
+	if r == nil {
+		return nil
+	}
+	return &PolicyRule{
+		ID:            r.ID,
+		Name:          r.Name,
+		Enabled:       !r.Disabled,
+		Description:   r.Description,
+		Destinations:  r.Destination,
+		Sources:       r.Source,
+		Bidirectional: true,
+		Protocol:      PolicyRuleProtocolALL,
+		Action:        PolicyTrafficActionAccept,
+	}
+}
+
+// RuleToPolicy converts a Rule to a Policy query object
+func RuleToPolicy(rule *Rule) (*Policy, error) {
+	if rule == nil {
+		return nil, fmt.Errorf("rule is empty")
+	}
+	return &Policy{
+		ID:          rule.ID,
+		Name:        rule.Name,
+		Description: rule.Description,
+		Enabled:     !rule.Disabled,
+		Rules:       []*PolicyRule{rule.ToPolicyRule()},
+	}, nil
 }

--- a/management/server/sqlite_store.go
+++ b/management/server/sqlite_store.go
@@ -156,11 +156,6 @@ func (s *SqliteStore) SaveAccount(account *Account) error {
 		account.GroupsG = append(account.GroupsG, *group)
 	}
 
-	for id, rule := range account.Rules {
-		rule.ID = id
-		account.RulesG = append(account.RulesG, *rule)
-	}
-
 	for id, route := range account.Routes {
 		route.ID = id
 		account.RoutesG = append(account.RoutesG, *route)
@@ -356,7 +351,6 @@ func (s *SqliteStore) GetAllAccounts() (all []*Account) {
 
 func (s *SqliteStore) GetAccount(accountID string) (*Account, error) {
 	var account Account
-
 	result := s.db.Model(&account).
 		Preload("UsersG.PATsG"). // have to be specifies as this is nester reference
 		Preload(clause.Associations).
@@ -402,12 +396,6 @@ func (s *SqliteStore) GetAccount(accountID string) (*Account, error) {
 		account.Groups[group.ID] = group.Copy()
 	}
 	account.GroupsG = nil
-
-	account.Rules = make(map[string]*Rule, len(account.RulesG))
-	for _, rule := range account.RulesG {
-		account.Rules[rule.ID] = rule.Copy()
-	}
-	account.RulesG = nil
 
 	account.Routes = make(map[string]*route.Route, len(account.RoutesG))
 	for _, route := range account.RoutesG {


### PR DESCRIPTION
## Describe your changes

This PR removes all usage of `Account.Rules` in the management. We still keep the endpoint that translates rules to policies and the other way around.

#### Release note:

> The users with management on version < [v0.15.3](https://github.com/netbirdio/netbird/releases/tag/v0.15.3) should first upgrade their systems to [v0.25.8](https://github.com/netbirdio/netbird/releases/tag/v0.25.8), run management to properly migrate rules to policies, and then upgrade to **0.26.0+**.



## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
