### PR TITLE
Add FindExistingPostureCheck

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1963,11 +1963,7 @@ func (am *DefaultAccountManager) onPeersInvalidated(accountID string) {
 }
 
 func (am *DefaultAccountManager) FindExistingPostureCheck(accountID string, checks *posture.ChecksDefinition) (*posture.Checks, error) {
-	postureCheck, err := am.Store.GetPostureCheckByChecksDefinition(accountID, checks)
-	if err != nil {
-		return nil, err
-	}
-	return postureCheck, nil
+	return am.Store.GetPostureCheckByChecksDefinition(accountID, checks)
 }
 
 // addAllGroup to account object if it doesn't exist

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -132,6 +132,7 @@ type AccountManager interface {
 	GetValidatedPeers(account *Account) (map[string]struct{}, error)
 	SyncAndMarkPeer(peerPubKey string, realIP net.IP) (*nbpeer.Peer, *NetworkMap, error)
 	CancelPeerRoutines(peer *nbpeer.Peer) error
+	FindExistingPostureCheck(accountID string, checks *posture.ChecksDefinition) (*posture.Checks, error)
 }
 
 type DefaultAccountManager struct {
@@ -1959,6 +1960,14 @@ func (am *DefaultAccountManager) onPeersInvalidated(accountID string) {
 		return
 	}
 	am.updateAccountPeers(updatedAccount)
+}
+
+func (am *DefaultAccountManager) FindExistingPostureCheck(accountID string, checks *posture.ChecksDefinition) (*posture.Checks, error) {
+	postureCheck, err := am.Store.GetPostureCheckByChecksDefinition(accountID, checks)
+	if err != nil {
+		return nil, err
+	}
+	return postureCheck, nil
 }
 
 // addAllGroup to account object if it doesn't exist

--- a/management/server/file_store.go
+++ b/management/server/file_store.go
@@ -12,6 +12,7 @@ import (
 
 	nbgroup "github.com/netbirdio/netbird/management/server/group"
 	nbpeer "github.com/netbirdio/netbird/management/server/peer"
+	"github.com/netbirdio/netbird/management/server/posture"
 	"github.com/netbirdio/netbird/management/server/status"
 	"github.com/netbirdio/netbird/management/server/telemetry"
 
@@ -665,6 +666,10 @@ func (s *FileStore) SaveUserLastLogin(accountID, userID string, lastLogin time.T
 	peer.LastLogin = lastLogin
 
 	return nil
+}
+
+func (s *FileStore) GetPostureCheckByChecksDefinition(accountID string, checks *posture.ChecksDefinition) (*posture.Checks, error) {
+	return nil, status.Errorf(status.Internal, "GetPostureCheckByChecksDefinition is not implemented")
 }
 
 // Close the FileStore persisting data to disk

--- a/management/server/http/posture_checks_handler.go
+++ b/management/server/http/posture_checks_handler.go
@@ -3,12 +3,10 @@ package http
 import (
 	"encoding/json"
 	"net/http"
-	"net/netip"
 	"regexp"
 	"slices"
 
 	"github.com/gorilla/mux"
-	"github.com/rs/xid"
 
 	"github.com/netbirdio/netbird/management/server"
 	"github.com/netbirdio/netbird/management/server/geolocation"
@@ -59,7 +57,7 @@ func (p *PostureChecksHandler) GetAllPostureChecks(w http.ResponseWriter, r *htt
 
 	postureChecks := []*api.PostureCheck{}
 	for _, postureCheck := range accountPostureChecks {
-		postureChecks = append(postureChecks, toPostureChecksResponse(postureCheck))
+		postureChecks = append(postureChecks, postureCheck.ToAPIResponse())
 	}
 
 	util.WriteJSONObject(w, postureChecks)
@@ -130,7 +128,7 @@ func (p *PostureChecksHandler) GetPostureCheck(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	util.WriteJSONObject(w, toPostureChecksResponse(postureChecks))
+	util.WriteJSONObject(w, postureChecks.ToAPIResponse())
 }
 
 // DeletePostureCheck handles posture check deletion request
@@ -178,55 +176,27 @@ func (p *PostureChecksHandler) savePostureChecks(
 		return
 	}
 
-	if postureChecksID == "" {
-		postureChecksID = xid.New().String()
-	}
-
-	postureChecks := posture.Checks{
-		ID:          postureChecksID,
-		Name:        req.Name,
-		Description: req.Description,
-	}
-
-	if nbVersionCheck := req.Checks.NbVersionCheck; nbVersionCheck != nil {
-		postureChecks.Checks.NBVersionCheck = &posture.NBVersionCheck{
-			MinVersion: nbVersionCheck.MinVersion,
-		}
-	}
-
-	if osVersionCheck := req.Checks.OsVersionCheck; osVersionCheck != nil {
-		postureChecks.Checks.OSVersionCheck = &posture.OSVersionCheck{
-			Android: (*posture.MinVersionCheck)(osVersionCheck.Android),
-			Darwin:  (*posture.MinVersionCheck)(osVersionCheck.Darwin),
-			Ios:     (*posture.MinVersionCheck)(osVersionCheck.Ios),
-			Linux:   (*posture.MinKernelVersionCheck)(osVersionCheck.Linux),
-			Windows: (*posture.MinKernelVersionCheck)(osVersionCheck.Windows),
-		}
-	}
-
 	if geoLocationCheck := req.Checks.GeoLocationCheck; geoLocationCheck != nil {
 		if p.geolocationManager == nil {
 			// TODO: update error message to include geo db self hosted doc link when ready
 			util.WriteError(status.Errorf(status.PreconditionFailed, "Geo location database is not initialized"), w)
 			return
 		}
-		postureChecks.Checks.GeoLocationCheck = toPostureGeoLocationCheck(geoLocationCheck)
 	}
 
-	if peerNetworkRangeCheck := req.Checks.PeerNetworkRangeCheck; peerNetworkRangeCheck != nil {
-		postureChecks.Checks.PeerNetworkRangeCheck, err = toPeerNetworkRangeCheck(peerNetworkRangeCheck)
-		if err != nil {
-			util.WriteError(status.Errorf(status.InvalidArgument, "invalid network prefix"), w)
-			return
-		}
-	}
-
-	if err := p.accountManager.SavePostureChecks(account.Id, user.Id, &postureChecks); err != nil {
+	checks := posture.Checks{}
+	postureChecks, err := checks.FromAPIPostureCheckUpdate(req, postureChecksID)
+	if err != nil {
 		util.WriteError(err, w)
 		return
 	}
 
-	util.WriteJSONObject(w, toPostureChecksResponse(&postureChecks))
+	if err := p.accountManager.SavePostureChecks(account.Id, user.Id, postureChecks); err != nil {
+		util.WriteError(err, w)
+		return
+	}
+
+	util.WriteJSONObject(w, postureChecks.ToAPIResponse())
 }
 
 func validatePostureChecksUpdate(req api.PostureCheckUpdate) error {
@@ -293,106 +263,4 @@ func validatePostureChecksUpdate(req api.PostureCheckUpdate) error {
 	}
 
 	return nil
-}
-
-func toPostureChecksResponse(postureChecks *posture.Checks) *api.PostureCheck {
-	var checks api.Checks
-
-	if postureChecks.Checks.NBVersionCheck != nil {
-		checks.NbVersionCheck = &api.NBVersionCheck{
-			MinVersion: postureChecks.Checks.NBVersionCheck.MinVersion,
-		}
-	}
-
-	if postureChecks.Checks.OSVersionCheck != nil {
-		checks.OsVersionCheck = &api.OSVersionCheck{
-			Android: (*api.MinVersionCheck)(postureChecks.Checks.OSVersionCheck.Android),
-			Darwin:  (*api.MinVersionCheck)(postureChecks.Checks.OSVersionCheck.Darwin),
-			Ios:     (*api.MinVersionCheck)(postureChecks.Checks.OSVersionCheck.Ios),
-			Linux:   (*api.MinKernelVersionCheck)(postureChecks.Checks.OSVersionCheck.Linux),
-			Windows: (*api.MinKernelVersionCheck)(postureChecks.Checks.OSVersionCheck.Windows),
-		}
-	}
-
-	if postureChecks.Checks.GeoLocationCheck != nil {
-		checks.GeoLocationCheck = toGeoLocationCheckResponse(postureChecks.Checks.GeoLocationCheck)
-	}
-
-	if postureChecks.Checks.PeerNetworkRangeCheck != nil {
-		checks.PeerNetworkRangeCheck = toPeerNetworkRangeCheckResponse(postureChecks.Checks.PeerNetworkRangeCheck)
-	}
-
-	return &api.PostureCheck{
-		Id:          postureChecks.ID,
-		Name:        postureChecks.Name,
-		Description: &postureChecks.Description,
-		Checks:      checks,
-	}
-}
-
-func toGeoLocationCheckResponse(geoLocationCheck *posture.GeoLocationCheck) *api.GeoLocationCheck {
-	locations := make([]api.Location, 0, len(geoLocationCheck.Locations))
-	for _, loc := range geoLocationCheck.Locations {
-		l := loc // make G601 happy
-		var cityName *string
-		if loc.CityName != "" {
-			cityName = &l.CityName
-		}
-		locations = append(locations, api.Location{
-			CityName:    cityName,
-			CountryCode: loc.CountryCode,
-		})
-	}
-
-	return &api.GeoLocationCheck{
-		Action:    api.GeoLocationCheckAction(geoLocationCheck.Action),
-		Locations: locations,
-	}
-}
-
-func toPostureGeoLocationCheck(apiGeoLocationCheck *api.GeoLocationCheck) *posture.GeoLocationCheck {
-	locations := make([]posture.Location, 0, len(apiGeoLocationCheck.Locations))
-	for _, loc := range apiGeoLocationCheck.Locations {
-		cityName := ""
-		if loc.CityName != nil {
-			cityName = *loc.CityName
-		}
-		locations = append(locations, posture.Location{
-			CountryCode: loc.CountryCode,
-			CityName:    cityName,
-		})
-	}
-
-	return &posture.GeoLocationCheck{
-		Action:    string(apiGeoLocationCheck.Action),
-		Locations: locations,
-	}
-}
-
-func toPeerNetworkRangeCheckResponse(check *posture.PeerNetworkRangeCheck) *api.PeerNetworkRangeCheck {
-	netPrefixes := make([]string, 0, len(check.Ranges))
-	for _, netPrefix := range check.Ranges {
-		netPrefixes = append(netPrefixes, netPrefix.String())
-	}
-
-	return &api.PeerNetworkRangeCheck{
-		Ranges: netPrefixes,
-		Action: api.PeerNetworkRangeCheckAction(check.Action),
-	}
-}
-
-func toPeerNetworkRangeCheck(check *api.PeerNetworkRangeCheck) (*posture.PeerNetworkRangeCheck, error) {
-	prefixes := make([]netip.Prefix, 0)
-	for _, prefix := range check.Ranges {
-		parsedPrefix, err := netip.ParsePrefix(prefix)
-		if err != nil {
-			return nil, err
-		}
-		prefixes = append(prefixes, parsedPrefix)
-	}
-
-	return &posture.PeerNetworkRangeCheck{
-		Ranges: prefixes,
-		Action: string(check.Action),
-	}, nil
 }

--- a/management/server/http/posture_checks_handler.go
+++ b/management/server/http/posture_checks_handler.go
@@ -184,8 +184,7 @@ func (p *PostureChecksHandler) savePostureChecks(
 		}
 	}
 
-	checks := posture.Checks{}
-	postureChecks, err := checks.FromAPIPostureCheckUpdate(req, postureChecksID)
+	postureChecks, err := posture.NewChecksFromAPIPostureCheckUpdate(req, postureChecksID)
 	if err != nil {
 		util.WriteError(err, w)
 		return

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -95,6 +95,7 @@ type MockAccountManager struct {
 	GetIdpManagerFunc                   func() idp.Manager
 	UpdateIntegratedValidatorGroupsFunc func(accountID string, userID string, groups []string) error
 	GroupValidationFunc                 func(accountId string, groups []string) (bool, error)
+	FindExistingPostureCheckFunc        func(accountID, postureChecksID string) (*posture.Checks, error)
 }
 
 func (am *MockAccountManager) SyncAndMarkPeer(peerPubKey string, realIP net.IP) (*nbpeer.Peer, *server.NetworkMap, error) {
@@ -733,4 +734,12 @@ func (am *MockAccountManager) GroupValidation(accountId string, groups []string)
 		return am.GroupValidationFunc(accountId, groups)
 	}
 	return false, status.Errorf(codes.Unimplemented, "method GroupValidation is not implemented")
+}
+
+// FindExistingPostureCheck mocks FindExistingPostureCheck of the AccountManager interface
+func (am *MockAccountManager) FindExistingPostureCheck(accountID, postureChecksID string) (*posture.Checks, error) {
+	if am.FindExistingPostureCheckFunc != nil {
+		return am.FindExistingPostureCheckFunc(accountID, postureChecksID)
+	}
+	return nil, status.Errorf(codes.Unimplemented, "method FindExistingPostureCheck is not implemented")
 }

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -95,7 +95,7 @@ type MockAccountManager struct {
 	GetIdpManagerFunc                   func() idp.Manager
 	UpdateIntegratedValidatorGroupsFunc func(accountID string, userID string, groups []string) error
 	GroupValidationFunc                 func(accountId string, groups []string) (bool, error)
-	FindExistingPostureCheckFunc        func(accountID, postureChecksID string) (*posture.Checks, error)
+	FindExistingPostureCheckFunc        func(accountID string, checks *posture.ChecksDefinition) (*posture.Checks, error)
 }
 
 func (am *MockAccountManager) SyncAndMarkPeer(peerPubKey string, realIP net.IP) (*nbpeer.Peer, *server.NetworkMap, error) {
@@ -737,9 +737,9 @@ func (am *MockAccountManager) GroupValidation(accountId string, groups []string)
 }
 
 // FindExistingPostureCheck mocks FindExistingPostureCheck of the AccountManager interface
-func (am *MockAccountManager) FindExistingPostureCheck(accountID, postureChecksID string) (*posture.Checks, error) {
+func (am *MockAccountManager) FindExistingPostureCheck(accountID string, checks *posture.ChecksDefinition) (*posture.Checks, error) {
 	if am.FindExistingPostureCheckFunc != nil {
-		return am.FindExistingPostureCheckFunc(accountID, postureChecksID)
+		return am.FindExistingPostureCheckFunc(accountID, checks)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method FindExistingPostureCheck is not implemented")
 }

--- a/management/server/posture/checks.go
+++ b/management/server/posture/checks.go
@@ -5,8 +5,12 @@ import (
 	"net/netip"
 
 	"github.com/hashicorp/go-version"
+	"github.com/rs/xid"
+	log "github.com/sirupsen/logrus"
 
+	"github.com/netbirdio/netbird/management/server/http/api"
 	nbpeer "github.com/netbirdio/netbird/management/server/peer"
+	"github.com/netbirdio/netbird/management/server/status"
 )
 
 const (
@@ -136,6 +140,133 @@ func (pc *Checks) GetChecks() []Check {
 	return checks
 }
 
+func (pc *Checks) FromAPIPostureCheck(source api.PostureCheck, accountID string) *Checks {
+	postureChecksID := source.Id
+	if postureChecksID == "" {
+		postureChecksID = xid.New().String()
+	}
+
+	description := ""
+	if source.Description != nil {
+		description = *source.Description
+	}
+
+	postureChecks := Checks{
+		ID:          postureChecksID,
+		Name:        source.Name,
+		Description: description,
+		AccountID:   accountID,
+	}
+
+	if nbVersionCheck := source.Checks.NbVersionCheck; nbVersionCheck != nil {
+		postureChecks.Checks.NBVersionCheck = &NBVersionCheck{
+			MinVersion: nbVersionCheck.MinVersion,
+		}
+	}
+
+	if osVersionCheck := source.Checks.OsVersionCheck; osVersionCheck != nil {
+		postureChecks.Checks.OSVersionCheck = &OSVersionCheck{
+			Android: (*MinVersionCheck)(osVersionCheck.Android),
+			Darwin:  (*MinVersionCheck)(osVersionCheck.Darwin),
+			Ios:     (*MinVersionCheck)(osVersionCheck.Ios),
+			Linux:   (*MinKernelVersionCheck)(osVersionCheck.Linux),
+			Windows: (*MinKernelVersionCheck)(osVersionCheck.Windows),
+		}
+	}
+
+	if geoLocationCheck := source.Checks.GeoLocationCheck; geoLocationCheck != nil {
+		postureChecks.Checks.GeoLocationCheck = toPostureGeoLocationCheck(geoLocationCheck)
+	}
+
+	var err error
+	if peerNetworkRangeCheck := source.Checks.PeerNetworkRangeCheck; peerNetworkRangeCheck != nil {
+		postureChecks.Checks.PeerNetworkRangeCheck, err = toPeerNetworkRangeCheck(peerNetworkRangeCheck)
+		if err != nil {
+			log.Errorf("failed to convert peer network range check: %v", err)
+			return &Checks{}
+		}
+	}
+
+	return &postureChecks
+}
+
+func (pc *Checks) FromAPIPostureCheckUpdate(source api.PostureCheckUpdate, postureChecksID string) (*Checks, error) {
+	if postureChecksID == "" {
+		postureChecksID = xid.New().String()
+	}
+
+	postureChecks := Checks{
+		ID:          postureChecksID,
+		Name:        source.Name,
+		Description: source.Description,
+	}
+
+	if nbVersionCheck := source.Checks.NbVersionCheck; nbVersionCheck != nil {
+		postureChecks.Checks.NBVersionCheck = &NBVersionCheck{
+			MinVersion: nbVersionCheck.MinVersion,
+		}
+	}
+
+	if osVersionCheck := source.Checks.OsVersionCheck; osVersionCheck != nil {
+		postureChecks.Checks.OSVersionCheck = &OSVersionCheck{
+			Android: (*MinVersionCheck)(osVersionCheck.Android),
+			Darwin:  (*MinVersionCheck)(osVersionCheck.Darwin),
+			Ios:     (*MinVersionCheck)(osVersionCheck.Ios),
+			Linux:   (*MinKernelVersionCheck)(osVersionCheck.Linux),
+			Windows: (*MinKernelVersionCheck)(osVersionCheck.Windows),
+		}
+	}
+
+	if geoLocationCheck := source.Checks.GeoLocationCheck; geoLocationCheck != nil {
+		postureChecks.Checks.GeoLocationCheck = toPostureGeoLocationCheck(geoLocationCheck)
+	}
+
+	var err error
+	if peerNetworkRangeCheck := source.Checks.PeerNetworkRangeCheck; peerNetworkRangeCheck != nil {
+		postureChecks.Checks.PeerNetworkRangeCheck, err = toPeerNetworkRangeCheck(peerNetworkRangeCheck)
+		if err != nil {
+			return nil, status.Errorf(status.InvalidArgument, "invalid network prefix")
+		}
+	}
+
+	return &postureChecks, nil
+}
+
+func (pc *Checks) ToAPIResponse() *api.PostureCheck {
+	var checks api.Checks
+
+	if pc.Checks.NBVersionCheck != nil {
+		checks.NbVersionCheck = &api.NBVersionCheck{
+			MinVersion: pc.Checks.NBVersionCheck.MinVersion,
+		}
+	}
+
+	if pc.Checks.OSVersionCheck != nil {
+		checks.OsVersionCheck = &api.OSVersionCheck{
+			Android: (*api.MinVersionCheck)(pc.Checks.OSVersionCheck.Android),
+			Darwin:  (*api.MinVersionCheck)(pc.Checks.OSVersionCheck.Darwin),
+			Ios:     (*api.MinVersionCheck)(pc.Checks.OSVersionCheck.Ios),
+			Linux:   (*api.MinKernelVersionCheck)(pc.Checks.OSVersionCheck.Linux),
+			Windows: (*api.MinKernelVersionCheck)(pc.Checks.OSVersionCheck.Windows),
+		}
+	}
+
+	if pc.Checks.GeoLocationCheck != nil {
+		checks.GeoLocationCheck = toGeoLocationCheckResponse(pc.Checks.GeoLocationCheck)
+	}
+
+	if pc.Checks.PeerNetworkRangeCheck != nil {
+		checks.PeerNetworkRangeCheck = toPeerNetworkRangeCheckResponse(pc.Checks.PeerNetworkRangeCheck)
+	}
+
+	return &api.PostureCheck{
+		Id:          pc.ID,
+		Name:        pc.Name,
+		Description: &pc.Description,
+		Checks:      checks,
+	}
+}
+
 func (pc *Checks) Validate() error {
 	if check := pc.Checks.NBVersionCheck; check != nil {
 		if !isVersionValid(check.MinVersion) {
@@ -191,4 +322,71 @@ func isVersionValid(ver string) bool {
 	}
 
 	return false
+}
+
+func toGeoLocationCheckResponse(geoLocationCheck *GeoLocationCheck) *api.GeoLocationCheck {
+	locations := make([]api.Location, 0, len(geoLocationCheck.Locations))
+	for _, loc := range geoLocationCheck.Locations {
+		l := loc // make G601 happy
+		var cityName *string
+		if loc.CityName != "" {
+			cityName = &l.CityName
+		}
+		locations = append(locations, api.Location{
+			CityName:    cityName,
+			CountryCode: loc.CountryCode,
+		})
+	}
+
+	return &api.GeoLocationCheck{
+		Action:    api.GeoLocationCheckAction(geoLocationCheck.Action),
+		Locations: locations,
+	}
+}
+
+func toPostureGeoLocationCheck(apiGeoLocationCheck *api.GeoLocationCheck) *GeoLocationCheck {
+	locations := make([]Location, 0, len(apiGeoLocationCheck.Locations))
+	for _, loc := range apiGeoLocationCheck.Locations {
+		cityName := ""
+		if loc.CityName != nil {
+			cityName = *loc.CityName
+		}
+		locations = append(locations, Location{
+			CountryCode: loc.CountryCode,
+			CityName:    cityName,
+		})
+	}
+
+	return &GeoLocationCheck{
+		Action:    string(apiGeoLocationCheck.Action),
+		Locations: locations,
+	}
+}
+
+func toPeerNetworkRangeCheckResponse(check *PeerNetworkRangeCheck) *api.PeerNetworkRangeCheck {
+	netPrefixes := make([]string, 0, len(check.Ranges))
+	for _, netPrefix := range check.Ranges {
+		netPrefixes = append(netPrefixes, netPrefix.String())
+	}
+
+	return &api.PeerNetworkRangeCheck{
+		Ranges: netPrefixes,
+		Action: api.PeerNetworkRangeCheckAction(check.Action),
+	}
+}
+
+func toPeerNetworkRangeCheck(check *api.PeerNetworkRangeCheck) (*PeerNetworkRangeCheck, error) {
+	prefixes := make([]netip.Prefix, 0)
+	for _, prefix := range check.Ranges {
+		parsedPrefix, err := netip.ParsePrefix(prefix)
+		if err != nil {
+			return nil, err
+		}
+		prefixes = append(prefixes, parsedPrefix)
+	}
+
+	return &PeerNetworkRangeCheck{
+		Ranges: prefixes,
+		Action: string(check.Action),
+	}, nil
 }

--- a/management/server/posture/checks.go
+++ b/management/server/posture/checks.go
@@ -139,7 +139,7 @@ func (pc *Checks) GetChecks() []Check {
 	return checks
 }
 
-func (pc *Checks) FromAPIPostureCheck(source api.PostureCheck) (*Checks, error) {
+func NewChecksFromAPIPostureCheck(source api.PostureCheck) (*Checks, error) {
 	description := ""
 	if source.Description != nil {
 		description = *source.Description
@@ -148,7 +148,7 @@ func (pc *Checks) FromAPIPostureCheck(source api.PostureCheck) (*Checks, error) 
 	return buildPostureCheck(source.Id, source.Name, description, source.Checks)
 }
 
-func (pc *Checks) FromAPIPostureCheckUpdate(source api.PostureCheckUpdate, postureChecksID string) (*Checks, error) {
+func NewChecksFromAPIPostureCheckUpdate(source api.PostureCheckUpdate, postureChecksID string) (*Checks, error) {
 	return buildPostureCheck(postureChecksID, source.Name, source.Description, *source.Checks)
 }
 

--- a/management/server/sql_store.go
+++ b/management/server/sql_store.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -536,6 +537,21 @@ func (s *SqlStore) SaveUserLastLogin(accountID, userID string, lastLogin time.Ti
 	user.LastLogin = lastLogin
 
 	return s.db.Save(user).Error
+}
+
+func (s *SqlStore) GetPostureCheckByChecksDefinition(accountID string, checks *posture.ChecksDefinition) (*posture.Checks, error) {
+	definitionJSON, err := json.Marshal(checks)
+	if err != nil {
+		return nil, err
+	}
+
+	var postureCheck posture.Checks
+	err = s.db.Where("account_id = ? AND checks = ?", accountID, string(definitionJSON)).First(&postureCheck).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &postureCheck, nil
 }
 
 // Close closes the underlying DB connection

--- a/management/server/store.go
+++ b/management/server/store.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/netbirdio/netbird/management/server/migration"
 	nbpeer "github.com/netbirdio/netbird/management/server/peer"
+	"github.com/netbirdio/netbird/management/server/posture"
 	"github.com/netbirdio/netbird/management/server/telemetry"
 	"github.com/netbirdio/netbird/management/server/testutil"
 	"github.com/netbirdio/netbird/route"
@@ -31,6 +32,7 @@ type Store interface {
 	GetAccountByPrivateDomain(domain string) (*Account, error)
 	GetTokenIDByHashedToken(secret string) (string, error)
 	GetUserByTokenID(tokenID string) (*User, error)
+	GetPostureCheckByChecksDefinition(accountID string, checks *posture.ChecksDefinition) (*posture.Checks, error)
 	SaveAccount(account *Account) error
 	DeleteHashedPAT2TokenIDIndex(hashedToken string) error
 	DeleteTokenID2UserIDIndex(tokenID string) error


### PR DESCRIPTION
## Describe your changes
This PR refactors the conversion of posture checks from API objects to system objects and backward.
It adds a method to find an existing posture check definition based on the check definition.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
