### PR TITLE
Support custom SSL certificates for the signal service

### DIFF
--- a/signal/README.md
+++ b/signal/README.md
@@ -18,6 +18,8 @@ Flags:
       --letsencrypt-domain string   a domain to issue Let's Encrypt certificate for. Enables TLS using Let's Encrypt. Will fetch and renew certificate, and run the server with TLS
       --port int                    Server port to listen on (e.g. 10000) (default 10000)
       --ssl-dir string              server ssl directory location. *Required only for Let's Encrypt certificates. (default "/var/lib/netbird/")
+      --cert-file string            Location of your SSL certificate. Can be used when you have an existing certificate and don't want a new certificate be generated automatically. If letsencrypt-domain is specified this property has no effect
+      --cert-key string             Location of your SSL certificate private key. Can be used when you have an existing certificate and don't want a new certificate be generated automatically. If letsencrypt-domain is specified this property has no effect
 
 Global Flags:
       --log-file string    sets Netbird log path. If console is specified the the log will be output to stdout (default "/var/log/netbird/signal.log")

--- a/signal/cmd/run.go
+++ b/signal/cmd/run.go
@@ -156,41 +156,7 @@ var (
 					// Start the HTTP cert manager server separately
 					serveHTTP(httpListener, certManager.HTTPHandler(nil))
 					log.Infof("running HTTP server (LetsEncrypt challenge handler): %s", httpListener.Addr().String())
-					// grpcListener, err = tls.Listen("tcp", fmt.Sprintf(":%d", signalPort), certManager.TLSConfig())
-					// if err != nil {
-					// 	return fmt.Errorf("failed creating TLS gRPC listener on port %d: %v", signalPort, err)
-					// }
-					// // The Signal gRPC server was running on port 10000 previously. Old agents that are already connected to Signal
-					// // are using port 10000. For compatibility purposes we keep running a 2nd gRPC server on port 10000.
-					// if signalPort != 10000 {
-					// 	compatListener, err = tls.Listen("tcp", fmt.Sprintf(":%d", 10000), tlsConfig)
-					// 	if err != nil {
-					// 		return err
-					// 	}
-					// }
 				}
-			// } else if tlsConfig != nil {
-			// 	grpcListener, err = tls.Listen("tcp", fmt.Sprintf(":%d", signalPort), tlsConfig)
-			// 	if err != nil {
-			// 		return fmt.Errorf("failed creating TLS gRPC listener on port %d: %v", signalPort, err)
-			// 	}
-			// 	if signalPort != 10000 {
-			// 		compatListener, err = tls.Listen("tcp", fmt.Sprintf(":%d", 10000), tlsConfig)
-			// 		if err != nil {
-			// 			return err
-			// 		}
-			// 	}
-			// } else {
-			// 	grpcListener, err = net.Listen("tcp", fmt.Sprintf(":%d", signalPort))
-			// 	if err != nil {
-			// 		return fmt.Errorf("failed creating gRPC listener on port %d: %v", signalPort, err)
-			// 	}
-			// 	if signalPort != 10000 {
-			// 		compatListener, err = net.Listen("tcp", fmt.Sprintf(":%d", 10000))
-			// 		if err != nil {
-			// 			return err
-			// 		}
-			// 	}
 			}
 
 			// If certManager is configured and signalPort == 443, then the gRPC server has already been started
@@ -273,14 +239,6 @@ func serveHTTP(httpListener net.Listener, handler http.Handler) {
 	}()
 }
 
-// func serveGRPC(grpcListener net.Listener, grpcServer *grpc.Server) {
-// 	go func() {
-// 		err := grpcServer.Serve(grpcListener)
-// 		if err != nil {
-// 			notifyStop(fmt.Sprintf("failed running gRPC server %v", err))
-// 		}
-// 	}()
-// }
 func serveGRPC(grpcServer *grpc.Server, port int) (net.Listener, error) {
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {

--- a/signal/cmd/run.go
+++ b/signal/cmd/run.go
@@ -140,7 +140,7 @@ var (
 			}
 			proto.RegisterSignalExchangeServer(grpcServer, srv)
 
-            grpcRootHandler := grpcHandlerFunc(grpcServer)
+			grpcRootHandler := grpcHandlerFunc(grpcServer)
 			var compatListener net.Listener
 			var grpcListener net.Listener
 			var httpListener net.Listener

--- a/signal/cmd/run.go
+++ b/signal/cmd/run.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"context"
- 	"crypto/tls"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
@@ -153,7 +153,7 @@ var (
 				} else {
 					serveHTTP(httpListener, certManager.HTTPHandler(nil))
 					log.Infof("running HTTP server (LetsEncrypt challenge handler): %s", httpListener.Addr().String())
-					grpcListener = tls.Listen("tcp", fmt.Sprintf(":%d", signalPort), certManager.TLSConfig())
+					grpcListener, err = tls.Listen("tcp", fmt.Sprintf(":%d", signalPort), certManager.TLSConfig())
 					if err != nil {
 						return fmt.Errorf("failed creating TLS gRPC listener on port %d: %v", signalPort, err)
 					}
@@ -176,7 +176,7 @@ var (
 					}
 				}
 			} else {
-				grpcListener, err := net.Listen("tcp", fmt.Sprintf(":%d", signalPort))
+				grpcListener, err = net.Listen("tcp", fmt.Sprintf(":%d", signalPort))
 				if err != nil {
 					return fmt.Errorf("failed creating gRPC listener on port %d: %v", signalPort, err)
 				}


### PR DESCRIPTION
## Describe your changes
This PR adds the ability to provide custom SSL certificates to the signal service. Most of the code was adapted from [management/cmd/management.go](https://github.com/netbirdio/netbird/blob/e8c2fafccd9ebb649a3d15f1b361e09bb2b61639/management/cmd/management.go) since it already offers the functionality I was looking to implement.

Two flags have been added, `--cert-file` and `--cert-key`, which accept a string pointing to a file path for the SSL certificate and key. When `--letsencrypt-domain` is set, these options are ignored.

This is my first try at go, so please let me know if anything needs refactored and fixed!
 
## Issue ticket number and link
Along with https://github.com/netbirdio/dashboard/pull/399, closes #2242
### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] Extended the README / documentation, if necessary