### PR TITLE
Prevent building test code for client

### DIFF
--- a/client/cmd/testutil_test.go
+++ b/client/cmd/testutil_test.go
@@ -108,7 +108,7 @@ func startManagement(t *testing.T, config *mgmt.Config) (*grpc.Server, net.Liste
 }
 
 func startClientDaemon(
-	t *testing.T, ctx context.Context, managementURL, configPath string,
+	t *testing.T, ctx context.Context, _, configPath string,
 ) (*grpc.Server, net.Listener) {
 	t.Helper()
 	lis, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
This will reduce the client binary size in almost 25%

## Describe your changes

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
