### PR TITLE
Get scope from endpoint url instead of hardcoding for Azure (Entra ID)

### DIFF
--- a/management/server/idp/azure.go
+++ b/management/server/idp/azure.go
@@ -115,7 +115,15 @@ func (ac *AzureCredentials) requestJWTToken() (*http.Response, error) {
 	data.Set("client_id", ac.clientConfig.ClientID)
 	data.Set("client_secret", ac.clientConfig.ClientSecret)
 	data.Set("grant_type", ac.clientConfig.GrantType)
-	data.Set("scope", "https://graph.microsoft.com/.default")
+	parsedURL, err := url.Parse(ac.clientConfig.GraphAPIEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// get base url and add "/.default" as scope
+	baseURL := parsedURL.Scheme + "://" + parsedURL.Host
+	scopeURL := baseURL + "/.default"
+	data.Set("scope", scopeURL)
 
 	payload := strings.NewReader(data.Encode())
 	req, err := http.NewRequest(http.MethodPost, ac.clientConfig.TokenEndpoint, payload)


### PR DESCRIPTION
## Describe your changes
Get scope from endpoint url instead of hardcoding for Azure (Entra ID). This is to fix errors occured when the endpoint is not https://graph.microsoft.com.
## Issue ticket number and link
#1663 
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
