### PR TITLE
[client] Retry on tun creation for darwin

### DIFF
--- a/iface/iface_create.go
+++ b/iface/iface_create.go
@@ -1,4 +1,4 @@
-//go:build !android
+//go:build !android && !darwin
 
 package iface
 

--- a/iface/iface_create.go
+++ b/iface/iface_create.go
@@ -1,4 +1,4 @@
-//go:build !android && !darwin
+//go:build (!android && !darwin) || ios
 
 package iface
 

--- a/iface/iface_darwin.go
+++ b/iface/iface_darwin.go
@@ -4,7 +4,9 @@ package iface
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pion/transport/v3"
 
 	"github.com/netbirdio/netbird/iface/bind"
@@ -35,4 +37,29 @@ func NewWGIFace(iFaceName string, address string, wgPort int, wgPrivKey string, 
 // CreateOnAndroid this function make sense on mobile only
 func (w *WGIface) CreateOnAndroid([]string, string, []string) error {
 	return fmt.Errorf("this function has not implemented on this platform")
+}
+
+// Create creates a new Wireguard interface, sets a given IP and brings it up.
+// Will reuse an existing one.
+// this function is different on Android
+func (w *WGIface) Create() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	backOff := &backoff.ExponentialBackOff{
+		InitialInterval: 20 * time.Millisecond,
+		MaxElapsedTime:  500 * time.Millisecond,
+		Clock:           backoff.SystemClock,
+	}
+
+	operation := func() error {
+		cfgr, err := w.tun.Create()
+		if err != nil {
+			return err
+		}
+		w.configurer = cfgr
+		return nil
+	}
+
+	return backoff.Retry(operation, backOff)
 }

--- a/iface/iface_darwin.go
+++ b/iface/iface_darwin.go
@@ -49,6 +49,7 @@ func (w *WGIface) Create() error {
 	backOff := &backoff.ExponentialBackOff{
 		InitialInterval: 20 * time.Millisecond,
 		MaxElapsedTime:  500 * time.Millisecond,
+		Stop:            backoff.Stop,
 		Clock:           backoff.SystemClock,
 	}
 

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -550,8 +550,6 @@ func (am *DefaultAccountManager) SyncPeer(ctx context.Context, sync PeerSync, ac
 	}
 
 	if peer.UserID != "" {
-		log.Infof("Peer has no userID")
-
 		user, err := account.FindUser(peer.UserID)
 		if err != nil {
 			return nil, nil, nil, err


### PR DESCRIPTION
## Describe your changes
The interface creation on macOS seems to be asynchronus why the tun.create methode somethimes failes becasue the interface is not ready yet. To work around this issue we introduce a retry on tun.create

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
