### PR TITLE
On iOS add error handling for getRouteselector

### DIFF
--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -272,6 +272,9 @@ func (c *Client) GetRoutesSelectionDetails() (*RoutesSelectionDetails, error) {
 
 	routesMap := engine.GetClientRoutesWithNetID()
 	routeSelector := engine.GetRouteManager().GetRouteSelector()
+	if routeSelector == nil {
+		return nil, fmt.Errorf("could not get route selector")
+	}
 
 	var routes []*selectRoute
 	for id, rt := range routesMap {

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -271,7 +271,11 @@ func (c *Client) GetRoutesSelectionDetails() (*RoutesSelectionDetails, error) {
 	}
 
 	routesMap := engine.GetClientRoutesWithNetID()
-	routeSelector := engine.GetRouteManager().GetRouteSelector()
+	routeManager := engine.GetRouteManager()
+	if routeManager == nil {
+		return nil, fmt.Errorf("could not get route manager")
+	}
+	routeSelector := routeManager.GetRouteSelector()
 	if routeSelector == nil {
 		return nil, fmt.Errorf("could not get route selector")
 	}


### PR DESCRIPTION
## Describe your changes
Adding a nullpointer check to the GetRouteSelection for iOS to avoid possible nullpointer exceptions.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
