### PR TITLE
Separate Unix process path into Linux and macOS paths

### DIFF
--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -717,8 +717,11 @@ func toPeerChecks(accountManager AccountManager, peerKey string) []*proto.Checks
 
 		if check := postureCheck.Checks.ProcessCheck; check != nil {
 			for _, process := range check.Processes {
-				if process.Path != "" {
-					protoCheck.Files = append(protoCheck.Files, process.Path)
+				if process.LinuxPath != "" {
+					protoCheck.Files = append(protoCheck.Files, process.LinuxPath)
+				}
+				if process.MacPath != "" {
+					protoCheck.Files = append(protoCheck.Files, process.MacPath)
 				}
 				if process.WindowsPath != "" {
 					protoCheck.Files = append(protoCheck.Files, process.WindowsPath)

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -916,10 +916,14 @@ components:
       description: Describes the operational activity within a peer's system.
       type: object
       properties:
-        path:
-          description: Path to the process executable file in a Unix-like operating system
+        linux_path:
+          description: Path to the process executable file in a Linux operating system
           type: string
           example: "/usr/local/bin/netbird"
+        mac_path:
+          description: Path to the process executable file in a Mac operating system
+          type: string
+          example: "/Applications/NetBird.app/Contents/MacOS/netbird"
         windows_path:
           description: Path to the process executable file in a Windows operating system
           type: string

--- a/management/server/http/api/types.gen.go
+++ b/management/server/http/api/types.gen.go
@@ -945,8 +945,11 @@ type PostureCheckUpdate struct {
 
 // Process Describes the operational activity within a peer's system.
 type Process struct {
-	// Path Path to the process executable file in a Unix-like operating system
-	Path *string `json:"path,omitempty"`
+	// LinuxPath Path to the process executable file in a Linux operating system
+	LinuxPath *string `json:"linux_path,omitempty"`
+
+	// MacPath Path to the process executable file in a Mac operating system
+	MacPath *string `json:"mac_path,omitempty"`
 
 	// WindowsPath Path to the process executable file in a Windows operating system
 	WindowsPath *string `json:"windows_path,omitempty"`

--- a/management/server/http/posture_checks_handler.go
+++ b/management/server/http/posture_checks_handler.go
@@ -333,7 +333,8 @@ func toProcessCheckResponse(check *posture.ProcessCheck) *api.ProcessCheck {
 	processes := make([]api.Process, 0, len(check.Processes))
 	for i := range check.Processes {
 		processes = append(processes, api.Process{
-			Path:        &check.Processes[i].Path,
+			LinuxPath:   &check.Processes[i].LinuxPath,
+			MacPath:     &check.Processes[i].MacPath,
 			WindowsPath: &check.Processes[i].WindowsPath,
 		})
 	}
@@ -347,8 +348,11 @@ func toProcessCheck(check *api.ProcessCheck) *posture.ProcessCheck {
 	processes := make([]posture.Process, 0, len(check.Processes))
 	for _, process := range check.Processes {
 		var p posture.Process
-		if process.Path != nil {
-			p.Path = *process.Path
+		if process.LinuxPath != nil {
+			p.LinuxPath = *process.LinuxPath
+		}
+		if process.MacPath != nil {
+			p.MacPath = *process.MacPath
 		}
 		if process.WindowsPath != nil {
 			p.WindowsPath = *process.WindowsPath

--- a/management/server/http/posture_checks_handler_test.go
+++ b/management/server/http/posture_checks_handler_test.go
@@ -450,7 +450,8 @@ func TestPostureCheckUpdate(t *testing.T) {
 						"process_check": {
 							"processes": [
 								{ 
-									"path": "/usr/local/bin/netbird",
+									"linux_path": "/usr/local/bin/netbird",
+									"mac_path": "/Applications/NetBird.app/Contents/MacOS/netbird",
 									"windows_path": "C:\\ProgramData\\NetBird\\netbird.exe"
 								}
 							]
@@ -467,7 +468,8 @@ func TestPostureCheckUpdate(t *testing.T) {
 					ProcessCheck: &api.ProcessCheck{
 						Processes: []api.Process{
 							{
-								Path:        str("/usr/local/bin/netbird"),
+								LinuxPath:   str("/usr/local/bin/netbird"),
+								MacPath:     str("/Applications/NetBird.app/Contents/MacOS/netbird"),
 								WindowsPath: str("C:\\ProgramData\\NetBird\\netbird.exe"),
 							},
 						},

--- a/management/server/posture/checks_test.go
+++ b/management/server/posture/checks_test.go
@@ -278,7 +278,7 @@ func TestChecks_Copy(t *testing.T) {
 			ProcessCheck: &ProcessCheck{
 				Processes: []Process{
 					{
-						Path:        "/Applications/NetBird.app/Contents/MacOS/netbird",
+						MacPath:     "/Applications/NetBird.app/Contents/MacOS/netbird",
 						WindowsPath: "C:\\ProgramData\\NetBird\\netbird.exe",
 					},
 				},

--- a/management/server/posture/process.go
+++ b/management/server/posture/process.go
@@ -8,7 +8,8 @@ import (
 )
 
 type Process struct {
-	Path        string
+	LinuxPath   string
+	MacPath     string
 	WindowsPath string
 }
 
@@ -27,9 +28,16 @@ func (p *ProcessCheck) Check(peer nbpeer.Peer) (bool, error) {
 	}
 
 	switch peer.Meta.GoOS {
-	case "darwin", "linux":
+	case "linux":
 		for _, process := range p.Processes {
-			if process.Path == "" || !slices.Contains(peerActiveProcesses, process.Path) {
+			if process.LinuxPath == "" || !slices.Contains(peerActiveProcesses, process.LinuxPath) {
+				return false, nil
+			}
+		}
+		return true, nil
+	case "darwin":
+		for _, process := range p.Processes {
+			if process.MacPath == "" || !slices.Contains(peerActiveProcesses, process.MacPath) {
 				return false, nil
 			}
 		}
@@ -56,7 +64,7 @@ func (p *ProcessCheck) Validate() error {
 	}
 
 	for _, process := range p.Processes {
-		if process.Path == "" && process.WindowsPath == "" {
+		if process.LinuxPath == "" && process.MacPath == "" && process.WindowsPath == "" {
 			return fmt.Errorf("%s path shouldn't be empty", p.Name())
 		}
 	}

--- a/management/server/posture/process_test.go
+++ b/management/server/posture/process_test.go
@@ -29,8 +29,8 @@ func TestProcessCheck_Check(t *testing.T) {
 			},
 			check: ProcessCheck{
 				Processes: []Process{
-					{Path: "/Applications/process1.app"},
-					{Path: "/Applications/process2.app"},
+					{MacPath: "/Applications/process1.app"},
+					{MacPath: "/Applications/process2.app"},
 				},
 			},
 			wantErr: false,
@@ -69,8 +69,8 @@ func TestProcessCheck_Check(t *testing.T) {
 			},
 			check: ProcessCheck{
 				Processes: []Process{
-					{Path: "/usr/bin/process1"},
-					{Path: "/usr/bin/process2"},
+					{LinuxPath: "/usr/bin/process1"},
+					{LinuxPath: "/usr/bin/process2"},
 				},
 			},
 			wantErr: false,
@@ -89,8 +89,8 @@ func TestProcessCheck_Check(t *testing.T) {
 			},
 			check: ProcessCheck{
 				Processes: []Process{
-					{Path: "/usr/bin/process1"},
-					{Path: "/usr/bin/process2"},
+					{LinuxPath: "/usr/bin/process1"},
+					{LinuxPath: "/usr/bin/process2"},
 				},
 			},
 			wantErr: false,
@@ -129,8 +129,8 @@ func TestProcessCheck_Check(t *testing.T) {
 			},
 			check: ProcessCheck{
 				Processes: []Process{
-					{Path: "/usr/bin/process1"},
-					{Path: "/usr/bin/process2"},
+					{LinuxPath: "/usr/bin/process1"},
+					{LinuxPath: "/usr/bin/process2"},
 				},
 			},
 			wantErr: false,
@@ -169,8 +169,8 @@ func TestProcessCheck_Check(t *testing.T) {
 			},
 			check: ProcessCheck{
 				Processes: []Process{
-					{Path: "/Applications/process1.app"},
-					{Path: "/Applications/process2.app"},
+					{MacPath: "/Applications/process1.app"},
+					{LinuxPath: "/Applications/process2.app"},
 				},
 			},
 			wantErr: false,
@@ -205,15 +205,15 @@ func TestProcessCheck_Check(t *testing.T) {
 			},
 			check: ProcessCheck{
 				Processes: []Process{
-					{Path: "C:\\Program Files\\process1.exe"},
-					{Path: "C:\\Program Files\\process2.exe"},
+					{WindowsPath: "C:\\Program Files\\process1.exe"},
+					{MacPath: "/Applications/process2.app"},
 				},
 			},
 			wantErr: true,
 			isValid: false,
 		},
 		{
-			name: "unsupported android operating system with matching processes",
+			name: "unsupported android operating system",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
 					GoOS: "android",
@@ -221,8 +221,9 @@ func TestProcessCheck_Check(t *testing.T) {
 			},
 			check: ProcessCheck{
 				Processes: []Process{
-					{Path: "/usr/bin/process1"},
-					{Path: "/usr/bin/process2"},
+					{WindowsPath: "C:\\Program Files\\process1.exe"},
+					{MacPath: "/Applications/process2.app"},
+					{LinuxPath: "/usr/bin/process2"},
 				},
 			},
 			wantErr: true,
@@ -250,11 +251,12 @@ func TestProcessCheck_Validate(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name: "Valid unix and windows processes",
+			name: "Valid linux, mac and windows processes",
 			check: ProcessCheck{
 				Processes: []Process{
 					{
-						Path:        "/usr/local/bin/netbird",
+						LinuxPath:   "/usr/local/bin/netbird",
+						MacPath:     "/usr/local/bin/netbird",
 						WindowsPath: "C:\\ProgramData\\NetBird\\netbird.exe",
 					},
 				},
@@ -262,11 +264,22 @@ func TestProcessCheck_Validate(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Valid unix process",
+			name: "Valid linux process",
 			check: ProcessCheck{
 				Processes: []Process{
 					{
-						Path: "/usr/local/bin/netbird",
+						LinuxPath: "/usr/local/bin/netbird",
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "Valid mac process",
+			check: ProcessCheck{
+				Processes: []Process{
+					{
+						MacPath: "/Applications/NetBird.app/Contents/MacOS/netbird",
 					},
 				},
 			},


### PR DESCRIPTION
## Describe your changes

Separate the unix process path into Linux and MacOS process path for  handling platform-specific paths more effectively.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
