### PR TITLE
[client] Anonymize relay address in status peers view

### DIFF
--- a/client/cmd/status.go
+++ b/client/cmd/status.go
@@ -805,6 +805,9 @@ func anonymizePeerDetail(a *anonymize.Anonymizer, peer *peerStateDetailOutput) {
 	if remoteIP, port, err := net.SplitHostPort(peer.IceCandidateEndpoint.Remote); err == nil {
 		peer.IceCandidateEndpoint.Remote = fmt.Sprintf("%s:%s", a.AnonymizeIPString(remoteIP), port)
 	}
+
+	peer.RelayAddress = a.AnonymizeURI(peer.RelayAddress)
+
 	for i, route := range peer.Routes {
 		peer.Routes[i] = a.AnonymizeIPString(route)
 	}


### PR DESCRIPTION
## Describe your changes

```
 docker0.netbird.cloud:
  NetBird IP: 100.64.122.40
  Public key: NEtQbOTpIVdmQFm4VMXXZvauPI9gdkrNarfAbuzeFVY=
  Status: Connected
  -- detail --
  Connection type: P2P
  ICE candidate (Local/Remote): host/prflx
  ICE candidate endpoints (Local/Remote): 192.168.100.235:57255/192.168.100.1:51820
  Relay server address: rel://192.168.anon-5QCcF.domain:8086
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
  Last connection update: 5 minutes, 19 seconds ago
  Last WireGuard handshake: 2 minutes, 24 seconds ago
  Transfer status (received/sent) 600 B/360 B
  Quantum resistance: false
  Routes: -
  Latency: 877.896µs
```

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
