### PR TITLE
Remove redundant check for empty JWT groups

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -770,10 +770,6 @@ func (a *Account) GetPeer(peerID string) *nbpeer.Peer {
 // SetJWTGroups updates the user's auto groups by synchronizing JWT groups.
 // Returns true if there are changes in the JWT group membership.
 func (a *Account) SetJWTGroups(userID string, groupsNames []string) bool {
-	if len(groupsNames) == 0 {
-		return false
-	}
-
 	user, ok := a.Users[userID]
 	if !ok {
 		return false

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -2219,6 +2219,13 @@ func TestAccount_SetJWTGroups(t *testing.T) {
 		assert.Len(t, account.Users["user2"].AutoGroups, 1, "new group should be added")
 		assert.Contains(t, account.Groups, account.Users["user2"].AutoGroups[0], "groups must contain group3 from user groups")
 	})
+
+	t.Run("remove all JWT groups", func(t *testing.T) {
+		updated := account.SetJWTGroups("user1", []string{})
+		assert.True(t, updated, "account should be updated")
+		assert.Len(t, account.Users["user1"].AutoGroups, 1, "only non-JWT groups should remain")
+		assert.Contains(t, account.Users["user1"].AutoGroups, "group1", " group1 should still be present")
+	})
 }
 
 func TestAccount_UserGroupsAddToPeers(t *testing.T) {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
- [Unexpected behaviour when syncing groups from IdP(Zitadel)](https://github.com/netbirdio/netbird/issues/2322)

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
