### PR TITLE
Return the proper error when a peer is deleted

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1840,6 +1840,9 @@ func (am *DefaultAccountManager) getAccountWithAuthorizationClaims(claims jwtcla
 func (am *DefaultAccountManager) SyncAndMarkPeer(peerPubKey string, realIP net.IP) (*nbpeer.Peer, *NetworkMap, error) {
 	accountID, err := am.Store.GetAccountIDByPeerPubKey(peerPubKey)
 	if err != nil {
+		if errStatus, ok := status.FromError(err); ok && errStatus.Type() == status.NotFound {
+			return nil, nil, status.Errorf(status.Unauthenticated, "peer not registered")
+		}
 		return nil, nil, err
 	}
 
@@ -1867,6 +1870,9 @@ func (am *DefaultAccountManager) SyncAndMarkPeer(peerPubKey string, realIP net.I
 func (am *DefaultAccountManager) CancelPeerRoutines(peer *nbpeer.Peer) error {
 	accountID, err := am.Store.GetAccountIDByPeerPubKey(peer.Key)
 	if err != nil {
+		if errStatus, ok := status.FromError(err); ok && errStatus.Type() == status.NotFound {
+			return status.Errorf(status.Unauthenticated, "peer not registered")
+		}
 		return err
 	}
 

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -136,7 +136,7 @@ func (s *GRPCServer) Sync(req *proto.EncryptedMessage, srv proto.ManagementServi
 
 	peer, netMap, err := s.accountManager.SyncAndMarkPeer(peerKey.String(), realIP)
 	if err != nil {
-		return err
+		return mapError(err)
 	}
 
 	err = s.sendInitialSync(peerKey, peer, netMap, srv)


### PR DESCRIPTION
## Describe your changes

this fixes an issue causing peers to keep retrying the connection after a peer is removed from the management system

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
