### PR TITLE
[management] enable optional zitadel configuration of a PAT

### DIFF
--- a/management/server/idp/idp.go
+++ b/management/server/idp/idp.go
@@ -149,6 +149,7 @@ func NewManager(ctx context.Context, config Config, appMetrics telemetry.AppMetr
 				GrantType:          config.ClientConfig.GrantType,
 				TokenEndpoint:      config.ClientConfig.TokenEndpoint,
 				ManagementEndpoint: config.ExtraConfig["ManagementEndpoint"],
+				PAT:                config.ExtraConfig["PAT"],
 			}
 		}
 


### PR DESCRIPTION
 for service user via the ExtraConfig fields

## Describe your changes

I'm sure this one is a little spicier of a take than my last PR to merge in some extra logging. During my struggle to get the recent zitadel working with netbird, I added the ability for netbird to just use a PAT to work around it while I investigated further.

Since the JWT and PAT both use the same mechanism to pass the token in the authorization header, the existing struct for `JWTToken` can be used and the authentication step short-circuited by supplying a long lasting `AccessToken`.

My current configuration looks somewhat like this:

```json
    "IdpManagerConfig": {
        "ManagerType": "zitadel",
        "ClientConfig": {
           ...
        },
        "ExtraConfig": {
            "ManagementEndpoint": "https://zitadel-domain/management/v1",
            "PAT": "*****************************"
        },
```

As zitadel operators for more than just netbird, we have PATs for multiple different project service accounts across other orgs that integrate with it, and would prefer to use a PAT to simplify our security procedures too.

I'm not sure if this is the best end state for user experience as I rushed to implement something that worked in a fire, but figured this would be a good starting place to open the conversation.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
