### PR TITLE
[client] Use static requested GUID when creating Windows interface

### DIFF
--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pion/transport/v3/stdnet"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -836,6 +837,8 @@ func TestEngine_MultiplePeers(t *testing.T) {
 	for i := 0; i < numPeers; i++ {
 		j := i
 		go func() {
+			guid := fmt.Sprintf("{%s}", uuid.New().String())
+			iface.CustomWindowsGUIDString = strings.ToLower(guid)
 			engine, err := createEngine(ctx, cancel, setupKey, j, mgmtAddr, signalAddr)
 			if err != nil {
 				wg.Done()

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -837,8 +837,6 @@ func TestEngine_MultiplePeers(t *testing.T) {
 	for i := 0; i < numPeers; i++ {
 		j := i
 		go func() {
-			guid := fmt.Sprintf("{%s}", uuid.New().String())
-			iface.CustomWindowsGUIDString = strings.ToLower(guid)
 			engine, err := createEngine(ctx, cancel, setupKey, j, mgmtAddr, signalAddr)
 			if err != nil {
 				wg.Done()
@@ -848,6 +846,8 @@ func TestEngine_MultiplePeers(t *testing.T) {
 			engine.dnsServer = &dns.MockServer{}
 			mu.Lock()
 			defer mu.Unlock()
+			guid := fmt.Sprintf("{%s}", uuid.New().String())
+			iface.CustomWindowsGUIDString = strings.ToLower(guid)
 			err = engine.Start()
 			if err != nil {
 				t.Errorf("unable to start engine for peer %d with error %v", j, err)

--- a/iface/iface_test.go
+++ b/iface/iface_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pion/transport/v3/stdnet"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -345,6 +347,9 @@ func Test_ConnectPeers(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	guid := fmt.Sprintf("{%s}", uuid.New().String())
+	CustomWindowsGUIDString = strings.ToLower(guid)
+
 	iface1, err := NewWGIFace(peer1ifaceName, peer1wgIP, peer1wgPort, peer1Key.String(), DefaultMTU, newNet, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -363,6 +368,9 @@ func Test_ConnectPeers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	guid = fmt.Sprintf("{%s}", uuid.New().String())
+	CustomWindowsGUIDString = strings.ToLower(guid)
 
 	newNet, err = stdnet.NewNet()
 	if err != nil {

--- a/iface/tun.go
+++ b/iface/tun.go
@@ -7,6 +7,11 @@ import (
 	"github.com/netbirdio/netbird/iface/bind"
 )
 
+const defaultWindowsGUIDSTring = "{f2f29e61-d91f-4d76-8151-119b20c4bdeb}"
+
+// CustomWindowsGUIDString is a custom GUID string for the interface
+var CustomWindowsGUIDString string
+
 type wgTunDevice interface {
 	Create() (wgConfigurer, error)
 	Up() (*bind.UniversalUDPMuxDefault, error)

--- a/iface/tun.go
+++ b/iface/tun.go
@@ -7,8 +7,6 @@ import (
 	"github.com/netbirdio/netbird/iface/bind"
 )
 
-const defaultWindowsGUIDSTring = "{f2f29e61-d91f-4d76-8151-119b20c4bdeb}"
-
 // CustomWindowsGUIDString is a custom GUID string for the interface
 var CustomWindowsGUIDString string
 

--- a/iface/tun_windows.go
+++ b/iface/tun_windows.go
@@ -41,7 +41,11 @@ func newTunDevice(name string, address WGAddress, port int, key string, mtu int,
 }
 
 func getGUID() (windows.GUID, error) {
-	return windows.GUIDFromString("{f2f29e61-d91f-4d76-8151-119b20c4bdeb}")
+	guidString := defaultWindowsGUIDSTring
+	if CustomWindowsGUIDString != "" {
+		guidString = CustomWindowsGUIDString
+	}
+	return windows.GUIDFromString(guidString)
 }
 
 func (t *tunDevice) Create() (wgConfigurer, error) {

--- a/iface/tun_windows.go
+++ b/iface/tun_windows.go
@@ -14,6 +14,8 @@ import (
 	"github.com/netbirdio/netbird/iface/bind"
 )
 
+const defaultWindowsGUIDSTring = "{f2f29e61-d91f-4d76-8151-119b20c4bdeb}"
+
 type tunDevice struct {
 	name    string
 	address WGAddress

--- a/iface/tun_windows.go
+++ b/iface/tun_windows.go
@@ -40,9 +40,18 @@ func newTunDevice(name string, address WGAddress, port int, key string, mtu int,
 	}
 }
 
+func getGUID() (windows.GUID, error) {
+	return windows.GUIDFromString("{f2f29e61-d91f-4d76-8151-119b20c4bdeb}")
+}
+
 func (t *tunDevice) Create() (wgConfigurer, error) {
+	guid, err := getGUID()
+	if err != nil {
+		log.Errorf("failed to get GUID: %s", err)
+		return nil, err
+	}
 	log.Info("create tun interface")
-	tunDevice, err := tun.CreateTUN(t.name, t.mtu)
+	tunDevice, err := tun.CreateTUNWithRequestedGUID(t.name, &guid, t.mtu)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes
RequestedGUID is the GUID of the created network adapter, which then influences NLA generation deterministically.

With this change, NetBird should not generate multiple interfaces in every restart on Windows.

## Issue ticket number and link
Resolves #1658 #2004
### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
