### PR TITLE
add MACOSX_DEPLOYMENT_TARGET environment to control GUI build target

### DIFF
--- a/.goreleaser_ui_darwin.yaml
+++ b/.goreleaser_ui_darwin.yaml
@@ -3,7 +3,9 @@ builds:
   - id: netbird-ui-darwin
     dir: client/ui
     binary: netbird-ui
-    env: [CGO_ENABLED=1]
+    env:
+      - CGO_ENABLED=1
+      - CGO_CFLAGS=-mmacosx-version-min=11.0
 
     goos:
       - darwin

--- a/.goreleaser_ui_darwin.yaml
+++ b/.goreleaser_ui_darwin.yaml
@@ -5,8 +5,8 @@ builds:
     binary: netbird-ui
     env:
       - CGO_ENABLED=1
-      - CGO_CFLAGS=-mmacosx-version-min=11.0
-
+      - MACOSX_DEPLOYMENT_TARGET=11.0
+      - MACOS_DEPLOYMENT_TARGET=11.0
     goos:
       - darwin
     goarch:

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.5
+FROM alpine:3.19
 RUN apk add --no-cache ca-certificates iptables ip6tables
 ENV NB_FOREGROUND_MODE=true
 ENTRYPOINT [ "/usr/local/bin/netbird","up"]


### PR DESCRIPTION
## Describe your changes
Add MACOSX_DEPLOYMENT_TARGET and MACOS_DEPLOYMENT_TARGET to target build compatible with macOS 11+ instead of relying on the builder's local Xcode version.

## Issue ticket number and link
fixes #2218

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
