### PR TITLE
[relay] Rename RelayConfig to Relay

### DIFF
--- a/client/cmd/testutil_test.go
+++ b/client/cmd/testutil_test.go
@@ -99,7 +99,7 @@ func startManagement(t *testing.T, config *mgmt.Config) (*grpc.Server, net.Liste
 		t.Fatal(err)
 	}
 
-	rc := &mgmt.RelayConfig{
+	rc := &mgmt.Relay{
 		Address: "localhost:0",
 	}
 	turnManager := mgmt.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig, rc)

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -36,8 +36,8 @@ import (
 	mgmtProto "github.com/netbirdio/netbird/management/proto"
 	"github.com/netbirdio/netbird/management/server"
 	"github.com/netbirdio/netbird/management/server/activity"
-	relayClient "github.com/netbirdio/netbird/relay/client"
 	"github.com/netbirdio/netbird/management/server/telemetry"
+	relayClient "github.com/netbirdio/netbird/relay/client"
 	"github.com/netbirdio/netbird/route"
 	signal "github.com/netbirdio/netbird/signal/client"
 	"github.com/netbirdio/netbird/signal/proto"
@@ -1106,7 +1106,7 @@ func startManagement(t *testing.T, dataDir string) (*grpc.Server, string, error)
 	if err != nil {
 		return nil, "", err
 	}
-	rc := &server.RelayConfig{
+	rc := &server.Relay{
 		Address: "127.0.0.1:1234",
 	}
 	turnManager := server.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig, rc)

--- a/client/server/server_test.go
+++ b/client/server/server_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netbirdio/management-integrations/integrations"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+
+	"github.com/netbirdio/management-integrations/integrations"
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -129,7 +130,7 @@ func startManagement(t *testing.T, signalAddr string, counter *int) (*grpc.Serve
 	if err != nil {
 		return nil, "", err
 	}
-	rc := &server.RelayConfig{
+	rc := &server.Relay{
 		Address: "localhost:0",
 	}
 	turnManager := server.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig, rc)

--- a/management/client/client_test.go
+++ b/management/client/client_test.go
@@ -82,7 +82,7 @@ func startManagement(t *testing.T) (*grpc.Server, net.Listener) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rc := &mgmt.RelayConfig{
+	rc := &mgmt.Relay{
 		Address: "localhost:0",
 	}
 	turnManager := mgmt.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig, rc)

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -195,7 +195,7 @@ var (
 				return fmt.Errorf("failed to build default manager: %v", err)
 			}
 
-			turnRelayTokenManager := server.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig, config.RelayConfig)
+			turnRelayTokenManager := server.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig, config.Relay)
 
 			trustedPeers := config.ReverseProxy.TrustedPeers
 			defaultTrustedPeers := []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0"), netip.MustParsePrefix("::/0")}
@@ -538,8 +538,8 @@ func loadMgmtConfig(ctx context.Context, mgmtConfigPath string) (*server.Config,
 		}
 	}
 
-	if loadedConfig.RelayConfig != nil {
-		log.Infof("Relay address: %v", loadedConfig.RelayConfig.Address)
+	if loadedConfig.Relay != nil {
+		log.Infof("Relay address: %v", loadedConfig.Relay.Address)
 	}
 
 	return loadedConfig, err

--- a/management/cmd/management_test.go
+++ b/management/cmd/management_test.go
@@ -29,10 +29,10 @@ func Test_loadMgmtConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load management config: %s", err)
 	}
-	if cfg.RelayConfig == nil {
+	if cfg.Relay == nil {
 		t.Fatalf("config is nil")
 	}
-	if cfg.RelayConfig.Address == "" {
+	if cfg.Relay.Address == "" {
 		t.Fatalf("relay address is empty")
 	}
 }

--- a/management/cmd/management_test.go
+++ b/management/cmd/management_test.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	exampleConfig = `{	
-		"RelayConfig": {
+		"Relay": {
 		   "Address": "rels://relay.stage.npeer.io"
 		},
 		"HttpConfig": {

--- a/management/server/config.go
+++ b/management/server/config.go
@@ -32,10 +32,10 @@ const (
 
 // Config of the Management service
 type Config struct {
-	Stuns       []*Host
-	TURNConfig  *TURNConfig
-	RelayConfig *RelayConfig `json:"relay"`
-	Signal      *Host
+	Stuns      []*Host
+	TURNConfig *TURNConfig
+	Relay      *Relay
+	Signal     *Host
 
 	Datadir                string
 	DataStoreEncryptionKey string
@@ -76,7 +76,7 @@ type TURNConfig struct {
 	Turns                []*Host
 }
 
-type RelayConfig struct {
+type Relay struct {
 	Address string
 }
 

--- a/management/server/config.go
+++ b/management/server/config.go
@@ -34,7 +34,7 @@ const (
 type Config struct {
 	Stuns       []*Host
 	TURNConfig  *TURNConfig
-	RelayConfig *RelayConfig
+	RelayConfig *RelayConfig `json:"relay"`
 	Signal      *Host
 
 	Datadir                string

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -518,9 +518,9 @@ func toWiretrusteeConfig(config *Config, turnCredentials *TURNRelayToken, relayT
 	}
 
 	var relayCfg *proto.RelayConfig
-	if config.RelayConfig != nil && config.RelayConfig.Address != "" {
+	if config.Relay != nil && config.Relay.Address != "" {
 		relayCfg = &proto.RelayConfig{
-			Urls: []string{config.RelayConfig.Address},
+			Urls: []string{config.Relay.Address},
 		}
 
 		if relayToken != nil {

--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -430,7 +430,7 @@ func startManagement(t *testing.T, config *Config) (*grpc.Server, *DefaultAccoun
 		return nil, nil, "", err
 	}
 
-	rc := &RelayConfig{
+	rc := &Relay{
 		Address: "localhost:0",
 	}
 	turnManager := NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig, rc)

--- a/management/server/management_test.go
+++ b/management/server/management_test.go
@@ -553,7 +553,7 @@ func startServer(config *server.Config) (*grpc.Server, net.Listener) {
 		log.Fatalf("failed creating a manager: %v", err)
 	}
 
-	rc := &server.RelayConfig{
+	rc := &server.Relay{
 		Address: "localhost:0",
 	}
 	turnManager := server.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig, rc)

--- a/management/server/token_mgr.go
+++ b/management/server/token_mgr.go
@@ -31,7 +31,7 @@ type TimeBasedAuthSecretsManager struct {
 
 type TURNRelayToken auth.Token
 
-func NewTimeBasedAuthSecretsManager(updateManager *PeersUpdateManager, turnCfg *TURNConfig, relayConfig *RelayConfig) *TimeBasedAuthSecretsManager {
+func NewTimeBasedAuthSecretsManager(updateManager *PeersUpdateManager, turnCfg *TURNConfig, relayConfig *Relay) *TimeBasedAuthSecretsManager {
 
 	var relayAddr string
 	if relayConfig != nil {

--- a/management/server/token_mgr_test.go
+++ b/management/server/token_mgr_test.go
@@ -23,7 +23,7 @@ func TestTimeBasedAuthSecretsManager_GenerateCredentials(t *testing.T) {
 	secret := "some_secret"
 	peersManager := NewPeersUpdateManager(nil)
 
-	rc := &RelayConfig{
+	rc := &Relay{
 		Address: "localhost:0",
 	}
 	tested := NewTimeBasedAuthSecretsManager(peersManager, &TURNConfig{
@@ -52,7 +52,7 @@ func TestTimeBasedAuthSecretsManager_SetupRefresh(t *testing.T) {
 	peer := "some_peer"
 	updateChannel := peersManager.CreateChannel(context.Background(), peer)
 
-	rc := &RelayConfig{
+	rc := &Relay{
 		Address: "localhost:0",
 	}
 	tested := NewTimeBasedAuthSecretsManager(peersManager, &TURNConfig{
@@ -103,7 +103,7 @@ func TestTimeBasedAuthSecretsManager_CancelRefresh(t *testing.T) {
 	peersManager := NewPeersUpdateManager(nil)
 	peer := "some_peer"
 
-	rc := &RelayConfig{
+	rc := &Relay{
 		Address: "localhost:0",
 	}
 	tested := NewTimeBasedAuthSecretsManager(peersManager, &TURNConfig{


### PR DESCRIPTION
In the config file make no sense to use the config keyword.

Rename RelayConfig to Relay

## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
