### PR TITLE
[misc] Fix ip range posture check example in API doc

### DIFF
--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -950,7 +950,7 @@ components:
           type: array
           items:
             type: string
-            example: ["192.168.1.0/24", "10.0.0.0/8", "2001:db8:1234:1a00::/56"]
+          example: ["192.168.1.0/24", "10.0.0.0/8", "2001:db8:1234:1a00::/56"]
         action:
           description: Action to take upon policy match
           type: string


### PR DESCRIPTION
## Describe your changes
Our API doc was generating the wrong example for the IP range posture check call because the openAPI definition was type string but got an example array. Moved the example to the array level to avoid duplicated array brackets.

<img width="438" alt="Screenshot 2024-09-22 at 14 22 30" src="https://github.com/user-attachments/assets/388c6fea-00ad-478c-a469-2ee508d05800">

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
