### PR TITLE
Add latency based routing

### DIFF
--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -115,6 +115,8 @@ func (c *clientNetwork) getBestRouteFromStatuses(routePeerStatuses map[string]ro
 		latency := time.Second
 		if peerStatus.latency != 0 {
 			latency = peerStatus.latency
+		} else {
+			log.Warnf("peer %s has 0 latency", r.Peer)
 		}
 		tempScore += 1 - latency.Seconds()
 

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -153,12 +153,16 @@ func calculateLatencyScores(routePeerStatuses map[string]routerPeerStatus) map[s
 	}
 
 	sort.Slice(latencies, func(i, j int) bool {
-		return latencies[i].Latency < latencies[j].Latency
+		return latencies[i].Latency > latencies[j].Latency
 	})
 
 	positions := make(map[string]int)
 	for i, latencyInfo := range latencies {
-		positions[latencyInfo.ID] = i + 1
+		score := 0
+		if latencyInfo.Latency > 0 {
+			score = i + 1
+		}
+		positions[latencyInfo.ID] = score
 	}
 
 	return positions

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -141,17 +141,15 @@ func (c *clientNetwork) getBestRouteFromStatuses(routePeerStatuses map[string]ro
 		}
 	}
 
-	if chosen == "" {
+	switch {
+	case chosen == "":
 		var peers []string
 		for _, r := range c.routes {
 			peers = append(peers, r.Peer)
 		}
 
 		log.Warnf("the network %s has not been assigned a routing peer as no peers from the list %s are currently connected", c.network, peers)
-
-	} else if currID == "" {
-		return chosen
-	} else if chosen != currID {
+	case chosen != currID:
 		if currScore != 0 && currScore < chosenScore+0.1 {
 			return currID
 		} else {

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -87,6 +87,7 @@ func (c *clientNetwork) getRouterPeerStatuses() map[string]routerPeerStatus {
 // * Non-relayed: Routes without relays are preferred.
 // * Direct connections: Routes with direct peer connections are favored.
 // * Stability: In case of equal scores, the currently active route (if any) is maintained.
+// * Latency: Routes with lower latency are prioritized.
 //
 // It returns the ID of the selected optimal route.
 func (c *clientNetwork) getBestRouteFromStatuses(routePeerStatuses map[string]routerPeerStatus) string {

--- a/client/internal/routemanager/client_test.go
+++ b/client/internal/routemanager/client_test.go
@@ -3,6 +3,7 @@ package routemanager
 import (
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/netbirdio/netbird/route"
 )
@@ -178,6 +179,60 @@ func TestGetBestrouteFromStatuses(t *testing.T) {
 			},
 			currentRoute:    nil,
 			expectedRouteID: "route1",
+		},
+		{
+			name: "multiple connected peers with different latencies",
+			statuses: map[string]routerPeerStatus{
+				"route1": {
+					connected: true,
+					latency:   30 * time.Millisecond,
+				},
+				"route2": {
+					connected: true,
+					latency:   10 * time.Millisecond,
+				},
+			},
+			existingRoutes: map[string]*route.Route{
+				"route1": {
+					ID:     "route1",
+					Metric: route.MaxMetric,
+					Peer:   "peer1",
+				},
+				"route2": {
+					ID:     "route2",
+					Metric: route.MaxMetric,
+					Peer:   "peer2",
+				},
+			},
+			currentRoute:    nil,
+			expectedRouteID: "route2",
+		},
+		{
+			name: "should ignore routes with latency 0",
+			statuses: map[string]routerPeerStatus{
+				"route1": {
+					connected: true,
+					latency:   0 * time.Millisecond,
+				},
+				"route2": {
+					connected: true,
+					latency:   10 * time.Millisecond,
+				},
+			},
+			existingRoutes: map[string]*route.Route{
+				"route1": {
+					ID:     "route1",
+					Metric: route.MaxMetric,
+					Peer:   "peer1",
+				},
+				"route2": {
+					ID:     "route2",
+					Metric: route.MaxMetric,
+					Peer:   "peer2",
+				},
+			},
+			currentRoute:    nil,
+			expectedRouteID: "route2",
 		},
 	}
 


### PR DESCRIPTION
## Describe your changes
Now that we have the latency between peers available we can use this data to consider when choosing the beste route. This way the route with the routing peer with the lowes latency will be prefered over others with the same target network.

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/1554

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
