### PR TITLE
[relay-server] Move the handshake logic to separated struct

### DIFF
--- a/relay/metrics/realy.go
+++ b/relay/metrics/realy.go
@@ -16,8 +16,10 @@ const (
 type Metrics struct {
 	metric.Meter
 
-	TransferBytesSent metric.Int64Counter
-	TransferBytesRecv metric.Int64Counter
+	TransferBytesSent  metric.Int64Counter
+	TransferBytesRecv  metric.Int64Counter
+	AuthenticationTime metric.Float64Histogram
+	PeerStoreTime      metric.Float64Histogram
 
 	peers            metric.Int64UpDownCounter
 	peerActivityChan chan string
@@ -52,11 +54,23 @@ func NewMetrics(ctx context.Context, meter metric.Meter) (*Metrics, error) {
 		return nil, err
 	}
 
+	authTime, err := meter.Float64Histogram("relay_peer_authentication_time_milliseconds", metric.WithExplicitBucketBoundaries(getStandardBucketBoundaries()...))
+	if err != nil {
+		return nil, err
+	}
+
+	peerStoreTime, err := meter.Float64Histogram("relay_peer_store_time_milliseconds", metric.WithExplicitBucketBoundaries(getStandardBucketBoundaries()...))
+	if err != nil {
+		return nil, err
+	}
+
 	m := &Metrics{
-		Meter:             meter,
-		TransferBytesSent: bytesSent,
-		TransferBytesRecv: bytesRecv,
-		peers:             peers,
+		Meter:              meter,
+		TransferBytesSent:  bytesSent,
+		TransferBytesRecv:  bytesRecv,
+		AuthenticationTime: authTime,
+		PeerStoreTime:      peerStoreTime,
+		peers:              peers,
 
 		ctx:              ctx,
 		peerActivityChan: make(chan string, 10),
@@ -87,6 +101,16 @@ func (m *Metrics) PeerConnected(id string) {
 	defer m.mutexActivity.Unlock()
 
 	m.peerLastActive[id] = time.Time{}
+}
+
+// RecordAuthenticationTime measures the time taken for peer authentication
+func (m *Metrics) RecordAuthenticationTime(duration time.Duration) {
+	m.AuthenticationTime.Record(m.ctx, float64(duration.Nanoseconds())/1e6)
+}
+
+// RecordPeerStoreTime measures the time to store the peer in map
+func (m *Metrics) RecordPeerStoreTime(duration time.Duration) {
+	m.PeerStoreTime.Record(m.ctx, float64(duration.Nanoseconds())/1e6)
 }
 
 // PeerDisconnected decrements the number of connected peers and decrements number of idle or active connections
@@ -132,5 +156,21 @@ func (m *Metrics) readPeerActivity() {
 		case <-m.ctx.Done():
 			return
 		}
+	}
+}
+
+func getStandardBucketBoundaries() []float64 {
+	return []float64{
+		0.1,
+		0.5,
+		1,
+		5,
+		10,
+		50,
+		100,
+		500,
+		1000,
+		5000,
+		10000,
 	}
 }

--- a/relay/server/handshake.go
+++ b/relay/server/handshake.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"fmt"
+	"net"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/relay/auth"
+	"github.com/netbirdio/netbird/relay/messages"
+	"github.com/netbirdio/netbird/relay/messages/address"
+	authmsg "github.com/netbirdio/netbird/relay/messages/auth"
+)
+
+// preparedMsg contains the marshalled success response messages
+type preparedMsg struct {
+	responseHelloMsg []byte
+	responseAuthMsg  []byte
+}
+
+func newPreparedMsg(instanceURL string) (*preparedMsg, error) {
+	rhm, err := marshalResponseHelloMsg(instanceURL)
+	if err != nil {
+		return nil, err
+	}
+
+	ram, err := messages.MarshalAuthResponse(instanceURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal auth response msg: %w", err)
+	}
+
+	return &preparedMsg{
+		responseHelloMsg: rhm,
+		responseAuthMsg:  ram,
+	}, nil
+}
+
+func marshalResponseHelloMsg(instanceURL string) ([]byte, error) {
+	addr := &address.Address{URL: instanceURL}
+	addrData, err := addr.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response address: %w", err)
+	}
+
+	//nolint:staticcheck
+	responseMsg, err := messages.MarshalHelloResponse(addrData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal hello response: %w", err)
+	}
+	return responseMsg, nil
+}
+
+type handshake struct {
+	conn        net.Conn
+	validator   auth.Validator
+	preparedMsg *preparedMsg
+
+	handshakeMethodAuth bool
+	peerID              string
+}
+
+func (h *handshake) handshakeReceive() ([]byte, error) {
+	buf := make([]byte, messages.MaxHandshakeSize)
+	n, err := h.conn.Read(buf)
+	if err != nil {
+		return nil, fmt.Errorf("read from %s: %w", h.conn.RemoteAddr(), err)
+	}
+
+	_, err = messages.ValidateVersion(buf[:n])
+	if err != nil {
+		return nil, fmt.Errorf("validate version from %s: %w", h.conn.RemoteAddr(), err)
+	}
+
+	msgType, err := messages.DetermineClientMessageType(buf[messages.SizeOfVersionByte:n])
+	if err != nil {
+		return nil, fmt.Errorf("determine message type from %s: %w", h.conn.RemoteAddr(), err)
+	}
+
+	var (
+		bytePeerID []byte
+		peerID     string
+	)
+	switch msgType {
+	//nolint:staticcheck
+	case messages.MsgTypeHello:
+		bytePeerID, peerID, err = h.handleHelloMsg(buf[messages.SizeOfProtoHeader:n])
+	case messages.MsgTypeAuth:
+		h.handshakeMethodAuth = true
+		bytePeerID, peerID, err = h.handleAuthMsg(buf[messages.SizeOfProtoHeader:n])
+	default:
+		return nil, fmt.Errorf("invalid message type %d from %s", msgType, h.conn.RemoteAddr())
+	}
+	if err != nil {
+		return nil, err
+	}
+	h.peerID = peerID
+	return bytePeerID, nil
+}
+
+func (h *handshake) handshakeResponse() error {
+	var responseMsg []byte
+	if h.handshakeMethodAuth {
+		responseMsg = h.preparedMsg.responseAuthMsg
+	} else {
+		responseMsg = h.preparedMsg.responseHelloMsg
+	}
+
+	if _, err := h.conn.Write(responseMsg); err != nil {
+		return fmt.Errorf("handshake response write to %s (%s): %w", h.peerID, h.conn.RemoteAddr(), err)
+	}
+
+	return nil
+}
+
+func (h *handshake) handleHelloMsg(buf []byte) ([]byte, string, error) {
+	//nolint:staticcheck
+	rawPeerID, authData, err := messages.UnmarshalHelloMsg(buf)
+	if err != nil {
+		return nil, "", fmt.Errorf("unmarshal hello message: %w", err)
+	}
+
+	peerID := messages.HashIDToString(rawPeerID)
+	log.Warnf("peer %s (%s) is using deprecated initial message type", peerID, h.conn.RemoteAddr())
+
+	authMsg, err := authmsg.UnmarshalMsg(authData)
+	if err != nil {
+		return nil, "", fmt.Errorf("unmarshal auth message: %w", err)
+	}
+
+	//nolint:staticcheck
+	if err := h.validator.ValidateHelloMsgType(authMsg.AdditionalData); err != nil {
+		return nil, "", fmt.Errorf("validate %s (%s): %w", peerID, h.conn.RemoteAddr(), err)
+	}
+
+	return rawPeerID, peerID, nil
+}
+
+func (h *handshake) handleAuthMsg(buf []byte) ([]byte, string, error) {
+	rawPeerID, authPayload, err := messages.UnmarshalAuthMsg(buf)
+	if err != nil {
+		return nil, "", fmt.Errorf("unmarshal hello message: %w", err)
+	}
+
+	peerID := messages.HashIDToString(rawPeerID)
+
+	if err := h.validator.Validate(authPayload); err != nil {
+		return nil, "", fmt.Errorf("validate %s (%s): %w", peerID, h.conn.RemoteAddr(), err)
+	}
+
+	return rawPeerID, peerID, nil
+}

--- a/relay/server/handshake.go
+++ b/relay/server/handshake.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/netbirdio/netbird/relay/auth"
 	"github.com/netbirdio/netbird/relay/messages"
+	//nolint:staticcheck
 	"github.com/netbirdio/netbird/relay/messages/address"
+	//nolint:staticcheck
 	authmsg "github.com/netbirdio/netbird/relay/messages/auth"
 )
 

--- a/relay/server/relay.go
+++ b/relay/server/relay.go
@@ -135,8 +135,8 @@ func (r *Relay) Accept(conn net.Conn) {
 	}()
 
 	if err := h.handshakeResponse(); err != nil {
-		r.store.DeletePeer(peer)
-		_ = conn.Close()
+		log.Errorf("failed to send handshake response, close peer: %s", err)
+		peer.Close()
 	}
 }
 


### PR DESCRIPTION
## Describe your changes

### Fix flickering unit test

Move the handshake logic to separated struct but fully keep the protocol.

- The server will respond to the client after it is ready to process the peer
- Preload the response messages

The authentication step is faster because do not need to marshal the response messages and this change fix flickering tests (see: NB-1047).

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
