### PR TITLE
fix: save peer status correctly in sqlstore

### DIFF
--- a/management/server/sql_store.go
+++ b/management/server/sql_store.go
@@ -274,9 +274,23 @@ func (s *SqlStore) GetInstallationID() string {
 func (s *SqlStore) SavePeerStatus(accountID, peerID string, peerStatus nbpeer.PeerStatus) error {
 	var peerCopy nbpeer.Peer
 	peerCopy.Status = &peerStatus
+
+	peerStatusJson, err := json.Marshal(peerCopy.Status)
+	if err != nil {
+		log.Errorf("cannot marshal peer %s status", peerID)
+		return err
+	}
+
+	parsedPeerStatus := make(map[string]interface{})
+	err = json.Unmarshal(peerStatusJson, &parsedPeerStatus)
+	if err != nil {
+		log.Errorf("cannot unmarshal peer %s status", peerID)
+		return err
+	}
+
 	result := s.db.Model(&nbpeer.Peer{}).
 		Where("account_id = ? AND id = ?", accountID, peerID).
-		Updates(peerCopy)
+		Updates(parsedPeerStatus)
 
 	if result.Error != nil {
 		return result.Error

--- a/management/server/sql_store.go
+++ b/management/server/sql_store.go
@@ -275,23 +275,14 @@ func (s *SqlStore) SavePeerStatus(accountID, peerID string, peerStatus nbpeer.Pe
 	var peerCopy nbpeer.Peer
 	peerCopy.Status = &peerStatus
 
-	peerStatusJson, err := json.Marshal(peerCopy.Status)
-	if err != nil {
-		log.Errorf("cannot marshal peer %s status", peerID)
-		return err
+	fieldsToUpdate := []string{
+		"peer_status_last_seen", "peer_status_connected",
+		"peer_status_login_expired", "peer_status_required_approval",
 	}
-
-	parsedPeerStatus := make(map[string]interface{})
-	err = json.Unmarshal(peerStatusJson, &parsedPeerStatus)
-	if err != nil {
-		log.Errorf("cannot unmarshal peer %s status", peerID)
-		return err
-	}
-
 	result := s.db.Model(&nbpeer.Peer{}).
+		Select(fieldsToUpdate).
 		Where("account_id = ? AND id = ?", accountID, peerID).
-		Updates(parsedPeerStatus)
-
+		Updates(&peerCopy)
 	if result.Error != nil {
 		return result.Error
 	}

--- a/management/server/sql_store_test.go
+++ b/management/server/sql_store_test.go
@@ -362,7 +362,7 @@ func TestSqlite_SavePeerStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	// save status of non-existing peer
-	newStatus := nbpeer.PeerStatus{Connected: true, LastSeen: time.Now().UTC()}
+	newStatus := nbpeer.PeerStatus{Connected: false, LastSeen: time.Now().UTC()}
 	err = store.SavePeerStatus(account.Id, "non-existing-peer", newStatus)
 	assert.Error(t, err)
 	parsedErr, ok := status.FromError(err)
@@ -377,7 +377,7 @@ func TestSqlite_SavePeerStatus(t *testing.T) {
 		IP:       net.IP{127, 0, 0, 1},
 		Meta:     nbpeer.PeerSystemMeta{},
 		Name:     "peer name",
-		Status:   &nbpeer.PeerStatus{Connected: false, LastSeen: time.Now().UTC()},
+		Status:   &nbpeer.PeerStatus{Connected: true, LastSeen: time.Now().UTC()},
 	}
 
 	err = store.SaveAccount(context.Background(), account)


### PR DESCRIPTION
## Describe your changes
This change fixes an inconsistency between the value of the boolean fields in the peer status struct, and those same values in the db table.

The problem should be in how the fields get updated in the `SavePeerStatus` function in the `management/server/sql_store.go` file, particularly because of how GORM manages the update itself. There's an [explanation on the GORM documentation](https://gorm.io/docs/update.html#Updates-multiple-columns) on why this happens.

This could be an issue for other boolean fields updates as well.

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/2110

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
