### PR TITLE
Routes is a map, employing safe read/writes ops

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -794,6 +794,7 @@ func (e *Engine) updateOfflinePeers(offlinePeers []*mgmProto.RemotePeerConfig) {
 			FQDN:             offlinePeer.GetFqdn(),
 			ConnStatus:       peer.StatusDisconnected,
 			ConnStatusUpdate: time.Now(),
+			Mux:              new(sync.RWMutex),
 		}
 	}
 	e.statusRecorder.ReplaceOfflinePeers(replacement)

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -229,7 +229,6 @@ func (conn *Conn) reCreateAgent() error {
 	}
 
 	conn.agent, err = ice.NewAgent(agentConfig)
-
 	if err != nil {
 		return err
 	}
@@ -285,6 +284,7 @@ func (conn *Conn) Open() error {
 		IP:               strings.Split(conn.config.WgConfig.AllowedIps, "/")[0],
 		ConnStatusUpdate: time.Now(),
 		ConnStatus:       conn.status,
+		Mux:              new(sync.RWMutex),
 	}
 	err := conn.statusRecorder.UpdatePeerState(peerState)
 	if err != nil {
@@ -344,6 +344,7 @@ func (conn *Conn) Open() error {
 		PubKey:           conn.config.Key,
 		ConnStatus:       conn.status,
 		ConnStatusUpdate: time.Now(),
+		Mux:              new(sync.RWMutex),
 	}
 	err = conn.statusRecorder.UpdatePeerState(peerState)
 	if err != nil {
@@ -468,6 +469,7 @@ func (conn *Conn) configureConnection(remoteConn net.Conn, remoteWgPort int, rem
 		RemoteIceCandidateEndpoint: fmt.Sprintf("%s:%d", pair.Remote.Address(), pair.Local.Port()),
 		Direct:                     !isRelayCandidate(pair.Local),
 		RosenpassEnabled:           rosenpassEnabled,
+		Mux:                        new(sync.RWMutex),
 	}
 	if pair.Local.Type() == ice.CandidateTypeRelay || pair.Remote.Type() == ice.CandidateTypeRelay {
 		peerState.Relayed = true
@@ -558,6 +560,7 @@ func (conn *Conn) cleanup() error {
 		PubKey:           conn.config.Key,
 		ConnStatus:       conn.status,
 		ConnStatusUpdate: time.Now(),
+		Mux:              new(sync.RWMutex),
 	}
 	err := conn.statusRecorder.UpdatePeerState(peerState)
 	if err != nil {

--- a/client/internal/peer/status_test.go
+++ b/client/internal/peer/status_test.go
@@ -3,6 +3,7 @@ package peer
 import (
 	"errors"
 	"testing"
+	"sync"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -42,6 +43,7 @@ func TestUpdatePeerState(t *testing.T) {
 	status := NewRecorder("https://mgm")
 	peerState := State{
 		PubKey: key,
+		Mux:	new(sync.RWMutex),
 	}
 
 	status.peers[key] = peerState
@@ -62,6 +64,7 @@ func TestStatus_UpdatePeerFQDN(t *testing.T) {
 	status := NewRecorder("https://mgm")
 	peerState := State{
 		PubKey: key,
+		Mux:	new(sync.RWMutex),
 	}
 
 	status.peers[key] = peerState
@@ -80,6 +83,7 @@ func TestGetPeerStateChangeNotifierLogic(t *testing.T) {
 	status := NewRecorder("https://mgm")
 	peerState := State{
 		PubKey: key,
+		Mux:	new(sync.RWMutex),
 	}
 
 	status.peers[key] = peerState
@@ -104,6 +108,7 @@ func TestRemovePeer(t *testing.T) {
 	status := NewRecorder("https://mgm")
 	peerState := State{
 		PubKey: key,
+		Mux:	new(sync.RWMutex),
 	}
 
 	status.peers[key] = peerState

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -174,7 +174,7 @@ func (c *clientNetwork) removeRouteFromWireguardPeer(peerKey string) error {
 		return fmt.Errorf("get peer state: %v", err)
 	}
 
-	delete(state.Routes, c.network.String())
+	state.DeleteRoute(c.network.String())
 	if err := c.statusRecorder.UpdatePeerState(state); err != nil {
 		log.Warnf("Failed to update peer state: %v", err)
 	}
@@ -246,10 +246,7 @@ func (c *clientNetwork) recalculateRouteAndUpdatePeerAndSystem() error {
 	if err != nil {
 		log.Errorf("Failed to get peer state: %v", err)
 	} else {
-		if state.Routes == nil {
-			state.Routes = map[string]struct{}{}
-		}
-		state.Routes[c.network.String()] = struct{}{}
+		state.AddRoute(c.network.String())
 		if err := c.statusRecorder.UpdatePeerState(state); err != nil {
 			log.Warnf("Failed to update peer state: %v", err)
 		}

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -718,7 +718,7 @@ func toProtoFullStatus(fullStatus peer.FullStatus) *proto.FullStatus {
 			BytesRx:                    peerState.BytesRx,
 			BytesTx:                    peerState.BytesTx,
 			RosenpassEnabled:           peerState.RosenpassEnabled,
-			Routes:                     maps.Keys(peerState.Routes),
+			Routes:                     maps.Keys(peerState.GetRoutes()),
 			Latency:                    durationpb.New(peerState.Latency),
 		}
 		pbFullStatus.Peers = append(pbFullStatus.Peers, pbPeerState)


### PR DESCRIPTION
Adding a mutex to the struct although the norm, could not be used due to the state being copied around. Fixes #1759 

## Describe your changes

## Issue ticket number and link

### Checklist
- [x ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
