### PR TITLE
[relay] Add health check attempt threshold

### DIFF
--- a/relay/client/client.go
+++ b/relay/client/client.go
@@ -306,7 +306,7 @@ func (c *Client) handShake() error {
 
 func (c *Client) readLoop(relayConn net.Conn) {
 	internallyStoppedFlag := newInternalStopFlag()
-	hc := healthcheck.NewReceiver()
+	hc := healthcheck.NewReceiver(c.log)
 	go c.listenForStopEvents(hc, relayConn, internallyStoppedFlag)
 
 	var (

--- a/relay/healthcheck/receiver_test.go
+++ b/relay/healthcheck/receiver_test.go
@@ -1,6 +1,7 @@
 package healthcheck
 
 import (
+	"os"
 	"testing"
 	"time"
 )
@@ -38,5 +39,124 @@ func TestNewReceiverAck(t *testing.T) {
 	case <-r.OnTimeout:
 		t.Error("unexpected timeout")
 	case <-time.After(3 * time.Second):
+	}
+}
+
+func TestDefaultAttemptThreshold(t *testing.T) {
+	originalTimeout := heartbeatTimeout
+	heartbeatTimeout = 50 * time.Millisecond
+	defer func() { heartbeatTimeout = originalTimeout }()
+
+	os.Unsetenv(defaultAttemptThresholdEnv)
+
+	r := NewReceiver()
+	defer r.Stop()
+
+	if r.attemptThreshold != defaultAttemptThreshold {
+		t.Fatalf("Expected attemptThreshold to be %d, got %d", defaultAttemptThreshold, r.attemptThreshold)
+	}
+}
+
+func TestCustomAttemptThreshold(t *testing.T) {
+	originalTimeout := heartbeatTimeout
+	heartbeatTimeout = 50 * time.Millisecond
+	defer func() { heartbeatTimeout = originalTimeout }()
+
+	os.Setenv(defaultAttemptThresholdEnv, "3")
+	defer os.Unsetenv(defaultAttemptThresholdEnv)
+
+	r := NewReceiver()
+	defer r.Stop()
+
+	if r.attemptThreshold != 3 {
+		t.Fatalf("Expected attemptThreshold to be 3, got %d", r.attemptThreshold)
+	}
+}
+
+func TestInvalidAttemptThreshold(t *testing.T) {
+	originalTimeout := heartbeatTimeout
+	heartbeatTimeout = 50 * time.Millisecond
+	defer func() { heartbeatTimeout = originalTimeout }()
+
+	os.Setenv(defaultAttemptThresholdEnv, "invalid")
+	defer os.Unsetenv(defaultAttemptThresholdEnv)
+
+	r := NewReceiver()
+	defer r.Stop()
+
+	if r.attemptThreshold != defaultAttemptThreshold {
+		t.Fatalf("Expected attemptThreshold to be default (%d), got %d", defaultAttemptThreshold, r.attemptThreshold)
+	}
+}
+
+func TestHeartbeatTimeout(t *testing.T) {
+	originalTimeout := heartbeatTimeout
+	heartbeatTimeout = 50 * time.Millisecond
+	defer func() { heartbeatTimeout = originalTimeout }()
+
+	os.Setenv(defaultAttemptThresholdEnv, "3")
+	defer os.Unsetenv(defaultAttemptThresholdEnv)
+
+	r := NewReceiver()
+	defer r.Stop()
+
+	timeoutCh := r.OnTimeout
+
+	r.Heartbeat()
+
+	time.Sleep(heartbeatTimeout / 2)
+
+	r.Heartbeat()
+
+	time.Sleep(heartbeatTimeout + 10*time.Millisecond)
+
+	select {
+	case <-timeoutCh:
+		t.Fatal("Received timeout before reaching attemptThreshold")
+	default:
+	}
+
+	time.Sleep(heartbeatTimeout * time.Duration(r.attemptThreshold))
+
+	select {
+	case <-timeoutCh:
+	case <-time.After(heartbeatTimeout):
+		t.Fatal("Did not receive timeout after missing heartbeats equal to attemptThreshold")
+	}
+}
+
+func TestFailureCounterReset(t *testing.T) {
+	originalTimeout := heartbeatTimeout
+	heartbeatTimeout = 50 * time.Millisecond
+	defer func() { heartbeatTimeout = originalTimeout }()
+
+	os.Setenv(defaultAttemptThresholdEnv, "2")
+	defer os.Unsetenv(defaultAttemptThresholdEnv)
+
+	// Create a new Receiver
+	r := NewReceiver()
+	defer r.Stop()
+
+	timeoutCh := r.OnTimeout
+
+	// Do not send any heartbeat, wait for one heartbeatTimeout
+	time.Sleep(heartbeatTimeout + 10*time.Millisecond)
+
+	r.Heartbeat()
+
+	time.Sleep(heartbeatTimeout * 2)
+
+	select {
+	case <-timeoutCh:
+		t.Fatal("Received timeout unexpectedly after failure counter reset")
+	default:
+	}
+
+	time.Sleep(heartbeatTimeout * time.Duration(r.attemptThreshold))
+
+	select {
+	case <-timeoutCh:
+	case <-time.After(heartbeatTimeout):
+		t.Fatal("Did not receive timeout after missing heartbeats equal to attemptThreshold")
 	}
 }

--- a/relay/healthcheck/receiver_test.go
+++ b/relay/healthcheck/receiver_test.go
@@ -67,6 +67,7 @@ func TestReceiverHealthCheckAttemptThreshold(t *testing.T) {
 				healthCheckInterval = originalInterval
 				heartbeatTimeout = originalTimeout
 			}()
+			//nolint:tenv
 			os.Setenv(defaultAttemptThresholdEnv, fmt.Sprintf("%d", tc.threshold))
 			defer os.Unsetenv(defaultAttemptThresholdEnv)
 

--- a/relay/healthcheck/sender.go
+++ b/relay/healthcheck/sender.go
@@ -2,7 +2,16 @@ package healthcheck
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	defaultAttemptThreshold    = 1
+	defaultAttemptThresholdEnv = "NB_RELAY_HC_ATTEMPT_THRESHOLD"
 )
 
 var (
@@ -15,20 +24,24 @@ var (
 // If the receiver does not receive the signal in a certain time, it will send a timeout signal and stop to work
 // It will also stop if the context is canceled
 type Sender struct {
+	log *log.Entry
 	// HealthCheck is a channel to send health check signal to the peer
 	HealthCheck chan struct{}
 	// Timeout is a channel to the health check signal is not received in a certain time
 	Timeout chan struct{}
 
-	ack chan struct{}
+	ack              chan struct{}
+	attemptThreshold int
 }
 
 // NewSender creates a new healthcheck sender
-func NewSender() *Sender {
+func NewSender(log *log.Entry) *Sender {
 	hc := &Sender{
-		HealthCheck: make(chan struct{}, 1),
-		Timeout:     make(chan struct{}, 1),
-		ack:         make(chan struct{}, 1),
+		log:              log,
+		HealthCheck:      make(chan struct{}, 1),
+		Timeout:          make(chan struct{}, 1),
+		ack:              make(chan struct{}, 1),
+		attemptThreshold: getAttemptThresholdFromEnv(),
 	}
 
 	return hc
@@ -46,23 +59,47 @@ func (hc *Sender) StartHealthCheck(ctx context.Context) {
 	ticker := time.NewTicker(healthCheckInterval)
 	defer ticker.Stop()
 
-	timeoutTimer := time.NewTimer(healthCheckInterval + healthCheckTimeout)
+	timeoutTimer := time.NewTimer(hc.getTimeoutTime())
 	defer timeoutTimer.Stop()
 
 	defer close(hc.HealthCheck)
 	defer close(hc.Timeout)
 
+	failureCounter := 0
 	for {
 		select {
 		case <-ticker.C:
 			hc.HealthCheck <- struct{}{}
 		case <-timeoutTimer.C:
+			failureCounter++
+			if failureCounter < hc.attemptThreshold {
+				hc.log.Warnf("Health check failed attempt %d.", failureCounter)
+				timeoutTimer.Reset(hc.getTimeoutTime())
+				continue
+			}
 			hc.Timeout <- struct{}{}
 			return
 		case <-hc.ack:
-			timeoutTimer.Reset(healthCheckInterval + healthCheckTimeout)
+			failureCounter = 0
+			timeoutTimer.Reset(hc.getTimeoutTime())
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+func (hc *Sender) getTimeoutTime() time.Duration {
+	return healthCheckInterval + healthCheckTimeout
+}
+
+func getAttemptThresholdFromEnv() int {
+	if attemptThreshold := os.Getenv(defaultAttemptThresholdEnv); attemptThreshold != "" {
+		threshold, err := strconv.ParseInt(attemptThreshold, 10, 64)
+		if err != nil {
+			log.Errorf("Failed to parse attempt threshold from environment variable \"%s\" should be an integer. Using default value", attemptThreshold)
+			return defaultAttemptThreshold
+		}
+		return int(threshold)
+	}
+	return defaultAttemptThreshold
 }

--- a/relay/healthcheck/sender_test.go
+++ b/relay/healthcheck/sender_test.go
@@ -2,9 +2,12 @@ package healthcheck
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
@@ -18,7 +21,7 @@ func TestMain(m *testing.M) {
 func TestNewHealthPeriod(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	hc := NewSender()
+	hc := NewSender(log.WithContext(ctx))
 	go hc.StartHealthCheck(ctx)
 
 	iterations := 0
@@ -38,7 +41,7 @@ func TestNewHealthPeriod(t *testing.T) {
 func TestNewHealthFailed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	hc := NewSender()
+	hc := NewSender(log.WithContext(ctx))
 	go hc.StartHealthCheck(ctx)
 
 	select {
@@ -50,7 +53,7 @@ func TestNewHealthFailed(t *testing.T) {
 
 func TestNewHealthcheckStop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	hc := NewSender()
+	hc := NewSender(log.WithContext(ctx))
 	go hc.StartHealthCheck(ctx)
 
 	time.Sleep(100 * time.Millisecond)
@@ -75,7 +78,7 @@ func TestNewHealthcheckStop(t *testing.T) {
 func TestTimeoutReset(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	hc := NewSender()
+	hc := NewSender(log.WithContext(ctx))
 	go hc.StartHealthCheck(ctx)
 
 	iterations := 0
@@ -99,5 +102,101 @@ func TestTimeoutReset(t *testing.T) {
 		t.Fatalf("context is done")
 	case <-time.After(10 * time.Second):
 		t.Fatalf("is not exited")
+	}
+}
+
+func TestSenderHealthCheckAttemptThreshold(t *testing.T) {
+	testsCases := []struct {
+		name             string
+		threshold        int
+		resetCounterOnce bool
+	}{
+		{"Default attempt threshold", defaultAttemptThreshold, false},
+		{"Custom attempt threshold", 3, false},
+		{"Should reset threshold once", 2, true},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalInterval := healthCheckInterval
+			originalTimeout := healthCheckTimeout
+			healthCheckInterval = 1 * time.Second
+			healthCheckTimeout = 500 * time.Millisecond
+			defer func() {
+				healthCheckInterval = originalInterval
+				healthCheckTimeout = originalTimeout
+			}()
+			os.Setenv(defaultAttemptThresholdEnv, fmt.Sprintf("%d", tc.threshold))
+			defer os.Unsetenv(defaultAttemptThresholdEnv)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sender := NewSender(log.WithField("test_name", tc.name))
+			go sender.StartHealthCheck(ctx)
+
+			go func() {
+				responded := false
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case _, ok := <-sender.HealthCheck:
+						if !ok {
+							return
+						}
+						if tc.resetCounterOnce && !responded {
+							responded = true
+							sender.OnHCResponse()
+						}
+					}
+				}
+			}()
+
+			testTimeout := sender.getTimeoutTime()*time.Duration(tc.threshold) + healthCheckInterval
+
+			select {
+			case <-sender.Timeout:
+				if tc.resetCounterOnce {
+					t.Fatalf("should not have timed out before %s", testTimeout)
+				}
+			case <-time.After(testTimeout):
+				if tc.resetCounterOnce {
+					return
+				}
+				t.Fatalf("should have timed out before %s", testTimeout)
+			}
+
+		})
+	}
+
+}
+
+func TestGetAttemptThresholdFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected int
+	}{
+		{"Default attempt threshold when env is not set", "", defaultAttemptThreshold},
+		{"Custom attempt threshold when env is set to a valid integer", "3", 3},
+		{"Default attempt threshold when env is set to an invalid value", "invalid", defaultAttemptThreshold},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue == "" {
+				os.Unsetenv(defaultAttemptThresholdEnv)
+			} else {
+				os.Setenv(defaultAttemptThresholdEnv, tt.envValue)
+			}
+
+			result := getAttemptThresholdFromEnv()
+			if result != tt.expected {
+				t.Fatalf("Expected %d, got %d", tt.expected, result)
+			}
+
+			os.Unsetenv(defaultAttemptThresholdEnv)
+		})
 	}
 }

--- a/relay/healthcheck/sender_test.go
+++ b/relay/healthcheck/sender_test.go
@@ -126,6 +126,8 @@ func TestSenderHealthCheckAttemptThreshold(t *testing.T) {
 				healthCheckInterval = originalInterval
 				healthCheckTimeout = originalTimeout
 			}()
+
+			//nolint:tenv
 			os.Setenv(defaultAttemptThresholdEnv, fmt.Sprintf("%d", tc.threshold))
 			defer os.Unsetenv(defaultAttemptThresholdEnv)
 
@@ -172,6 +174,7 @@ func TestSenderHealthCheckAttemptThreshold(t *testing.T) {
 
 }
 
+//nolint:tenv
 func TestGetAttemptThresholdFromEnv(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/relay/server/peer.go
+++ b/relay/server/peer.go
@@ -49,7 +49,7 @@ func (p *Peer) Work() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc := healthcheck.NewSender()
+	hc := healthcheck.NewSender(p.log)
 	go hc.StartHealthCheck(ctx)
 	go p.handleHealthcheckEvents(ctx, hc)
 


### PR DESCRIPTION
## Describe your changes

Add support to relay heath check threshold using the environment variable NB_RELAY_HC_ATTEMPT_THRESHOLD. By default that is set to 1 try.

It is recommended to change this setting on both the server and clients connecting to the relay.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
