### PR TITLE
Check if route interface is a Microsoft ISATAP device

### DIFF
--- a/client/internal/networkmonitor/monitor_windows.go
+++ b/client/internal/networkmonitor/monitor_windows.go
@@ -232,14 +232,20 @@ func stateFromInt(state uint8) string {
 }
 
 func compareIntf(a, b *net.Interface) int {
-	if a == nil && b == nil {
+	switch {
+	case a == nil && b == nil:
 		return 0
-	}
-	if a == nil {
+	case a == nil:
 		return -1
-	}
-	if b == nil {
+	case b == nil:
 		return 1
+	case isIsatapInterface(a.Name) && isIsatapInterface(b.Name):
+		return 0
+	default:
+		return a.Index - b.Index
 	}
-	return a.Index - b.Index
+}
+
+func isIsatapInterface(name string) bool {
+	return strings.HasPrefix(strings.ToLower(name), "isatap")
 }


### PR DESCRIPTION

## Describe your changes
check if the nexthop interfaces are Microsoft ISATAP devices and ignore their suffixes when comparing them

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
