### PR TITLE
Log version when starting management and signal

### DIFF
--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -43,6 +43,7 @@ import (
 	"github.com/netbirdio/netbird/management/server/metrics"
 	"github.com/netbirdio/netbird/management/server/telemetry"
 	"github.com/netbirdio/netbird/util"
+	"github.com/netbirdio/netbird/version"
 )
 
 // ManagementLegacyPort is the port that was used before by the Management gRPC server.
@@ -315,6 +316,7 @@ var (
 				}
 			}
 
+			log.Infof("management server version %s", version.NetbirdVersion())
 			log.Infof("running HTTP server and gRPC server on the same port: %s", listener.Addr().String())
 			serveGRPCWithHTTP(listener, rootHandler, tlsEnabled)
 

--- a/signal/cmd/run.go
+++ b/signal/cmd/run.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"golang.org/x/crypto/acme/autocert"
 	"io"
 	"io/fs"
 	"net"
@@ -14,10 +13,14 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/acme/autocert"
+
 	"github.com/netbirdio/netbird/encryption"
 	"github.com/netbirdio/netbird/signal/proto"
 	"github.com/netbirdio/netbird/signal/server"
 	"github.com/netbirdio/netbird/util"
+	"github.com/netbirdio/netbird/version"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -129,6 +132,7 @@ var (
 				log.Infof("running gRPC server: %s", grpcListener.Addr().String())
 			}
 
+			log.Infof("signal server version %s", version.NetbirdVersion())
 			log.Infof("started Signal Service")
 
 			SetupCloseHandler()


### PR DESCRIPTION
## Describe your changes

Output log version at service startup. e.g.:

```
2024-02-29T14:52:33+01:00 INFO management/cmd/management.go:319: management server version 0.26.2
2024-02-29T14:52:33+01:00 INFO management/cmd/management.go:320: running HTTP server and gRPC server on the same port: [::]:3001
```

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
