### PR TITLE
Ignore cloned routes on bsd

### DIFF
--- a/client/internal/routemanager/systemops_bsd.go
+++ b/client/internal/routemanager/systemops_bsd.go
@@ -12,20 +12,6 @@ import (
 	"golang.org/x/net/route"
 )
 
-// selected BSD Route flags.
-const (
-	RTF_UP        = 0x1
-	RTF_GATEWAY   = 0x2
-	RTF_HOST      = 0x4
-	RTF_REJECT    = 0x8
-	RTF_DYNAMIC   = 0x10
-	RTF_MODIFIED  = 0x20
-	RTF_STATIC    = 0x800
-	RTF_BLACKHOLE = 0x1000
-	RTF_LOCAL     = 0x200000
-	RTF_BROADCAST = 0x400000
-	RTF_MULTICAST = 0x800000
-)
 
 func getRoutesFromTable() ([]netip.Prefix, error) {
 	tab, err := route.FetchRIB(syscall.AF_UNSPEC, route.RIBTypeRoute, 0)
@@ -47,8 +33,8 @@ func getRoutesFromTable() ([]netip.Prefix, error) {
 			return nil, fmt.Errorf("unexpected RIB message type: %d", m.Type)
 		}
 
-		if m.Flags&RTF_UP == 0 ||
-			m.Flags&(RTF_REJECT|RTF_BLACKHOLE) != 0 {
+		if m.Flags&syscall.RTF_UP == 0 ||
+			m.Flags&(syscall.RTF_REJECT|syscall.RTF_BLACKHOLE|syscall.RTF_WASCLONED) != 0 {
 			continue
 		}
 


### PR DESCRIPTION
## Describe your changes

Sometimes the bsd routing table contains routes with the flag `W`:

> W      RTF_WASCLONED   Route was generated as a result of cloning

These routes only appear using the `a` flag:
`netstat -nra`

This prevents us from creating routes for netbird.
This change ignores routes of this types and creates the routes, overriding the cloned ones.

## Issue ticket number and link

#1900

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
