### PR TITLE
Fix invalid cross-device link when moving geolocation databases

### DIFF
--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -162,6 +162,12 @@ jobs:
           test $count -eq 4
         working-directory: infrastructure_files/artifacts
 
+      - name: test geolocation databases
+        run: |
+          sleep 10
+          docker compose exec management ls -l /var/lib/netbird/ | grep -i GeoLite2-City.mmdb
+          docker compose exec management ls -l /var/lib/netbird/ | grep -i geonames.db
+
   test-getting-started-script:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -164,6 +164,7 @@ jobs:
 
       - name: test geolocation databases
         run: |
+          set -x
           sleep 10
           docker compose exec management ls -l /var/lib/netbird/ | grep -i GeoLite2-City.mmdb
           docker compose exec management ls -l /var/lib/netbird/ | grep -i geonames.db

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -163,9 +163,9 @@ jobs:
         working-directory: infrastructure_files/artifacts
 
       - name: test geolocation databases
+        working-directory: infrastructure_files/artifacts
         run: |
-          set -x
-          sleep 10
+          sleep 30
           docker compose exec management ls -l /var/lib/netbird/ | grep -i GeoLite2-City.mmdb
           docker compose exec management ls -l /var/lib/netbird/ | grep -i geonames.db
 

--- a/management/server/geolocation/database.go
+++ b/management/server/geolocation/database.go
@@ -3,6 +3,7 @@ package geolocation
 import (
 	"encoding/csv"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path"
@@ -35,7 +36,7 @@ func loadGeolocationDatabases(dataDir string) error {
 				if err := decompressTarGzFile(src, dst); err != nil {
 					return err
 				}
-				return os.Rename(path.Join(dst, MMDBFileName), path.Join(dataDir, MMDBFileName))
+				return copyFile(path.Join(dst, MMDBFileName), path.Join(dataDir, MMDBFileName))
 			}
 			if err := loadDatabase(
 				geoLiteCitySha256TarURL,
@@ -184,4 +185,26 @@ func getDatabaseFileName(urlStr string) string {
 	ext := u.Query().Get("suffix")
 	fileName := fmt.Sprintf("%s.%s", path.Base(u.Path), ext)
 	return fileName
+}
+
+// copyFile performs a file copy operation from the source file to the destination.
+func copyFile(src string, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Describe your changes

Resolve the issue of a cross-device link error when transferring geolocation databases to the management datadir, which is mounted on Docker.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
