### PR TITLE
Fix invalid token on peer login due to the cache race

### DIFF
--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -343,10 +343,18 @@ func (s *GRPCServer) Login(ctx context.Context, req *proto.EncryptedMessage) (*p
 	userID := ""
 	// JWT token is not always provided, it is fine for userID to be empty cuz it might be that peer is already registered,
 	// or it uses a setup key to register.
+
 	if loginReq.GetJwtToken() != "" {
-		userID, err = s.validateToken(loginReq.GetJwtToken())
+		for i := 0; i < 3; i++ {
+			userID, err = s.validateToken(loginReq.GetJwtToken())
+			if err == nil {
+				break
+			}
+			log.Warnf("failed validating JWT token sent from peer %s with error %v. "+
+				"Trying again as it may be due to the IdP cache issue", peerKey, err)
+			time.Sleep(200 * time.Millisecond)
+		}
 		if err != nil {
-			log.Warnf("failed validating JWT token sent from peer %s", peerKey)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Describe your changes
The issue happens when a new account is created not through the dashboard but by logging in a new machine.

The fix just does 3 retries with a delay on token validation.
## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
