### PR TITLE
Skip network map check if not regular user

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -65,18 +65,24 @@ func (am *DefaultAccountManager) GetPeers(ctx context.Context, accountID, userID
 	peers := make([]*nbpeer.Peer, 0)
 	peersMap := make(map[string]*nbpeer.Peer)
 
-	if !user.HasAdminPower() && !user.IsServiceUser && account.Settings.RegularUsersViewBlocked {
+	regularUser := !user.HasAdminPower() && !user.IsServiceUser
+
+	if regularUser && account.Settings.RegularUsersViewBlocked {
 		return peers, nil
 	}
 
 	for _, peer := range account.Peers {
-		if !(user.HasAdminPower() || user.IsServiceUser) && user.Id != peer.UserID {
+		if regularUser && user.Id != peer.UserID {
 			// only display peers that belong to the current user if the current user is not an admin
 			continue
 		}
 		p := peer.Copy()
 		peers = append(peers, p)
 		peersMap[peer.ID] = p
+	}
+
+	if !regularUser {
+		return peers, nil
 	}
 
 	// fetch all the peers that have access to the user's peers


### PR DESCRIPTION
## Describe your changes
when getting all peers we don't need to calculate network map when not a regular user

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
