### PR TITLE
[management] improve zitadel idp error response detail by decoding errors

### DIFF
--- a/management/server/idp/zitadel.go
+++ b/management/server/idp/zitadel.go
@@ -2,6 +2,7 @@ package idp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -128,10 +129,10 @@ func readZitadelError(body io.ReadCloser) error {
 	}
 
 	if len(errsOut) == 0 {
-		return fmt.Errorf("data missing")
+		return errors.New("unknown error")
 	}
 
-	return fmt.Errorf(strings.Join(errsOut, " "))
+	return errors.New(strings.Join(errsOut, " "))
 }
 
 // NewZitadelManager creates a new instance of the ZitadelManager.

--- a/management/server/idp/zitadel_test.go
+++ b/management/server/idp/zitadel_test.go
@@ -252,7 +252,7 @@ func TestZitadelAuthenticate(t *testing.T) {
 		inputCode:               400,
 		inputResBody:            "{}",
 		helper:                  JsonParser{},
-		expectedFuncExitErrDiff: fmt.Errorf("unable to get zitadel token, statusCode 400, zitadel: data missing"),
+		expectedFuncExitErrDiff: fmt.Errorf("unable to get zitadel token, statusCode 400, zitadel: unknown error"),
 		expectedCode:            200,
 		expectedToken:           "",
 	}

--- a/management/server/idp/zitadel_test.go
+++ b/management/server/idp/zitadel_test.go
@@ -66,7 +66,6 @@ func TestNewZitadelManager(t *testing.T) {
 }
 
 func TestZitadelRequestJWTToken(t *testing.T) {
-
 	type requestJWTTokenTest struct {
 		name                    string
 		inputCode               int
@@ -88,15 +87,14 @@ func TestZitadelRequestJWTToken(t *testing.T) {
 	requestJWTTokenTestCase2 := requestJWTTokenTest{
 		name:                    "Request Bad Status Code",
 		inputCode:               400,
-		inputRespBody:           "{}",
+		inputRespBody:           "{\"error\": \"invalid_scope\", \"error_description\":\"openid missing\"}",
 		helper:                  JsonParser{},
-		expectedFuncExitErrDiff: fmt.Errorf("unable to get zitadel token, statusCode 400"),
+		expectedFuncExitErrDiff: fmt.Errorf("unable to get zitadel token, statusCode 400, zitadel: error: invalid_scope error_description: openid missing"),
 		expectedToken:           "",
 	}
 
 	for _, testCase := range []requestJWTTokenTest{requestJWTTokenTesttCase1, requestJWTTokenTestCase2} {
 		t.Run(testCase.name, func(t *testing.T) {
-
 			jwtReqClient := mockHTTPClient{
 				resBody: testCase.inputRespBody,
 				code:    testCase.inputCode,
@@ -156,7 +154,7 @@ func TestZitadelParseRequestJWTResponse(t *testing.T) {
 	}
 	parseRequestJWTResponseTestCase2 := parseRequestJWTResponseTest{
 		name:                 "Parse Bad json JWT Body",
-		inputRespBody:        "",
+		inputRespBody:        "{}",
 		helper:               JsonParser{},
 		expectedToken:        "",
 		expectedExpiresIn:    0,
@@ -254,7 +252,7 @@ func TestZitadelAuthenticate(t *testing.T) {
 		inputCode:               400,
 		inputResBody:            "{}",
 		helper:                  JsonParser{},
-		expectedFuncExitErrDiff: fmt.Errorf("unable to get zitadel token, statusCode 400"),
+		expectedFuncExitErrDiff: fmt.Errorf("unable to get zitadel token, statusCode 400, zitadel: data missing"),
 		expectedCode:            200,
 		expectedToken:           "",
 	}


### PR DESCRIPTION

## Describe your changes

Adds a zitadelErrorResponse struct to decode errors returned from zitadel rather than just returning a status code, so more information can be learned about potential configuration issues. Helped to diagnose #2616

I have some other small changes and improvements to compatibility later, but this was a pretty clear cut and standalone improvement.

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
