### PR TITLE
Truncate DNS messages to the max 512 buffer size

### DIFF
--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -121,6 +121,8 @@ func (u *upstreamResolverBase) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 
 		log.Tracef("took %s to query the upstream %s", t, upstream)
 
+		rm.Truncate(512)
+
 		err = w.WriteMsg(rm)
 		if err != nil {
 			log.WithError(err).Error("got an error while writing the upstream resolver response")


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
