### PR TITLE
[misc] Add support for NETBIRD_STORE_ENGINE_POSTGRES_DSN environment variable in setup.env

### DIFF
--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -41,6 +41,18 @@ if [[ "x-$NETBIRD_DOMAIN" == "x-" ]]; then
   exit 1
 fi
 
+# Check if PostgreSQL is set as the store engine
+if [[ "$NETBIRD_STORE_CONFIG_ENGINE" == "postgres" ]]; then
+  # Exit if 'NETBIRD_STORE_ENGINE_POSTGRES_DSN' is not set
+  if [[ -z "$NETBIRD_STORE_ENGINE_POSTGRES_DSN" ]]; then
+    echo "Warning: NETBIRD_STORE_CONFIG_ENGINE=postgres but NETBIRD_STORE_ENGINE_POSTGRES_DSN is not set."
+    echo "Please add the following line to your setup.env file:"
+    echo 'NETBIRD_STORE_ENGINE_POSTGRES_DSN="host=<PG_HOST> user=<PG_USER> password=<PG_PASSWORD> dbname=<PG_DB_NAME> port=<PG_PORT>"'
+    exit 1
+  fi
+  export NETBIRD_STORE_ENGINE_POSTGRES_DSN
+fi
+
 # local development or tests
 if [[ $NETBIRD_DOMAIN == "localhost" || $NETBIRD_DOMAIN == "127.0.0.1" ]]; then
   export NETBIRD_MGMT_SINGLE_ACCOUNT_MODE_DOMAIN="netbird.selfhosted"

--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -79,6 +79,7 @@ services:
         max-file: "2"
     environment:
       - NETBIRD_STORE_ENGINE_POSTGRES_DSN=$NETBIRD_STORE_ENGINE_POSTGRES_DSN
+      
   # Coturn
   coturn:
     image: coturn/coturn:$COTURN_TAG

--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -77,6 +77,8 @@ services:
       options:
         max-size: "500m"
         max-file: "2"
+    environment:
+      - NETBIRD_STORE_ENGINE_POSTGRES_DSN=$NETBIRD_STORE_ENGINE_POSTGRES_DSN
   # Coturn
   coturn:
     image: coturn/coturn:$COTURN_TAG

--- a/infrastructure_files/docker-compose.yml.tmpl.traefik
+++ b/infrastructure_files/docker-compose.yml.tmpl.traefik
@@ -83,7 +83,7 @@ services:
     - traefik.http.services.netbird-management.loadbalancer.server.scheme=h2c
     environment:
       - NETBIRD_STORE_ENGINE_POSTGRES_DSN=$NETBIRD_STORE_ENGINE_POSTGRES_DSN
-q      
+      
   # Coturn
   coturn:
     image: coturn/coturn:$COTURN_TAG

--- a/infrastructure_files/docker-compose.yml.tmpl.traefik
+++ b/infrastructure_files/docker-compose.yml.tmpl.traefik
@@ -81,7 +81,9 @@ services:
     - traefik.http.routers.netbird-management.service=netbird-management
     - traefik.http.services.netbird-management.loadbalancer.server.port=443
     - traefik.http.services.netbird-management.loadbalancer.server.scheme=h2c
-
+    environment:
+      - NETBIRD_STORE_ENGINE_POSTGRES_DSN=$NETBIRD_STORE_ENGINE_POSTGRES_DSN
+q      
   # Coturn
   coturn:
     image: coturn/coturn:$COTURN_TAG


### PR DESCRIPTION
## Describe your changes

Updated the configure script and docker-compose templates to better support deployment with postgres. Prevents the need to manually add the NETBIRD_STORE_ENGINE_POSTGRES_DSN environment variable to the docker-compose file after the configuration script is run (https://docs.netbird.io/selfhosted/postgres-store). Also provides warning to the user if the NETBIRD_STORE_CONFIG_ENGINE=postgres and NETBIRD_STORE_ENGINE_POSTGRES_DSN is not set.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
