### PR TITLE
Feature/Use Zitadel Postgres Integration by default

### DIFF
--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -184,10 +184,13 @@ jobs:
       - name: test zdb.env file gen
         run: test -f zdb.env
 
-      - name: run script with Zitadel CockroachDB
+      - name: Postgres run cleanup
         run: |
+          docker-compose down
           rm -f docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-admin-sa.token turnserver.conf management.json zdb.env
-          bash -x infrastructure_files/getting-started-with-zitadel.sh
+
+      - name: run script with Zitadel CockroachDB
+        run: bash -x infrastructure_files/getting-started-with-zitadel.sh
         env:
           NETBIRD_DOMAIN: use-ip
           DATABASE: cockroach

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Postgres run cleanup
         run: |
-          docker-compose down
+          docker-compose down --volumes --rmi
           rm -rf docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-admin-sa.token turnserver.conf management.json zdb.env
 
       - name: run script with Zitadel CockroachDB

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -215,7 +215,7 @@ jobs:
         run: bash -x infrastructure_files/getting-started-with-zitadel.sh
         env:
           NETBIRD_DOMAIN: use-ip
-          DATABASE: cockroach
+          ZITADEL_DATABASE: cockroach
 
       - name: test Caddy file gen CockroachDB
         run: test -f Caddyfile

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -187,7 +187,8 @@ jobs:
       - name: Postgres run cleanup
         run: |
           docker-compose down
-          rm -f docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-admin-sa.token turnserver.conf management.json zdb.env
+          rm -rf docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-admin-sa.token turnserver.conf management.json zdb.env
+          ls -la ./
 
       - name: run script with Zitadel CockroachDB
         run: bash -x infrastructure_files/getting-started-with-zitadel.sh

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -209,7 +209,6 @@ jobs:
         run: |
           docker-compose down
           rm -rf docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-admin-sa.token turnserver.conf management.json zdb.env
-          ls -la ./
 
       - name: run script with Zitadel CockroachDB
         run: bash -x infrastructure_files/getting-started-with-zitadel.sh

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -181,7 +181,28 @@ jobs:
       - name: run script with Zitadel PostgreSQL
         run: NETBIRD_DOMAIN=use-ip bash -x infrastructure_files/getting-started-with-zitadel.sh
 
-      - name: test zdb.env file gen
+      - name: test Caddy file gen postgres
+        run: test -f Caddyfile
+
+      - name: test docker-compose file gen postgres
+        run: test -f docker-compose.yml
+
+      - name: test management.json file gen postgres
+        run: test -f management.json
+
+      - name: test turnserver.conf file gen postgres
+        run: | 
+          set -x
+          test -f turnserver.conf
+          grep external-ip turnserver.conf
+
+      - name: test zitadel.env file gen postgres
+        run: test -f zitadel.env
+
+      - name: test dashboard.env file gen postgres
+        run: test -f dashboard.env
+
+      - name: test zdb.env file gen postgres
         run: test -f zdb.env
 
       - name: Postgres run cleanup
@@ -196,25 +217,25 @@ jobs:
           NETBIRD_DOMAIN: use-ip
           DATABASE: cockroach
 
-      - name: test Caddy file gen
+      - name: test Caddy file gen CockroachDB
         run: test -f Caddyfile
 
-      - name: test docker-compose file gen
+      - name: test docker-compose file gen CockroachDB
         run: test -f docker-compose.yml
 
-      - name: test management.json file gen
+      - name: test management.json file gen CockroachDB
         run: test -f management.json
 
-      - name: test turnserver.conf file gen
+      - name: test turnserver.conf file gen CockroachDB
         run: | 
           set -x
           test -f turnserver.conf
           grep external-ip turnserver.conf
 
-      - name: test zitadel.env file gen
+      - name: test zitadel.env file gen CockroachDB
         run: test -f zitadel.env
 
-      - name: test dashboard.env file gen
+      - name: test dashboard.env file gen CockroachDB
         run: test -f dashboard.env
 
   test-download-geolite2-script:

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -178,34 +178,55 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: run script
+      - name: run script with Zitadel PostgreSQL
         run: NETBIRD_DOMAIN=use-ip bash -x infrastructure_files/getting-started-with-zitadel.sh
+
+      - name: test zdb.env file gen
+        run: test -f zdb.env
+
+      - name: run script with Zitadel CockroachDB
+        run: |
+          rm -f docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-admin-sa.token turnserver.conf management.json zdb.env
+          bash -x infrastructure_files/getting-started-with-zitadel.sh
+        env:
+          NETBIRD_DOMAIN: use-ip
+          DATABASE: cockroach
 
       - name: test Caddy file gen
         run: test -f Caddyfile
+
       - name: test docker-compose file gen
         run: test -f docker-compose.yml
+
       - name: test management.json file gen
         run: test -f management.json
+
       - name: test turnserver.conf file gen
         run: | 
           set -x
           test -f turnserver.conf
           grep external-ip turnserver.conf
+
       - name: test zitadel.env file gen
         run: test -f zitadel.env
+
       - name: test dashboard.env file gen
         run: test -f dashboard.env
+
   test-download-geolite2-script:
     runs-on: ubuntu-latest
     steps:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y unzip sqlite3
+
       - name: Checkout code
         uses: actions/checkout@v3
+
       - name: test script
         run: bash -x infrastructure_files/download-geolite2.sh
+
       - name: test mmdb file exists
         run: test -f GeoLite2-City.mmdb
+
       - name: test geonames file exists
         run: test -f geonames.db

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Postgres run cleanup
         run: |
-          docker-compose down --volumes --rmi
+          docker-compose down --volumes --rmi all
           rm -rf docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-admin-sa.token turnserver.conf management.json zdb.env
 
       - name: run script with Zitadel CockroachDB

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -464,11 +464,14 @@ initEnvironment() {
   fi
 
   if [[ $ZITADEL_DATABASE == "" ]]; then
-    CRDB=$(renderDockerComposeCockroachDB)
-    ZITADEL_DB_ENV=$(renderZidatelCockroachDBEnv)
-  elif [[ $DATABASE == "postgres" ]]; then
+    echo "Use Postgres as default Zitadel database."
+    echo "For using CockroachDB please the environment variable 'export ZITADEL_DATABASE=cockroach'."
     CRDB=$(renderDockerComposePostgres)
     ZITADEL_DB_ENV=$(renderZidatelPostgresEnv)
+  elif [[ $DATABASE == "cockroach" ]]; then
+    echo "Use CockroachDB as Zitadel database."
+    CRDB=$(renderDockerComposeCockroachDB)
+    ZITADEL_DB_ENV=$(renderZidatelCockroachDBEnv)
   fi
 
   echo Rendering initial files...

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -832,8 +832,6 @@ renderDockerComposeCockroachDB() {
     networks: [netbird]
     image: 'cockroachdb/cockroach:latest-v23.2'
     command: 'start-single-node --advertise-addr zdb'
-    env_file:
-      - ./zdb.env
     volumes:
       - netbird_zdb_data:/cockroach/cockroach-data
       - netbird_zdb_certs:/cockroach/certs
@@ -857,16 +855,16 @@ renderDockerComposePostgres() {
     restart: 'always'
     networks: [netbird]
     image: 'postgres:16-alpine'
+    env_file:
+      - ./zdb.env
+    volumes:
+      - netbird_zdb_data:/var/lib/postgresql/data:rw
     healthcheck:
       test: ["CMD-SHELL", "pg_isready", "-d", "db_prod"]
       interval: 5s
       timeout: 60s
       retries: 10
       start_period: 5s
-    ports:
-      - '5432:5432'
-    volumes:
-      - netbird_zdb_data:/var/lib/postgresql/data:rw
 
 volumes:
 EOF

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -760,7 +760,7 @@ services:
   zitadel:
     restart: 'always'
     networks: [netbird]
-    image: 'ghcr.io/zitadel/zitadel:v2.31.3'
+    image: 'ghcr.io/zitadel/zitadel:v2.54.3'
     command: 'start-from-init --masterkeyFromEnv --tlsMode $ZITADEL_TLS_MODE'
     env_file:
       - ./zitadel.env
@@ -774,7 +774,7 @@ services:
   crdb:
     restart: 'always'
     networks: [netbird]
-    image: 'cockroachdb/cockroach:v22.2.2'
+    image: 'cockroachdb/cockroach:latest-v23.2'
     command: 'start-single-node --advertise-addr crdb'
     volumes:
       - netbird_crdb_data:/cockroach/cockroach-data

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -50,7 +50,7 @@ check_jq() {
 wait_crdb() {
   set +e
   while true; do
-    if $DOCKER_COMPOSE_COMMAND exec -T crdb curl -sf -o /dev/null 'http://localhost:8080/health?ready=1'; then
+    if $DOCKER_COMPOSE_COMMAND exec -T zdb curl -sf -o /dev/null 'http://localhost:8080/health?ready=1'; then
       break
     fi
     echo -n " ."
@@ -63,12 +63,12 @@ wait_crdb() {
 init_crdb() {
   if [[ $ZITADEL_DATABASE == "cockroach" ]]; then
     echo -e "\nInitializing Zitadel's CockroachDB\n\n"
-    $DOCKER_COMPOSE_COMMAND up -d crdb
+    $DOCKER_COMPOSE_COMMAND up -d zrdb
     echo ""
     # shellcheck disable=SC2028
     echo -n "Waiting cockroachDB  to become ready "
     wait_crdb
-    $DOCKER_COMPOSE_COMMAND exec -T crdb /bin/bash -c "cp /cockroach/certs/* /zitadel-certs/ && cockroach cert create-client --overwrite --certs-dir /zitadel-certs/ --ca-key /zitadel-certs/ca.key zitadel_user && chown -R 1000:1000 /zitadel-certs/"
+    $DOCKER_COMPOSE_COMMAND exec -T zrdb /bin/bash -c "cp /cockroach/certs/* /zitadel-certs/ && cockroach cert create-client --overwrite --certs-dir /zitadel-certs/ --ca-key /zitadel-certs/ca.key zitadel_user && chown -R 1000:1000 /zitadel-certs/"
     handle_request_command_status $? "init_crdb failed" ""
   fi
 }

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -360,9 +360,6 @@ init_zitadel() {
 
   DATE=$(add_organization_user_manager "$INSTANCE_URL" "$PAT" "$MACHINE_USER_ID")
 
-  POSTGRES_ROOT_PASSWORD="$(openssl rand -base64 32 | sed 's/=//g')@"
-  POSTGRES_ZITADEL_PASSWORD="$(openssl rand -base64 32 | sed 's/=//g')@"
-
   ZITADEL_ADMIN_USERNAME="admin@$NETBIRD_DOMAIN"
   ZITADEL_ADMIN_PASSWORD="$(openssl rand -base64 32 | sed 's/=//g')@"
 
@@ -469,13 +466,15 @@ initEnvironment() {
   if [[ $ZITADEL_DATABASE == "" ]]; then
     echo "Use Postgres as default Zitadel database."
     echo "For using CockroachDB please the environment variable 'export ZITADEL_DATABASE=cockroach'."
+    POSTGRES_ROOT_PASSWORD="$(openssl rand -base64 32 | sed 's/=//g')@"
+    POSTGRES_ZITADEL_PASSWORD="$(openssl rand -base64 32 | sed 's/=//g')@"
     ZDB=$(renderDockerComposePostgres)
-    ZITADEL_DB_ENV=$(renderZidatelPostgresEnv)
+    ZITADEL_DB_ENV=$(renderZitadelPostgresEnv)
     renderPostgresEnv > zdb.env
   elif [[ $DATABASE == "cockroach" ]]; then
     echo "Use CockroachDB as Zitadel database."
     ZDB=$(renderDockerComposeCockroachDB)
-    ZITADEL_DB_ENV=$(renderZidatelCockroachDBEnv)
+    ZITADEL_DB_ENV=$(renderZitadelCockroachDBEnv)
   fi
 
   echo Rendering initial files...
@@ -491,7 +490,7 @@ initEnvironment() {
 
   init_crdb
 
-  echo -e "\nStarting Zidatel IDP for user management\n\n"
+  echo -e "\nStarting Zitadel IDP for user management\n\n"
   $DOCKER_COMPOSE_COMMAND up -d caddy zitadel
   init_zitadel
 
@@ -709,7 +708,7 @@ $ZITADEL_DB_ENV
 EOF
 }
 
-renderZidatelCockroachDBEnv() {
+renderZitadelCockroachDBEnv() {
   cat <<EOF
 ZITADEL_DATABASE_COCKROACH_HOST=zdb
 ZITADEL_DATABASE_COCKROACH_USER_USERNAME=zitadel_user
@@ -724,7 +723,7 @@ ZITADEL_DATABASE_COCKROACH_ADMIN_SSL_KEY="/zdb-certs/client.root.key"
 EOF
 }
 
-renderZidatelPostgresEnv() {
+renderZitadelPostgresEnv() {
   cat <<EOF
 ZITADEL_DATABASE_POSTGRES_HOST=zdb
 ZITADEL_DATABASE_POSTGRES_PORT=5432

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -66,7 +66,7 @@ init_crdb() {
     $DOCKER_COMPOSE_COMMAND up -d zdb
     echo ""
     # shellcheck disable=SC2028
-    echo -n "Waiting cockroachDB  to become ready "
+    echo -n "Waiting CockroachDB to become ready"
     wait_crdb
     $DOCKER_COMPOSE_COMMAND exec -T zdb /bin/bash -c "cp /cockroach/certs/* /zitadel-certs/ && cockroach cert create-client --overwrite --certs-dir /zitadel-certs/ --ca-key /zitadel-certs/ca.key zitadel_user && chown -R 1000:1000 /zitadel-certs/"
     handle_request_command_status $? "init_crdb failed" ""

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -832,6 +832,8 @@ renderDockerComposeCockroachDB() {
     networks: [netbird]
     image: 'cockroachdb/cockroach:latest-v23.2'
     command: 'start-single-node --advertise-addr zdb'
+    env_file:
+      - ./zdb.env
     volumes:
       - netbird_zdb_data:/cockroach/cockroach-data
       - netbird_zdb_certs:/cockroach/certs

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -717,7 +717,7 @@ services:
     volumes:
       - netbird_caddy_data:/data
       - ./Caddyfile:/etc/caddy/Caddyfile
-  #UI dashboard
+  # UI dashboard
   dashboard:
     image: netbirdio/dashboard:latest
     restart: unless-stopped

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -61,7 +61,7 @@ wait_crdb() {
 }
 
 init_crdb() {
-  if [[ $ZITADEL_DATABASE == "" ]]; then
+  if [[ $ZITADEL_DATABASE == "cockroach" ]]; then
     echo -e "\nInitializing Zitadel's CockroachDB\n\n"
     $DOCKER_COMPOSE_COMMAND up -d crdb
     echo ""

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -61,14 +61,16 @@ wait_crdb() {
 }
 
 init_crdb() {
-  echo -e "\nInitializing Zitadel's CockroachDB\n\n"
-  $DOCKER_COMPOSE_COMMAND up -d crdb
-  echo ""
-  # shellcheck disable=SC2028
-  echo -n "Waiting cockroachDB  to become ready "
-  wait_crdb
-  $DOCKER_COMPOSE_COMMAND exec -T crdb /bin/bash -c "cp /cockroach/certs/* /zitadel-certs/ && cockroach cert create-client --overwrite --certs-dir /zitadel-certs/ --ca-key /zitadel-certs/ca.key zitadel_user && chown -R 1000:1000 /zitadel-certs/"
-  handle_request_command_status $? "init_crdb failed" ""
+  if [[ $ZITADEL_DATABASE == "" ]]; then
+    echo -e "\nInitializing Zitadel's CockroachDB\n\n"
+    $DOCKER_COMPOSE_COMMAND up -d crdb
+    echo ""
+    # shellcheck disable=SC2028
+    echo -n "Waiting cockroachDB  to become ready "
+    wait_crdb
+    $DOCKER_COMPOSE_COMMAND exec -T crdb /bin/bash -c "cp /cockroach/certs/* /zitadel-certs/ && cockroach cert create-client --overwrite --certs-dir /zitadel-certs/ --ca-key /zitadel-certs/ca.key zitadel_user && chown -R 1000:1000 /zitadel-certs/"
+    handle_request_command_status $? "init_crdb failed" ""
+  fi
 }
 
 get_main_ip_address() {
@@ -156,7 +158,7 @@ create_new_application() {
       "'"$BASE_REDIRECT_URL2"'"
     ],
     "postLogoutRedirectUris": [
-       "'"$LOGOUT_URL"'"
+      "'"$LOGOUT_URL"'"
     ],
     "RESPONSETypes": [
       "OIDC_RESPONSE_TYPE_CODE"
@@ -461,6 +463,14 @@ initEnvironment() {
     exit 1
   fi
 
+  if [[ $ZITADEL_DATABASE == "" ]]; then
+    CRDB=$(renderDockerComposeCockroachDB)
+    ZITADEL_DB_ENV=$(renderZidatelCockroachDBEnv)
+  elif [[ $DATABASE == "postgres" ]]; then
+    CRDB=$(renderDockerComposePostgres)
+    ZITADEL_DB_ENV=$(renderZidatelPostgresEnv)
+  fi
+
   echo Rendering initial files...
   renderDockerCompose > docker-compose.yml
   renderCaddyfile > Caddyfile
@@ -634,15 +644,15 @@ renderManagementJson() {
         "ExtraConfig": {
             "ManagementEndpoint": "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN/management/v1"
         }
-     },
-   "DeviceAuthorizationFlow": {
-       "Provider": "hosted",
-       "ProviderConfig": {
-           "Audience": "$NETBIRD_AUTH_CLIENT_ID_CLI",
-           "ClientID": "$NETBIRD_AUTH_CLIENT_ID_CLI",
-           "Scope": "openid"
-       }
-     },
+    },
+  "DeviceAuthorizationFlow": {
+      "Provider": "hosted",
+      "ProviderConfig": {
+          "Audience": "$NETBIRD_AUTH_CLIENT_ID_CLI",
+          "ClientID": "$NETBIRD_AUTH_CLIENT_ID_CLI",
+          "Scope": "openid"
+      }
+    },
     "PKCEAuthorizationFlow": {
         "ProviderConfig": {
             "Audience": "$NETBIRD_AUTH_CLIENT_ID_CLI",
@@ -679,6 +689,21 @@ renderZitadelEnv() {
   cat <<EOF
 ZITADEL_LOG_LEVEL=debug
 ZITADEL_MASTERKEY=$ZITADEL_MASTERKEY
+ZITADEL_EXTERNALSECURE=$ZITADEL_EXTERNALSECURE
+ZITADEL_TLS_ENABLED="false"
+ZITADEL_EXTERNALPORT=$NETBIRD_PORT
+ZITADEL_EXTERNALDOMAIN=$NETBIRD_DOMAIN
+ZITADEL_FIRSTINSTANCE_PATPATH=/machinekey/zitadel-admin-sa.token
+ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME=zitadel-admin-sa
+ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME=Admin
+ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_SCOPES=openid
+ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_EXPIRATIONDATE=$ZIDATE_TOKEN_EXPIRATION_DATE
+$ZITADEL_DB_ENV
+EOF
+}
+
+renderZidatelCockroachDBEnv() {
+  cat <<EOF
 ZITADEL_DATABASE_COCKROACH_HOST=crdb
 ZITADEL_DATABASE_COCKROACH_USER_USERNAME=zitadel_user
 ZITADEL_DATABASE_COCKROACH_USER_SSL_MODE=verify-full
@@ -689,15 +714,20 @@ ZITADEL_DATABASE_COCKROACH_ADMIN_SSL_MODE=verify-full
 ZITADEL_DATABASE_COCKROACH_ADMIN_SSL_ROOTCERT="/crdb-certs/ca.crt"
 ZITADEL_DATABASE_COCKROACH_ADMIN_SSL_CERT="/crdb-certs/client.root.crt"
 ZITADEL_DATABASE_COCKROACH_ADMIN_SSL_KEY="/crdb-certs/client.root.key"
-ZITADEL_EXTERNALSECURE=$ZITADEL_EXTERNALSECURE
-ZITADEL_TLS_ENABLED="false"
-ZITADEL_EXTERNALPORT=$NETBIRD_PORT
-ZITADEL_EXTERNALDOMAIN=$NETBIRD_DOMAIN
-ZITADEL_FIRSTINSTANCE_PATPATH=/machinekey/zitadel-admin-sa.token
-ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME=zitadel-admin-sa
-ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME=Admin
-ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_SCOPES=openid
-ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_EXPIRATIONDATE=$ZIDATE_TOKEN_EXPIRATION_DATE
+EOF
+}
+
+renderZidatelPostgresEnv() {
+  cat <<EOF
+ZITADEL_DATABASE_POSTGRES_HOST=crdb
+ZITADEL_DATABASE_POSTGRES_PORT=5432
+ZITADEL_DATABASE_POSTGRES_DATABASE=zitadel
+ZITADEL_DATABASE_POSTGRES_USER_USERNAME=zitadel
+ZITADEL_DATABASE_POSTGRES_USER_PASSWORD=zitadel
+ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE=disable
+ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME=root
+ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD=postgres
+ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE=disable
 EOF
 }
 
@@ -770,7 +800,20 @@ services:
     volumes:
       - ./machinekey:/machinekey
       - netbird_zitadel_certs:/crdb-certs:ro
-  # CockroachDB for zitadel
+$CRDB
+  netbird_management:
+  netbird_caddy_data:
+  netbird_crdb_data:
+  netbird_zitadel_certs:
+
+networks:
+  netbird:
+EOF
+}
+
+renderDockerComposeCockroachDB() {
+  cat <<EOF
+  # CockroachDB for Zitadel
   crdb:
     restart: 'always'
     networks: [netbird]
@@ -788,14 +831,32 @@ services:
       start_period: '20s'
 
 volumes:
-  netbird_management:
-  netbird_caddy_data:
-  netbird_crdb_data:
   netbird_crdb_certs:
-  netbird_zitadel_certs:
+EOF
+}
 
-networks:
-  netbird:
+renderDockerComposePostgres() {
+  cat <<EOF
+  # Postgres for Zitadel
+  crdb:
+    restart: 'always'
+    networks: [netbird]
+    image: 'postgres:16-alpine'
+    environment:
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "-d", "db_prod"]
+      interval: 5s
+      timeout: 60s
+      retries: 10
+      start_period: 5s
+    ports:
+      - '5432:5432'
+    volumes:
+      - netbird_crdb_data:/var/lib/postgresql/data:rw
+
+volumes:
 EOF
 }
 

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -63,12 +63,12 @@ wait_crdb() {
 init_crdb() {
   if [[ $ZITADEL_DATABASE == "cockroach" ]]; then
     echo -e "\nInitializing Zitadel's CockroachDB\n\n"
-    $DOCKER_COMPOSE_COMMAND up -d zrdb
+    $DOCKER_COMPOSE_COMMAND up -d zdb
     echo ""
     # shellcheck disable=SC2028
     echo -n "Waiting cockroachDB  to become ready "
     wait_crdb
-    $DOCKER_COMPOSE_COMMAND exec -T zrdb /bin/bash -c "cp /cockroach/certs/* /zitadel-certs/ && cockroach cert create-client --overwrite --certs-dir /zitadel-certs/ --ca-key /zitadel-certs/ca.key zitadel_user && chown -R 1000:1000 /zitadel-certs/"
+    $DOCKER_COMPOSE_COMMAND exec -T zdb /bin/bash -c "cp /cockroach/certs/* /zitadel-certs/ && cockroach cert create-client --overwrite --certs-dir /zitadel-certs/ --ca-key /zitadel-certs/ca.key zitadel_user && chown -R 1000:1000 /zitadel-certs/"
     handle_request_command_status $? "init_crdb failed" ""
   fi
 }

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -471,7 +471,7 @@ initEnvironment() {
     ZDB=$(renderDockerComposePostgres)
     ZITADEL_DB_ENV=$(renderZitadelPostgresEnv)
     renderPostgresEnv > zdb.env
-  elif [[ $DATABASE == "cockroach" ]]; then
+  elif [[ $ZITADEL_DATABASE == "cockroach" ]]; then
     echo "Use CockroachDB as Zitadel database."
     ZDB=$(renderDockerComposeCockroachDB)
     ZITADEL_DB_ENV=$(renderZitadelCockroachDBEnv)


### PR DESCRIPTION
This PR replaces cockroachDB as default DB for Zitadel  in the getting started script to deploy script. Users can switch back to cockroachDB by setting the environment variable ```ZITADEL_DATABASE``` to ```cockroach```.

The PR fix some typos as well.

## Issue ticket number and link
- #1785 

### Checklist
- [x] Is it a bug fix
- [x] Is a feature enhancement
