### PR TITLE
[relay] Fix peer close function

### DIFF
--- a/relay/client/client.go
+++ b/relay/client/client.go
@@ -472,8 +472,8 @@ func (c *Client) close(gracefullyExit bool) error {
 	c.closeAllConns()
 	if gracefullyExit {
 		c.writeCloseMsg()
-		err = c.relayConn.Close()
 	}
+	err = c.relayConn.Close()
 	c.mu.Unlock()
 
 	c.wgReadLoop.Wait()


### PR DESCRIPTION

## Describe your changes

Fix **netbird down** command

The ICE agent closes the connection in async way. After the close event, it restarted the connection upgrade to Relay. In the relay code it started new go routines. Check the context.Err() in all cases when an event can happen in async way.


## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
