### PR TITLE
Do not fail on virtualized windows systems

### DIFF
--- a/client/system/info_windows.go
+++ b/client/system/info_windows.go
@@ -165,6 +165,10 @@ func sysProductName() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// `ComputerSystemProduct` could be empty on some virtualized systems
+	if len(dst) < 1 {
+		return "unknown", nil
+	}
 	return dst[0].Name, nil
 }
 


### PR DESCRIPTION
## Describe your changes

this handles virtualized systems without Win32_ComputerSystemProduct entries by returning 'unknown' for system product name

## Issue ticket number and link

n/a

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
