### PR TITLE
Don't add exclusion routes for IPs that are part of connected networks

### DIFF
--- a/client/internal/routemanager/systemops/systemops_generic.go
+++ b/client/internal/routemanager/systemops/systemops_generic.go
@@ -50,7 +50,7 @@ func (r *SysOps) setupRefCounter(initAddresses []net.IP) (nbnet.AddHookFunc, nbn
 			nexthop, err := r.addRouteToNonVPNIntf(prefix, r.wgInterface, initialNexthop)
 			if errors.Is(err, vars.ErrRouteNotAllowed) || errors.Is(err, vars.ErrRouteNotFound) {
 				log.Tracef("Adding for prefix %s: %v", prefix, err)
-				// These errors are not critical but also we should not track and try to remove the routes either.
+				// These errors are not critical, but also we should not track and try to remove the routes either.
 				return nexthop, refcounter.ErrIgnore
 			}
 			return nexthop, err
@@ -135,6 +135,11 @@ func (r *SysOps) addRouteToNonVPNIntf(prefix netip.Prefix, vpnIntf *iface.WGIfac
 		return Nexthop{}, vars.ErrRouteNotAllowed
 	}
 
+	// Check if the prefix is part of any local subnets
+	if isLocal, subnet := r.isPrefixInLocalSubnets(prefix); isLocal {
+		return Nexthop{}, fmt.Errorf("prefix %s is part of local subnet %s: %v", prefix, subnet, vars.ErrRouteNotAllowed)
+	}
+
 	// Determine the exit interface and next hop for the prefix, so we can add a specific route
 	nexthop, err := GetNextHop(addr)
 	if err != nil {
@@ -165,6 +170,36 @@ func (r *SysOps) addRouteToNonVPNIntf(prefix netip.Prefix, vpnIntf *iface.WGIfac
 	}
 
 	return exitNextHop, nil
+}
+
+func (r *SysOps) isPrefixInLocalSubnets(prefix netip.Prefix) (bool, *net.IPNet) {
+	localInterfaces, err := net.Interfaces()
+	if err != nil {
+		log.Errorf("Failed to get local interfaces: %v", err)
+		return false, nil
+	}
+
+	for _, intf := range localInterfaces {
+		addrs, err := intf.Addrs()
+		if err != nil {
+			log.Errorf("Failed to get addresses for interface %s: %v", intf.Name, err)
+			continue
+		}
+
+		for _, addr := range addrs {
+			ipnet, ok := addr.(*net.IPNet)
+			if !ok {
+				log.Errorf("Failed to convert address to IPNet: %v", addr)
+				continue
+			}
+
+			if ipnet.Contains(prefix.Addr().AsSlice()) {
+				return true, ipnet
+			}
+		}
+	}
+
+	return false, nil
 }
 
 // genericAddVPNRoute adds a new route to the vpn interface, it splits the default prefix

--- a/client/internal/routemanager/systemops/systemops_generic.go
+++ b/client/internal/routemanager/systemops/systemops_generic.go
@@ -137,7 +137,7 @@ func (r *SysOps) addRouteToNonVPNIntf(prefix netip.Prefix, vpnIntf *iface.WGIfac
 
 	// Check if the prefix is part of any local subnets
 	if isLocal, subnet := r.isPrefixInLocalSubnets(prefix); isLocal {
-		return Nexthop{}, fmt.Errorf("prefix %s is part of local subnet %s: %v", prefix, subnet, vars.ErrRouteNotAllowed)
+		return Nexthop{}, fmt.Errorf("prefix %s is part of local subnet %s: %w", prefix, subnet, vars.ErrRouteNotAllowed)
 	}
 
 	// Determine the exit interface and next hop for the prefix, so we can add a specific route


### PR DESCRIPTION
When adding a host route for a peer's IP address that belongs to a connected network, macOS may stop using ARP/NDP to resolve the IP address. This will lead to unreachability of the targeted IP. 


## Describe your changes
This PR prevents adding exclusion routes for connected networks.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
