### PR TITLE
Changing the dashboard image pull from wiretrustee to netbirdio for traefik docker template

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl.traefik
+++ b/infrastructure_files/docker-compose.yml.tmpl.traefik
@@ -2,7 +2,7 @@ version: "3"
 services:
   #UI dashboard
   dashboard:
-    image: wiretrustee/dashboard:$NETBIRD_DASHBOARD_TAG
+    image: netbirdio/dashboard:$NETBIRD_DASHBOARD_TAG
     restart: unless-stopped
     #ports:
     #  - 80:80


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

### Checklist
- [] Is it a bug fix
- [X] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
