### PR TITLE
Support DNS routes on iOS

### DIFF
--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -16,6 +16,7 @@ import (
 	firewall "github.com/netbirdio/netbird/client/firewall/manager"
 	"github.com/netbirdio/netbird/client/internal/listener"
 	"github.com/netbirdio/netbird/client/internal/peer"
+	"github.com/netbirdio/netbird/client/internal/routemanager/notifier"
 	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
 	"github.com/netbirdio/netbird/client/internal/routemanager/systemops"
 	"github.com/netbirdio/netbird/client/internal/routemanager/vars"
@@ -50,7 +51,7 @@ type DefaultManager struct {
 	statusRecorder       *peer.Status
 	wgInterface          *iface.WGIface
 	pubKey               string
-	notifier             *notifier
+	notifier             *notifier.Notifier
 	routeRefCounter      *refcounter.RouteRefCounter
 	allowedIPsRefCounter *refcounter.AllowedIPsRefCounter
 	dnsRouteInterval     time.Duration
@@ -65,7 +66,8 @@ func NewManager(
 	initialRoutes []*route.Route,
 ) *DefaultManager {
 	mCTX, cancel := context.WithCancel(ctx)
-	sysOps := systemops.NewSysOps(wgInterface)
+	notifier := notifier.NewNotifier()
+	sysOps := systemops.NewSysOps(wgInterface, notifier)
 
 	dm := &DefaultManager{
 		ctx:              mCTX,
@@ -77,7 +79,7 @@ func NewManager(
 		statusRecorder:   statusRecorder,
 		wgInterface:      wgInterface,
 		pubKey:           pubKey,
-		notifier:         newNotifier(),
+		notifier:         notifier,
 	}
 
 	dm.routeRefCounter = refcounter.New(
@@ -107,7 +109,7 @@ func NewManager(
 
 	if runtime.GOOS == "android" {
 		cr := dm.clientRoutes(initialRoutes)
-		dm.notifier.setInitialClientRoutes(cr)
+		dm.notifier.SetInitialClientRoutes(cr)
 	}
 	return dm
 }
@@ -186,7 +188,7 @@ func (m *DefaultManager) UpdateRoutes(updateSerial uint64, newRoutes []*route.Ro
 
 		filteredClientRoutes := m.routeSelector.FilterSelected(newClientRoutesIDMap)
 		m.updateClientNetworks(updateSerial, filteredClientRoutes)
-		m.notifier.onNewRoutes(filteredClientRoutes)
+		m.notifier.OnNewRoutes(filteredClientRoutes)
 
 		if m.serverRouter != nil {
 			err := m.serverRouter.updateRoutes(newServerRoutesMap)
@@ -199,14 +201,14 @@ func (m *DefaultManager) UpdateRoutes(updateSerial uint64, newRoutes []*route.Ro
 	}
 }
 
-// SetRouteChangeListener set RouteListener for route change notifier
+// SetRouteChangeListener set RouteListener for route change Notifier
 func (m *DefaultManager) SetRouteChangeListener(listener listener.NetworkChangeListener) {
-	m.notifier.setListener(listener)
+	m.notifier.SetListener(listener)
 }
 
 // InitialRouteRange return the list of initial routes. It used by mobile systems
 func (m *DefaultManager) InitialRouteRange() []string {
-	return m.notifier.getInitialRouteRanges()
+	return m.notifier.GetInitialRouteRanges()
 }
 
 // GetRouteSelector returns the route selector
@@ -226,7 +228,7 @@ func (m *DefaultManager) TriggerSelection(networks route.HAMap) {
 
 	networks = m.routeSelector.FilterSelected(networks)
 
-	m.notifier.onNewRoutes(networks)
+	m.notifier.OnNewRoutes(networks)
 
 	m.stopObsoleteClients(networks)
 

--- a/client/internal/routemanager/systemops/systemops.go
+++ b/client/internal/routemanager/systemops/systemops.go
@@ -22,9 +22,9 @@ type SysOps struct {
 	wgInterface *iface.WGIface
 	// prefixes is tracking all the current added prefixes im memory
 	// (this is used in iOS as all route updates require a full table update)
-	//lint:ignore
+	//nolint
 	prefixes map[netip.Prefix]struct{}
-	//lint:ignore
+	//nolint
 	mu sync.Mutex
 	// notifier is used to notify the system of route changes (also used on mobile)
 	notifier *notifier.Notifier

--- a/client/internal/routemanager/systemops/systemops.go
+++ b/client/internal/routemanager/systemops/systemops.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/netip"
 
+	"github.com/netbirdio/netbird/client/internal/routemanager/notifier"
 	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
 	"github.com/netbirdio/netbird/iface"
 )
@@ -18,10 +19,17 @@ type ExclusionCounter = refcounter.Counter[any, Nexthop]
 type SysOps struct {
 	refCounter  *ExclusionCounter
 	wgInterface *iface.WGIface
+	// prefixes is tracking all the current added prefix im memory
+	// (this is used in iOS as all route updates require a full table update)
+	prefixes map[netip.Prefix]struct{}
+	// notifier is used to notify the system of route changes (also used on mobile)
+	notifier *notifier.Notifier
 }
 
-func NewSysOps(wgInterface *iface.WGIface) *SysOps {
+func NewSysOps(wgInterface *iface.WGIface, notifier *notifier.Notifier) *SysOps {
 	return &SysOps{
 		wgInterface: wgInterface,
+		prefixes:    make(map[netip.Prefix]struct{}),
+		notifier:    notifier,
 	}
 }

--- a/client/internal/routemanager/systemops/systemops.go
+++ b/client/internal/routemanager/systemops/systemops.go
@@ -22,8 +22,10 @@ type SysOps struct {
 	wgInterface *iface.WGIface
 	// prefixes is tracking all the current added prefixes im memory
 	// (this is used in iOS as all route updates require a full table update)
+	//lint:ignore
 	prefixes map[netip.Prefix]struct{}
-	mu       sync.Mutex
+	//lint:ignore
+	mu sync.Mutex
 	// notifier is used to notify the system of route changes (also used on mobile)
 	notifier *notifier.Notifier
 }

--- a/client/internal/routemanager/systemops/systemops.go
+++ b/client/internal/routemanager/systemops/systemops.go
@@ -19,7 +19,7 @@ type ExclusionCounter = refcounter.Counter[any, Nexthop]
 type SysOps struct {
 	refCounter  *ExclusionCounter
 	wgInterface *iface.WGIface
-	// prefixes is tracking all the current added prefix im memory
+	// prefixes is tracking all the current added prefixes im memory
 	// (this is used in iOS as all route updates require a full table update)
 	prefixes map[netip.Prefix]struct{}
 	// notifier is used to notify the system of route changes (also used on mobile)

--- a/client/internal/routemanager/systemops/systemops.go
+++ b/client/internal/routemanager/systemops/systemops.go
@@ -3,6 +3,7 @@ package systemops
 import (
 	"net"
 	"net/netip"
+	"sync"
 
 	"github.com/netbirdio/netbird/client/internal/routemanager/notifier"
 	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
@@ -22,6 +23,7 @@ type SysOps struct {
 	// prefixes is tracking all the current added prefixes im memory
 	// (this is used in iOS as all route updates require a full table update)
 	prefixes map[netip.Prefix]struct{}
+	mu       sync.Mutex
 	// notifier is used to notify the system of route changes (also used on mobile)
 	notifier *notifier.Notifier
 }
@@ -29,7 +31,6 @@ type SysOps struct {
 func NewSysOps(wgInterface *iface.WGIface, notifier *notifier.Notifier) *SysOps {
 	return &SysOps{
 		wgInterface: wgInterface,
-		prefixes:    make(map[netip.Prefix]struct{}),
 		notifier:    notifier,
 	}
 }

--- a/client/internal/routemanager/systemops/systemops_android.go
+++ b/client/internal/routemanager/systemops/systemops_android.go
@@ -1,4 +1,4 @@
-//go:build ios || android
+//go:build android
 
 package systemops
 

--- a/client/internal/routemanager/systemops/systemops_bsd_test.go
+++ b/client/internal/routemanager/systemops/systemops_bsd_test.go
@@ -36,7 +36,7 @@ func TestConcurrentRoutes(t *testing.T) {
 	baseIP := netip.MustParseAddr("192.0.2.0")
 	intf := &net.Interface{Name: "lo0"}
 
-	r := NewSysOps(nil)
+	r := NewSysOps(nil, nil)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 1024; i++ {

--- a/client/internal/routemanager/systemops/systemops_generic_test.go
+++ b/client/internal/routemanager/systemops/systemops_generic_test.go
@@ -68,7 +68,7 @@ func TestAddRemoveRoutes(t *testing.T) {
 			err = wgInterface.Create()
 			require.NoError(t, err, "should create testing wireguard interface")
 
-			r := NewSysOps(wgInterface)
+			r := NewSysOps(wgInterface, nil)
 
 			_, _, err = r.SetupRouting(nil)
 			require.NoError(t, err)
@@ -224,7 +224,7 @@ func TestAddExistAndRemoveRoute(t *testing.T) {
 			require.NoError(t, err, "InterfaceByName should not return err")
 			intf := &net.Interface{Index: index.Index, Name: wgInterface.Name()}
 
-			r := NewSysOps(wgInterface)
+			r := NewSysOps(wgInterface, nil)
 
 			// Prepare the environment
 			if testCase.preExistingPrefix.IsValid() {
@@ -379,7 +379,7 @@ func setupTestEnv(t *testing.T) {
 		assert.NoError(t, wgInterface.Close())
 	})
 
-	r := NewSysOps(wgInterface)
+	r := NewSysOps(wgInterface, nil)
 	_, _, err := r.SetupRouting(nil)
 	require.NoError(t, err, "setupRouting should not return err")
 	t.Cleanup(func() {

--- a/client/internal/routemanager/systemops/systemops_ios.go
+++ b/client/internal/routemanager/systemops/systemops_ios.go
@@ -1,0 +1,52 @@
+//go:build ios
+
+package systemops
+
+import (
+	"net"
+	"net/netip"
+	"runtime"
+
+	log "github.com/sirupsen/logrus"
+
+	nbnet "github.com/netbirdio/netbird/util/net"
+)
+
+func (r *SysOps) SetupRouting([]net.IP) (nbnet.AddHookFunc, nbnet.RemoveHookFunc, error) {
+	return nil, nil, nil
+}
+
+func (r *SysOps) CleanupRouting() error {
+	r.prefixes = make(map[netip.Prefix]struct{})
+	r.notify()
+	return nil
+}
+
+func (r *SysOps) AddVPNRoute(prefix netip.Prefix, _ *net.Interface) error {
+	r.prefixes[prefix] = struct{}{}
+	r.notify()
+	return nil
+}
+
+func (r *SysOps) RemoveVPNRoute(prefix netip.Prefix, _ *net.Interface) error {
+	delete(r.prefixes, prefix)
+	r.notify()
+	return nil
+}
+
+func EnableIPForwarding() error {
+	log.Infof("Enable IP forwarding is not implemented on %s", runtime.GOOS)
+	return nil
+}
+
+func IsAddrRouted(netip.Addr, []netip.Prefix) (bool, netip.Prefix) {
+	return false, netip.Prefix{}
+}
+
+func (r *SysOps) notify() {
+	prefixes := make([]netip.Prefix, 0, len(r.prefixes))
+	for prefix := range r.prefixes {
+		prefixes = append(prefixes, prefix)
+	}
+	r.notifier.OnNewPrefixes(prefixes)
+}

--- a/client/internal/routemanager/systemops/systemops_ios.go
+++ b/client/internal/routemanager/systemops/systemops_ios.go
@@ -56,9 +56,6 @@ func IsAddrRouted(netip.Addr, []netip.Prefix) (bool, netip.Prefix) {
 }
 
 func (r *SysOps) notify() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	prefixes := make([]netip.Prefix, 0, len(r.prefixes))
 	for prefix := range r.prefixes {
 		prefixes = append(prefixes, prefix)

--- a/client/ios/NetBirdSDK/routes.go
+++ b/client/ios/NetBirdSDK/routes.go
@@ -16,7 +16,23 @@ type RoutesSelectionDetails struct {
 type RoutesSelectionInfo struct {
 	ID       string
 	Network  string
+	Domains  *DomainDetails
 	Selected bool
+}
+
+type DomainCollection interface {
+	Add(s DomainInfo) DomainCollection
+	Get(i int) *DomainInfo
+	Size() int
+}
+
+type DomainDetails struct {
+	items []DomainInfo
+}
+
+type DomainInfo struct {
+	Domain      string
+	ResolvedIPs string
 }
 
 // Add new PeerInfo to the collection
@@ -32,5 +48,18 @@ func (array RoutesSelectionDetails) Get(i int) *RoutesSelectionInfo {
 
 // Size return with the size of the collection
 func (array RoutesSelectionDetails) Size() int {
+	return len(array.items)
+}
+
+func (array DomainDetails) Add(s DomainInfo) DomainCollection {
+	array.items = append(array.items, s)
+	return array
+}
+
+func (array DomainDetails) Get(i int) *DomainInfo {
+	return &array.items[i]
+}
+
+func (array DomainDetails) Size() int {
 	return len(array.items)
 }

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -44,9 +44,8 @@ const (
 
 // Server for service control.
 type Server struct {
-	rootCtx       context.Context
-	actCancel     context.CancelFunc
-	engineRunning bool
+	rootCtx   context.Context
+	actCancel context.CancelFunc
 
 	latestConfigInput internal.ConfigInput
 
@@ -160,10 +159,6 @@ func (s *Server) connectWithRetryRuns(ctx context.Context, config *internal.Conf
 	backOff := getConnectWithBackoff(ctx)
 	retryStarted := false
 
-	if s.engineRunning {
-		return
-	}
-
 	go func() {
 		t := time.NewTicker(24 * time.Hour)
 		for {
@@ -189,7 +184,6 @@ func (s *Server) connectWithRetryRuns(ctx context.Context, config *internal.Conf
 
 	runOperation := func() error {
 		log.Tracef("running client connection")
-		s.engineRunning = true
 		s.connectClient = internal.NewConnectClient(ctx, config, statusRecorder)
 		err := s.connectClient.RunWithProbes(mgmProbe, signalProbe, relayProbe, wgProbe)
 		if err != nil {
@@ -546,10 +540,6 @@ func (s *Server) Up(callerCtx context.Context, _ *proto.UpRequest) (*proto.UpRes
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if s.engineRunning {
-		return nil, fmt.Errorf("service is already up")
-	}
-
 	state := internal.CtxGetState(s.rootCtx)
 
 	// if current state contains any error, return it
@@ -586,10 +576,7 @@ func (s *Server) Up(callerCtx context.Context, _ *proto.UpRequest) (*proto.UpRes
 	s.statusRecorder.UpdateManagementAddress(s.config.ManagementURL.String())
 	s.statusRecorder.UpdateRosenpass(s.config.RosenpassEnabled, s.config.RosenpassPermissive)
 
-	go func() {
-		s.connectWithRetryRuns(ctx, s.config, s.statusRecorder, s.mgmProbe, s.signalProbe, s.relayProbe, s.wgProbe)
-		s.engineRunning = false
-	}()
+	go s.connectWithRetryRuns(ctx, s.config, s.statusRecorder, s.mgmProbe, s.signalProbe, s.relayProbe, s.wgProbe)
 
 	return &proto.UpResponse{}, nil
 }
@@ -599,16 +586,12 @@ func (s *Server) Down(_ context.Context, _ *proto.DownRequest) (*proto.DownRespo
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	s.connectClient = nil
-
 	if s.actCancel == nil {
 		return nil, fmt.Errorf("service is not up")
 	}
 	s.actCancel()
 	state := internal.CtxGetState(s.rootCtx)
 	state.Set(internal.StatusIdle)
-
-	s.engineRunning = false
 
 	return &proto.DownResponse{}, nil
 }


### PR DESCRIPTION
## Describe your changes
This PR adds support for exit nodes on iOS. It includes a small refactor to move the mobile notifier into the systemops and keep an in-memory map off all routes so that we can reuse the same logic for routing than on the desktop clients. It updates the route selection to show the domain names and the resolved IPs in the UI.


## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
