### PR TITLE
Fix route selection IDs

### DIFF
--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -156,7 +156,7 @@ func (c *clientNetwork) getBestRouteFromStatuses(routePeerStatuses map[string]ro
 			return currID
 		} else {
 			var peer string
-			if route, _ := c.routes[chosen]; route != nil {
+			if route := c.routes[chosen]; route != nil {
 				peer = route.Peer
 			}
 			log.Infof("new chosen route is %s with peer %s with score %f for network %s", chosen, peer, chosenScore, c.network)

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -155,7 +155,11 @@ func (c *clientNetwork) getBestRouteFromStatuses(routePeerStatuses map[string]ro
 		if currScore != 0 && currScore < chosenScore+0.1 {
 			return currID
 		} else {
-			log.Infof("new chosen route is %s with peer %s with score %f for network %s", chosen, c.routes[chosen].Peer, chosenScore, c.network)
+			var peer string
+			if route, _ := c.routes[chosen]; route != nil {
+				peer = route.Peer
+			}
+			log.Infof("new chosen route is %s with peer %s with score %f for network %s", chosen, peer, chosenScore, c.network)
 		}
 	}
 

--- a/route/route.go
+++ b/route/route.go
@@ -107,9 +107,12 @@ func (r *Route) Copy() *Route {
 
 // IsEqual compares one route with the other
 func (r *Route) IsEqual(other *Route) bool {
-	if other == nil {
+	if r == nil && other == nil {
+		return true
+	} else if r == nil || other == nil {
 		return false
 	}
+
 	return other.ID == r.ID &&
 		other.Description == r.Description &&
 		other.NetID == r.NetID &&

--- a/route/route.go
+++ b/route/route.go
@@ -107,6 +107,9 @@ func (r *Route) Copy() *Route {
 
 // IsEqual compares one route with the other
 func (r *Route) IsEqual(other *Route) bool {
+	if other == nil {
+		return false
+	}
 	return other.ID == r.ID &&
 		other.Description == r.Description &&
 		other.NetID == r.NetID &&


### PR DESCRIPTION
## Describe your changes

Copying the IDs for `routes list` accidentally modified the original routes, resulting in a panic.
Now we copy the desired values explicitly

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
