### PR TITLE
[management] Limit max open conns for SQLite to 1

### DIFF
--- a/management/server/sql_store.go
+++ b/management/server/sql_store.go
@@ -69,6 +69,11 @@ func NewSqlStore(ctx context.Context, db *gorm.DB, storeEngine StoreEngine, metr
 	if err != nil {
 		conns = runtime.NumCPU()
 	}
+
+	if storeEngine == SqliteStoreEngine {
+		conns = 1
+	}
+
 	sql.SetMaxOpenConns(conns)
 
 	log.Infof("Set max open db connections to %d", conns)


### PR DESCRIPTION
## Describe your changes
It was causing issues with locking and the database being locked when selecting sqlite store engine with more than one open connection allowed.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
