### PR TITLE
Add retry to IdP cache lookup

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: codespell
         uses: codespell-project/actions-codespell@v2
         with:
-          ignore_words_list: erro,clienta
+          ignore_words_list: erro,clienta,HasTable,
           skip: go.mod,go.sum
           only_warn: 1
   golangci:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: codespell
         uses: codespell-project/actions-codespell@v2
         with:
-          ignore_words_list: erro,clienta,hashtable,
+          ignore_words_list: erro,clienta,hastable,
           skip: go.mod,go.sum
           only_warn: 1
   golangci:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: codespell
         uses: codespell-project/actions-codespell@v2
         with:
-          ignore_words_list: erro,clienta,HasTable,
+          ignore_words_list: erro,clienta,hashtable,
           skip: go.mod,go.sum
           only_warn: 1
   golangci:

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1229,6 +1229,7 @@ func (am *DefaultAccountManager) loadAccount(_ context.Context, accountID interf
 		return nil, err
 	}
 	if len(userData) == 0 {
+		log.Debugf("no entries received from IdP management for account %s, going to retry in 200ms", accountIDString)
 		// wait for the data to be populated as sometimes the IdP can be to slow
 		time.Sleep(200 * time.Millisecond)
 		userData, err = am.idpManager.GetAccount(accountIDString)

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1228,6 +1228,14 @@ func (am *DefaultAccountManager) loadAccount(_ context.Context, accountID interf
 	if err != nil {
 		return nil, err
 	}
+	if len(userData) == 0 {
+		// wait for the data to be populated as sometimes the cache can be to slow
+		time.Sleep(200 * time.Millisecond)
+		userData, err = am.idpManager.GetAccount(accountIDString)
+		if err != nil {
+			return nil, err
+		}
+	}
 	log.Debugf("%d entries received from IdP management", len(userData))
 
 	dataMap := make(map[string]*idp.UserData, len(userData))

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1361,6 +1361,7 @@ func (am *DefaultAccountManager) lookupCache(accountUsers map[string]userLoggedI
 			return nil, err
 		}
 		if !am.validateCache(accountUsers, data) {
+			// if the cache is still invalid after the refresh, we wait for a bit and try again as IdP sometimes is slow to update
 			time.Sleep(200 * time.Millisecond)
 			data, err = am.refreshCache(accountID)
 			if err != nil {
@@ -1397,7 +1398,7 @@ func (am *DefaultAccountManager) validateCache(accountUsers map[string]userLogge
 
 	// if we know users that are not yet in cache more likely cache is outdated
 	if knownUsersCount > 0 {
-		log.Infof("cache invlaid. Users unknown to the cache: %d", knownUsersCount)
+		log.Infof("cache invalid. Users unknown to the cache: %d", knownUsersCount)
 		return false
 	}
 

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1229,7 +1229,7 @@ func (am *DefaultAccountManager) loadAccount(_ context.Context, accountID interf
 		return nil, err
 	}
 	if len(userData) == 0 {
-		// wait for the data to be populated as sometimes the cache can be to slow
+		// wait for the data to be populated as sometimes the IdP can be to slow
 		time.Sleep(200 * time.Millisecond)
 		userData, err = am.idpManager.GetAccount(accountIDString)
 		if err != nil {

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -374,7 +374,7 @@ func (am *DefaultAccountManager) AddPeer(setupKey, userID string, peer *nbpeer.P
 	if strings.ToLower(peer.Meta.Hostname) == "iphone" || strings.ToLower(peer.Meta.Hostname) == "ipad" && userID != "" {
 		if am.idpManager != nil {
 			userdata, err := am.lookupUserInCache(userID, account)
-			if err == nil {
+			if err == nil && userdata != nil {
 				peer.Meta.Hostname = fmt.Sprintf("%s-%s", peer.Meta.Hostname, strings.Split(userdata.Email, "@")[0])
 			}
 		}


### PR DESCRIPTION
## Describe your changes
Added one retry to the IdP lookup. Properly handle empty userdata when creating account during peer login from an iphone.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
