### PR TITLE
Delete route from system only if added by the client

### DIFF
--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -221,6 +221,8 @@ func (c *clientNetwork) removeRouteFromPeerAndSystem() error {
 				return fmt.Errorf("remove route %s from system, err: %v", c.network, err)
 			}
 			c.systemUpdated = false
+		} else {
+			log.Debugf("system is not updated for network %s, skiping removal from system route table", c.network)
 		}
 
 		if err := c.removeRouteFromWireguardPeer(c.chosenRoute.Peer); err != nil {

--- a/client/internal/routemanager/systemops.go
+++ b/client/internal/routemanager/systemops.go
@@ -256,8 +256,7 @@ func addNonExistingRoute(prefix netip.Prefix, intf string) error {
 		return fmt.Errorf("exists in route table: %w", err)
 	}
 	if ok {
-		log.Warnf("Skipping adding a new route for network %s because it already exists", prefix)
-		return nil
+		return fmt.Errorf("Skipping adding a new route for network %s because it already exists", prefix)
 	}
 
 	ok, err = isSubRange(prefix)

--- a/client/internal/routemanager/systemops.go
+++ b/client/internal/routemanager/systemops.go
@@ -256,7 +256,7 @@ func addNonExistingRoute(prefix netip.Prefix, intf string) error {
 		return fmt.Errorf("exists in route table: %w", err)
 	}
 	if ok {
-		return fmt.Errorf("Skipping adding a new route for network %s because it already exists", prefix)
+		return fmt.Errorf("skipping adding a new route for network %s because it already exists", prefix)
 	}
 
 	ok, err = isSubRange(prefix)


### PR DESCRIPTION
This adds a flags to check if the addVPNRoute executed without issues before removing a route from the system

## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
