### PR TITLE
[misc] Support rpm-ostree based distros in installation script

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
-	github.com/kardianos/service v1.2.1-0.20210728001519-a323c3813bc7
+	github.com/kardianos/service v1.2.3-0.20240613133416-becf2eb62b83
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.23.0
 	github.com/pion/ice/v3 v3.0.2
@@ -205,7 +205,7 @@ require (
 	k8s.io/apimachinery v0.26.2 // indirect
 )
 
-replace github.com/kardianos/service => github.com/netbirdio/service v0.0.0-20230215170314-b923b89432b0
+replace github.com/kardianos/service => github.com/netbirdio/service v0.0.0-20240904111318-17777758453a
 
 replace github.com/getlantern/systray => github.com/netbirdio/systray v0.0.0-20231030152038-ef1ed2a27949
 

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/netbirdio/ice/v3 v3.0.0-20240315174635-e72a50fcb64e h1:PURA50S8u4mF6R
 github.com/netbirdio/ice/v3 v3.0.0-20240315174635-e72a50fcb64e/go.mod h1:YMLU7qbKfVjmEv7EoZPIVEI+kNYxWCdPK3VS0BU+U4Q=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20240703085513-32605f7ffd8e h1:LYxhAmiEzSldLELHSMVoUnRPq3ztTNQImrD27frrGsI=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20240703085513-32605f7ffd8e/go.mod h1:nykwWZnxb+sJz2Z//CEq45CMRWSHllH8pODKRB8eY7Y=
-github.com/netbirdio/service v0.0.0-20230215170314-b923b89432b0 h1:hirFRfx3grVA/9eEyjME5/z3nxdJlN9kfQpvWWPk32g=
-github.com/netbirdio/service v0.0.0-20230215170314-b923b89432b0/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
+github.com/netbirdio/service v0.0.0-20240904111318-17777758453a h1:2EcDFDT39Odz5EC38pOSyjCd3bLUjPi7pMQpH6k+zzk=
+github.com/netbirdio/service v0.0.0-20240904111318-17777758453a/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20240820130728-bc0683599080 h1:mXJkoWLdqJTlkQ7DgQ536kcXHXIdUPeagkN8i4eFDdg=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20240820130728-bc0683599080/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
 github.com/netbirdio/wireguard-go v0.0.0-20240105182236-6c340dd55aed h1:t0UADZUJDaaZgfKrt8JUPrOLL9Mg/ryjP85RAH53qgs=

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -242,6 +242,13 @@ install_netbird() {
             ${SUDO} dnf -y install netbird-ui
         fi
     ;;
+    rpm-ostree)
+        add_rpm_repo
+        ${SUDO} rpm-ostree -y install netbird
+        if ! $SKIP_UI_APP; then
+            ${SUDO} rpm-ostree -y install netbird-ui
+        fi
+    ;;
     pacman)
         ${SUDO} pacman -Syy
         add_aur_repo
@@ -403,6 +410,9 @@ if type uname >/dev/null 2>&1; then
               elif [ -x "$(command -v dnf)" ]; then
                   PACKAGE_MANAGER="dnf"
                   echo "The installation will be performed using dnf package manager"
+              elif [ -x "$(command -v rpm-ostree)" ]; then
+                  PACKAGE_MANAGER="rpm-ostree"
+                  echo "The installation will be performed using rpm-ostree package manager"
               elif [ -x "$(command -v yum)" ]; then
                   PACKAGE_MANAGER="yum"
                   echo "The installation will be performed using yum package manager"


### PR DESCRIPTION
## Describe your changes
This add `rpm-ostree` binary detection in installation script and update `kardianos/service` module to lastest commits. It should close https://github.com/netbirdio/netbird/issues/1634

Latest commits of `kardianos/service` correctly detect and discriminate between `/etc` folders (init.d, systemd/system....) 
