### PR TITLE
Handle canceling schedule and avoid recursive call

### DIFF
--- a/management/server/scheduler.go
+++ b/management/server/scheduler.go
@@ -103,15 +103,16 @@ func (wm *DefaultScheduler) Schedule(in time.Duration, ID string, job func() (ne
 					ticker.Stop()
 					return
 				}
-				if runIn != in { // do we need to compare it with the original duration?
+				// we need this comparison to avoid resetting the ticker with the same duration and missing the current elapsesed time
+				if runIn != in {
 					ticker.Reset(runIn)
 				}
 			case <-cancel:
 				ticker.Stop()
-				log.Debugf("stopped scheduled job %s ", ID)
 				wm.mu.Lock()
 				defer wm.mu.Unlock()
 				delete(wm.jobs, ID)
+				log.Debugf("stopped scheduled job %s ", ID)
 				return
 			}
 		}


### PR DESCRIPTION
## Describe your changes

Using time.Ticker allows us to avoid recursive calls that may end up in schedule running and possible deadlock if no routine is listening for cancel calls

switch to closing channel
## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
