### PR TITLE
[management] Add buffering for getAccount requests during login

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -2233,11 +2233,10 @@ func (am *DefaultAccountManager) GetAccountWithBackpressure(ctx context.Context,
 		ResultChan: make(chan *AccountResult, 1),
 	}
 
-	// Send the request to the processing channel
 	am.requestCh <- req
 
-	// Wait for the result
 	result := <-req.ResultChan
+	close(req.ResultChan)
 	return result.Account, result.Err
 }
 
@@ -2251,16 +2250,11 @@ func (am *DefaultAccountManager) processBatch(accountID string) {
 		return
 	}
 
-	// Perform the database query
 	ctx := context.Background()
-	fmt.Printf("Processing batch for account %s\n", accountID)
 	account, err := am.Store.GetAccount(ctx, accountID)
 	result := &AccountResult{Account: account, Err: err}
 
-	fmt.Printf("Sending to %d requests\n", len(requests))
-	// Send the result to all waiting requests
 	for _, req := range requests {
 		req.ResultChan <- result
-		close(req.ResultChan)
 	}
 }

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -9,9 +9,11 @@ import (
 	"math/rand"
 	"net"
 	"net/netip"
+	"os"
 	"reflect"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1045,7 +1047,16 @@ func BuildManager(
 		am.onPeersInvalidated(ctx, accountID)
 	})
 
-	go am.processGetAccountRequests(ctx)
+	bufferIntervalStr := os.Getenv("NB_GET_ACCOUNT_BUFFER_INTERVAL")
+	bufferInterval, err := strconv.Atoi(bufferIntervalStr)
+	if err != nil {
+		bufferInterval = 300
+	}
+	bufferDuration := time.Duration(bufferInterval)
+
+	log.WithContext(ctx).Infof("set GetAccount buffer to %s", bufferDuration)
+
+	go am.processGetAccountRequests(ctx, bufferDuration)
 
 	return am, nil
 }

--- a/management/server/account_cache.go
+++ b/management/server/account_cache.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// AccountRequest holds the result channel to return the requested account.
+type AccountRequest struct {
+	AccountID  string
+	ResultChan chan *AccountResult
+}
+
+// AccountResult holds the account data or an error.
+type AccountResult struct {
+	Account *Account
+	Err     error
+}
+
+type AccountCache struct {
+	store               Store
+	getAccountRequests  map[string][]*AccountRequest
+	mu                  sync.Mutex
+	getAccountRequestCh chan *AccountRequest
+	bufferInterval      time.Duration
+}
+
+func NewAccountCache(ctx context.Context, store Store) *AccountCache {
+	bufferIntervalStr := os.Getenv("NB_GET_ACCOUNT_BUFFER_INTERVAL")
+	bufferInterval, err := time.ParseDuration(bufferIntervalStr)
+	if err != nil {
+		bufferInterval = 300 * time.Millisecond
+	}
+
+	log.WithContext(ctx).Infof("set account cache buffer interval to %s", bufferInterval)
+
+	ac := AccountCache{
+		store:               store,
+		getAccountRequests:  make(map[string][]*AccountRequest),
+		getAccountRequestCh: make(chan *AccountRequest),
+		bufferInterval:      bufferInterval,
+	}
+
+	go ac.processGetAccountRequests(ctx)
+
+	return &ac
+}
+func (ac *AccountCache) GetAccountWithBackpressure(ctx context.Context, accountID string) (*Account, error) {
+	req := &AccountRequest{
+		AccountID:  accountID,
+		ResultChan: make(chan *AccountResult, 1),
+	}
+
+	log.WithContext(ctx).Tracef("requesting account %s with backpressure", accountID)
+	startTime := time.Now()
+	ac.getAccountRequestCh <- req
+
+	result := <-req.ResultChan
+	log.WithContext(ctx).Tracef("got account with backpressure after %s", time.Since(startTime))
+	return result.Account, result.Err
+}
+
+func (ac *AccountCache) processGetAccountBatch(ctx context.Context, accountID string) {
+	ac.mu.Lock()
+	requests := ac.getAccountRequests[accountID]
+	delete(ac.getAccountRequests, accountID)
+	ac.mu.Unlock()
+
+	if len(requests) == 0 {
+		return
+	}
+
+	startTime := time.Now()
+	account, err := ac.store.GetAccount(ctx, accountID)
+	log.WithContext(ctx).Tracef("getting account %s in batch took %s", accountID, time.Since(startTime))
+	result := &AccountResult{Account: account, Err: err}
+
+	for _, req := range requests {
+		req.ResultChan <- result
+		close(req.ResultChan)
+	}
+}
+
+func (ac *AccountCache) processGetAccountRequests(ctx context.Context) {
+	for {
+		select {
+		case req := <-ac.getAccountRequestCh:
+			ac.mu.Lock()
+			ac.getAccountRequests[req.AccountID] = append(ac.getAccountRequests[req.AccountID], req)
+			if len(ac.getAccountRequests[req.AccountID]) == 1 {
+				go func(ctx context.Context, accountID string) {
+					time.Sleep(ac.bufferInterval)
+					ac.processGetAccountBatch(ctx, accountID)
+				}(ctx, req.AccountID)
+			}
+			ac.mu.Unlock()
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/management/server/account_cache.go
+++ b/management/server/account_cache.go
@@ -32,7 +32,8 @@ type AccountCache struct {
 func NewAccountCache(ctx context.Context, store Store) *AccountCache {
 	bufferIntervalStr := os.Getenv("NB_GET_ACCOUNT_BUFFER_INTERVAL")
 	bufferInterval, err := time.ParseDuration(bufferIntervalStr)
-	if err != nil {
+	if err != nil && bufferIntervalStr != "" {
+		log.WithContext(ctx).Warnf("failed to parse account cache buffer interval: %s", err)
 		bufferInterval = 300 * time.Millisecond
 	}
 

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -818,22 +818,22 @@ func testLoginPerformance(t *testing.T, loginCalls []func() error) {
 	t.Logf("starting login calls")
 	close(startChan)
 	wgDone.Wait()
-	var min, max, avg time.Duration
+	var tMin, tMax, tSum time.Duration
 	for i, d := range durations {
 		if i == 0 {
-			min = d
-			max = d
-			avg = d
+			tMin = d
+			tMax = d
+			tSum = d
 			continue
 		}
-		if d < min {
-			min = d
+		if d < tMin {
+			tMin = d
 		}
-		if d > max {
-			max = d
+		if d > tMax {
+			tMax = d
 		}
-		avg += d
+		tSum += d
 	}
-	avg = avg / time.Duration(len(durations))
-	t.Logf("Min: %v, Max: %v, Avg: %v", min, max, avg)
+	tAvg := tSum / time.Duration(len(durations))
+	t.Logf("Min: %v, Max: %v, Avg: %v", tMin, tMax, tAvg)
 }

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -708,7 +708,7 @@ func Test_LoginPerformance(t *testing.T) {
 
 					account, err := createAccount(am, fmt.Sprintf("account-%d", j), fmt.Sprintf("user-%d", j), fmt.Sprintf("domain-%d", j))
 					if err != nil {
-						t.Logf("acocunt creation failed: %v", err)
+						t.Logf("account creation failed: %v", err)
 						return
 					}
 

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -637,7 +637,10 @@ func testSyncStatusRace(t *testing.T) {
 }
 
 func Test_LoginPerformance(t *testing.T) {
-	t.Skip("Skipping performance test in automated tests")
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping on CI")
+	}
+
 	t.Setenv("NETBIRD_STORE_ENGINE", "sqlite")
 
 	benchCases := []struct {

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -783,6 +783,7 @@ func Test_LoginPerformance(t *testing.T) {
 }
 
 func testLoginPerformance(t *testing.T, loginCalls []func() error) {
+	t.Helper()
 	wgSetup := sync.WaitGroup{}
 	startChan := make(chan struct{})
 

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -980,7 +982,13 @@ func (am *DefaultAccountManager) processGetAccountRequests(ctx context.Context) 
 			am.getAccountRequests[req.AccountID] = append(am.getAccountRequests[req.AccountID], req)
 			if len(am.getAccountRequests[req.AccountID]) == 1 {
 				go func(ctx context.Context, accountID string) {
-					time.Sleep(300 * time.Millisecond)
+					bufferIntervalStr := os.Getenv("NB_GET_ACCOUNT_BUFFER_INTERVAL")
+					bufferInterval, err := strconv.Atoi(bufferIntervalStr)
+					if err != nil {
+						bufferInterval = 300
+					}
+					fmt.Printf("Buffer interval: %d\n", bufferInterval)
+					time.Sleep(time.Duration(bufferInterval) * time.Millisecond)
 					am.processGetAccountBatch(ctx, accountID)
 				}(ctx, req.AccountID)
 			}

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -973,7 +973,6 @@ func (am *DefaultAccountManager) updateAccountPeers(ctx context.Context, account
 }
 
 func (am *DefaultAccountManager) processRequests() {
-	// Map to track active goroutines for each AccountID
 	activeGoroutines := make(map[string]bool)
 
 	for {
@@ -982,13 +981,11 @@ func (am *DefaultAccountManager) processRequests() {
 			am.mu.Lock()
 			am.requests[req.AccountID] = append(am.requests[req.AccountID], req)
 			if !activeGoroutines[req.AccountID] {
-				// Mark the goroutine as active
 				activeGoroutines[req.AccountID] = true
-				timeout := time.NewTimer(500 * time.Millisecond)
+				timeout := time.NewTimer(100 * time.Millisecond)
 				go func(accountID string) {
 					defer func() {
 						am.mu.Lock()
-						// Mark the goroutine as inactive
 						activeGoroutines[accountID] = false
 						am.mu.Unlock()
 					}()

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -972,16 +972,16 @@ func (am *DefaultAccountManager) updateAccountPeers(ctx context.Context, account
 	wg.Wait()
 }
 
-func (am *DefaultAccountManager) processRequests(ctx context.Context) {
+func (am *DefaultAccountManager) processGetAccountRequests(ctx context.Context) {
 	for {
 		select {
-		case req := <-am.requestCh:
+		case req := <-am.getAccountRequestCh:
 			am.mu.Lock()
-			am.requests[req.AccountID] = append(am.requests[req.AccountID], req)
-			if len(am.requests[req.AccountID]) == 1 {
+			am.getAccountRequests[req.AccountID] = append(am.getAccountRequests[req.AccountID], req)
+			if len(am.getAccountRequests[req.AccountID]) == 1 {
 				go func(ctx context.Context, accountID string) {
 					time.Sleep(300 * time.Millisecond)
-					am.processBatch(ctx, accountID)
+					am.processGetAccountBatch(ctx, accountID)
 				}(ctx, req.AccountID)
 			}
 			am.mu.Unlock()


### PR DESCRIPTION
## Describe your changes
This PR adds a buffer for the getAccount operation during login to collect requests over a specific time inteval and only call the database once. This way reducing overall load on the DB.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
