### PR TITLE
Add limited dashboard view

### DIFF
--- a/management/server/http/accounts_handler.go
+++ b/management/server/http/accounts_handler.go
@@ -94,6 +94,9 @@ func (h *AccountsHandler) UpdateAccount(w http.ResponseWriter, r *http.Request) 
 	if req.Settings.JwtAllowGroups != nil {
 		settings.JWTAllowGroups = *req.Settings.JwtAllowGroups
 	}
+	if req.Settings.PeerViewBlocked != nil {
+		settings.PeerViewBlocked = *req.Settings.PeerViewBlocked
+	}
 
 	updatedAccount, err := h.accountManager.UpdateAccountSettings(accountID, user.Id, settings)
 	if err != nil {
@@ -143,6 +146,7 @@ func toAccountResponse(account *server.Account) *api.Account {
 		JwtGroupsEnabled:           &account.Settings.JWTGroupsEnabled,
 		JwtGroupsClaimName:         &account.Settings.JWTGroupsClaimName,
 		JwtAllowGroups:             &jwtAllowGroups,
+		PeerViewBlocked:            &account.Settings.PeerViewBlocked,
 	}
 
 	if account.Settings.Extra != nil {

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -54,6 +54,10 @@ components:
           description: Period of time after which peer login expires (seconds).
           type: integer
           example: 43200
+        peer_view_blocked:
+          description: Allows blocking regular users from viewing any peers.
+          type: boolean
+          example: true
         groups_propagation_enabled:
           description: Allows propagate the new user auto groups to peers that belongs to the user
           type: boolean
@@ -144,6 +148,8 @@ components:
           description: How user was issued by API or Integration
           type: string
           example: api
+        permissions:
+            $ref: '#/components/schemas/UserPermissions'
       required:
         - id
         - email
@@ -152,6 +158,14 @@ components:
         - auto_groups
         - status
         - is_blocked
+    UserPermissions:
+      type: object
+      properties:
+        dashboard_view:
+          description: User's permission to view the dashboard
+          type: string
+          enum: [ "limited", "blocked", "full" ]
+          example: limited
     UserRequest:
       type: object
       properties:
@@ -588,8 +602,6 @@ components:
           description: How the group was issued (api, integration, jwt)
           type: string
           enum: ["api", "integration", "jwt"]
-          example: api
-          type: string
           example: api
       required:
         - id

--- a/management/server/http/api/types.gen.go
+++ b/management/server/http/api/types.gen.go
@@ -69,6 +69,20 @@ const (
 	GeoLocationCheckActionDeny  GeoLocationCheckAction = "deny"
 )
 
+// Defines values for GroupIssued.
+const (
+	GroupIssuedApi         GroupIssued = "api"
+	GroupIssuedIntegration GroupIssued = "integration"
+	GroupIssuedJwt         GroupIssued = "jwt"
+)
+
+// Defines values for GroupMinimumIssued.
+const (
+	GroupMinimumIssuedApi         GroupMinimumIssued = "api"
+	GroupMinimumIssuedIntegration GroupMinimumIssued = "integration"
+	GroupMinimumIssuedJwt         GroupMinimumIssued = "jwt"
+)
+
 // Defines values for NameserverNsType.
 const (
 	NameserverNsTypeUdp NameserverNsType = "udp"
@@ -129,6 +143,13 @@ const (
 	UserStatusInvited UserStatus = "invited"
 )
 
+// Defines values for UserPermissionsDashboardView.
+const (
+	UserPermissionsDashboardViewBlocked UserPermissionsDashboardView = "blocked"
+	UserPermissionsDashboardViewFull    UserPermissionsDashboardView = "full"
+	UserPermissionsDashboardViewLimited UserPermissionsDashboardView = "limited"
+)
+
 // AccessiblePeer defines model for AccessiblePeer.
 type AccessiblePeer struct {
 	// DnsLabel Peer's DNS label is the parsed peer name for domain resolution. It is used to form an FQDN by appending the account's domain to the peer label. e.g. peer-dns-label.netbird.cloud
@@ -186,6 +207,9 @@ type AccountSettings struct {
 
 	// PeerLoginExpirationEnabled Enables or disables peer login expiration globally. After peer's login has expired the user has to log in (authenticate). Applies only to peers that were added by a user (interactive SSO login).
 	PeerLoginExpirationEnabled bool `json:"peer_login_expiration_enabled"`
+
+	// PeerViewBlocked Allows blocking regular users from viewing any peers.
+	PeerViewBlocked *bool `json:"peer_view_blocked,omitempty"`
 }
 
 // Checks List of objects that perform the actual checks
@@ -283,8 +307,8 @@ type Group struct {
 	// Id Group ID
 	Id string `json:"id"`
 
-	// Issued How group was issued by API or from JWT token
-	Issued *string `json:"issued,omitempty"`
+	// Issued How the group was issued (api, integration, jwt)
+	Issued *GroupIssued `json:"issued,omitempty"`
 
 	// Name Group Name identifier
 	Name string `json:"name"`
@@ -296,13 +320,16 @@ type Group struct {
 	PeersCount int `json:"peers_count"`
 }
 
+// GroupIssued How the group was issued (api, integration, jwt)
+type GroupIssued string
+
 // GroupMinimum defines model for GroupMinimum.
 type GroupMinimum struct {
 	// Id Group ID
 	Id string `json:"id"`
 
-	// Issued How group was issued by API or from JWT token
-	Issued *string `json:"issued,omitempty"`
+	// Issued How the group was issued (api, integration, jwt)
+	Issued *GroupMinimumIssued `json:"issued,omitempty"`
 
 	// Name Group Name identifier
 	Name string `json:"name"`
@@ -310,6 +337,9 @@ type GroupMinimum struct {
 	// PeersCount Count of peers associated to the group
 	PeersCount int `json:"peers_count"`
 }
+
+// GroupMinimumIssued How the group was issued (api, integration, jwt)
+type GroupMinimumIssued string
 
 // GroupRequest defines model for GroupRequest.
 type GroupRequest struct {
@@ -1072,7 +1102,8 @@ type User struct {
 	LastLogin *time.Time `json:"last_login,omitempty"`
 
 	// Name User's name from idp provider
-	Name string `json:"name"`
+	Name        string           `json:"name"`
+	Permissions *UserPermissions `json:"permissions,omitempty"`
 
 	// Role User's NetBird account role
 	Role string `json:"role"`
@@ -1101,6 +1132,15 @@ type UserCreateRequest struct {
 	// Role User's NetBird account role
 	Role string `json:"role"`
 }
+
+// UserPermissions defines model for UserPermissions.
+type UserPermissions struct {
+	// DashboardView User's permission to view the dashboard
+	DashboardView *UserPermissionsDashboardView `json:"dashboard_view,omitempty"`
+}
+
+// UserPermissionsDashboardView User's permission to view the dashboard
+type UserPermissionsDashboardView string
 
 // UserRequest defines model for UserRequest.
 type UserRequest struct {

--- a/management/server/http/groups_handler.go
+++ b/management/server/http/groups_handler.go
@@ -239,7 +239,7 @@ func toGroupResponse(account *server.Account, group *server.Group) *api.Group {
 	gr := api.Group{
 		Id:     group.ID,
 		Name:   group.Name,
-		Issued: &group.Issued,
+		Issued: (*api.GroupIssued)(&group.Issued),
 	}
 
 	for _, pid := range group.Peers {

--- a/management/server/http/users_handler.go
+++ b/management/server/http/users_handler.go
@@ -288,5 +288,8 @@ func toUserResponse(user *server.UserInfo, currenUserID string) *api.User {
 		IsBlocked:     user.IsBlocked,
 		LastLogin:     &user.LastLogin,
 		Issued:        &user.Issued,
+		Permissions: &api.UserPermissions{
+			DashboardView: (*api.UserPermissionsDashboardView)(&user.Permissions.DashboardView),
+		},
 	}
 }

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -54,6 +54,11 @@ func (am *DefaultAccountManager) GetPeers(accountID, userID string) ([]*nbpeer.P
 
 	peers := make([]*nbpeer.Peer, 0)
 	peersMap := make(map[string]*nbpeer.Peer)
+
+	if !user.HasAdminPower() && !user.IsServiceUser && account.Settings.PeerViewBlocked {
+		return peers, nil
+	}
+
 	for _, peer := range account.Peers {
 		if !(user.HasAdminPower() || user.IsServiceUser) && user.Id != peer.UserID {
 			// only display peers that belong to the current user if the current user is not an admin
@@ -736,6 +741,10 @@ func (am *DefaultAccountManager) GetPeer(accountID, peerID, userID string) (*nbp
 	user, err := account.FindUser(userID)
 	if err != nil {
 		return nil, err
+	}
+
+	if !user.HasAdminPower() && !user.IsServiceUser && account.Settings.PeerViewBlocked {
+		return nil, status.Errorf(status.Internal, "user %s has no access to his own peer %s under account %s", userID, peerID, accountID)
 	}
 
 	peer := account.GetPeer(peerID)

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -113,10 +113,18 @@ func (u *User) HasAdminPower() bool {
 }
 
 // ToUserInfo converts a User object to a UserInfo object.
-func (u *User) ToUserInfo(userData *idp.UserData) (*UserInfo, error) {
+func (u *User) ToUserInfo(userData *idp.UserData, settings *Settings) (*UserInfo, error) {
 	autoGroups := u.AutoGroups
 	if autoGroups == nil {
 		autoGroups = []string{}
+	}
+
+	dashboardViewPermissions := "full"
+	if !u.HasAdminPower() {
+		dashboardViewPermissions = "limited"
+		if settings.PeerViewBlocked {
+			dashboardViewPermissions = "blocked"
+		}
 	}
 
 	if userData == nil {
@@ -131,6 +139,9 @@ func (u *User) ToUserInfo(userData *idp.UserData) (*UserInfo, error) {
 			IsBlocked:     u.Blocked,
 			LastLogin:     u.LastLogin,
 			Issued:        u.Issued,
+			Permissions: UserPermissions{
+				DashboardView: dashboardViewPermissions,
+			},
 		}, nil
 	}
 	if userData.ID != u.Id {
@@ -153,6 +164,9 @@ func (u *User) ToUserInfo(userData *idp.UserData) (*UserInfo, error) {
 		IsBlocked:     u.Blocked,
 		LastLogin:     u.LastLogin,
 		Issued:        u.Issued,
+		Permissions: UserPermissions{
+			DashboardView: dashboardViewPermissions,
+		},
 	}, nil
 }
 
@@ -358,7 +372,7 @@ func (am *DefaultAccountManager) inviteNewUser(accountID, userID string, invite 
 
 	am.StoreEvent(userID, newUser.Id, accountID, activity.UserInvited, nil)
 
-	return newUser.ToUserInfo(idpUser)
+	return newUser.ToUserInfo(idpUser, account.Settings)
 }
 
 // GetUser looks up a user by provided authorization claims.
@@ -905,9 +919,9 @@ func (am *DefaultAccountManager) SaveOrAddUser(accountID, initiatorUserID string
 		if err != nil {
 			return nil, err
 		}
-		return newUser.ToUserInfo(userData)
+		return newUser.ToUserInfo(userData, account.Settings)
 	}
-	return newUser.ToUserInfo(nil)
+	return newUser.ToUserInfo(nil, account.Settings)
 }
 
 // GetOrCreateAccountByUser returns an existing account for a given user id or creates a new one if doesn't exist
@@ -998,7 +1012,7 @@ func (am *DefaultAccountManager) GetUsersFromAccount(accountID, userID string) (
 				// if user is not an admin then show only current user and do not show other users
 				continue
 			}
-			info, err := accountUser.ToUserInfo(nil)
+			info, err := accountUser.ToUserInfo(nil, account.Settings)
 			if err != nil {
 				return nil, err
 			}
@@ -1015,7 +1029,7 @@ func (am *DefaultAccountManager) GetUsersFromAccount(accountID, userID string) (
 
 		var info *UserInfo
 		if queriedUser, contains := findUserInIDPUserdata(localUser.Id, queriedUsers); contains {
-			info, err = localUser.ToUserInfo(queriedUser)
+			info, err = localUser.ToUserInfo(queriedUser, account.Settings)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Describe your changes
This PR adds a new settings field `peer_view_blocked`. Is this field is set to true it will the peer responses for regular users (admins and owners still have full response). Additionally it will extend the api response when querying for users with a permissions object that includes the `dashboard_view`. This will help the dashboard on what to show for each user until we have a full permissions functionality throughout the project. 


## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
