### PR TITLE
Add account locks to getAccountWithAuthorizationClaims method

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1795,7 +1795,7 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 	} else if s, ok := status.FromError(err); ok && s.Type() == status.NotFound {
 		unlockAccount := am.Store.AcquireAccountLock(domainAccount.Id)
 		defer unlockAccount()
-		account, err = am.Store.GetAccountByUser(claims.UserId)
+		domainAccount, err := am.Store.GetAccountByPrivateDomain(claims.Domain)
 		if err != nil {
 			return nil, err
 		}

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1787,6 +1787,10 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 		if err != nil {
 			return nil, err
 		}
+		domainAccount, err = am.Store.GetAccountByPrivateDomain(claims.Domain)
+		if err != nil {
+			return nil, err
+		}
 		err = am.handleExistingUserAccount(account, domainAccount, claims)
 		if err != nil {
 			return nil, err
@@ -1795,7 +1799,7 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 	} else if s, ok := status.FromError(err); ok && s.Type() == status.NotFound {
 		unlockAccount := am.Store.AcquireAccountLock(domainAccount.Id)
 		defer unlockAccount()
-		domainAccount, err := am.Store.GetAccountByPrivateDomain(claims.Domain)
+		domainAccount, err = am.Store.GetAccountByPrivateDomain(claims.Domain)
 		if err != nil {
 			return nil, err
 		}

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1789,7 +1789,11 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 		}
 		domainAccount, err = am.Store.GetAccountByPrivateDomain(claims.Domain)
 		if err != nil {
-			return nil, err
+			// if NotFound we are good to continue, otherwise return error
+			e, ok := status.FromError(err)
+			if !ok || e.Type() != status.NotFound {
+				return nil, err
+			}
 		}
 		err = am.handleExistingUserAccount(account, domainAccount, claims)
 		if err != nil {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1784,6 +1784,9 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 		unlockAccount := am.Store.AcquireAccountLock(account.Id)
 		defer unlockAccount()
 		account, err = am.Store.GetAccountByUser(claims.UserId)
+		if err != nil {
+			return nil, err
+		}
 		err = am.handleExistingUserAccount(account, domainAccount, claims)
 		if err != nil {
 			return nil, err
@@ -1793,6 +1796,9 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 		unlockAccount := am.Store.AcquireAccountLock(domainAccount.Id)
 		defer unlockAccount()
 		account, err = am.Store.GetAccountByUser(claims.UserId)
+		if err != nil {
+			return nil, err
+		}
 		return am.handleNewUserAccount(domainAccount, claims)
 	} else {
 		// other error

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1777,7 +1777,7 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 		// non-primary account for the domain. We don't merge accounts at this stage, because of cases when a domain
 		// was previously unclassified or classified as public so N users that logged int that time, has they own account
 		// and peers that shouldn't be lost.
-		primaryDomain := domainAccount == nil || account.Id == account.Id
+		primaryDomain := domainAccount == nil || account.Id == domainAccount.Id
 
 		err = am.handleExistingUserAccount(account, primaryDomain, claims)
 		if err != nil {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1801,6 +1801,10 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 		}
 		return account, nil
 	} else if s, ok := status.FromError(err); ok && s.Type() == status.NotFound {
+		if domainAccount != nil {
+			unlockAccount := am.Store.AcquireAccountLock(domainAccount.Id)
+			defer unlockAccount()
+		}
 		return am.handleNewUserAccount(domainAccount, claims)
 	} else {
 		// other error

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1797,12 +1797,6 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 		}
 		return account, nil
 	} else if s, ok := status.FromError(err); ok && s.Type() == status.NotFound {
-		unlockAccount := am.Store.AcquireAccountLock(domainAccount.Id)
-		defer unlockAccount()
-		domainAccount, err = am.Store.GetAccountByPrivateDomain(claims.Domain)
-		if err != nil {
-			return nil, err
-		}
 		return am.handleNewUserAccount(domainAccount, claims)
 	} else {
 		// other error


### PR DESCRIPTION
## Describe your changes
There was a race condition within the `getAccountWithAuthorizationClaims` method which was causing some operations to not store the updated data properly in the backend because it was overwriting with an old state. This PR adds account locks to this method to avoid overwriting.

How I reproduced:
- make sure you reach line 1782 in account.go (either remove the top conditions or use single account mode and change your env)
- add a random sleep between 0 and 2 seconds either in the `updateAccountDomainAttributes` right before the `SaveAccount` (line 1420) or within the `SaveAccount` method itself like
```
time.Sleep(time.Duration(rand.Float64() * float64(time.Second)))
```
- add a process querying any api endpoint so that the domain attributes get updated with a small enough frequency like
```
while true; do
 curl --request GET --url http://localhost/api/setup-keys --header 'Authorization: Token <PAT>' >/dev/null 2>&1
 sleep 0.2
done
```
- try to create a setup key
```
curl --request POST --url http://localhost/api/setup-keys --header 'Accept: application/json' --header 'Authorization: Token <PAT>' --header 'Content-Type: application/json' --data '{"name":"key1","type":"one-off","expires_in":604800,"revoked":false,"auto_groups":[],"usage_limit":1,"ephemeral":false}'
```

For the majority of attempts, this will not work and the key is not persistent in the database even though the API returns with success.

## Issue ticket number and link
https://github.com/netbirdio/dashboard/issues/371

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
