### PR TITLE
add --service/-s flag for specifying system service name

### DIFF
--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -61,6 +61,7 @@ var (
 	serverSSHAllowed        bool
 	interfaceName           string
 	wireguardPort           uint16
+	serviceName             string
 	autoConnectDisabled     bool
 	rootCmd                 = &cobra.Command{
 		Use:          "netbird",
@@ -100,9 +101,16 @@ func init() {
 	if runtime.GOOS == "windows" {
 		defaultDaemonAddr = "tcp://127.0.0.1:41731"
 	}
+
+	defaultServiceName := "netbird"
+	if runtime.GOOS == "windows" {
+		defaultServiceName = "Netbird"
+	}
+
 	rootCmd.PersistentFlags().StringVar(&daemonAddr, "daemon-addr", defaultDaemonAddr, "Daemon service address to serve CLI requests [unix|tcp]://[path|host:port]")
 	rootCmd.PersistentFlags().StringVarP(&managementURL, "management-url", "m", "", fmt.Sprintf("Management Service URL [http|https]://[host]:[port] (default \"%s\")", internal.DefaultManagementURL))
 	rootCmd.PersistentFlags().StringVar(&adminURL, "admin-url", "", fmt.Sprintf("Admin Panel URL [http|https]://[host]:[port] (default \"%s\")", internal.DefaultAdminURL))
+	rootCmd.PersistentFlags().StringVarP(&serviceName, "service", "s", defaultServiceName, "Netbird system service name")
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", defaultConfigPath, "Netbird config file location")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "sets Netbird log level")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout")

--- a/client/cmd/service.go
+++ b/client/cmd/service.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"context"
-	"runtime"
-
 	"github.com/kardianos/service"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -24,12 +22,8 @@ func newProgram(ctx context.Context, cancel context.CancelFunc) *program {
 }
 
 func newSVCConfig() *service.Config {
-	name := "netbird"
-	if runtime.GOOS == "windows" {
-		name = "Netbird"
-	}
 	return &service.Config{
-		Name:        name,
+		Name:        serviceName,
 		DisplayName: "Netbird",
 		Description: "A WireGuard-based mesh network that connects your devices into a single private network.",
 		Option:      make(service.KeyValue),


### PR DESCRIPTION
## Describe your changes

allows telling CLI what is the service name to control (for multi-instance deployments)

## Issue ticket number and link

separated out of https://github.com/netbirdio/netbird/pull/1586

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
