### PR TITLE
Add extra auth audience field on HttpConfig for automation user to authorize via zitadel

### DIFF
--- a/management/server/config.go
+++ b/management/server/config.go
@@ -56,6 +56,10 @@ type Config struct {
 func (c Config) GetAuthAudiences() []string {
 	audiences := []string{c.HttpConfig.AuthAudience}
 
+	if c.HttpConfig.ExtraAuthAudience != "" {
+		audiences = append(audiences, c.HttpConfig.ExtraAuthAudience)
+	}
+
 	if c.DeviceAuthorizationFlow != nil && c.DeviceAuthorizationFlow.ProviderConfig.Audience != "" {
 		audiences = append(audiences, c.DeviceAuthorizationFlow.ProviderConfig.Audience)
 	}
@@ -90,6 +94,8 @@ type HttpServerConfig struct {
 	OIDCConfigEndpoint string
 	// IdpSignKeyRefreshEnabled identifies the signing key is currently being rotated or not
 	IdpSignKeyRefreshEnabled bool
+	// Extra audience
+	ExtraAuthAudience string
 }
 
 // Host represents a Wiretrustee host (e.g. STUN, TURN, Signal)


### PR DESCRIPTION
## Describe your changes
Currently in the setup that is used in getting started with zitadel script, only 2 audiences are configured when the http server checks the auth token.  Those 2 are:  1. HttpConfig.AuthAudience and 2. DeviceAuthorization.ProviderConfig.Audience.

The HttpConfig authAudience is setup like this: "AuthAudience": "$NETBIRD_AUTH_CLIENT_ID"
The DeviceAuthorization.ProviderConfig.Audience is setup like this:  "Audience": "$NETBIRD_AUTH_CLIENT_ID_CLI",

Therefore, any auth token that will be accepted by the api server has to have either of those 2 audiences set. 

In order to provide an automation user (zitadel machine user) with a clientid/clientsecret to allow for unattended login by ansible/terraform/etc, it is not obvious how to get a token with that audience, at least I haven't figured out how.

I can only seem to create a machine user with its unique clientid which is set as the audience.  

So, this addition of an extra audience field to the httpconfig is intended to allow for specifying the audience of the automation user.

If this achievable in another way, happy to know how.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
