### PR TITLE
Include users' own activity in active users calculation

### DIFF
--- a/management/server/file_store_test.go
+++ b/management/server/file_store_test.go
@@ -674,15 +674,15 @@ func TestFileStore_CalculateUsageStats(t *testing.T) {
 	stats1, err := store.CalculateUsageStats(context.TODO(), "account-1", startDate, endDate)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(2), stats1.ActiveUsers)
-	assert.Equal(t, int64(4), stats1.TotalUsers)
+	assert.Equal(t, int64(3), stats1.ActiveUsers)
+	assert.Equal(t, int64(5), stats1.TotalUsers)
 	assert.Equal(t, int64(3), stats1.ActivePeers)
-	assert.Equal(t, int64(7), stats1.TotalPeers)
+	assert.Equal(t, int64(8), stats1.TotalPeers)
 
 	stats2, err := store.CalculateUsageStats(context.TODO(), "account-2", startDate, endDate)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(1), stats2.ActiveUsers)
+	assert.Equal(t, int64(2), stats2.ActiveUsers)
 	assert.Equal(t, int64(2), stats2.TotalUsers)
 	assert.Equal(t, int64(1), stats2.ActivePeers)
 	assert.Equal(t, int64(2), stats2.TotalPeers)

--- a/management/server/sqlite_store_test.go
+++ b/management/server/sqlite_store_test.go
@@ -360,15 +360,15 @@ func TestSqliteStore_CalculateUsageStats(t *testing.T) {
 	stats1, err := store.CalculateUsageStats(context.TODO(), "account-1", startDate, endDate)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(2), stats1.ActiveUsers)
-	assert.Equal(t, int64(4), stats1.TotalUsers)
+	assert.Equal(t, int64(3), stats1.ActiveUsers)
+	assert.Equal(t, int64(5), stats1.TotalUsers)
 	assert.Equal(t, int64(3), stats1.ActivePeers)
-	assert.Equal(t, int64(7), stats1.TotalPeers)
+	assert.Equal(t, int64(8), stats1.TotalPeers)
 
 	stats2, err := store.CalculateUsageStats(context.TODO(), "account-2", startDate, endDate)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(1), stats2.ActiveUsers)
+	assert.Equal(t, int64(2), stats2.ActiveUsers)
 	assert.Equal(t, int64(2), stats2.TotalUsers)
 	assert.Equal(t, int64(1), stats2.ActivePeers)
 	assert.Equal(t, int64(2), stats2.TotalPeers)

--- a/management/server/testdata/store_stats.json
+++ b/management/server/testdata/store_stats.json
@@ -13,20 +13,29 @@
       },
       "Users": {
         "user-1-account-1": {
-          "Id": "user-1-account-1"
+          "Id": "user-1-account-1",
+          "LastLogin": "2023-01-15T00:00:00Z"
         },
         "user-2-account-1": {
-          "Id": "user-2-account-1"
+          "Id": "user-2-account-1",
+          "LastLogin": "2024-01-02T00:00:00Z"
         },
         "user-3-account-1": {
-          "Id": "user-3-account-1"
+          "Id": "user-3-account-1",
+          "LastLogin": "2024-02-05T00:00:00Z"
         },
         "user-4-account-1": {
-          "Id": "user-4-account-1"
+          "Id": "user-4-account-1",
+          "LastLogin": "2024-01-20T00:00:00Z"
         },
         "user-5-account-1": {
           "Id": "user-5-account-1",
-          "IsServiceUser": true
+          "IsServiceUser": true,
+          "LastLogin": "2024-02-15T00:00:00Z"
+        },
+        "user-6-account-1": {
+          "Id": "user-6-account-1",
+          "LastLogin": "2024-02-10T00:00:00Z"
         }
       },
       "Peers": {
@@ -106,6 +115,17 @@
           "Meta": {
             "Hostname": "peer7-host"
           }
+        },
+        "peer-8-account-1": {
+          "ID": "peer-8-account-1",
+          "UserID": "user-6-account-1",
+          "Status": {
+            "LastSeen": "2024-01-01T00:00:00Z"
+          },
+          "Name": "Peer Eight",
+          "Meta": {
+            "Hostname": "peer8-host"
+          }
         }
       }
     },
@@ -122,14 +142,17 @@
       },
       "Users": {
         "user-1-account-2": {
-          "Id": "user-1-account-2"
+          "Id": "user-1-account-2",
+          "LastLogin": "2023-12-15T00:00:00Z"
         },
         "user-2-account-2": {
-          "Id": "user-1-account-2"
+          "Id": "user-2-account-2",
+          "LastLogin": "2024-02-28T00:00:00Z"
         },
         "user-3-account-2": {
           "Id": "user-3-account-2",
-          "IsServiceUser": true
+          "IsServiceUser": true,
+          "LastLogin": "2024-01-30T00:00:00Z"
         }
       },
       "Peers": {


### PR DESCRIPTION
## Describe your changes
Updated the active users calculation to include both users' own login activity and their peers' activity. Ensured service users are excluded accurately across SQL and FileStore implementations.


## Issue ticket number and link

### Checklist
- [] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
