### PR TITLE
[relay-client] Fix Relay disconnection handling

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -586,13 +586,15 @@ func (conn *Conn) onWorkerRelayStateDisconnected() {
 		return
 	}
 
-	if conn.wgProxyRelay != nil {
+	if conn.currentConnPriority == connPriorityRelay {
 		log.Debugf("relayed connection is closed, clean up WireGuard config")
 		err := conn.config.WgConfig.WgInterface.RemovePeer(conn.config.WgConfig.RemoteKey)
 		if err != nil {
 			conn.log.Errorf("failed to remove wg endpoint: %v", err)
 		}
+	}
 
+	if conn.wgProxyRelay != nil {
 		conn.endpointRelay = nil
 		_ = conn.wgProxyRelay.CloseConn()
 		conn.wgProxyRelay = nil

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -586,8 +586,10 @@ func (conn *Conn) onWorkerRelayStateDisconnected() {
 		return
 	}
 
+	log.Debugf("relay connection is disconnected")
+
 	if conn.currentConnPriority == connPriorityRelay {
-		log.Debugf("relayed connection is closed, clean up WireGuard config")
+		log.Debugf("clean up WireGuard config")
 		err := conn.config.WgConfig.WgInterface.RemovePeer(conn.config.WgConfig.RemoteKey)
 		if err != nil {
 			conn.log.Errorf("failed to remove wg endpoint: %v", err)


### PR DESCRIPTION
## Describe your changes

If it has an active P2P connection meanwhile the Relay connection is broken with the server then we removed the WireGuard peer configuration.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
