### PR TITLE
Don't use the custom dialer as non-root

### DIFF
--- a/util/grpc/dialer.go
+++ b/util/grpc/dialer.go
@@ -3,6 +3,8 @@ package grpc
 import (
 	"context"
 	"net"
+	"os/user"
+	"runtime"
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -12,6 +14,20 @@ import (
 
 func WithCustomDialer() grpc.DialOption {
 	return grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+		if runtime.GOOS == "linux" {
+			currentUser, err := user.Current()
+			if err != nil {
+				log.Fatalf("failed to get current user: %v", err)
+			}
+
+			// the custom dialer requires root permissions which are not required for use cases run as non-root
+			if currentUser.Uid != "0" {
+				dialer := &net.Dialer{}
+				return dialer.DialContext(ctx, "tcp", addr)
+			}
+		}
+
+
 		conn, err := nbnet.NewDialer().DialContext(ctx, "tcp", addr)
 		if err != nil {
 			log.Errorf("Failed to dial: %s", err)


### PR DESCRIPTION
## Describe your changes

Running `netbird login` as non-root will fail setting the fwmark, which is not required for this procedure, hence we don't use the custom dialer for it

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
