### PR TITLE
[client] Feature/relay integration fix reconnection

### DIFF
--- a/relay/server/store.go
+++ b/relay/server/store.go
@@ -19,7 +19,7 @@ func NewStore() *Store {
 }
 
 // AddPeer adds a peer to the store
-// It distinguishes the peers by their ID
+// todo: consider to close peer conn if the peer already exists
 func (s *Store) AddPeer(peer *Peer) {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
@@ -30,6 +30,16 @@ func (s *Store) AddPeer(peer *Peer) {
 func (s *Store) DeletePeer(peer *Peer) {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
+
+	dp, ok := s.peers[peer.String()]
+	if !ok {
+
+		return
+	}
+	if dp != peer {
+		return
+	}
+
 	delete(s.peers, peer.String())
 }
 

--- a/relay/server/store.go
+++ b/relay/server/store.go
@@ -33,7 +33,6 @@ func (s *Store) DeletePeer(peer *Peer) {
 
 	dp, ok := s.peers[peer.String()]
 	if !ok {
-
 		return
 	}
 	if dp != peer {

--- a/relay/server/store_test.go
+++ b/relay/server/store_test.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestStore_DeletePeer(t *testing.T) {
+	s := NewStore()
+	p := NewPeer([]byte("peer_one"), nil, nil)
+	s.AddPeer(p)
+	s.DeletePeer(p)
+	if _, ok := s.Peer(p.String()); ok {
+		t.Errorf("peer was not deleted")
+	}
+}
+
+func TestStore_DeleteDeprecatedPeer(t *testing.T) {
+	s := NewStore()
+
+	p1 := NewPeer([]byte("peer_id"), nil, nil)
+	p2 := NewPeer([]byte("peer_id"), nil, nil)
+
+	s.AddPeer(p1)
+	s.AddPeer(p2)
+	s.DeletePeer(p1)
+
+	if _, ok := s.Peer(p2.String()); !ok {
+		t.Errorf("second peer was deleted")
+	}
+}


### PR DESCRIPTION
## Describe your changes
When a peer disconnects gracefully from the server and immediately connects back, then the server will clean up an incorrect peer instance from the in-memory store. In this fix the store checks the peers instance before deleting it.

Error happened here:
https://github.com/netbirdio/netbird/actions/runs/10281624634/job/28451564919?pr=2399

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
