### PR TITLE
[management] Add GCM encryption and migrate legacy encrypted events

### DIFF
--- a/management/server/activity/sqlite/crypt.go
+++ b/management/server/activity/sqlite/crypt.go
@@ -61,13 +61,17 @@ func (ec *FieldEncrypt) LegacyEncrypt(payload string) string {
 
 // Encrypt encrypts plaintext using AES-GCM
 func (ec *FieldEncrypt) Encrypt(payload string) (string, error) {
-	nonce := make([]byte, ec.gcm.NonceSize())
+	plaintext := []byte(payload)
+	nonceSize := ec.gcm.NonceSize()
+
+	nonce := make([]byte, nonceSize, len(plaintext)+nonceSize+ec.gcm.Overhead())
 	if _, err := rand.Read(nonce); err != nil {
 		return "", err
 	}
 
-	cipherText := ec.gcm.Seal(nonce, nonce, []byte(payload), nil)
-	return base64.StdEncoding.EncodeToString(cipherText), nil
+	ciphertext := ec.gcm.Seal(nonce, nonce, plaintext, nil)
+
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
 func (ec *FieldEncrypt) LegacyDecrypt(data string) (string, error) {

--- a/management/server/activity/sqlite/crypt.go
+++ b/management/server/activity/sqlite/crypt.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 )
 
@@ -93,7 +94,7 @@ func (ec *FieldEncrypt) Decrypt(data string) (string, error) {
 
 	nonceSize := ec.gcm.NonceSize()
 	if len(cipherText) < nonceSize {
-		return "", fmt.Errorf("cipher text too short")
+		return "", errors.New("cipher text too short")
 	}
 
 	nonce, cipherText := cipherText[:nonceSize], cipherText[nonceSize:]

--- a/management/server/activity/sqlite/crypt_test.go
+++ b/management/server/activity/sqlite/crypt_test.go
@@ -15,12 +15,42 @@ func TestGenerateKey(t *testing.T) {
 		t.Fatalf("failed to init email encryption: %s", err)
 	}
 
-	encrypted := ee.Encrypt(testData)
+	encrypted, err := ee.Encrypt(testData)
+	if err != nil {
+		t.Fatalf("failed to encrypt data: %s", err)
+	}
+
 	if encrypted == "" {
 		t.Fatalf("invalid encrypted text")
 	}
 
 	decrypted, err := ee.Decrypt(encrypted)
+	if err != nil {
+		t.Fatalf("failed to decrypt data: %s", err)
+	}
+
+	if decrypted != testData {
+		t.Fatalf("decrypted data is not match with test data: %s, %s", testData, decrypted)
+	}
+}
+
+func TestGenerateKeyLegacy(t *testing.T) {
+	testData := "exampl@netbird.io"
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %s", err)
+	}
+	ee, err := NewFieldEncrypt(key)
+	if err != nil {
+		t.Fatalf("failed to init email encryption: %s", err)
+	}
+
+	encrypted := ee.LegacyEncrypt(testData)
+	if encrypted == "" {
+		t.Fatalf("invalid encrypted text")
+	}
+
+	decrypted, err := ee.LegacyDecrypt(encrypted)
 	if err != nil {
 		t.Fatalf("failed to decrypt data: %s", err)
 	}
@@ -41,7 +71,11 @@ func TestCorruptKey(t *testing.T) {
 		t.Fatalf("failed to init email encryption: %s", err)
 	}
 
-	encrypted := ee.Encrypt(testData)
+	encrypted, err := ee.Encrypt(testData)
+	if err != nil {
+		t.Fatalf("failed to encrypt data: %s", err)
+	}
+
 	if encrypted == "" {
 		t.Fatalf("invalid encrypted text")
 	}

--- a/management/server/activity/sqlite/migration.go
+++ b/management/server/activity/sqlite/migration.go
@@ -1,0 +1,124 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func migrate(ctx context.Context, crypt *FieldEncrypt, db *sql.DB) error {
+	if err := updateDeletedUsersTable(ctx, db); err != nil {
+		return fmt.Errorf("failed to update deleted_users table: %v", err)
+	}
+
+	return migrateLegacyEncryptedUsersToGCM(ctx, crypt, db)
+}
+
+// updateDeletedUsersTable checks and updates the deleted_users table schema to ensure required columns exist.
+func updateDeletedUsersTable(ctx context.Context, db *sql.DB) error {
+	exists, err := checkColumnExists(db, "deleted_users", "name")
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		log.WithContext(ctx).Debug("Adding name column to the deleted_users table")
+
+		_, err = db.Exec(`ALTER TABLE deleted_users ADD COLUMN name TEXT;`)
+		if err != nil {
+			return err
+		}
+
+		log.WithContext(ctx).Debug("Successfully added name column to the deleted_users table")
+	}
+
+	exists, err = checkColumnExists(db, "deleted_users", "enc_algo")
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		log.WithContext(ctx).Debug("Adding enc_algo column to the deleted_users table")
+
+		_, err = db.Exec(`ALTER TABLE deleted_users ADD COLUMN enc_algo TEXT;`)
+		if err != nil {
+			return err
+		}
+
+		log.WithContext(ctx).Debug("Successfully added enc_algo column to the deleted_users table")
+	}
+
+	return nil
+}
+
+// migrateLegacyEncryptedUsersToGCM migrates previously encrypted data using,
+// legacy CBC encryption with a static IV to the new GCM encryption method.
+func migrateLegacyEncryptedUsersToGCM(ctx context.Context, crypt *FieldEncrypt, db *sql.DB) error {
+	log.WithContext(ctx).Debug("Migrating CBC encrypted deleted users to GCM")
+
+	rows, err := db.Query(fmt.Sprintf(`SELECT id, email, name FROM deleted_users where enc_algo != '%s'`, gcmEncAlgo))
+	if err != nil {
+		return fmt.Errorf("failed to execute select query: %v", err)
+	}
+	defer rows.Close()
+
+	updateStmt, err := db.Prepare(`UPDATE deleted_users SET email = ?, name = ?, enc_algo = ? WHERE id = ?`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare update statement: %v", err)
+	}
+	defer updateStmt.Close()
+
+	if err = processUserRows(ctx, crypt, rows, updateStmt); err != nil {
+		return err
+	}
+
+	log.WithContext(ctx).Debug("Successfully migrated CBC encrypted deleted users to GCM")
+	return nil
+}
+
+// processUserRows processes database rows of user data, decrypts legacy encryption fields, and re-encrypts them using GCM.
+func processUserRows(ctx context.Context, crypt *FieldEncrypt, rows *sql.Rows, updateStmt *sql.Stmt) error {
+	for rows.Next() {
+		var id int
+		var email, name string
+
+		if err := rows.Scan(&id, &email, &name); err != nil {
+			return err
+		}
+
+		decryptedEmail, err := crypt.LegacyDecrypt(email)
+		if err != nil {
+			log.WithContext(ctx).Warnf("failed to decrypt email for deleted user: %d", id)
+			email = fallbackEmail
+		}
+
+		decryptedName, err := crypt.LegacyDecrypt(name)
+		if err != nil {
+			log.WithContext(ctx).Warnf("failed to decrypt name for deleted user: %d", id)
+			name = fallbackName
+		}
+
+		encryptedEmail, err := crypt.Encrypt(decryptedEmail)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt email for deleted user: %d", id)
+		}
+
+		encryptedName, err := crypt.Encrypt(decryptedName)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt name for deleted user: %d", id)
+		}
+
+		_, err = updateStmt.Exec(encryptedEmail, encryptedName, gcmEncAlgo, id)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/management/server/activity/sqlite/migration.go
+++ b/management/server/activity/sqlite/migration.go
@@ -70,7 +70,11 @@ func migrateLegacyEncryptedUsersToGCM(ctx context.Context, crypt *FieldEncrypt, 
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if err = tx.Rollback(); err != nil {
+			log.WithContext(ctx).Warnf("failed to rollback transaction: %v", err)
+		}
+	}()
 
 	rows, err := tx.Query(fmt.Sprintf(`SELECT id, email, name FROM deleted_users where enc_algo IS NULL OR enc_algo != '%s'`, gcmEncAlgo))
 	if err != nil {

--- a/management/server/activity/sqlite/migration_test.go
+++ b/management/server/activity/sqlite/migration_test.go
@@ -1,0 +1,84 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/netbirdio/netbird/management/server/activity"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setupDatabase(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dbFile := filepath.Join(t.TempDir(), eventSinkDB)
+	db, err := sql.Open("sqlite3", dbFile)
+	require.NoError(t, err, "Failed to open database")
+
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	_, err = db.Exec(createTableQuery)
+	require.NoError(t, err, "Failed to create events table")
+
+	_, err = db.Exec(`CREATE TABLE deleted_users (id TEXT NOT NULL, email TEXT NOT NULL, name TEXT);`)
+	require.NoError(t, err, "Failed to create deleted_users table")
+
+	return db
+}
+
+func TestMigrate(t *testing.T) {
+	db := setupDatabase(t)
+
+	key, err := GenerateKey()
+	require.NoError(t, err, "Failed to generate key")
+
+	crypt, err := NewFieldEncrypt(key)
+	require.NoError(t, err, "Failed to initialize FieldEncrypt")
+
+	legacyEmail := crypt.LegacyEncrypt("testaccount@test.com")
+	legacyName := crypt.LegacyEncrypt("Test Account")
+
+	_, err = db.Exec(`INSERT INTO events(activity, timestamp, initiator_id, target_id, account_id, meta) VALUES(?, ?, ?, ?, ?, ?)`,
+		activity.UserDeleted, time.Now(), "initiatorID", "targetID", "accountID", "")
+	require.NoError(t, err, "Failed to insert event")
+
+	_, err = db.Exec(`INSERT INTO deleted_users(id, email, name) VALUES(?, ?, ?)`, "targetID", legacyEmail, legacyName)
+	require.NoError(t, err, "Failed to insert legacy encrypted data")
+
+	colExists, err := checkColumnExists(db, "deleted_users", "enc_algo")
+	require.NoError(t, err, "Failed to check if enc_algo column exists")
+	require.False(t, colExists, "enc_algo column should not exist before migration")
+
+	err = migrate(context.Background(), crypt, db)
+	require.NoError(t, err, "Migration failed")
+
+	colExists, err = checkColumnExists(db, "deleted_users", "enc_algo")
+	require.NoError(t, err, "Failed to check if enc_algo column exists after migration")
+	require.True(t, colExists, "enc_algo column should exist after migration")
+
+	var encAlgo string
+	err = db.QueryRow(`SELECT enc_algo FROM deleted_users LIMIT 1`, "").Scan(&encAlgo)
+	require.NoError(t, err, "Failed to select updated data")
+	require.Equal(t, gcmEncAlgo, encAlgo, "enc_algo should be set to 'GCM' after migration")
+
+	store, err := createStore(crypt, db)
+	require.NoError(t, err, "Failed to create store")
+
+	events, err := store.Get(context.Background(), "accountID", 0, 1, false)
+	require.NoError(t, err, "Failed to get events")
+
+	require.Len(t, events, 1, "Should have one event")
+	require.Equal(t, activity.UserDeleted, events[0].Activity, "activity should match")
+	require.Equal(t, "initiatorID", events[0].InitiatorID, "initiator id should match")
+	require.Equal(t, "targetID", events[0].TargetID, "target id should match")
+	require.Equal(t, "accountID", events[0].AccountID, "account id should match")
+	require.Equal(t, "testaccount@test.com", events[0].Meta["email"], "email should match")
+	require.Equal(t, "Test Account", events[0].Meta["username"], "username should match")
+}

--- a/management/server/activity/sqlite/sqlite.go
+++ b/management/server/activity/sqlite/sqlite.go
@@ -104,7 +104,7 @@ func NewSQLiteStore(ctx context.Context, dataDir string, encryptionKey string) (
 
 	if err = migrate(ctx, crypt, db); err != nil {
 		_ = db.Close()
-		return nil, fmt.Errorf("failed to migrate database: %w", err)
+		return nil, fmt.Errorf("events database migration: %w", err)
 	}
 
 	return createStore(crypt, db)

--- a/management/server/activity/sqlite/sqlite.go
+++ b/management/server/activity/sqlite/sqlite.go
@@ -302,9 +302,16 @@ func (store *Store) saveDeletedUserEmailAndNameInEncrypted(event *activity.Event
 		return event.Meta, nil
 	}
 
-	encryptedEmail := store.fieldEncrypt.Encrypt(fmt.Sprintf("%s", email))
-	encryptedName := store.fieldEncrypt.Encrypt(fmt.Sprintf("%s", name))
-	_, err := store.deleteUserStmt.Exec(event.TargetID, encryptedEmail, encryptedName)
+	encryptedEmail, err := store.fieldEncrypt.Encrypt(fmt.Sprintf("%s", email))
+	if err != nil {
+		return nil, err
+	}
+	encryptedName, err := store.fieldEncrypt.Encrypt(fmt.Sprintf("%s", name))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = store.deleteUserStmt.Exec(event.TargetID, encryptedEmail, encryptedName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes

This PR updates the encryption scheme for events data from the legacy CBC encryption with a static IV to the GCM (Galois/Counter Mode) encryption. 

## Issue ticket number and link

Closes #2246

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
