### PR TITLE
Allow setup keys to be provided in a file

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -39,6 +39,13 @@ var loginCmd = &cobra.Command{
 			ctx = context.WithValue(ctx, system.DeviceNameCtxKey, hostName)
 		}
 
+		if setupKeyPath != "" && setupKey == "" {
+			setupKey, err = getSetupKeyFromFile(setupKeyPath)
+			if err != nil {
+				return err
+			}
+		}
+
 		// workaround to run without service
 		if logFile == "console" {
 			err = handleRebrand(cmd)

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -55,6 +55,7 @@ var (
 	managementURL           string
 	adminURL                string
 	setupKey                string
+	setupKeyPath            string
 	hostName                string
 	preSharedKey            string
 	natExternalIPs          []string
@@ -123,6 +124,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "sets Netbird log level")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout. If syslog is specified the log will be sent to syslog daemon.")
 	rootCmd.PersistentFlags().StringVarP(&setupKey, "setup-key", "k", "", "Setup key obtained from the Management Service Dashboard (used to register peer)")
+	rootCmd.PersistentFlags().StringVar(&setupKeyPath, "setup-key-path", "", "The path to a setup key obtained from the Management Service Dashboard (used to register peer)")
 	rootCmd.PersistentFlags().StringVar(&preSharedKey, preSharedKeyFlag, "", "Sets Wireguard PreSharedKey property. If set, then only peers that have the same key can communicate.")
 	rootCmd.PersistentFlags().StringVarP(&hostName, "hostname", "n", "", "Sets a custom hostname for the device")
 	rootCmd.PersistentFlags().BoolVarP(&anonymizeFlag, "anonymize", "A", false, "anonymize IP addresses and non-netbird.io domains in logs and status output")
@@ -231,6 +233,10 @@ func DialClientGRPCServer(ctx context.Context, addr string) (*grpc.ClientConn, e
 // WithBackOff execute function in backoff cycle.
 func WithBackOff(bf func() error) error {
 	return backoff.RetryNotify(bf, CLIBackOffSettings, func(err error, duration time.Duration) {
+
+		log.Warnf("%+v\n", setupKeyPath)
+		log.Warnf("%+v\n", setupKey)
+
 		log.Warnf("retrying Login to the Management service in %v due to error %v", duration, err)
 	})
 }
@@ -244,6 +250,11 @@ var CLIBackOffSettings = &backoff.ExponentialBackOff{
 	MaxElapsedTime:      30 * time.Second,
 	Stop:                backoff.Stop,
 	Clock:               backoff.SystemClock,
+}
+
+func getSetupKeyFromFile(setupKeyPath string) (string, error) {
+	data, err := os.ReadFile(setupKeyPath)
+	return string(data), err
 }
 
 func handleRebrand(cmd *cobra.Command) error {

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -124,7 +124,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "sets Netbird log level")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout. If syslog is specified the log will be sent to syslog daemon.")
 	rootCmd.PersistentFlags().StringVarP(&setupKey, "setup-key", "k", "", "Setup key obtained from the Management Service Dashboard (used to register peer)")
-	rootCmd.PersistentFlags().StringVar(&setupKeyPath, "setup-key-path", "", "The path to a setup key obtained from the Management Service Dashboard (used to register peer)")
+	rootCmd.PersistentFlags().StringVar(&setupKeyPath, "setup-key-file", "", "The path to a setup key obtained from the Management Service Dashboard (used to register peer) This is ignored if the setup-key flag is provided.")
+	rootCmd.MarkFlagsMutuallyExclusive("setup-key", "setup-key-file")
 	rootCmd.PersistentFlags().StringVar(&preSharedKey, preSharedKeyFlag, "", "Sets Wireguard PreSharedKey property. If set, then only peers that have the same key can communicate.")
 	rootCmd.PersistentFlags().StringVarP(&hostName, "hostname", "n", "", "Sets a custom hostname for the device")
 	rootCmd.PersistentFlags().BoolVarP(&anonymizeFlag, "anonymize", "A", false, "anonymize IP addresses and non-netbird.io domains in logs and status output")
@@ -233,10 +234,6 @@ func DialClientGRPCServer(ctx context.Context, addr string) (*grpc.ClientConn, e
 // WithBackOff execute function in backoff cycle.
 func WithBackOff(bf func() error) error {
 	return backoff.RetryNotify(bf, CLIBackOffSettings, func(err error, duration time.Duration) {
-
-		log.Warnf("%+v\n", setupKeyPath)
-		log.Warnf("%+v\n", setupKey)
-
 		log.Warnf("retrying Login to the Management service in %v due to error %v", duration, err)
 	})
 }

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -73,6 +73,13 @@ func upFunc(cmd *cobra.Command, args []string) error {
 		ctx = context.WithValue(ctx, system.DeviceNameCtxKey, hostName)
 	}
 
+	if setupKeyPath != "" && setupKey == "" {
+		setupKey, err = getSetupKeyFromFile(setupKeyPath)
+		if err != nil {
+			return err
+		}
+	}
+
 	if foregroundMode {
 		return runInForegroundMode(ctx, cmd)
 	}


### PR DESCRIPTION
## Describe your changes
Adds a flag and a bit of logic to allow a setup key to be passed in using a file. The flag should be exclusive with the standard `--setup-key` flag.

## Issue ticket number and link
N/A

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

#### Why?
I am attempting to set up netbird automatically in a Lix environment, but the secrets library I use requires that I write the secrets to files and ask programs to use those at runtime. I believe this change will also allow someone to use docker secrets to provide a setup key.

I am unsure what/if changes should be made to any documentation or to the README file.

(I apologize if I have missed anything, this is my first time contributing to an open source project.)