### PR TITLE
Fix lost root zone handler

### DIFF
--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -549,9 +549,7 @@ func (s *DefaultServer) upstreamCallbacks(
 
 		if nsGroup.Primary {
 			s.currentConfig.RouteAll = true
-			if runtime.GOOS == "android" {
-				s.service.RegisterMux(nbdns.RootZone, handler)
-			}
+			s.service.RegisterMux(nbdns.RootZone, handler)
 		}
 		if err := s.hostManager.applyDNSConfig(s.currentConfig); err != nil {
 			l.WithError(err).Error("reactivate temporary disabled nameserver group, DNS update apply")


### PR DESCRIPTION
## Describe your changes

In 0.27.5 we started removing the handler for the root zone in case of a network failure. But when the failure was gone we didn't add the handler back to the local resolver. 

This PR adds the handler again fix the issue and add it back to the resolver.

## Issue ticket number and link
fixes #1969
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
