### PR TITLE
Increase garbage collection on ios

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -91,6 +91,9 @@ func (c *ConnectClient) RunOniOS(
 	networkChangeListener listener.NetworkChangeListener,
 	dnsManager dns.IosDnsManager,
 ) error {
+	// Set GC percent to 5% to reduce memory usage as iOS only allows 50MB of memory for the extension.
+	debug.SetGCPercent(5)
+
 	mobileDependency := MobileDependency{
 		FileDescriptor:        fileDescriptor,
 		NetworkChangeListener: networkChangeListener,

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -487,7 +487,9 @@ func (conn *Conn) configureConnection(remoteConn net.Conn, remoteWgPort int, rem
 		return nil, err
 	}
 
-	runtime.GC()
+	if runtime.GOOS != "ios" {
+		runtime.GC()
+	}
 
 	if conn.onConnected != nil {
 		conn.onConnected(conn.config.Key, remoteRosenpassPubKey, ipNet.IP.String(), remoteRosenpassAddr)

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -487,7 +487,7 @@ func (conn *Conn) configureConnection(remoteConn net.Conn, remoteWgPort int, rem
 		return nil, err
 	}
 
-	if runtime.GOOS != "ios" {
+	if runtime.GOOS == "ios" {
 		runtime.GC()
 	}
 

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -487,6 +487,8 @@ func (conn *Conn) configureConnection(remoteConn net.Conn, remoteWgPort int, rem
 		return nil, err
 	}
 
+	runtime.GC()
+
 	if conn.onConnected != nil {
 		conn.onConnected(conn.config.Key, remoteRosenpassPubKey, ipNet.IP.String(), remoteRosenpassAddr)
 	}


### PR DESCRIPTION
## Describe your changes
The iOS app only allows to connect to a limited number of peers before it reaches its memory limits (currently 50MB for the network extension). This PR is the first step in optimizing the memory usage for iOS by increasing the garbage collection.

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/1899#issuecomment-2109235977

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
