### PR TITLE
Adding geolocation download log message.

### DIFF
--- a/management/server/geolocation/database.go
+++ b/management/server/geolocation/database.go
@@ -28,8 +28,10 @@ func loadGeolocationDatabases(dataDir string) error {
 		exists, _ := fileExists(path.Join(dataDir, file))
 		if exists {
 			continue
+		}else{
+			log.Infof("geo location file %s not found , file will be downloaded", file)
 		}
-
+		
 		switch file {
 		case MMDBFileName:
 			extractFunc := func(src string, dst string) error {

--- a/management/server/geolocation/database.go
+++ b/management/server/geolocation/database.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strconv"
 
+	log "github.com/sirupsen/logrus"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -28,10 +29,10 @@ func loadGeolocationDatabases(dataDir string) error {
 		exists, _ := fileExists(path.Join(dataDir, file))
 		if exists {
 			continue
-		}else{
-			log.Infof("geo location file %s not found , file will be downloaded", file)
 		}
-		
+
+		log.Infof("geo location file %s not found , file will be downloaded", file)
+
 		switch file {
 		case MMDBFileName:
 			extractFunc := func(src string, dst string) error {


### PR DESCRIPTION
## Describe your changes

Adding geolocation download prompt message.
When the network condition is poor, there are no prompts when downloading the geolocation file.

## Issue ticket number and link
#2046 
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
