### PR TITLE
Get cache from external cache when refresh fails

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1223,6 +1223,21 @@ func (am *DefaultAccountManager) lookupUserInCache(userID string, account *Accou
 		}
 	}
 
+	user, err := account.FindUser(userID)
+	if err != nil {
+		log.Errorf("failed finding user %s in account %s", userID, account.Id)
+		return nil, err
+	}
+
+	key := user.IntegrationReference.CacheKey(account.Id, userID)
+	ud, err := am.externalCacheManager.Get(am.ctx, key)
+	if err == nil {
+		log.Debugf("user %s found in external cache", userID)
+		return ud, nil
+	}
+
+	log.Debugf("user %s not found in cache", userID)
+
 	return nil, nil //nolint:nilnil
 }
 

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1232,8 +1232,8 @@ func (am *DefaultAccountManager) lookupUserInCache(userID string, account *Accou
 	key := user.IntegrationReference.CacheKey(account.Id, userID)
 	ud, err := am.externalCacheManager.Get(am.ctx, key)
 	if err == nil {
-		log.Debugf("user %s found in external cache", userID)
-		return ud, nil
+		log.Errorf("failed to get externalCache for key: %s, error: %s", key, err)
+		return ud, status.Errorf(status.NotFound, "user %s not found in the IdP", userID)
 	}
 
 	log.Infof("user %s not found in any cache", userID)

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1236,7 +1236,7 @@ func (am *DefaultAccountManager) lookupUserInCache(userID string, account *Accou
 		return ud, nil
 	}
 
-	log.Debugf("user %s not found in cache", userID)
+	log.Infof("user %s not found in any cache", userID)
 
 	return nil, nil //nolint:nilnil
 }

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -890,18 +890,6 @@ func (am *DefaultAccountManager) SaveOrAddUser(accountID, initiatorUserID string
 		if err != nil {
 			return nil, err
 		}
-		if userData == nil {
-			// lets check external cache
-			key := newUser.IntegrationReference.CacheKey(account.Id, newUser.Id)
-			log.Debugf("looking up user %s of account %s in external cache", key, account.Id)
-			info, err := am.externalCacheManager.Get(am.ctx, key)
-			if err != nil {
-				log.Infof("Get ExternalCache for key: %s, error: %s", key, err)
-				return nil, status.Errorf(status.NotFound, "user %s not found in the IdP", newUser.Id)
-			}
-
-			return newUser.ToUserInfo(info)
-		}
 		return newUser.ToUserInfo(userData)
 	}
 	return newUser.ToUserInfo(nil)


### PR DESCRIPTION
## Describe your changes

In some cases, when the refresh cache fails, we should try to get the cache from the external cache obj.

This may happen if the IDP is not responsive between storing metadata and refreshing the cache


## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
