### PR TITLE
fix(util): syslog output contains duplicated timestamp

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.go]
+indent_style = tab

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLogMessageFormat(t *testing.T) {
+func TestLogTextFormat(t *testing.T) {
 
 	someEntry := &logrus.Entry{
 		Data:    logrus.Fields{"att1": 1, "att2": 2, "source": "some/fancy/path.go:46"},
@@ -22,5 +22,22 @@ func TestLogMessageFormat(t *testing.T) {
 
 	parsedString := string(result)
 	expectedString := "^2021-02-21T01:10:30Z WARN \\[(att1: 1, att2: 2|att2: 2, att1: 1)\\] some/fancy/path.go:46: Some Message\\s+$"
+	assert.Regexp(t, expectedString, parsedString)
+}
+
+func TestLogSyslogFormat(t *testing.T) {
+
+	someEntry := &logrus.Entry{
+		Data:    logrus.Fields{"att1": 1, "att2": 2, "source": "some/fancy/path.go:46"},
+		Time:    time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC),
+		Level:   3,
+		Message: "Some Message",
+	}
+
+	formatter := NewSyslogFormatter()
+	result, _ := formatter.Format(someEntry)
+
+	parsedString := string(result)
+	expectedString := "^\\[(att1: 1, att2: 2|att2: 2, att1: 1)\\] Some Message\\s+$"
 	assert.Regexp(t, expectedString, parsedString)
 }

--- a/formatter/set.go
+++ b/formatter/set.go
@@ -10,6 +10,12 @@ func SetTextFormatter(logger *logrus.Logger) {
 	logger.ReportCaller = true
 	logger.AddHook(NewContextHook())
 }
+// SetSyslogFormatter set the text formatter for given logger.
+func SetSyslogFormatter(logger *logrus.Logger) {
+	logger.Formatter = NewSyslogFormatter()
+	logger.ReportCaller = true
+	logger.AddHook(NewContextHook())
+}
 
 // SetJSONFormatter set the JSON formatter for given logger.
 func SetJSONFormatter(logger *logrus.Logger) {

--- a/util/log.go
+++ b/util/log.go
@@ -35,8 +35,11 @@ func InitLog(logLevel string, logPath string) error {
 		AddSyslogHook()
 	}
 
+	//nolint:gocritic
 	if os.Getenv("NB_LOG_FORMAT") == "json" {
 		formatter.SetJSONFormatter(log.StandardLogger())
+	} else if logPath == "syslog" {
+		formatter.SetSyslogFormatter(log.StandardLogger())
 	} else {
 		formatter.SetTextFormatter(log.StandardLogger())
 	}


### PR DESCRIPTION
## Describe your changes

```console
journalctl
```
```diff
- Jul 19 14:41:01 rpi /usr/bin/netbird[614]: 2024-07-19T14:41:01+02:00 ERRO %!s(<nil>): error while handling message of Peer [key: REDACTED] error: [wrongly addressed message REDACTED]
- Jul 19 21:53:03 rpi /usr/bin/netbird[614]: 2024-07-19T21:53:03+02:00 WARN %!s(<nil>): disconnected from the Signal service but will retry silently. Reason: rpc error: code = Internal desc = server closed the stream without sending trailers
- Jul 19 21:53:04 rpi /usr/bin/netbird[614]: 2024-07-19T21:53:04+02:00 INFO %!s(<nil>): connected to the Signal Service stream
- Jul 19 22:24:10 rpi /usr/bin/netbird[614]: 2024-07-19T22:24:10+02:00 WARN [error: read udp 192.168.1.11:48398->9.9.9.9:53: i/o timeout, upstream: 9.9.9.9:53] %!s(<nil>): got an error while connecting to upstream
+ Jul 19 14:41:01 rpi /usr/bin/netbird[614]: error while handling message of Peer [key: REDACTED] error: [wrongly addressed message REDACTED]
+ Jul 19 21:53:03 rpi /usr/bin/netbird[614]: disconnected from the Signal service but will retry silently. Reason: rpc error: code = Internal desc = server closed the stream without sending trailers
+ Jul 19 21:53:04 rpi /usr/bin/netbird[614]: connected to the Signal Service stream
+ Jul 19 22:24:10 rpi /usr/bin/netbird[614]: [error: read udp 192.168.1.11:48398->9.9.9.9:53: i/o timeout, upstream: 9.9.9.9:53] got an error while connecting to upstream
```

please notice that although log level is no longer present in the syslog message it is still respected by syslog logger, so the log levels are not lost:
```console
journalctl -p 3
```
```diff
- Jul 19 14:41:01 rpi /usr/bin/netbird[614]: 2024-07-19T14:41:01+02:00 ERRO %!s(<nil>): error while handling message of Peer [key: REDACTED] error: [wrongly addressed message REDACTED]
+ Jul 19 14:41:01 rpi /usr/bin/netbird[614]: error while handling message of Peer [key: REDACTED] error: [wrongly addressed message REDACTED]
```

## Issue ticket number and link
this is a follow-up of #2259

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
