### PR TITLE
Update Zitadel and CockroachDB Container Image Version

### DIFF
--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -760,7 +760,7 @@ services:
   zitadel:
     restart: 'always'
     networks: [netbird]
-    image: 'ghcr.io/zitadel/zitadel:v2.31.3'
+    image: 'ghcr.io/zitadel/zitadel:v2.54.3'
     command: 'start-from-init --masterkeyFromEnv --tlsMode $ZITADEL_TLS_MODE'
     env_file:
       - ./zitadel.env
@@ -774,7 +774,7 @@ services:
   crdb:
     restart: 'always'
     networks: [netbird]
-    image: 'cockroachdb/cockroach:v22.2.2'
+    image: 'cockroachdb/cockroach:latest-v23.2'
     command: 'start-single-node --advertise-addr crdb'
     volumes:
       - netbird_crdb_data:/cockroach/cockroach-data

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -717,7 +717,7 @@ services:
     volumes:
       - netbird_caddy_data:/data
       - ./Caddyfile:/etc/caddy/Caddyfile
-  #UI dashboard
+  # UI dashboard
   dashboard:
     image: netbirdio/dashboard:latest
     restart: unless-stopped


### PR DESCRIPTION
Update the container images in the `getting-started-with-zitadel.sh` Docker Compose template of:
- Zitadel -> `2.54.3`
- CockroachDB -> `latest-v23.2`

This change brings Zitadel to a stable version and fixes many bugs. Zitadel now requires CockroachDB at least version 23.2.

And the pull request also fixed a typo in the Docker Compose template.

### Checklist
- [x] Is it a bug fix
- [x] Is a typo/documentation fix
- [x] Is a feature enhancement
