### PR TITLE
Use SQLite store as default when running tests when env is not set

### DIFF
--- a/management/server/store.go
+++ b/management/server/store.go
@@ -111,6 +111,6 @@ func NewStoreFromJson(dataDir string, metrics telemetry.AppMetrics) (Store, erro
 	case SqliteStoreEngine:
 		return NewSqliteStoreFromFileStore(fstore, dataDir, metrics)
 	default:
-		return nil, fmt.Errorf("unsupported store engine %s", kind)
+		return NewSqliteStoreFromFileStore(fstore, dataDir, metrics)
 	}
 }


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
