### PR TITLE
Never skip removing allowed IPs

### DIFF
--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -206,19 +206,10 @@ func (c *clientNetwork) startPeersStatusChangeWatcher() {
 	}
 }
 
-func (c *clientNetwork) removeRouteFromWireguardPeer(peerKey string) error {
+func (c *clientNetwork) removeRouteFromWireguardPeer() error {
 	c.removeStateRoute()
 
-	state, err := c.statusRecorder.GetPeer(peerKey)
-	if err != nil {
-		return fmt.Errorf("get peer state: %w", err)
-	}
-
-	if state.ConnStatus != peer.StatusConnected {
-		return nil
-	}
-
-	if err = c.handler.RemoveAllowedIPs(); err != nil {
+	if err := c.handler.RemoveAllowedIPs(); err != nil {
 		return fmt.Errorf("remove allowed IPs: %w", err)
 	}
 	return nil
@@ -231,7 +222,7 @@ func (c *clientNetwork) removeRouteFromPeerAndSystem() error {
 
 	var merr *multierror.Error
 
-	if err := c.removeRouteFromWireguardPeer(c.currentChosen.Peer); err != nil {
+	if err := c.removeRouteFromWireguardPeer(); err != nil {
 		merr = multierror.Append(merr, fmt.Errorf("remove allowed IPs for peer %s: %w", c.currentChosen.Peer, err))
 	}
 	if err := c.handler.RemoveRoute(); err != nil {
@@ -270,7 +261,7 @@ func (c *clientNetwork) recalculateRouteAndUpdatePeerAndSystem() error {
 		}
 	} else {
 		// Otherwise, remove the allowed IPs from the previous peer first
-		if err := c.removeRouteFromWireguardPeer(c.currentChosen.Peer); err != nil {
+		if err := c.removeRouteFromWireguardPeer(); err != nil {
 			return fmt.Errorf("remove allowed IPs for peer %s: %w", c.currentChosen.Peer, err)
 		}
 	}

--- a/client/internal/routemanager/dynamic/route.go
+++ b/client/internal/routemanager/dynamic/route.go
@@ -310,10 +310,9 @@ func (r *Route) incrementAllowedIP(domain domain.Domain, prefix netip.Prefix, pe
 	if ref, err := r.allowedIPsRefcounter.Increment(prefix, peerKey); err != nil {
 		return fmt.Errorf(addAllowedIP, prefix, err)
 	} else if ref.Count > 1 && ref.Out != peerKey {
-		log.Warnf("IP [%s] for domain [%s] was already resolved for a different domain routed by peer [%s]. Routing for this IP will be done by peer [%s], HA routing disabled",
+		log.Warnf("IP [%s] for domain [%s] is already routed by peer [%s]. HA routing disabled",
 			prefix.Addr(),
 			domain.SafeString(),
-			ref.Out,
 			ref.Out,
 		)
 

--- a/client/internal/routemanager/refcounter/refcounter.go
+++ b/client/internal/routemanager/refcounter/refcounter.go
@@ -51,11 +51,11 @@ func (rm *Counter[I, O]) Increment(prefix netip.Prefix, in I) (Ref[O], error) {
 	defer rm.refCountMu.Unlock()
 
 	ref := rm.refCountMap[prefix]
-	log.Tracef("Increasing ref count %d for prefix %s", ref.Count, prefix)
+	log.Tracef("Increasing ref count %d for prefix %s with [%v]", ref.Count, prefix, ref.Out)
 
 	// Call AddFunc only if it's a new prefix
 	if ref.Count == 0 {
-		log.Tracef("Adding for prefix %s", prefix)
+		log.Tracef("Adding for prefix %s with [%v]", prefix, ref.Out)
 		out, err := rm.add(prefix, in)
 
 		if errors.Is(err, ErrIgnore) {
@@ -100,9 +100,9 @@ func (rm *Counter[I, O]) Decrement(prefix netip.Prefix) (Ref[O], error) {
 		return ref, nil
 	}
 
-	log.Tracef("Decreasing ref count %d for prefix %s", ref.Count, prefix)
+	log.Tracef("Decreasing ref count %d for prefix %s with [%v]", ref.Count, prefix, ref.Out)
 	if ref.Count == 1 {
-		log.Tracef("Removing for prefix %s", prefix)
+		log.Tracef("Removing for prefix %s with [%v]", prefix, ref.Out)
 		if err := rm.remove(prefix, ref.Out); err != nil {
 			return ref, fmt.Errorf("remove for prefix %s: %w", prefix, err)
 		}


### PR DESCRIPTION
## Describe your changes
Removes the check about whether a peer is still connected before removing allowed IPs (= decreasing ref count to 0)

## Issue ticket number and link
Fixes #2093

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
