### PR TITLE
Redeem invite only when incoming user was invited

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1379,7 +1379,7 @@ func (am *DefaultAccountManager) lookupCache(accountUsers map[string]userLoggedI
 	}
 
 	// if we know users that are not yet in cache more likely cache is outdated
-	if knownUsersCount > 0 && mustRefreshInviteStatus {
+	if knownUsersCount > 0 || mustRefreshInviteStatus {
 		log.Debugf("reloading cache with IDP manager. Users unknown to the cache: %d, Must refresh invite status? %t", knownUsersCount, mustRefreshInviteStatus)
 		// reload cache once avoiding loops
 		data, err = am.refreshCache(accountID)

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1380,7 +1380,7 @@ func (am *DefaultAccountManager) lookupCache(accountUsers map[string]userLoggedI
 
 	// if we know users that are not yet in cache more likely cache is outdated
 	if knownUsersCount > 0 && mustRefreshInviteStatus {
-		log.Debugf("reloading cache with IDP manager. Users unkonwn to the cache: %d, Must refresh invite status? %t", knownUsersCount, mustRefreshInviteStatus)
+		log.Debugf("reloading cache with IDP manager. Users unkown to the cache: %d, Must refresh invite status? %t", knownUsersCount, mustRefreshInviteStatus)
 		// reload cache once avoiding loops
 		data, err = am.refreshCache(accountID)
 		if err != nil {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1380,7 +1380,7 @@ func (am *DefaultAccountManager) lookupCache(accountUsers map[string]userLoggedI
 
 	// if we know users that are not yet in cache more likely cache is outdated
 	if knownUsersCount > 0 && mustRefreshInviteStatus {
-		log.Debugf("reloading cache with IDP manager. Users unkown to the cache: %d, Must refresh invite status? %t", knownUsersCount, mustRefreshInviteStatus)
+		log.Debugf("reloading cache with IDP manager. Users unknown to the cache: %d, Must refresh invite status? %t", knownUsersCount, mustRefreshInviteStatus)
 		// reload cache once avoiding loops
 		data, err = am.refreshCache(accountID)
 		if err != nil {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1370,6 +1370,7 @@ func (am *DefaultAccountManager) lookupCache(accountUsers map[string]userLoggedI
 			// check if the matching user data has a pending invite and if the user has logged in once, forcing the cache to be refreshed
 			if datum.AppMetadata.WTPendingInvite != nil && *datum.AppMetadata.WTPendingInvite && loggedInOnce == true { //nolint:gosimple
 				mustRefreshInviteStatus = true
+				log.Infof("user %s has a pending invite and has logged in once, forcing cache refresh", user)
 				break
 			}
 			knownUsersCount--
@@ -1380,7 +1381,9 @@ func (am *DefaultAccountManager) lookupCache(accountUsers map[string]userLoggedI
 
 	// if we know users that are not yet in cache more likely cache is outdated
 	if knownUsersCount > 0 || mustRefreshInviteStatus {
-		log.Debugf("reloading cache with IDP manager. Users unknown to the cache: %d, Must refresh invite status? %t", knownUsersCount, mustRefreshInviteStatus)
+		if !mustRefreshInviteStatus {
+			log.Infof("reloading cache with IDP manager. Users unknown to the cache: %d", knownUsersCount)
+		}
 		// reload cache once avoiding loops
 		data, err = am.refreshCache(accountID)
 		if err != nil {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1367,7 +1367,8 @@ func (am *DefaultAccountManager) lookupCache(accountUsers map[string]userLoggedI
 	knownUsersCount := len(accountUsers)
 	for user, loggedInOnce := range accountUsers {
 		if datum, ok := userDataMap[user]; ok {
-			if datum.AppMetadata.WTPendingInvite != nil && *datum.AppMetadata.WTPendingInvite && loggedInOnce == true {
+			// check if the matching user data has a pending invite and if the user has logged in once, forcing the cache to be refreshed
+			if datum.AppMetadata.WTPendingInvite != nil && *datum.AppMetadata.WTPendingInvite && loggedInOnce == true { //nolint:gosimple
 				mustRefreshInviteStatus = true
 				break
 			}
@@ -1379,7 +1380,7 @@ func (am *DefaultAccountManager) lookupCache(accountUsers map[string]userLoggedI
 
 	// if we know users that are not yet in cache more likely cache is outdated
 	if knownUsersCount > 0 && mustRefreshInviteStatus {
-		log.Debugf("reloading cache with IDP manager. Users unkonw to the cache: %d, Must refresh invite status? %t", knownUsersCount, mustRefreshInviteStatus)
+		log.Debugf("reloading cache with IDP manager. Users unkonwn to the cache: %d, Must refresh invite status? %t", knownUsersCount, mustRefreshInviteStatus)
 		// reload cache once avoiding loops
 		data, err = am.refreshCache(accountID)
 		if err != nil {

--- a/management/server/http/users_handler.go
+++ b/management/server/http/users_handler.go
@@ -198,8 +198,6 @@ func (h *UsersHandler) GetAllUsers(w http.ResponseWriter, r *http.Request) {
 
 	serviceUser := r.URL.Query().Get("service_user")
 
-	log.Debugf("UserCount: %v", len(data))
-
 	users := make([]*api.User, 0)
 	for _, r := range data {
 		if r.NonDeletable {

--- a/management/server/jwtclaims/claims.go
+++ b/management/server/jwtclaims/claims.go
@@ -13,6 +13,7 @@ type AuthorizationClaims struct {
 	Domain         string
 	DomainCategory string
 	LastLogin      time.Time
+	Invited        bool
 
 	Raw jwt.MapClaims
 }

--- a/management/server/jwtclaims/extractor.go
+++ b/management/server/jwtclaims/extractor.go
@@ -20,6 +20,8 @@ const (
 	UserIDClaim = "sub"
 	// LastLoginSuffix claim for the last login
 	LastLoginSuffix = "nb_last_login"
+	// Invited claim indicates that an incoming JWT is from a user that just accepted an invitation
+	Invited = "nb_invited"
 )
 
 // ExtractClaims Extract function type
@@ -99,6 +101,10 @@ func (c *ClaimsExtractor) FromToken(token *jwt.Token) AuthorizationClaims {
 	LastLoginClaimString, ok := claims[c.authAudience+LastLoginSuffix]
 	if ok {
 		jwtClaims.LastLogin = parseTime(LastLoginClaimString.(string))
+	}
+	invitedBool, ok := claims[c.authAudience+Invited]
+	if ok {
+		jwtClaims.Invited = invitedBool.(bool)
 	}
 	return jwtClaims
 }

--- a/management/server/jwtclaims/extractor_test.go
+++ b/management/server/jwtclaims/extractor_test.go
@@ -30,6 +30,10 @@ func newTestRequestWithJWT(t *testing.T, claims AuthorizationClaims, audience st
 	if claims.LastLogin != (time.Time{}) {
 		claimMaps[audience+LastLoginSuffix] = claims.LastLogin.Format(layout)
 	}
+
+	if claims.Invited {
+		claimMaps[audience+Invited] = true
+	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claimMaps)
 	r, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
 	require.NoError(t, err, "creating testing request failed")
@@ -59,12 +63,14 @@ func TestExtractClaimsFromRequestContext(t *testing.T) {
 			AccountId:      "testAcc",
 			LastLogin:      lastLogin,
 			DomainCategory: "public",
+			Invited:        true,
 			Raw: jwt.MapClaims{
 				"https://login/wt_account_domain":          "test.com",
 				"https://login/wt_account_domain_category": "public",
 				"https://login/wt_account_id":              "testAcc",
 				"https://login/nb_last_login":              lastLogin.Format(layout),
 				"sub":                                      "test",
+				"https://login/" + Invited:                 true,
 			},
 		},
 		testingFunc: require.EqualValues,

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -960,7 +960,7 @@ func (am *DefaultAccountManager) GetUsersFromAccount(accountID, userID string) (
 
 	queriedUsers := make([]*idp.UserData, 0)
 	if !isNil(am.idpManager) {
-		users := make(map[string]struct{}, len(account.Users))
+		users := make(map[string]userLoggedInOnce, len(account.Users))
 		usersFromIntegration := make([]*idp.UserData, 0)
 		for _, user := range account.Users {
 			if user.Issued == UserIssuedIntegration {
@@ -968,14 +968,14 @@ func (am *DefaultAccountManager) GetUsersFromAccount(accountID, userID string) (
 				info, err := am.externalCacheManager.Get(am.ctx, key)
 				if err != nil {
 					log.Infof("Get ExternalCache for key: %s, error: %s", key, err)
-					users[user.Id] = struct{}{}
+					users[user.Id] = true
 					continue
 				}
 				usersFromIntegration = append(usersFromIntegration, info)
 				continue
 			}
 			if !user.IsServiceUser {
-				users[user.Id] = struct{}{}
+				users[user.Id] = userLoggedInOnce(!user.LastLogin.IsZero())
 			}
 		}
 		queriedUsers, err = am.lookupCache(users, accountID)


### PR DESCRIPTION
## Describe your changes
This will reduce calls to cache and external IDP managers by reducing the redeem invite calls to only when the invited claim is received.
## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
