### PR TITLE
Fix/proxy close

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -259,7 +259,7 @@ func (e *Engine) Start() error {
 	}
 	e.ctx, e.cancel = context.WithCancel(e.clientCtx)
 
-	e.wgProxyFactory = wgproxy.NewFactory(e.clientCtx, e.config.WgPort)
+	e.wgProxyFactory = wgproxy.NewFactory(e.config.WgPort)
 
 	wgIface, err := e.newWgIface()
 	if err != nil {

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -423,7 +423,7 @@ func (conn *Conn) configureConnection(remoteConn net.Conn, remoteWgPort int, rem
 	var endpoint net.Addr
 	if isRelayCandidate(pair.Local) {
 		log.Debugf("setup relay connection")
-		conn.wgProxy = conn.wgProxyFactory.GetProxy(conn.ctx)
+		conn.wgProxy = conn.wgProxyFactory.GetProxy()
 		endpoint, err = conn.wgProxy.AddTurnConn(remoteConn)
 		if err != nil {
 			return nil, err

--- a/client/internal/peer/conn_test.go
+++ b/client/internal/peer/conn_test.go
@@ -1,7 +1,6 @@
 package peer
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -36,7 +35,7 @@ func TestNewConn_interfaceFilter(t *testing.T) {
 }
 
 func TestConn_GetKey(t *testing.T) {
-	wgProxyFactory := wgproxy.NewFactory(context.Background(), connConf.LocalWgPort)
+	wgProxyFactory := wgproxy.NewFactory(connConf.LocalWgPort)
 	defer func() {
 		_ = wgProxyFactory.Free()
 	}()
@@ -51,7 +50,7 @@ func TestConn_GetKey(t *testing.T) {
 }
 
 func TestConn_OnRemoteOffer(t *testing.T) {
-	wgProxyFactory := wgproxy.NewFactory(context.Background(), connConf.LocalWgPort)
+	wgProxyFactory := wgproxy.NewFactory(connConf.LocalWgPort)
 	defer func() {
 		_ = wgProxyFactory.Free()
 	}()
@@ -88,7 +87,7 @@ func TestConn_OnRemoteOffer(t *testing.T) {
 }
 
 func TestConn_OnRemoteAnswer(t *testing.T) {
-	wgProxyFactory := wgproxy.NewFactory(context.Background(), connConf.LocalWgPort)
+	wgProxyFactory := wgproxy.NewFactory(connConf.LocalWgPort)
 	defer func() {
 		_ = wgProxyFactory.Free()
 	}()
@@ -124,7 +123,7 @@ func TestConn_OnRemoteAnswer(t *testing.T) {
 	wg.Wait()
 }
 func TestConn_Status(t *testing.T) {
-	wgProxyFactory := wgproxy.NewFactory(context.Background(), connConf.LocalWgPort)
+	wgProxyFactory := wgproxy.NewFactory(connConf.LocalWgPort)
 	defer func() {
 		_ = wgProxyFactory.Free()
 	}()
@@ -154,7 +153,7 @@ func TestConn_Status(t *testing.T) {
 }
 
 func TestConn_Close(t *testing.T) {
-	wgProxyFactory := wgproxy.NewFactory(context.Background(), connConf.LocalWgPort)
+	wgProxyFactory := wgproxy.NewFactory(connConf.LocalWgPort)
 	defer func() {
 		_ = wgProxyFactory.Free()
 	}()

--- a/client/internal/wgproxy/factory.go
+++ b/client/internal/wgproxy/factory.go
@@ -1,17 +1,15 @@
 package wgproxy
 
-import "context"
-
 type Factory struct {
 	wgPort    int
 	ebpfProxy Proxy
 }
 
-func (w *Factory) GetProxy(ctx context.Context) Proxy {
+func (w *Factory) GetProxy() Proxy {
 	if w.ebpfProxy != nil {
 		return w.ebpfProxy
 	}
-	return NewWGUserSpaceProxy(ctx, w.wgPort)
+	return NewWGUserSpaceProxy(w.wgPort)
 }
 
 func (w *Factory) Free() error {

--- a/client/internal/wgproxy/factory_linux.go
+++ b/client/internal/wgproxy/factory_linux.go
@@ -3,15 +3,13 @@
 package wgproxy
 
 import (
-	"context"
-
 	log "github.com/sirupsen/logrus"
 )
 
-func NewFactory(ctx context.Context, wgPort int) *Factory {
+func NewFactory(wgPort int) *Factory {
 	f := &Factory{wgPort: wgPort}
 
-	ebpfProxy := NewWGEBPFProxy(ctx, wgPort)
+	ebpfProxy := NewWGEBPFProxy(wgPort)
 	err := ebpfProxy.listen()
 	if err != nil {
 		log.Warnf("failed to initialize ebpf proxy, fallback to user space proxy: %s", err)

--- a/client/internal/wgproxy/factory_nonlinux.go
+++ b/client/internal/wgproxy/factory_nonlinux.go
@@ -2,8 +2,6 @@
 
 package wgproxy
 
-import "context"
-
-func NewFactory(ctx context.Context, wgPort int) *Factory {
+func NewFactory(wgPort int) *Factory {
 	return &Factory{wgPort: wgPort}
 }

--- a/client/internal/wgproxy/proxy_ebpf.go
+++ b/client/internal/wgproxy/proxy_ebpf.go
@@ -270,7 +270,7 @@ func (p *WGEBPFProxy) sendPkg(data []byte, port uint16) error {
 
 	err := udpH.SetNetworkLayerForChecksum(ipH)
 	if err != nil {
-		log.Errorf("set network layer for checksum: %w", err)
+		log.Errorf("set network layer for checksum: %s", err)
 		return err
 	}
 
@@ -278,11 +278,11 @@ func (p *WGEBPFProxy) sendPkg(data []byte, port uint16) error {
 
 	err = gopacket.SerializeLayers(layerBuffer, gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}, ipH, udpH, payload)
 	if err != nil {
-		log.Errorf("serialize layers: %w", err)
+		log.Errorf("serialize layers: %s", err)
 		return err
 	}
 	if _, err = p.rawConn.WriteTo(layerBuffer.Bytes(), &net.IPAddr{IP: localhost}); err != nil {
-		log.Errorf("write to raw conn: %w", err)
+		log.Errorf("write to raw conn: %s", err)
 		return err
 	}
 	return nil

--- a/client/internal/wgproxy/proxy_ebpf_test.go
+++ b/client/internal/wgproxy/proxy_ebpf_test.go
@@ -3,12 +3,11 @@
 package wgproxy
 
 import (
-	"context"
 	"testing"
 )
 
 func TestWGEBPFProxy_connStore(t *testing.T) {
-	wgProxy := NewWGEBPFProxy(context.Background(), 1)
+	wgProxy := NewWGEBPFProxy(1)
 
 	p, _ := wgProxy.storeTurnConn(nil)
 	if p != 1 {
@@ -28,7 +27,7 @@ func TestWGEBPFProxy_connStore(t *testing.T) {
 }
 
 func TestWGEBPFProxy_portCalculation_overflow(t *testing.T) {
-	wgProxy := NewWGEBPFProxy(context.Background(), 1)
+	wgProxy := NewWGEBPFProxy(1)
 
 	_, _ = wgProxy.storeTurnConn(nil)
 	wgProxy.lastUsedPort = 65535
@@ -44,7 +43,7 @@ func TestWGEBPFProxy_portCalculation_overflow(t *testing.T) {
 }
 
 func TestWGEBPFProxy_portCalculation_maxConn(t *testing.T) {
-	wgProxy := NewWGEBPFProxy(context.Background(), 1)
+	wgProxy := NewWGEBPFProxy(1)
 
 	for i := 0; i < 65535; i++ {
 		_, _ = wgProxy.storeTurnConn(nil)

--- a/client/internal/wgproxy/proxy_userspace.go
+++ b/client/internal/wgproxy/proxy_userspace.go
@@ -21,12 +21,12 @@ type WGUserSpaceProxy struct {
 }
 
 // NewWGUserSpaceProxy instantiate a user space WireGuard proxy
-func NewWGUserSpaceProxy(ctx context.Context, wgPort int) *WGUserSpaceProxy {
+func NewWGUserSpaceProxy(wgPort int) *WGUserSpaceProxy {
 	log.Debugf("Initializing new user space proxy with port %d", wgPort)
 	p := &WGUserSpaceProxy{
 		localWGListenPort: wgPort,
 	}
-	p.ctx, p.cancel = context.WithCancel(ctx)
+	p.ctx, p.cancel = context.WithCancel(context.Background())
 	return p
 }
 
@@ -35,7 +35,7 @@ func (p *WGUserSpaceProxy) AddTurnConn(turnConn net.Conn) (net.Addr, error) {
 	p.remoteConn = turnConn
 
 	var err error
-	p.localConn, err = nbnet.NewDialer().DialContext(p.ctx, "udp", fmt.Sprintf(":%d", p.localWGListenPort))
+	p.localConn, err = nbnet.NewDialer().Dial("udp", fmt.Sprintf(":%d", p.localWGListenPort))
 	if err != nil {
 		log.Errorf("failed dialing to local Wireguard port %s", err)
 		return nil, err


### PR DESCRIPTION
## Describe your changes

Revert the context cancellation logic from the wg proxy and improve the error handling in case of resource freeing action.
- In eBPF proxy implementation we can not close individual turn connections. It frees up in an implicit way if the ice agent closes the conn.
- We should not mix in the resource freeing logic the context cancellation with the exported "close" functions. In the eBPF proxy was `CloseConn()`, `Free()`, and cancel by parent `context`.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
