### PR TITLE
Optimize peer sync by skipping unchanged SyncResponses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/pion/transport/v3 v3.0.1
 	github.com/pion/turn/v3 v3.0.1
 	github.com/prometheus/client_golang v1.19.1
+	github.com/r3labs/diff v1.1.0
 	github.com/rs/xid v1.3.0
 	github.com/shirou/gopsutil/v3 v3.24.4
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966

--- a/go.sum
+++ b/go.sum
@@ -413,6 +413,8 @@ github.com/prometheus/common v0.53.0 h1:U2pL9w9nmJwJDa4qqLQ3ZaePJ6ZTwt7cMD3AG3+a
 github.com/prometheus/common v0.53.0/go.mod h1:BrxBKv3FWBIGXw89Mg1AeBq7FSyRzXWI3l3e7W3RN5U=
 github.com/prometheus/procfs v0.15.0 h1:A82kmvXJq2jTu5YUhSGNlYoxh85zLnKgPz4bMZgI5Ek=
 github.com/prometheus/procfs v0.15.0/go.mod h1:Y0RJ/Y5g5wJpkTisOtqwDSo4HwhGmLB4VQSw2sQJLHk=
+github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
+github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/cors v1.8.0 h1:P2KMzcFwrPoSjkF1WLRPsp3UMLyql8L4v9hQpVeK5so=

--- a/management/server/network.go
+++ b/management/server/network.go
@@ -40,9 +40,9 @@ type Network struct {
 	Dns        string
 	// Serial is an ID that increments by 1 when any change to the network happened (e.g. new peer has been added).
 	// Used to synchronize state to the client apps.
-	Serial uint64
+	Serial uint64 `diff:"-"`
 
-	mu sync.Mutex `json:"-" gorm:"-"`
+	mu sync.Mutex `json:"-" gorm:"-" diff:"-"`
 }
 
 // NewNetwork creates a new Network initializing it with a Serial=0

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -261,6 +261,8 @@ func (am *DefaultAccountManager) deletePeers(ctx context.Context, account *Accou
 						FirewallRulesIsEmpty: true,
 					},
 				},
+				NetworkMap: &NetworkMap{},
+				Checks:     []*posture.Checks{},
 			})
 		am.peersUpdateManager.CloseChannel(ctx, peer.ID)
 		am.StoreEvent(ctx, userID, peer.ID, account.Id, activity.PeerRemovedByUser, peer.EventMeta(am.GetDNSDomain()))
@@ -932,6 +934,6 @@ func (am *DefaultAccountManager) updateAccountPeers(ctx context.Context, account
 		postureChecks := am.getPeerPostureChecks(account, peer)
 		remotePeerNetworkMap := account.GetPeerNetworkMap(ctx, peer.ID, am.dnsDomain, approvedPeersMap)
 		update := toSyncResponse(ctx, nil, peer, nil, remotePeerNetworkMap, am.GetDNSDomain(), postureChecks)
-		am.peersUpdateManager.SendUpdate(ctx, peer.ID, &UpdateMessage{Update: update})
+		am.peersUpdateManager.SendUpdate(ctx, peer.ID, &UpdateMessage{Update: update, NetworkMap: remotePeerNetworkMap, Checks: postureChecks})
 	}
 }

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -18,35 +18,35 @@ type Peer struct {
 	// WireGuard public key
 	Key string `gorm:"index"`
 	// A setup key this peer was registered with
-	SetupKey string
+	SetupKey string `diff:"-"`
 	// IP address of the Peer
 	IP net.IP `gorm:"serializer:json"`
 	// Meta is a Peer system meta data
-	Meta PeerSystemMeta `gorm:"embedded;embeddedPrefix:meta_"`
+	Meta PeerSystemMeta `gorm:"embedded;embeddedPrefix:meta_" diff:"-"`
 	// Name is peer's name (machine name)
 	Name string
 	// DNSLabel is the parsed peer name for domain resolution. It is used to form an FQDN by appending the account's
 	// domain to the peer label. e.g. peer-dns-label.netbird.cloud
 	DNSLabel string
 	// Status peer's management connection status
-	Status *PeerStatus `gorm:"embedded;embeddedPrefix:peer_status_"`
+	Status *PeerStatus `gorm:"embedded;embeddedPrefix:peer_status_" diff:"-"`
 	// The user ID that registered the peer
-	UserID string
+	UserID string `diff:"-"`
 	// SSHKey is a public SSH key of the peer
 	SSHKey string
 	// SSHEnabled indicates whether SSH server is enabled on the peer
 	SSHEnabled bool
 	// LoginExpirationEnabled indicates whether peer's login expiration is enabled and once expired the peer has to re-login.
 	// Works with LastLogin
-	LoginExpirationEnabled bool
+	LoginExpirationEnabled bool `diff:"-"`
 	// LastLogin the time when peer performed last login operation
-	LastLogin time.Time
+	LastLogin time.Time `diff:"-"`
 	// CreatedAt records the time the peer was created
-	CreatedAt time.Time
+	CreatedAt time.Time `diff:"-"`
 	// Indicate ephemeral peer attribute
-	Ephemeral bool
+	Ephemeral bool `diff:"-"`
 	// Geo location based on connection IP
-	Location Location `gorm:"embedded;embeddedPrefix:location_"`
+	Location Location `gorm:"embedded;embeddedPrefix:location_" diff:"-"`
 }
 
 type PeerStatus struct { //nolint:revive


### PR DESCRIPTION
## Describe your changes

Optimizes the network update process by skipping sending peer updates where no changes in the peer update message received.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
