### PR TITLE
Enable namserver deactivation if unresponsive on iOS

### DIFF
--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -260,13 +259,10 @@ func (u *upstreamResolverBase) disable(err error) {
 		return
 	}
 
-	// todo test the deactivation logic, it seems to affect the client
-	if runtime.GOOS != "ios" {
-		log.Warnf("Upstream resolving is Disabled for %v", reactivatePeriod)
-		u.deactivate(err)
-		u.disabled = true
-		go u.waitUntilResponse()
-	}
+	log.Warnf("Upstream resolving is Disabled for %v", reactivatePeriod)
+	u.deactivate(err)
+	u.disabled = true
+	go u.waitUntilResponse()
 }
 
 func (u *upstreamResolverBase) testNameserver(server string) error {


### PR DESCRIPTION
## Describe your changes
This PR enabled the temopary deactivation of nameservers in case they are unresponsive for some time.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
