### PR TITLE
Store location information in peer event meta

### DIFF
--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -216,7 +216,9 @@ func (p *Peer) FQDN(dnsDomain string) string {
 
 // EventMeta returns activity event meta related to the peer
 func (p *Peer) EventMeta(dnsDomain string) map[string]any {
-	return map[string]any{"name": p.Name, "fqdn": p.FQDN(dnsDomain), "ip": p.IP, "created_at": p.CreatedAt}
+	return map[string]any{"name": p.Name, "fqdn": p.FQDN(dnsDomain), "ip": p.IP, "created_at": p.CreatedAt,
+		"location_city_name": p.Location.CityName, "location_country_code": p.Location.CountryCode,
+		"location_geo_name_id": p.Location.GeoNameID, "location_connection_ip": p.Location.ConnectionIP}
 }
 
 // Copy PeerStatus


### PR DESCRIPTION
## Describe your changes

This change will store Peer.Location information with the peer meta allowing trace

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
