### PR TITLE
Enhance firewall manager checks to detect unsupported iptables

### DIFF
--- a/client/firewall/create_linux.go
+++ b/client/firewall/create_linux.go
@@ -111,6 +111,9 @@ func check() FWType {
 
 	nf := nftables.Conn{}
 	if chains, err := nf.ListChains(); err == nil && os.Getenv(SKIP_NFTABLES_ENV) != "true" {
+		if !useIPTABLES {
+			return NFTABLES
+		}
 		for _, chain := range chains {
 			if chain.Name == testingChain {
 				return NFTABLES


### PR DESCRIPTION
## Describe your changes
Our nftables firewall manager may cause issues when rules are created using older iptable versions

## Issue ticket number and link
fixes #2015 and #2030

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
