### PR TITLE
Unblock ACL apply filtering because of dns probes

### DIFF
--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -278,9 +278,15 @@ func (s *DefaultServer) SearchDomains() []string {
 // ProbeAvailability tests each upstream group's servers for availability
 // and deactivates the group if no server responds
 func (s *DefaultServer) ProbeAvailability() {
+	var wg sync.WaitGroup
 	for _, mux := range s.dnsMuxMap {
-		mux.probeAvailability()
+		wg.Add(1)
+		go func(mux handlerWithStop) {
+			defer wg.Done()
+			mux.probeAvailability()
+		}(mux)
 	}
+	wg.Wait()
 }
 
 func (s *DefaultServer) applyConfiguration(update nbdns.Config) error {

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -698,14 +698,15 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 		log.Errorf("failed to update dns server, err: %v", err)
 	}
 
-	// Test received (upstream) servers for availability right away instead of upon usage.
-	// If no server of a server group responds this will disable the respective handler and retry later.
-	e.dnsServer.ProbeAvailability()
-
 	if e.acl != nil {
 		e.acl.ApplyFiltering(networkMap)
 	}
+
 	e.networkSerial = serial
+
+	// Test received (upstream) servers for availability right away instead of upon usage.
+	// If no server of a server group responds this will disable the respective handler and retry later.
+	e.dnsServer.ProbeAvailability()
 
 	return nil
 }


### PR DESCRIPTION
## Describe your changes

moved the e.dnsServer.ProbeAvailability() to run after ACL apply filtering

run the probes in parallel


## Issue ticket number and link
fixes #1704
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
