### PR TITLE
Add missing `openid` scope when requesting JWT token in Zitadel

### DIFF
--- a/management/server/idp/zitadel.go
+++ b/management/server/idp/zitadel.go
@@ -154,7 +154,7 @@ func (zc *ZitadelCredentials) requestJWTToken() (*http.Response, error) {
 	data.Set("client_id", zc.clientConfig.ClientID)
 	data.Set("client_secret", zc.clientConfig.ClientSecret)
 	data.Set("grant_type", zc.clientConfig.GrantType)
-	data.Set("scope", "urn:zitadel:iam:org:project:id:zitadel:aud")
+	data.Set("scope", "openid urn:zitadel:iam:org:project:id:zitadel:aud")
 
 	payload := strings.NewReader(data.Encode())
 	req, err := http.NewRequest(http.MethodPost, zc.clientConfig.TokenEndpoint, payload)


### PR DESCRIPTION
## Describe your changes

According to the Zitadel documentation, `openid` scope is required when requesting JWT tokens.

Apparently Zitadel was accepting requests without it until very recently. Now lack thereof causes 400 Bad Requests which makes it impossible to authenticate to the Netbird dashboard.

https://zitadel.com/docs/guides/integrate/service-users/client-credentials#2-authenticating-a-service-user-and-request-a-token

## Issue ticket number and link
None

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
