### PR TITLE
Install sh alpine fixes

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -21,6 +21,8 @@ SUDO=""
 
 if command -v sudo > /dev/null && [ "$(id -u)" -ne 0 ]; then
     SUDO="sudo"
+elif command -v sudo > /dev/null && [ "$(id -u)" -ne 0 ]; then
+    SUDO="doas"
 fi
 
 if [ -z ${NETBIRD_RELEASE+x} ]; then
@@ -68,7 +70,7 @@ download_release_binary() {
     if [ -n "$GITHUB_TOKEN" ]; then
       cd /tmp && curl -H  "Authorization: token ${GITHUB_TOKEN}" -LO "$DOWNLOAD_URL"
     else
-      cd /tmp && curl -LO "$DOWNLOAD_URL"
+      cd /tmp && curl -LO --dns-servers 8.8.8.8 "$DOWNLOAD_URL"
     fi
 
 
@@ -316,7 +318,7 @@ install_netbird() {
 }
 
 version_greater_equal() {
-    printf '%s\n%s\n' "$2" "$1" | sort -V -C
+    printf '%s\n%s\n' "$2" "$1" | sort -V -c
 }
 
 is_bin_package_manager() {

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -21,7 +21,7 @@ SUDO=""
 
 if command -v sudo > /dev/null && [ "$(id -u)" -ne 0 ]; then
     SUDO="sudo"
-elif command -v sudo > /dev/null && [ "$(id -u)" -ne 0 ]; then
+elif command -v doas > /dev/null && [ "$(id -u)" -ne 0 ]; then
     SUDO="doas"
 fi
 

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -70,7 +70,7 @@ download_release_binary() {
     if [ -n "$GITHUB_TOKEN" ]; then
       cd /tmp && curl -H  "Authorization: token ${GITHUB_TOKEN}" -LO "$DOWNLOAD_URL"
     else
-      cd /tmp && curl -LO --dns-servers 8.8.8.8 "$DOWNLOAD_URL"
+      cd /tmp && curl -LO "$DOWNLOAD_URL" || curl -LO --dns-servers 8.8.8.8 "$DOWNLOAD_URL"
     fi
 
 


### PR DESCRIPTION
## Describe your changes
1. Made the script check for doas to work with alpine linux
2. Specified a set DNS server in the curl statement that downloads the binaries. I had issues where the curl request wouldnt resolve the URL, my theory is that since one of the redirect URL's are very long the standard DNS wont resolve it. This is what i experienced on alpine linux, and setting the google dns in the curl request fixed the issue.
3. Change "-C" to "-c" in the sort statement, the sort version in alpine linux doesnt have the "-C" function and it works just as well with "-c"

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
