### PR TITLE
[client] Refactor free port function

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -430,6 +430,6 @@ func closeConnWithLog(conn *net.UDPConn) {
 		log.Warnf("closing probe port %d failed: %v. NetBird will still attempt to use this port for connection.", conn.LocalAddr().(*net.UDPAddr).Port, err)
 	}
 	if time.Since(startClosing) > time.Second {
-		log.Warnf("closing the testing port %d took %s. Usually is safe to ignore, but continuous warnings may indicate a problem.", conn.LocalAddr().(*net.UDPAddr).Port, time.Since(startClosing))
+		log.Warnf("closing the testing port %d took %s. Usually it is safe to ignore, but continuous warnings may indicate a problem.", conn.LocalAddr().(*net.UDPAddr).Port, time.Since(startClosing))
 	}
 }

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -418,9 +418,13 @@ func freePort(initPort int) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("unable to get a free port: %v", err)
 	}
-	availablePort := conn.LocalAddr().(*net.UDPAddr).Port
+
+	udpAddr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return 0, errors.New("wrong address type when getting a free port")
+	}
 	closeConnWithLog(conn)
-	return availablePort, nil
+	return udpAddr.Port, nil
 }
 
 func closeConnWithLog(conn *net.UDPConn) {

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -397,7 +397,7 @@ func statusRecorderToSignalConnStateNotifier(statusRecorder *peer.Status) signal
 	return notifier
 }
 
-// freePort attempts to determine if the provided port is available, if not it will as the system for a free port.
+// freePort attempts to determine if the provided port is available, if not it will ask the system for a free port.
 func freePort(initPort int) (int, error) {
 	addr := net.UDPAddr{}
 	if initPort == 0 {

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -427,7 +427,7 @@ func closeConnWithLog(conn *net.UDPConn) {
 	startClosing := time.Now()
 	err := conn.Close()
 	if err != nil {
-		log.Warnf("closing probe port %d failed: %v. NetBird still will attempt to use this port for connection.", conn.LocalAddr().(*net.UDPAddr).Port, err)
+		log.Warnf("closing probe port %d failed: %v. NetBird will still attempt to use this port for connection.", conn.LocalAddr().(*net.UDPAddr).Port, err)
 	}
 	if time.Since(startClosing) > time.Second {
 		log.Warnf("closing the testing port %d took %s. Usually is safe to ignore, but continuous warnings may indicate a problem.", conn.LocalAddr().(*net.UDPAddr).Port, time.Since(startClosing))

--- a/client/internal/connect_test.go
+++ b/client/internal/connect_test.go
@@ -7,51 +7,55 @@ import (
 
 func Test_freePort(t *testing.T) {
 	tests := []struct {
-		name    string
-		port    int
-		want    int
-		wantErr bool
+		name        string
+		port        int
+		want        int
+		shouldMatch bool
 	}{
 		{
-			name:    "available",
-			port:    51820,
-			want:    51820,
-			wantErr: false,
+			name:        "not provided, fallback to default",
+			port:        0,
+			want:        51820,
+			shouldMatch: true,
 		},
 		{
-			name:    "notavailable",
-			port:    51830,
-			want:    51831,
-			wantErr: false,
+			name:        "provided and available",
+			port:        51821,
+			want:        51821,
+			shouldMatch: true,
 		},
 		{
-			name:    "noports",
-			port:    65535,
-			want:    0,
-			wantErr: true,
+			name:        "provided and not available",
+			port:        51830,
+			want:        51830,
+			shouldMatch: false,
 		},
 	}
+	c1, err := net.ListenUDP("udp", &net.UDPAddr{Port: 51830})
+	if err != nil {
+		t.Errorf("freePort error = %v", err)
+	}
+	defer func(c1 *net.UDPConn) {
+		_ = c1.Close()
+	}(c1)
+
 	for _, tt := range tests {
 
-		c1, err := net.ListenUDP("udp", &net.UDPAddr{Port: 51830})
-		if err != nil {
-			t.Errorf("freePort error = %v", err)
-		}
-		c2, err := net.ListenUDP("udp", &net.UDPAddr{Port: 65535})
-		if err != nil {
-			t.Errorf("freePort error = %v", err)
-		}
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := freePort(tt.port)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("freePort() error = %v, wantErr %v", err, tt.wantErr)
-				return
+
+			if err != nil {
+				t.Errorf("got an error while getting free port: %v", err)
 			}
-			if got != tt.want {
-				t.Errorf("freePort() = %v, want %v", got, tt.want)
+
+			if tt.shouldMatch && got != tt.want {
+				t.Errorf("got a different port %v, want %v", got, tt.want)
+			}
+
+			if !tt.shouldMatch && got == tt.want {
+				t.Errorf("got the same port %v, want a different port", tt.want)
 			}
 		})
-		c1.Close()
-		c2.Close()
+
 	}
 }


### PR DESCRIPTION
## Describe your changes
Rely on `net.ListenUDP` to get an available port for wireguard in case the configured one is in use
## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
