### PR TITLE
Fix JSON function compatibility for SQLite and PostgreSQL

### DIFF
--- a/management/server/sql_store.go
+++ b/management/server/sql_store.go
@@ -1154,6 +1154,8 @@ func (s *SqlStore) GetGroupByID(ctx context.Context, lockStrength LockingStrengt
 func (s *SqlStore) GetGroupByName(ctx context.Context, lockStrength LockingStrength, groupName, accountID string) (*nbgroup.Group, error) {
 	var group nbgroup.Group
 
+	// TODO: This fix is accepted for now, but if we need to handle this more frequently
+	// we may need to reconsider changing the types.
 	query := s.db.WithContext(ctx).Clauses(clause.Locking{Strength: string(lockStrength)}).Preload(clause.Associations)
 	if s.storeEngine == PostgresStoreEngine {
 		query = query.Order("json_array_length(peers::json) DESC")

--- a/management/server/sql_store_test.go
+++ b/management/server/sql_store_test.go
@@ -1251,3 +1251,16 @@ func TestSqlStore_UpdateAccountDomainAttributes(t *testing.T) {
 	})
 
 }
+
+func TestSqlite_GetGroupByName(t *testing.T) {
+	store, cleanup, err := NewTestStoreFromSQL(context.Background(), "testdata/extended-store.sql", t.TempDir())
+	t.Cleanup(cleanup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accountID := "bf1c8084-ba50-4ce7-9439-34653001fc3b"
+
+	group, err := store.GetGroupByName(context.Background(), LockingStrengthShare, "All", accountID)
+	require.NoError(t, err)
+	require.Equal(t, "All", group.Name)
+}


### PR DESCRIPTION
## Describe your changes

This PR resolves the issue with `json_array_length` compatibility between SQLite and PostgreSQL. It adjusts the query to conditionally cast types:

- **PostgreSQL**: Casts to `json` with `::json`.
- **SQLite**: Uses the text representation directly.

## Issue ticket number and link

Closes #2745

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
