### PR TITLE
Refactor firewall manager check

### DIFF
--- a/client/firewall/create_linux.go
+++ b/client/firewall/create_linux.go
@@ -86,7 +86,6 @@ func NewFirewall(context context.Context, iface IFaceMapper) (firewall.Manager, 
 // check returns the firewall type based on common lib checks. It returns UNKNOWN if no firewall is found.
 func check() FWType {
 	useIPTABLES := false
-	testingChain := "netbird-testing"
 	ip, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 	if err == nil && isIptablesClientAvailable(ip) {
 		major, minor, _ := ip.GetIptablesVersion()
@@ -96,40 +95,33 @@ func check() FWType {
 		}
 
 		useIPTABLES = true
-
-		// create a testing chain to check if iptables is working and to validate if nftables can be used
-		err = ip.NewChain("filter", testingChain)
-		if err != nil {
-			useIPTABLES = false
-		}
 	}
-
-	defer func() {
-		if !useIPTABLES {
-			return
-		}
-		err = ip.ClearChain("filter", testingChain)
-		if err != nil {
-			log.Errorf("failed to clear netbird-testing chain: %v", err)
-		}
-		err = ip.DeleteChain("filter", testingChain)
-		if err != nil {
-			log.Errorf("failed to delete netbird-testing chain: %v", err)
-		}
-	}()
 
 	nf := nftables.Conn{}
 	if chains, err := nf.ListChains(); err == nil && os.Getenv(SKIP_NFTABLES_ENV) != "true" {
 		if !useIPTABLES {
 			return NFTABLES
 		}
-		// search for the testing chain created by iptables client
-		// failing to find it means that nftables can be used but the system is using a version of iptables
-		// that doesn't work well with our nftables manager
+
+		// search for chains where table is filter
+		// if we find one, we assume that nftables manager can be used with iptables
 		for _, chain := range chains {
-			if chain.Name == testingChain {
+			if chain.Table.Name == "filter" {
 				return NFTABLES
 			}
+		}
+		// check tables for the following constraints:
+		// 1. there is no tables or more than one table, we assume that nftables manager can be used
+		// 2. there is only one table and its name is filter, we assume that nftables manager can not be used, since there was no chain in it
+		// 3. if we find an error we log and continue with iptables check
+		tables, err := nf.ListTables()
+		switch {
+		case err == nil && len(tables) != 1:
+			return NFTABLES
+		case err == nil && len(tables) == 1 && tables[0].Name == "filter":
+			return IPTABLES
+		case err != nil:
+			log.Errorf("failed to list nftables tables on fw manager discovery: %s", err)
 		}
 	}
 

--- a/client/firewall/create_linux.go
+++ b/client/firewall/create_linux.go
@@ -117,14 +117,15 @@ func check() FWType {
 				return NFTABLES
 			}
 		}
+
 		// check tables for the following constraints:
-		// 1. there is no tables in nftables and there is at least one chain in iptables, we assume that nftables manager can not be used
+		// 1. there is no chain in nftables for the filter table and there is at least one chain in iptables, we assume that nftables manager can not be used
 		// 2. there is no tables or more than one table, we assume that nftables manager can be used
 		// 3. there is only one table and its name is filter, we assume that nftables manager can not be used, since there was no chain in it
 		// 4. if we find an error we log and continue with iptables check
 		nbTablesList, err := nf.ListTables()
 		switch {
-		case err == nil && len(nbTablesList) == 0 && len(iptablesChains) > 0:
+		case err == nil && len(iptablesChains) > 0:
 			return IPTABLES
 		case err == nil && len(nbTablesList) != 1:
 			return NFTABLES


### PR DESCRIPTION
## Describe your changes

Some systems don't play nice with a test chain, so we dropped the idea, and instead, we just checked for the filter table

With this check, we might face a case where iptables is selected once, and on the next netbird up/down, it will go back to using nftables

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
