### PR TITLE
Add support for GUI app to display error

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -219,7 +219,7 @@ func (s *serviceClient) showUIElements() {
 // showErrorMSG opens a fyne app window to display the supplied message
 func showErrorMSG(msg string) {
 	app := app.New()
-	w := app.NewWindow("NetBird error")
+	w := app.NewWindow("NetBird Error")
 	content := widget.NewLabel(msg)
 	content.Wrapping = fyne.TextWrapWord
 	w.SetContent(content)

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -220,8 +220,10 @@ func (s *serviceClient) showUIElements() {
 func showErrorMSG(msg string) {
 	app := app.New()
 	w := app.NewWindow("NetBird error")
-	w.SetContent(widget.NewLabel(msg))
-	w.Resize(fyne.NewSize(300, 100))
+	content := widget.NewLabel(msg)
+	content.Wrapping = fyne.TextWrapWord
+	w.SetContent(content)
+	w.Resize(fyne.NewSize(400, 100))
 	w.Show()
 	app.Run()
 }


### PR DESCRIPTION
## Describe your changes
This PR adds support for the GUI client to display an error window when clicking connect or disconnect.

Example:
<img width="305" alt="image" src="https://github.com/netbirdio/netbird/assets/7747744/3e0ddb71-2cde-419b-929f-9fbe09740777">


## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
