### PR TITLE
Fix decompress zip path

### DIFF
--- a/client/ui/netbird-ui.rb.tmpl
+++ b/client/ui/netbird-ui.rb.tmpl
@@ -8,11 +8,11 @@ cask "{{ $projectName }}" do
   if Hardware::CPU.intel?
       url "{{ $amdURL }}"
       sha256 "{{ crypto.SHA256 $amdFileBytes }}"
-      app "netbird_ui_darwin_amd64", target: "Netbird UI.app"
+      app "netbird_ui_darwin", target: "Netbird UI.app"
   else
       url "{{ $armURL }}"
       sha256 "{{ crypto.SHA256 $armFileBytes }}"
-      app "netbird_ui_darwin_arm64", target: "Netbird UI.app"
+      app "netbird_ui_darwin", target: "Netbird UI.app"
   end
 
   depends_on formula: "netbird"

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -86,7 +86,7 @@ download_release_binary() {
 
         # Unzip the app and move to INSTALL_DIR
         unzip -q -o "$BINARY_NAME"
-        mv "netbird_ui_${OS_TYPE}_${ARCH}/" "$INSTALL_DIR/"
+        mv -v "netbird_ui_${OS_TYPE}/" "$INSTALL_DIR/" || mv -v "netbird_ui_${OS_TYPE}_${ARCH}/" "$INSTALL_DIR/"
     else
         ${SUDO} mkdir -p "$INSTALL_DIR"
         tar -xzvf "$BINARY_NAME"


### PR DESCRIPTION


## Describe your changes
Since 0.30.2, the decompressed binary path from the signed package has changed, now it doesn't contain the arch suffix 

This change handles that

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
