### PR TITLE
CentOS installations might have "apt" as "annotation processing tool"…

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -369,7 +369,7 @@ if type uname >/dev/null 2>&1; then
             # Check the availability of a compatible package manager
             if check_use_bin_variable; then
                 PACKAGE_MANAGER="bin"
-            elif [ -x "$(command -v apt)" ]; then
+            elif [ -x "$(command -v apt-get)" ]; then
                 PACKAGE_MANAGER="apt"
                 echo "The installation will be performed using apt package manager"
             elif [ -x "$(command -v dnf)" ]; then


### PR DESCRIPTION
Fixes so it checks for apt-get on ubuntu installations. Less chance of collision with other tools named "apt".

## Describe your changes

Changed so it checks for `command -v apt-get` which is commands they use for APT instead of `command -v apt` which is also a part of java tools `apt (1)              - annotation processing tool`

This makes some linux version think it is APT when it might not is.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
