### PR TITLE
fix: install.sh: avoid call of netbird executable after rpm-ostree installation

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -300,11 +300,13 @@ install_netbird() {
     echo "package_manager=$PACKAGE_MANAGER" | ${SUDO} tee "$CONFIG_FILE" > /dev/null
 
     # Load and start netbird service
-    if  ! ${SUDO} netbird service install 2>&1; then
-        echo "NetBird service has already been loaded"
-    fi
-    if  ! ${SUDO} netbird service start 2>&1; then
-        echo "NetBird service has already been started"
+    if [ "$PACKAGE_MANAGER" != "rpm-ostree" ]; then
+        if ! ${SUDO} netbird service install 2>&1; then
+            echo "NetBird service has already been loaded"
+        fi
+        if ! ${SUDO} netbird service start 2>&1; then
+            echo "NetBird service has already been started"
+        fi
     fi
 
 


### PR DESCRIPTION
## Describe your changes
After install.sh execution on rpm-ostree based distro this message appears

```
Changes queued for next boot. Run "systemctl reboot" to start a reboot
sudo: netbird: command not found
NetBird service has already been loaded
sudo: netbird: command not found
NetBird service has already been started
Installation has been finished. To connect, you need to run NetBird by executing the following command:
```

This is caused by a missing netbird executable, only available after reboot to a next deployment or after `rpm-ostree apply-live` execution.


