### PR TITLE
Return 1s when next expiration is too low

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -455,6 +455,11 @@ func (a *Account) GetNextPeerExpiration() (time.Duration, bool) {
 		}
 		_, duration := peer.LoginExpired(a.Settings.PeerLoginExpiration)
 		if nextExpiry == nil || duration < *nextExpiry {
+			// if expiration is below 1s return 1s duration
+			// this avoids issues with ticker that can't be set to < 0
+			if duration < time.Second {
+				return time.Second, true
+			}
 			nextExpiry = &duration
 		}
 	}


### PR DESCRIPTION
## Describe your changes
using the login expired issue could cause problems with the ticker used in the scheduler

This change makes 1s the minimum number returned when rescheduling the peer expiration task
## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
