### PR TITLE
[dashboard] Use X-Frame-Options sameorigin header

### DIFF
--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -541,7 +541,7 @@ renderCaddyfile() {
 
         # clickjacking protection
         # https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-frame-options
-        X-Frame-Options "DENY"
+        X-Frame-Options "SAMEORIGIN"
 
         # xss protection
         # https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection


### PR DESCRIPTION
## Describe your changes

The previous X-Frame DENY header prevented to display the page inside an iFrame. 
The current OIDC library for the dashboard uses iFrame to perform a silent login. 

> Silent signing uses cookies from your OIDC provider to restore the session and retrieve tokens. It opens an IFrame in the background, directed to a specific page on your OIDC provider.

This fix changes the X-Frame-Options header `DENY` to `SAMEORIGIN`

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
