### PR TITLE
Enforce permissions on Win

### DIFF
--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -130,7 +130,7 @@ func ReadConfig(configPath string) (*Config, error) {
 		if changed, err := config.apply(ConfigInput{}); err != nil {
 			return nil, err
 		} else if changed {
-			if err = writeOutConfig(configPath, config); err != nil {
+			if err = WriteOutConfig(configPath, config); err != nil {
 				return nil, err
 			}
 		}
@@ -143,7 +143,7 @@ func ReadConfig(configPath string) (*Config, error) {
 		return nil, err
 	}
 
-	err = writeOutConfig(configPath, cfg)
+	err = WriteOutConfig(configPath, cfg)
 	return cfg, err
 }
 
@@ -183,8 +183,8 @@ func CreateInMemoryConfig(input ConfigInput) (*Config, error) {
 	return createNewConfig(input)
 }
 
-// writeOutConfig write put the prepared config to the given path
-func writeOutConfig(path string, config *Config) error {
+// WriteOutConfig write put the prepared config to the given path
+func WriteOutConfig(path string, config *Config) error {
 	return util.WriteJson(path, config)
 }
 

--- a/util/permission.go
+++ b/util/permission.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package util
+
+func enforcePermission(dirPath string) error {
+	return nil
+}

--- a/util/permission.go
+++ b/util/permission.go
@@ -2,6 +2,6 @@
 
 package util
 
-func enforcePermission(dirPath string) error {
+func EnforcePermission(dirPath string) error {
 	return nil
 }

--- a/util/permission_windows.go
+++ b/util/permission_windows.go
@@ -55,22 +55,23 @@ func EnforcePermission(file string) error {
 }
 
 func sids() (*windows.SID, *windows.SID, error) {
-	t, err := windows.OpenCurrentProcessToken()
+	var token windows.Token
+	err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer func() {
-		if err := t.Close(); err != nil {
+		if err := token.Close(); err != nil {
 			log.Errorf("failed to close proces token: %v", err)
 		}
 	}()
 
-	tu, err := t.GetTokenUser()
+	tu, err := token.GetTokenUser()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	pg, err := t.GetTokenPrimaryGroup()
+	pg, err := token.GetTokenPrimaryGroup()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/util/permission_windows.go
+++ b/util/permission_windows.go
@@ -32,17 +32,23 @@ func EnforcePermission(file string) error {
 			windows.GENERIC_ALL,
 			windows.SET_ACCESS,
 			windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
-			windows.TRUSTEE{nil, windows.NO_MULTIPLE_TRUSTEE,
-				windows.TRUSTEE_IS_SID, windows.TRUSTEE_IS_USER,
-				(windows.TrusteeValueFromSID(user))},
+			windows.TRUSTEE{
+				MultipleTrusteeOperation: windows.NO_MULTIPLE_TRUSTEE,
+				TrusteeForm:              windows.TRUSTEE_IS_SID,
+				TrusteeType:              windows.TRUSTEE_IS_USER,
+				TrusteeValue:             windows.TrusteeValueFromSID(user),
+			},
 		},
 		{
 			windows.GENERIC_ALL,
 			windows.SET_ACCESS,
 			windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
-			windows.TRUSTEE{nil, windows.NO_MULTIPLE_TRUSTEE,
-				windows.TRUSTEE_IS_SID, windows.TRUSTEE_IS_WELL_KNOWN_GROUP,
-				windows.TrusteeValueFromSID(adminGroupSid)},
+			windows.TRUSTEE{
+				MultipleTrusteeOperation: windows.NO_MULTIPLE_TRUSTEE,
+				TrusteeForm:              windows.TRUSTEE_IS_SID,
+				TrusteeType:              windows.TRUSTEE_IS_WELL_KNOWN_GROUP,
+				TrusteeValue:             windows.TrusteeValueFromSID(adminGroupSid),
+			},
 		},
 	}
 

--- a/util/permission_windows.go
+++ b/util/permission_windows.go
@@ -29,10 +29,10 @@ func EnforcePermission(file string) error {
 
 	explicitAccess := []windows.EXPLICIT_ACCESS{
 		{
-			windows.GENERIC_ALL,
-			windows.SET_ACCESS,
-			windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
-			windows.TRUSTEE{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.SET_ACCESS,
+			Inheritance:       windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+			Trustee: windows.TRUSTEE{
 				MultipleTrusteeOperation: windows.NO_MULTIPLE_TRUSTEE,
 				TrusteeForm:              windows.TRUSTEE_IS_SID,
 				TrusteeType:              windows.TRUSTEE_IS_USER,
@@ -40,10 +40,10 @@ func EnforcePermission(file string) error {
 			},
 		},
 		{
-			windows.GENERIC_ALL,
-			windows.SET_ACCESS,
-			windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
-			windows.TRUSTEE{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.SET_ACCESS,
+			Inheritance:       windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+			Trustee: windows.TRUSTEE{
 				MultipleTrusteeOperation: windows.NO_MULTIPLE_TRUSTEE,
 				TrusteeForm:              windows.TRUSTEE_IS_SID,
 				TrusteeType:              windows.TRUSTEE_IS_WELL_KNOWN_GROUP,

--- a/util/permission_windows.go
+++ b/util/permission_windows.go
@@ -62,7 +62,7 @@ func sids() (*windows.SID, *windows.SID, error) {
 	}
 	defer func() {
 		if err := token.Close(); err != nil {
-			log.Errorf("failed to close proces token: %v", err)
+			log.Errorf("failed to close process token: %v", err)
 		}
 	}()
 

--- a/util/permission_windows.go
+++ b/util/permission_windows.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	securityFlags = windows.OWNER_SECURITY_INFORMATION |
+		windows.GROUP_SECURITY_INFORMATION |
+		windows.DACL_SECURITY_INFORMATION |
+		windows.PROTECTED_DACL_SECURITY_INFORMATION
+)
+
+func EnforcePermission(file string) error {
+	dirPath := filepath.Dir(file)
+
+	user, group, err := sids()
+	if err != nil {
+		return err
+	}
+
+	adminGroupSid, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return err
+	}
+
+	explicitAccess := []windows.EXPLICIT_ACCESS{
+		{
+			windows.GENERIC_ALL,
+			windows.SET_ACCESS,
+			windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+			windows.TRUSTEE{nil, windows.NO_MULTIPLE_TRUSTEE,
+				windows.TRUSTEE_IS_SID, windows.TRUSTEE_IS_USER,
+				(windows.TrusteeValueFromSID(user))},
+		},
+		{
+			windows.GENERIC_ALL,
+			windows.SET_ACCESS,
+			windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+			windows.TRUSTEE{nil, windows.NO_MULTIPLE_TRUSTEE,
+				windows.TRUSTEE_IS_SID, windows.TRUSTEE_IS_WELL_KNOWN_GROUP,
+				windows.TrusteeValueFromSID(adminGroupSid)},
+		},
+	}
+
+	dacl, err := windows.ACLFromEntries(explicitAccess, nil)
+	if err != nil {
+		return err
+	}
+
+	return windows.SetNamedSecurityInfo(dirPath, windows.SE_FILE_OBJECT, securityFlags, user, group, dacl, nil)
+}
+
+func sids() (*windows.SID, *windows.SID, error) {
+	t, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		if err := t.Close(); err != nil {
+			log.Errorf("failed to close proces token: %v", err)
+		}
+	}()
+
+	tu, err := t.GetTokenUser()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pg, err := t.GetTokenPrimaryGroup()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tu.User.Sid, pg.PrimaryGroup, nil
+}


### PR DESCRIPTION
## Describe your changes

Enforce folder permission on Windows, giving only administrators and system access to the NetBird folder.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
