### PR TITLE
[client] Exclude loopback from NAT

### DIFF
--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -433,10 +433,12 @@ func (r *router) removeNatRule(pair firewall.RouterPair) error {
 
 func genRuleSpec(jump string, source, destination netip.Prefix, intf string, inverse bool) []string {
 	intdir := "-i"
+	lointdir := "-o"
 	if inverse {
 		intdir = "-o"
+		lointdir = "-i"
 	}
-	return []string{intdir, intf, "-s", source.String(), "-d", destination.String(), "-j", jump}
+	return []string{intdir, intf, "!", lointdir, "lo", "-s", source.String(), "-d", destination.String(), "-j", jump}
 }
 
 func genRouteFilteringRuleSpec(params routeFilteringRuleParams) []string {

--- a/client/firewall/nftables/router_linux_test.go
+++ b/client/firewall/nftables/router_linux_test.go
@@ -69,6 +69,12 @@ func TestNftablesManager_AddNatRule(t *testing.T) {
 						Register: 1,
 						Data:     ifname(ifaceMock.Name()),
 					},
+					&expr.Meta{Key: expr.MetaKeyOIFNAME, Register: 1},
+					&expr.Cmp{
+						Op:       expr.CmpOpNeq,
+						Register: 1,
+						Data:     ifname("lo"),
+					},
 				)
 
 				natRuleKey := firewall.GenKey(firewall.NatFormat, testCase.InputPair)
@@ -96,6 +102,12 @@ func TestNftablesManager_AddNatRule(t *testing.T) {
 						Op:       expr.CmpOpEq,
 						Register: 1,
 						Data:     ifname(ifaceMock.Name()),
+					},
+					&expr.Meta{Key: expr.MetaKeyIIFNAME, Register: 1},
+					&expr.Cmp{
+						Op:       expr.CmpOpNeq,
+						Register: 1,
+						Data:     ifname("lo"),
 					},
 				)
 


### PR DESCRIPTION
## Describe your changes

This fixes  an issue with the ebpf proxy port being changed by the nat rules

```
-A NETBIRD-RT-NAT -i wt0 ! -o lo -j MASQUERADE
-A NETBIRD-RT-NAT ! -i lo -o wt0 -j MASQUERADE
```

```
       chain netbird-rt-postrouting {
                type nat hook postrouting priority srcnat - 1; policy accept;
                iifname "wt0" oifname != "lo" counter packets 0 bytes 0 masquerade
                oifname "wt0" iifname != "lo" counter packets 0 bytes 0 masquerade
        }
```
## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
