### PR TITLE
Add fallback retry to daemon

### DIFF
--- a/client/server/server.go
+++ b/client/server/server.go
@@ -154,7 +154,7 @@ func (s *Server) connectWithRetryRuns(ctx context.Context, config *internal.Conf
 					mgmtState := statusRecorder.GetManagementState()
 					signalState := statusRecorder.GetSignalState()
 					if mgmtState.Connected && signalState.Connected {
-						log.Tracef("reseting status")
+						log.Tracef("resetting status")
 						retryStarted = false
 					} else {
 						log.Tracef("not resetting status: mgmt: %v, signal: %v", mgmtState.Connected, signalState.Connected)

--- a/client/server/server_test.go
+++ b/client/server/server_test.go
@@ -69,8 +69,8 @@ func TestConnectWithRetryRuns(t *testing.T) {
 	t.Setenv(retryMultiplierVar, "1")
 
 	s.connectWithRetryRuns(ctx, config, s.statusRecorder, s.mgmProbe, s.signalProbe, s.relayProbe, s.wgProbe)
-	if counter < 2 || counter > 6 {
-		t.Fatalf("expected 2 < counter < 6, got %d", counter)
+	if counter < 3 {
+		t.Fatalf("expected counter > 2, got %d", counter)
 	}
 }
 

--- a/client/server/server_test.go
+++ b/client/server/server_test.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+
+	"github.com/netbirdio/netbird/client/internal"
+	"github.com/netbirdio/netbird/client/internal/peer"
+	mgmtProto "github.com/netbirdio/netbird/management/proto"
+	"github.com/netbirdio/netbird/management/server"
+	"github.com/netbirdio/netbird/management/server/activity"
+	"github.com/netbirdio/netbird/signal/proto"
+	signalServer "github.com/netbirdio/netbird/signal/server"
+)
+
+var (
+	kaep = keepalive.EnforcementPolicy{
+		MinTime:             15 * time.Second,
+		PermitWithoutStream: true,
+	}
+
+	kasp = keepalive.ServerParameters{
+		MaxConnectionIdle:     15 * time.Second,
+		MaxConnectionAgeGrace: 5 * time.Second,
+		Time:                  5 * time.Second,
+		Timeout:               2 * time.Second,
+	}
+)
+
+// TestConnectWithRetryRuns checks that the connectWithRetry function runs and runs the retries according to the times specified via environment variables
+// we will use a management server started via to simulate the server and capture the number of retries
+func TestConnectWithRetryRuns(t *testing.T) {
+	// start the signal server
+	_, signalAddr, err := startSignal()
+	if err != nil {
+		t.Fatalf("failed to start signal server: %v", err)
+	}
+
+	counter := 0
+	// start the management server
+	_, mgmtAddr, err := startManagement(t, signalAddr, &counter)
+	if err != nil {
+		t.Fatalf("failed to start management server: %v", err)
+	}
+
+	ctx := internal.CtxInitState(context.Background())
+
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
+	defer cancel()
+	// create new server
+	s := New(ctx, t.TempDir()+"/config.json", "debug")
+	s.latestConfigInput.ManagementURL = "http://" + mgmtAddr
+	config, err := internal.UpdateOrCreateConfig(s.latestConfigInput)
+	if err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+	s.config = config
+
+	s.statusRecorder = peer.NewRecorder(config.ManagementURL.String())
+	err = os.Setenv(retryInitialIntervalVar, "1s")
+	if err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+	err = os.Setenv(maxRetryIntervalVar, "2s")
+	if err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+	err = os.Setenv(maxRetryTimeVar, "5s")
+	if err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+	err = os.Setenv(retryMultiplierVar, "1")
+	if err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+	s.connectWithRetryRuns(ctx, config, s.statusRecorder, s.mgmProbe, s.signalProbe, s.relayProbe, s.wgProbe)
+	if counter < 2 || counter > 6 {
+		t.Fatalf("expected 2 < counter < 6, got %d", counter)
+	}
+}
+
+type mockServer struct {
+	mgmtProto.ManagementServiceServer
+	counter *int
+}
+
+func (m *mockServer) Login(ctx context.Context, req *mgmtProto.EncryptedMessage) (*mgmtProto.EncryptedMessage, error) {
+	*m.counter++
+	return m.ManagementServiceServer.Login(ctx, req)
+}
+
+func startManagement(t *testing.T, signalAddr string, counter *int) (*grpc.Server, string, error) {
+	dataDir := t.TempDir()
+
+	config := &server.Config{
+		Stuns:      []*server.Host{},
+		TURNConfig: &server.TURNConfig{},
+		Signal: &server.Host{
+			Proto: "http",
+			URI:   signalAddr,
+		},
+		Datadir:    dataDir,
+		HttpConfig: nil,
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, "", err
+	}
+	s := grpc.NewServer(grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp))
+	store, err := server.NewStoreFromJson(config.Datadir, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	peersUpdateManager := server.NewPeersUpdateManager(nil)
+	eventStore := &activity.InMemoryEventStore{}
+	if err != nil {
+		return nil, "", err
+	}
+	accountManager, err := server.BuildManager(store, peersUpdateManager, nil, "", "", eventStore, nil, false)
+	if err != nil {
+		return nil, "", err
+	}
+	turnManager := server.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig)
+	mgmtServer, err := server.NewServer(config, accountManager, peersUpdateManager, turnManager, nil, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	mock := &mockServer{
+		ManagementServiceServer: mgmtServer,
+		counter:                 counter,
+	}
+	mgmtProto.RegisterManagementServiceServer(s, mock)
+	go func() {
+		if err = s.Serve(lis); err != nil {
+			log.Fatalf("failed to serve: %v", err)
+		}
+	}()
+
+	return s, lis.Addr().String(), nil
+}
+
+func startSignal() (*grpc.Server, string, error) {
+	s := grpc.NewServer(grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp))
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+
+	proto.RegisterSignalExchangeServer(s, signalServer.NewServer())
+
+	go func() {
+		if err = s.Serve(lis); err != nil {
+			log.Fatalf("failed to serve: %v", err)
+		}
+	}()
+
+	return s, lis.Addr().String(), nil
+}

--- a/client/server/server_test.go
+++ b/client/server/server_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -64,22 +63,11 @@ func TestConnectWithRetryRuns(t *testing.T) {
 	s.config = config
 
 	s.statusRecorder = peer.NewRecorder(config.ManagementURL.String())
-	err = os.Setenv(retryInitialIntervalVar, "1s")
-	if err != nil {
-		t.Fatalf("failed to set env var: %v", err)
-	}
-	err = os.Setenv(maxRetryIntervalVar, "2s")
-	if err != nil {
-		t.Fatalf("failed to set env var: %v", err)
-	}
-	err = os.Setenv(maxRetryTimeVar, "5s")
-	if err != nil {
-		t.Fatalf("failed to set env var: %v", err)
-	}
-	err = os.Setenv(retryMultiplierVar, "1")
-	if err != nil {
-		t.Fatalf("failed to set env var: %v", err)
-	}
+	t.Setenv(retryInitialIntervalVar, "1s")
+	t.Setenv(maxRetryIntervalVar, "2s")
+	t.Setenv(maxRetryTimeVar, "5s")
+	t.Setenv(retryMultiplierVar, "1")
+
 	s.connectWithRetryRuns(ctx, config, s.statusRecorder, s.mgmProbe, s.signalProbe, s.relayProbe, s.wgProbe)
 	if counter < 2 || counter > 6 {
 		t.Fatalf("expected 2 < counter < 6, got %d", counter)
@@ -97,6 +85,7 @@ func (m *mockServer) Login(ctx context.Context, req *mgmtProto.EncryptedMessage)
 }
 
 func startManagement(t *testing.T, signalAddr string, counter *int) (*grpc.Server, string, error) {
+	t.Helper()
 	dataDir := t.TempDir()
 
 	config := &server.Config{


### PR DESCRIPTION
## Describe your changes
This change adds a fallback retry to the daemon service

this retry has a larger interval with a shorter max retry run time

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
