### PR TITLE
Retry reading routing table (bsd)

### DIFF
--- a/client/internal/routemanager/systemops_bsd.go
+++ b/client/internal/routemanager/systemops_bsd.go
@@ -88,7 +88,7 @@ func retryFetchRIB() ([]byte, error) {
 	operation := func() error {
 		var err error
 		out, err = route.FetchRIB(syscall.AF_UNSPEC, route.RIBTypeRoute, 0)
-		if err != nil && strings.Contains(err.Error(), "sysctl: cannot allocate memory") {
+		if errors.Is(err, syscall.ENOMEM) {
 			log.Debug("retrying fetchRIB due to 'cannot allocate memory' error")
 			return err
 		} else if err != nil {

--- a/client/internal/routemanager/systemops_bsd.go
+++ b/client/internal/routemanager/systemops_bsd.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"strings"
+	"errors"
 	"syscall"
 	"time"
 


### PR DESCRIPTION
Similar to #1817, BSD base OSes will return "cannot allocate memory" errors when routing table is expanding.

## Describe your changes
See issue #1681, this is an additional fix

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
