### PR TITLE
Revert "Accept any XDG_ environment variable to determine desktop"

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -219,15 +219,5 @@ func openURL(cmd *cobra.Command, verificationURIComplete, userCode string) {
 
 // isLinuxRunningDesktop checks if a Linux OS is running desktop environment
 func isLinuxRunningDesktop() bool {
-	if os.Getenv("DESKTOP_SESSION") != "" {
-		return true
-	}
-
-	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, "XDG_") {
-			return true
-		}
-	}
-
-	return false
+	return os.Getenv("DESKTOP_SESSION") != "" || os.Getenv("XDG_CURRENT_DESKTOP") != ""
 }

--- a/client/cmd/login_test.go
+++ b/client/cmd/login_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -50,18 +49,5 @@ func TestLogin(t *testing.T) {
 
 	if len(actualConf.PrivateKey) == 0 {
 		t.Errorf("expected non empty Private key, got empty")
-	}
-}
-
-func TestIsLinuxRunningDesktop(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("skipping test on non-linux platform")
-	}
-
-	t.Setenv("XDG_FOO", "BAR")
-
-	isDesktop := isLinuxRunningDesktop()
-	if !isDesktop {
-		t.Errorf("expected desktop environment, got false")
 	}
 }


### PR DESCRIPTION
Reverts netbirdio/netbird#2037

Some distributions based on debian actually sets the XDG_ variables even on server versions. 