### PR TITLE
Auto restart Windows agent daemon service

### DIFF
--- a/client/cmd/service_installer.go
+++ b/client/cmd/service_installer.go
@@ -64,6 +64,10 @@ var installCmd = &cobra.Command{
 			}
 		}
 
+		if runtime.GOOS == "windows" {
+			svcConfig.Option["OnFailure"] = "restart"
+		}
+
 		ctx, cancel := context.WithCancel(cmd.Context())
 
 		s, err := newSVC(newProgram(ctx, cancel), svcConfig)


### PR DESCRIPTION
## Describe your changes
This enables auto restart of the windows agent daemon service on event of failure

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
