### PR TITLE
Remove DNSSEC parameters and configure AuthenticatedData

### DIFF
--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -78,9 +78,10 @@ func (u *upstreamResolverBase) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	}()
 
 	log.WithField("question", r.Question[0]).Trace("received an upstream question")
-	// set the EDNS0 buffer size to 4096 bytes to support larger dns records
+	// set the AuthenticatedData flag and the EDNS0 buffer size to 4096 bytes to support larger dns records
 	if r.Extra == nil {
-		r.SetEdns0(4096, true)
+		r.SetEdns0(4096, false)
+		r.MsgHdr.AuthenticatedData = true
 	}
 
 	select {


### PR DESCRIPTION
## Describe your changes
this fixes an issue introduced when we set the DNS query to request DNSSEC records on macOS. 

## Issue ticket number and link
fixes #2201
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
