### PR TITLE
Update Zitadel version on quickstart script

### DIFF
--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -873,7 +873,7 @@ services:
   zitadel:
     restart: 'always'
     networks: [netbird]
-    image: 'ghcr.io/zitadel/zitadel:v2.54.3'
+    image: 'ghcr.io/zitadel/zitadel:v2.54.10'
     command: 'start-from-init --masterkeyFromEnv --tlsMode $ZITADEL_TLS_MODE'
     env_file:
       - ./zitadel.env


### PR DESCRIPTION
Update Zitadel version at docker compose in quickstart script from 2.54.3 to 2.54.10 because 2.54.3 isn't stable and has a lot of bugs.

## Describe your changes
Updated Zitadel version to 2.54.10 because most features don't work properly on 2.54.3 as I experienced.
As I updated my Zitadel version on my local Netbird installation, Zitadel features started working as intended.

## Issue ticket number and link
Issue is discussed with Zitadel in the link below:
https://github.com/zitadel/zitadel/discussions/8708#discussioncomment-10830883

### Checklist
- [+] Is it a bug fix
- [ ] Is a typo/documentation fix
- [+] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
