### PR TITLE
Support exposed address with scheme

### DIFF
--- a/relay/server/relay.go
+++ b/relay/server/relay.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -61,17 +62,39 @@ func NewRelay(meter metric.Meter, exposedAddress string, tlsSupport bool, valida
 		store:         NewStore(),
 	}
 
-	if tlsSupport {
-		r.instanceURL = fmt.Sprintf("rels://%s", exposedAddress)
-	} else {
-		r.instanceURL = fmt.Sprintf("rel://%s", exposedAddress)
-	}
-	_, err = url.ParseRequestURI(r.instanceURL)
+	r.instanceURL, err = getInstanceURL(exposedAddress, tlsSupport)
 	if err != nil {
-		return nil, fmt.Errorf("invalid exposed address: %v", err)
+		metricsCancel()
+		return nil, fmt.Errorf("get instance URL: %v", err)
 	}
 
 	return r, nil
+}
+
+// getInstanceURL checks if user supplied a URL scheme otherwise adds to the
+// provided address according to TLS definition and parses the address before returning it
+func getInstanceURL(exposedAddress string, tlsSupported bool) (string, error) {
+	addr := exposedAddress
+	split := strings.Split(exposedAddress, "://")
+	switch {
+	case len(split) == 1 && tlsSupported:
+		addr = "rels://" + exposedAddress
+	case len(split) == 1 && !tlsSupported:
+		addr = "rel://" + exposedAddress
+	case len(split) > 2:
+		return "", fmt.Errorf("invalid exposed address: %s", exposedAddress)
+	}
+
+	parsedURL, err := url.ParseRequestURI(addr)
+	if err != nil {
+		return "", fmt.Errorf("invalid exposed address: %v", err)
+	}
+
+	if parsedURL.Scheme != "rel" && parsedURL.Scheme != "rels" {
+		return "", fmt.Errorf("invalid scheme: %s", parsedURL.Scheme)
+	}
+
+	return parsedURL.String(), nil
 }
 
 // Accept start to handle a new peer connection

--- a/relay/server/relay_test.go
+++ b/relay/server/relay_test.go
@@ -1,0 +1,36 @@
+package server
+
+import "testing"
+
+func TestGetInstanceURL(t *testing.T) {
+	tests := []struct {
+		name           string
+		exposedAddress string
+		tlsSupported   bool
+		expectedURL    string
+		expectError    bool
+	}{
+		{"Valid address with TLS", "example.com", true, "rels://example.com", false},
+		{"Valid address without TLS", "example.com", false, "rel://example.com", false},
+		{"Valid address with scheme", "rel://example.com", false, "rel://example.com", false},
+		{"Valid address with non TLS scheme and TLS true", "rel://example.com", true, "rel://example.com", false},
+		{"Valid address with TLS scheme", "rels://example.com", true, "rels://example.com", false},
+		{"Valid address with TLS scheme and TLS false", "rels://example.com", false, "rels://example.com", false},
+		{"Valid address with TLS scheme and custom port", "rels://example.com:9300", true, "rels://example.com:9300", false},
+		{"Invalid address with multiple schemes", "rel://rels://example.com", false, "", true},
+		{"Invalid address with unsupported scheme", "http://example.com", false, "", true},
+		{"Invalid address format", "://example.com", false, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, err := getInstanceURL(tt.exposedAddress, tt.tlsSupported)
+			if (err != nil) != tt.expectError {
+				t.Errorf("expected error: %v, got: %v", tt.expectError, err)
+			}
+			if url != tt.expectedURL {
+				t.Errorf("expected URL: %s, got: %s", tt.expectedURL, url)
+			}
+		})
+	}
+}


### PR DESCRIPTION

## Describe your changes
This allows the relay to run behind a proxy doing TLS termination

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
