### PR TITLE
Support exit nodes on iOS 

### DIFF
--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -219,12 +219,9 @@ func (m *DefaultManager) clientRoutes(initialRoutes []*route.Route) []*route.Rou
 }
 
 func isPrefixSupported(prefix netip.Prefix) bool {
-	if runtime.GOOS == "ios" {
-		return true
-	}
 	if !nbnet.CustomRoutingDisabled() {
 		switch runtime.GOOS {
-		case "linux", "windows", "darwin":
+		case "linux", "windows", "darwin", "ios":
 			return true
 		}
 	}

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -219,6 +219,9 @@ func (m *DefaultManager) clientRoutes(initialRoutes []*route.Route) []*route.Rou
 }
 
 func isPrefixSupported(prefix netip.Prefix) bool {
+	if runtime.GOOS == "ios" {
+		return true
+	}
 	if !nbnet.CustomRoutingDisabled() {
 		switch runtime.GOOS {
 		case "linux", "windows", "darwin":

--- a/util/net/net.go
+++ b/util/net/net.go
@@ -2,7 +2,6 @@ package net
 
 import (
 	"os"
-	"runtime"
 
 	"github.com/google/uuid"
 )
@@ -24,8 +23,5 @@ func GenerateConnID() ConnectionID {
 }
 
 func CustomRoutingDisabled() bool {
-	if runtime.GOOS == "ios" {
-		return true
-	}
 	return os.Getenv(envDisableCustomRouting) == "true"
 }

--- a/util/net/net.go
+++ b/util/net/net.go
@@ -2,6 +2,7 @@ package net
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/google/uuid"
 )
@@ -23,5 +24,8 @@ func GenerateConnID() ConnectionID {
 }
 
 func CustomRoutingDisabled() bool {
+	if runtime.GOOS == "ios" {
+		return true
+	}
 	return os.Getenv(envDisableCustomRouting) == "true"
 }


### PR DESCRIPTION
## Describe your changes
This PR adds the required exception for the custom routing so that exit nodes can be used in the iOS app.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
