### PR TITLE
Wait on daemon down

### DIFF
--- a/client/cmd/down.go
+++ b/client/cmd/down.go
@@ -26,7 +26,7 @@ var downCmd = &cobra.Command{
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*7)
 		defer cancel()
 
 		conn, err := DialClientGRPCServer(ctx, daemonAddr)

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -266,8 +266,22 @@ func (e *Engine) Stop() error {
 
 	e.close()
 	e.wgConnWorker.Wait()
-	log.Infof("stopped Netbird Engine")
-	return nil
+
+	maxWaitTime := 5 * time.Second
+	startTime := time.Now()
+
+	for {
+		if !e.IsWGIfaceUp() {
+			log.Infof("stopped Netbird Engine")
+			return nil
+		}
+
+		if time.Since(startTime) > maxWaitTime {
+			return fmt.Errorf("timeout when waiting for interface shutdown")
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 // Start creates a new WireGuard tunnel interface and listens to events from Signal and Management services

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1543,7 +1543,6 @@ func (e *Engine) IsWGIfaceUp() bool {
 		return false
 	}
 
-	// Check if the interface is up
 	if iface.Flags&net.FlagUp != 0 {
 		return true
 	}

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1533,3 +1533,20 @@ func isChecksEqual(checks []*mgmProto.Checks, oChecks []*mgmProto.Checks) bool {
 		return slices.Equal(checks.Files, oChecks.Files)
 	})
 }
+
+func (e *Engine) IsWGIfaceUp() bool {
+	if e == nil || e.wgInterface == nil {
+		return false
+	}
+	iface, err := net.InterfaceByName(e.wgInterface.Name())
+	if err != nil {
+		return false
+	}
+
+	// Check if the interface is up
+	if iface.Flags&net.FlagUp != 0 {
+		return true
+	}
+
+	return false
+}

--- a/client/internal/networkmonitor/monitor_bsd.go
+++ b/client/internal/networkmonitor/monitor_bsd.go
@@ -43,8 +43,10 @@ func checkChange(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop, ca
 		default:
 			buf := make([]byte, 2048)
 			n, err := unix.Read(fd, buf)
-			if err != nil && !errors.Is(err, unix.EBADF) && !errors.Is(err, unix.EINVAL) {
-				log.Errorf("Network monitor: failed to read from routing socket: %v", err)
+			if err != nil {
+				if !errors.Is(err, unix.EBADF) && !errors.Is(err, unix.EINVAL) {
+					log.Errorf("Network monitor: failed to read from routing socket: %v", err)
+				}
 				continue
 			}
 			if n < unix.SizeofRtMsghdr {

--- a/client/internal/networkmonitor/monitor_bsd.go
+++ b/client/internal/networkmonitor/monitor_bsd.go
@@ -4,6 +4,7 @@ package networkmonitor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"syscall"
 	"unsafe"

--- a/client/internal/networkmonitor/monitor_bsd.go
+++ b/client/internal/networkmonitor/monitor_bsd.go
@@ -20,22 +20,19 @@ func checkChange(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop, ca
 	if err != nil {
 		return fmt.Errorf("failed to open routing socket: %v", err)
 	}
-	fdClosed := false
 	defer func() {
-		if fdClosed {
-			return
-		}
-		if err := unix.Close(fd); err != nil {
+		err := unix.Close(fd)
+		if err != nil && !errors.Is(err, unix.EBADF) {
 			log.Errorf("Network monitor: failed to close routing socket: %v", err)
 		}
 	}()
 
 	go func() {
 		<-ctx.Done()
-		if err := unix.Close(fd); err == nil {
+		err := unix.Close(fd)
+		if err != nil && !errors.Is(err, unix.EBADF) {
 			log.Debugf("Network monitor: closed routing socket")
 		}
-		fdClosed = true
 	}()
 
 	for {
@@ -45,10 +42,8 @@ func checkChange(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop, ca
 		default:
 			buf := make([]byte, 2048)
 			n, err := unix.Read(fd, buf)
-			if err != nil {
-				if !fdClosed {
-					log.Errorf("Network monitor: failed to read from routing socket: %v", err)
-				}
+			if err != nil && !errors.Is(err, unix.EBADF) && !errors.Is(err, unix.EINVAL) {
+				log.Errorf("Network monitor: failed to read from routing socket: %v", err)
 				continue
 			}
 			if n < unix.SizeofRtMsghdr {

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -611,7 +611,6 @@ func (s *Server) Down(ctx context.Context, _ *proto.DownRequest) (*proto.DownRes
 				return nil, fmt.Errorf("failed to shut down properly")
 			}
 
-			// Wait a short period before checking again to avoid busy waiting
 			time.Sleep(100 * time.Millisecond)
 		}
 	}

--- a/signal/client/grpc.go
+++ b/signal/client/grpc.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"sync"
@@ -14,9 +13,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
@@ -67,36 +63,16 @@ func NewClient(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled boo
 	var conn *grpc.ClientConn
 
 	operation := func() error {
-		transportOption := grpc.WithTransportCredentials(insecure.NewCredentials())
-
-		if tlsEnabled {
-			transportOption = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
-		}
-
-		sigCtx, cancel := context.WithTimeout(context.Background(), client.ConnectTimeout)
-		defer cancel()
-
 		var err error
-		conn, err = grpc.DialContext(
-			sigCtx,
-			addr,
-			transportOption,
-			nbgrpc.WithCustomDialer(),
-			grpc.WithBlock(),
-			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Time:    30 * time.Second,
-				Timeout: 10 * time.Second,
-			}),
-		)
+		conn, err = nbgrpc.CreateConnection(addr, tlsEnabled)
 		if err != nil {
-			log.Printf("DialContext error: %v", err)
+			log.Printf("createConnection error: %v", err)
 			return err
 		}
-
 		return nil
 	}
 
-	err := backoff.Retry(operation, grpcDialBackoff(ctx))
+	err := backoff.Retry(operation, nbgrpc.Backoff(ctx))
 	if err != nil {
 		log.Errorf("failed to connect to the signalling server: %v", err)
 		return nil, err
@@ -133,14 +109,6 @@ func defaultBackoff(ctx context.Context) backoff.BackOff {
 		Stop:                backoff.Stop,
 		Clock:               backoff.SystemClock,
 	}, ctx)
-}
-
-// grpcDialBackoff is the backoff mechanism for the grpc calls
-func grpcDialBackoff(ctx context.Context) backoff.BackOff {
-	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = 10 * time.Second
-	b.Clock = backoff.SystemClock
-	return backoff.WithContext(b, ctx)
 }
 
 // Receive Connects to the Signal Exchange message stream and starts receiving messages.

--- a/signal/client/grpc.go
+++ b/signal/client/grpc.go
@@ -96,7 +96,7 @@ func NewClient(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled boo
 		return nil
 	}
 
-	err := backoff.Retry(operation, defaultBackoff(ctx))
+	err := backoff.Retry(operation, grpcDialBackoff(ctx))
 	if err != nil {
 		log.Errorf("failed to connect to the signalling server: %v", err)
 		return nil, err
@@ -133,6 +133,14 @@ func defaultBackoff(ctx context.Context) backoff.BackOff {
 		Stop:                backoff.Stop,
 		Clock:               backoff.SystemClock,
 	}, ctx)
+}
+
+// grpcDialBackoff is the backoff mechanism for the grpc calls
+func grpcDialBackoff(ctx context.Context) backoff.BackOff {
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = 10 * time.Second
+	b.Clock = backoff.SystemClock
+	return backoff.WithContext(b, ctx)
 }
 
 // Receive Connects to the Signal Exchange message stream and starts receiving messages.

--- a/util/grpc/dialer.go
+++ b/util/grpc/dialer.go
@@ -2,12 +2,18 @@ package grpc
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"os/user"
 	"runtime"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 
 	nbnet "github.com/netbirdio/netbird/util/net"
 )
@@ -34,4 +40,41 @@ func WithCustomDialer() grpc.DialOption {
 		}
 		return conn, nil
 	})
+}
+
+// grpcDialBackoff is the backoff mechanism for the grpc calls
+func Backoff(ctx context.Context) backoff.BackOff {
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = 10 * time.Second
+	b.Clock = backoff.SystemClock
+	return backoff.WithContext(b, ctx)
+}
+
+func CreateConnection(addr string, tlsEnabled bool) (*grpc.ClientConn, error) {
+	transportOption := grpc.WithTransportCredentials(insecure.NewCredentials())
+
+	if tlsEnabled {
+		transportOption = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
+	}
+
+	connCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := grpc.DialContext(
+		connCtx,
+		addr,
+		transportOption,
+		WithCustomDialer(),
+		grpc.WithBlock(),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    30 * time.Second,
+			Timeout: 10 * time.Second,
+		}),
+	)
+	if err != nil {
+		log.Printf("DialContext error: %v", err)
+		return nil, err
+	}
+
+	return conn, nil
 }


### PR DESCRIPTION
## Describe your changes
This PR awaits the engine shutdown before sending the confirmation back to the cli. It also fixes an issue where there was a race condition when running multiple up and down commands in sequence.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
