### PR TITLE
fix 2260: fallback serial to Board

### DIFF
--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -89,9 +90,17 @@ func _getInfo() string {
 func sysInfo() (serialNumber string, productName string, manufacturer string) {
 	var si sysinfo.SysInfo
 	si.GetSysInfo()
+	isascii := regexp.MustCompile("^[[:ascii:]]+$")
 	serial := si.Chassis.Serial
 	if (serial == "Default string" || serial == "") && si.Product.Serial != "" {
 		serial = si.Product.Serial
 	}
-	return serial, si.Product.Name, si.Product.Vendor
+	if (!isascii.MatchString(serial)) && si.Board.Serial != "" {
+		serial = si.Board.Serial
+	}
+	name := si.Product.Name
+	if (!isascii.MatchString(name)) && si.Board.Name != "" {
+		name = si.Board.Name
+	}
+	return serial, name, si.Product.Vendor
 }


### PR DESCRIPTION
## Describe your changes
My device does not have any serial, this patch fallbacks to board serial to avoid marshall error during message encryption
note: this patch is arguable, I should also check that Board has a valid serial

my case is this one:
```bash
# cat /sys/class/dmi/id/chassis_serial
���������������������������������
# cat /sys/class/dmi/id/product_serial
���������������������������������
# cat /sys/class/dmi/id/board_serial
GETY419003GB

# cat /sys/class/dmi/id/product_name
���������������������������������
# cat /sys/class/dmi/id/board_name
DE3815TYKH
```

## Issue ticket number and link
fix https://github.com/netbirdio/netbird/issues/2260

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
