### PR TITLE
Add missing dns domain to tests to avoid verbose test logs

### DIFF
--- a/client/cmd/testutil.go
+++ b/client/cmd/testutil.go
@@ -78,7 +78,7 @@ func startManagement(t *testing.T, config *mgmt.Config) (*grpc.Server, net.Liste
 	if err != nil {
 		return nil, nil
 	}
-	accountManager, err := mgmt.BuildManager(store, peersUpdateManager, nil, "", "", eventStore, nil, false)
+	accountManager, err := mgmt.BuildManager(store, peersUpdateManager, nil, "", "netbird.selfhosted", eventStore, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -70,10 +70,10 @@ func TestEngine_SSH(t *testing.T) {
 	defer cancel()
 
 	engine := NewEngine(ctx, cancel, &signal.MockClient{}, &mgmt.MockClient{}, &EngineConfig{
-		WgIfaceName:  "utun101",
-		WgAddr:       "100.64.0.1/24",
-		WgPrivateKey: key,
-		WgPort:       33100,
+		WgIfaceName:      "utun101",
+		WgAddr:           "100.64.0.1/24",
+		WgPrivateKey:     key,
+		WgPort:           33100,
 		ServerSSHAllowed: true,
 	}, MobileDependency{}, peer.NewRecorder("https://mgm"))
 
@@ -1050,7 +1050,7 @@ func startManagement(dataDir string) (*grpc.Server, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	accountManager, err := server.BuildManager(store, peersUpdateManager, nil, "", "", eventStore, nil, false)
+	accountManager, err := server.BuildManager(store, peersUpdateManager, nil, "", "netbird.selfhosted", eventStore, nil, false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/client/server/server_test.go
+++ b/client/server/server_test.go
@@ -114,7 +114,7 @@ func startManagement(t *testing.T, signalAddr string, counter *int) (*grpc.Serve
 	if err != nil {
 		return nil, "", err
 	}
-	accountManager, err := server.BuildManager(store, peersUpdateManager, nil, "", "", eventStore, nil, false)
+	accountManager, err := server.BuildManager(store, peersUpdateManager, nil, "", "netbird.selfhosted", eventStore, nil, false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/management/client/client_test.go
+++ b/management/client/client_test.go
@@ -60,7 +60,7 @@ func startManagement(t *testing.T) (*grpc.Server, net.Listener) {
 
 	peersUpdateManager := mgmt.NewPeersUpdateManager(nil)
 	eventStore := &activity.InMemoryEventStore{}
-	accountManager, err := mgmt.BuildManager(store, peersUpdateManager, nil, "", "", eventStore, nil, false)
+	accountManager, err := mgmt.BuildManager(store, peersUpdateManager, nil, "", "netbird.selfhosted", eventStore, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/management/server/http/peers_handler_test.go
+++ b/management/server/http/peers_handler_test.go
@@ -55,6 +55,9 @@ func initTestMetaData(peers ...*nbpeer.Peer) *PeersHandler {
 			GetPeersFunc: func(accountID, userID string) ([]*nbpeer.Peer, error) {
 				return peers, nil
 			},
+			GetDNSDomainFunc: func() string {
+				return "netbird.selfhosted"
+			},
 			GetAccountFromTokenFunc: func(claims jwtclaims.AuthorizationClaims) (*server.Account, *server.User, error) {
 				user := server.NewAdminUser("test_user")
 				return &server.Account{

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -412,7 +412,7 @@ func startManagement(t *testing.T, config *Config) (*grpc.Server, string, error)
 	}
 	peersUpdateManager := NewPeersUpdateManager(nil)
 	eventStore := &activity.InMemoryEventStore{}
-	accountManager, err := BuildManager(store, peersUpdateManager, nil, "", "",
+	accountManager, err := BuildManager(store, peersUpdateManager, nil, "", "netbird.selfhosted",
 		eventStore, nil, false)
 	if err != nil {
 		return nil, "", err

--- a/management/server/management_test.go
+++ b/management/server/management_test.go
@@ -503,7 +503,7 @@ func startServer(config *server.Config) (*grpc.Server, net.Listener) {
 	}
 	peersUpdateManager := server.NewPeersUpdateManager(nil)
 	eventStore := &activity.InMemoryEventStore{}
-	accountManager, err := server.BuildManager(store, peersUpdateManager, nil, "", "",
+	accountManager, err := server.BuildManager(store, peersUpdateManager, nil, "", "netbird.selfhosted",
 		eventStore, nil, false)
 	if err != nil {
 		log.Fatalf("failed creating a manager: %v", err)

--- a/management/server/nameserver_test.go
+++ b/management/server/nameserver_test.go
@@ -759,7 +759,7 @@ func createNSManager(t *testing.T) (*DefaultAccountManager, error) {
 		return nil, err
 	}
 	eventStore := &activity.InMemoryEventStore{}
-	return BuildManager(store, NewPeersUpdateManager(nil), nil, "", "", eventStore, nil, false)
+	return BuildManager(store, NewPeersUpdateManager(nil), nil, "", "netbird.selfhosted", eventStore, nil, false)
 }
 
 func createNSStore(t *testing.T) (Store, error) {

--- a/management/server/route_test.go
+++ b/management/server/route_test.go
@@ -1014,7 +1014,7 @@ func createRouterManager(t *testing.T) (*DefaultAccountManager, error) {
 		return nil, err
 	}
 	eventStore := &activity.InMemoryEventStore{}
-	return BuildManager(store, NewPeersUpdateManager(nil), nil, "", "", eventStore, nil, false)
+	return BuildManager(store, NewPeersUpdateManager(nil), nil, "", "netbird.selfhosted", eventStore, nil, false)
 }
 
 func createRouterStore(t *testing.T) (Store, error) {


### PR DESCRIPTION
## Describe your changes
This should reduce the number of lines like:
```shell
2024-03-17T20:07:19.2357150Z time="2024-03-17T20:07:01Z" level=error msg="no dns domain is set, returning empty zone"
2024-03-17T20:07:19.2358679Z time="2024-03-17T20:07:01Z" level=error msg="no dns domain is set, returning empty zone"
2024-03-17T20:07:19.2360189Z time="2024-03-17T20:07:01Z" level=error msg="no dns domain is set, returning empty zone"
2024-03-17T20:07:19.2361706Z time="2024-03-17T20:07:01Z" level=error msg="no dns domain is set, returning empty zone"
2024-03-17T20:07:19.2363215Z time="2024-03-17T20:07:01Z" level=error msg="no dns domain is set, returning empty zone"
2024-03-17T20:07:19.2364841Z time="2024-03-17T20:07:01Z" level=error msg="no dns domain is set, returning empty zone"
2024-03-17T20:07:19.2366344Z time="2024-03-17T20:07:01Z" level=error msg="no dns domain is set, returning empty zone"
```
## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
