### PR TITLE
Allow adding 3 nameserver addresses

### DIFF
--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -904,7 +904,7 @@ components:
         nameservers:
           description: Nameserver list
           minLength: 1
-          maxLength: 2
+          maxLength: 3
           type: array
           items:
             $ref: '#/components/schemas/Nameserver'

--- a/management/server/nameserver.go
+++ b/management/server/nameserver.go
@@ -255,8 +255,8 @@ func validateNSGroupName(name, nsGroupID string, nsGroupMap map[string]*nbdns.Na
 
 func validateNSList(list []nbdns.NameServer) error {
 	nsListLenght := len(list)
-	if nsListLenght == 0 || nsListLenght > 2 {
-		return status.Errorf(status.InvalidArgument, "the list of nameservers should be 1 or 2, got %d", len(list))
+	if nsListLenght == 0 || nsListLenght > 3 {
+		return status.Errorf(status.InvalidArgument, "the list of nameservers should be 1 or 3, got %d", len(list))
 	}
 	return nil
 }

--- a/management/server/nameserver_test.go
+++ b/management/server/nameserver_test.go
@@ -216,7 +216,7 @@ func TestCreateNameServerGroup(t *testing.T) {
 			shouldCreate: false,
 		},
 		{
-			name: "Create A NS Group With More Than 2 Nameservers Should Fail",
+			name: "Create A NS Group With More Than 3 Nameservers Should Fail",
 			inputArgs: input{
 				name:        "super",
 				description: "super",
@@ -235,6 +235,11 @@ func TestCreateNameServerGroup(t *testing.T) {
 					},
 					{
 						IP:     netip.MustParseAddr("1.1.3.3"),
+						NSType: nbdns.UDPNameServerType,
+						Port:   nbdns.DefaultDNSPort,
+					},
+					{
+						IP:     netip.MustParseAddr("1.1.4.4"),
 						NSType: nbdns.UDPNameServerType,
 						Port:   nbdns.DefaultDNSPort,
 					},
@@ -454,6 +459,11 @@ func TestSaveNameServerGroup(t *testing.T) {
 		},
 		{
 			IP:     netip.MustParseAddr("1.1.3.3"),
+			NSType: nbdns.UDPNameServerType,
+			Port:   nbdns.DefaultDNSPort,
+		},
+		{
+			IP:     netip.MustParseAddr("1.1.4.4"),
 			NSType: nbdns.UDPNameServerType,
 			Port:   nbdns.DefaultDNSPort,
 		},


### PR DESCRIPTION
## Describe your changes
Allows administrators to add a third nameserver configuration. 

Dashboard PR: https://github.com/netbirdio/dashboard/pull/337
## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
