### PR TITLE
[relay] Store the StunTurn address in thread safe store

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1042,19 +1042,21 @@ func (e *Engine) createPeerConn(pubKey string, allowedIPs string) (*peer.Conn, e
 	// randomize connection timeout
 	timeout := time.Duration(rand.Intn(PeerConnectionTimeoutMax-PeerConnectionTimeoutMin)+PeerConnectionTimeoutMin) * time.Millisecond
 	config := peer.ConnConfig{
-		Key:                  pubKey,
-		LocalKey:             e.config.WgPrivateKey.PublicKey().String(),
-		StunTurn:             &e.stunTurn,
-		InterfaceBlackList:   e.config.IFaceBlackList,
-		DisableIPv6Discovery: e.config.DisableIPv6Discovery,
-		Timeout:              timeout,
-		UDPMux:               e.udpMux.UDPMuxDefault,
-		UDPMuxSrflx:          e.udpMux,
-		WgConfig:             wgConfig,
-		LocalWgPort:          e.config.WgPort,
-		NATExternalIPs:       e.parseNATExternalIPMappings(),
-		RosenpassPubKey:      e.getRosenpassPubKey(),
-		RosenpassAddr:        e.getRosenpassAddr(),
+		Key:             pubKey,
+		LocalKey:        e.config.WgPrivateKey.PublicKey().String(),
+		Timeout:         timeout,
+		WgConfig:        wgConfig,
+		LocalWgPort:     e.config.WgPort,
+		RosenpassPubKey: e.getRosenpassPubKey(),
+		RosenpassAddr:   e.getRosenpassAddr(),
+		ICEConfig: peer.ICEConfig{
+			StunTurn:             &e.stunTurn,
+			InterfaceBlackList:   e.config.IFaceBlackList,
+			DisableIPv6Discovery: e.config.DisableIPv6Discovery,
+			UDPMux:               e.udpMux.UDPMuxDefault,
+			UDPMuxSrflx:          e.udpMux,
+			NATExternalIPs:       e.parseNATExternalIPMappings(),
+		},
 	}
 
 	peerConn, err := peer.NewConn(config, e.statusRecorder, e.wgProxyFactory, e.mobileDep.TunAdapter, e.mobileDep.IFaceDiscover)

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -42,37 +42,41 @@ type WgConfig struct {
 	PreSharedKey *wgtypes.Key
 }
 
-// ConnConfig is a peer Connection configuration
-type ConnConfig struct {
-
-	// Key is a public key of a remote peer
-	Key string
-	// LocalKey is a public key of a local peer
-	LocalKey string
-
+type ICEConfig struct {
 	// StunTurn is a list of STUN and TURN URLs
-	StunTurn *atomic.Value
+	StunTurn *atomic.Value // []*stun.URI
 
 	// InterfaceBlackList is a list of machine interfaces that should be filtered out by ICE Candidate gathering
 	// (e.g. if eth0 is in the list, host candidate of this interface won't be used)
 	InterfaceBlackList   []string
 	DisableIPv6Discovery bool
 
+	UDPMux      ice.UDPMux
+	UDPMuxSrflx ice.UniversalUDPMux
+
+	NATExternalIPs []string
+}
+
+// ConnConfig is a peer Connection configuration
+type ConnConfig struct {
+	// Key is a public key of a remote peer
+	Key string
+	// LocalKey is a public key of a local peer
+	LocalKey string
+
 	Timeout time.Duration
 
 	WgConfig WgConfig
 
-	UDPMux      ice.UDPMux
-	UDPMuxSrflx ice.UniversalUDPMux
-
 	LocalWgPort int
-
-	NATExternalIPs []string
 
 	// RosenpassPubKey is this peer's Rosenpass public key
 	RosenpassPubKey []byte
 	// RosenpassPubKey is this peer's RosenpassAddr server address (IP:port)
 	RosenpassAddr string
+
+	// ICEConfig ICE protocol configuration
+	ICEConfig ICEConfig
 }
 
 // OfferAnswer represents a session establishment offer or answer
@@ -183,20 +187,20 @@ func (conn *Conn) reCreateAgent() error {
 	agentConfig := &ice.AgentConfig{
 		MulticastDNSMode:       ice.MulticastDNSModeDisabled,
 		NetworkTypes:           []ice.NetworkType{ice.NetworkTypeUDP4, ice.NetworkTypeUDP6},
-		Urls:                   conn.config.StunTurn.Load().([]*stun.URI),
+		Urls:                   conn.config.ICEConfig.StunTurn.Load().([]*stun.URI),
 		CandidateTypes:         conn.candidateTypes(),
 		FailedTimeout:          &failedTimeout,
-		InterfaceFilter:        stdnet.InterfaceFilter(conn.config.InterfaceBlackList),
-		UDPMux:                 conn.config.UDPMux,
-		UDPMuxSrflx:            conn.config.UDPMuxSrflx,
-		NAT1To1IPs:             conn.config.NATExternalIPs,
+		InterfaceFilter:        stdnet.InterfaceFilter(conn.config.ICEConfig.InterfaceBlackList),
+		UDPMux:                 conn.config.ICEConfig.UDPMux,
+		UDPMuxSrflx:            conn.config.ICEConfig.UDPMuxSrflx,
+		NAT1To1IPs:             conn.config.ICEConfig.NATExternalIPs,
 		Net:                    transportNet,
 		DisconnectedTimeout:    &iceDisconnectedTimeout,
 		KeepaliveInterval:      &iceKeepAlive,
 		RelayAcceptanceMinWait: &iceRelayAcceptanceMinWait,
 	}
 
-	if conn.config.DisableIPv6Discovery {
+	if conn.config.ICEConfig.DisableIPv6Discovery {
 		agentConfig.NetworkTypes = []ice.NetworkType{ice.NetworkTypeUDP4}
 	}
 
@@ -476,7 +480,7 @@ func (conn *Conn) punchRemoteWGPort(pair *ice.CandidatePair, remoteWgPort int) {
 		return
 	}
 
-	mux, ok := conn.config.UDPMuxSrflx.(*bind.UniversalUDPMuxDefault)
+	mux, ok := conn.config.ICEConfig.UDPMuxSrflx.(*bind.UniversalUDPMuxDefault)
 	if !ok {
 		log.Warn("invalid udp mux conversion")
 		return

--- a/client/internal/peer/conn_test.go
+++ b/client/internal/peer/conn_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/magiconair/properties/assert"
-	"github.com/pion/stun/v2"
 
 	"github.com/netbirdio/netbird/client/internal/stdnet"
 	"github.com/netbirdio/netbird/client/internal/wgproxy"
@@ -17,7 +16,6 @@ import (
 var connConf = ConnConfig{
 	Key:                "LLHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
 	LocalKey:           "RRHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
-	StunTurn:           []*stun.URI{},
 	InterfaceBlackList: nil,
 	Timeout:            time.Second,
 	LocalWgPort:        51820,

--- a/client/internal/peer/conn_test.go
+++ b/client/internal/peer/conn_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 var connConf = ConnConfig{
-	Key:                "LLHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
-	LocalKey:           "RRHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
-	InterfaceBlackList: nil,
-	Timeout:            time.Second,
-	LocalWgPort:        51820,
+	Key:         "LLHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
+	LocalKey:    "RRHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
+	Timeout:     time.Second,
+	LocalWgPort: 51820,
+	ICEConfig: ICEConfig{
+		InterfaceBlackList: nil,
+	},
 }
 
 func TestNewConn_interfaceFilter(t *testing.T) {

--- a/client/internal/peer/stdnet.go
+++ b/client/internal/peer/stdnet.go
@@ -7,5 +7,5 @@ import (
 )
 
 func (conn *Conn) newStdNet() (*stdnet.Net, error) {
-	return stdnet.NewNet(conn.config.InterfaceBlackList)
+	return stdnet.NewNet(conn.config.ICEConfig.InterfaceBlackList)
 }

--- a/client/internal/peer/stdnet_android.go
+++ b/client/internal/peer/stdnet_android.go
@@ -3,5 +3,5 @@ package peer
 import "github.com/netbirdio/netbird/client/internal/stdnet"
 
 func (conn *Conn) newStdNet() (*stdnet.Net, error) {
-	return stdnet.NewNetWithDiscover(conn.iFaceDiscover, conn.config.InterfaceBlackList)
+	return stdnet.NewNetWithDiscover(conn.iFaceDiscover, conn.config.ICEConfig.InterfaceBlackList)
 }


### PR DESCRIPTION
 Store the StunTurn address in atomic store

Does not need to apply a lock and extra function to update the addresses

## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
