### PR TITLE
Updating Zitadel from v2.54.10 to v2.64.1.

### DIFF
--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -873,7 +873,7 @@ services:
   zitadel:
     restart: 'always'
     networks: [netbird]
-    image: 'ghcr.io/zitadel/zitadel:v2.54.10'
+    image: 'ghcr.io/zitadel/zitadel:v2.64.1'
     command: 'start-from-init --masterkeyFromEnv --tlsMode $ZITADEL_TLS_MODE'
     env_file:
       - ./zitadel.env


### PR DESCRIPTION
## Describe your changes
Updating Zitadel from `v2.54.10` to `v2.64.1`. 
Tested this out in the client, tried to connect and do everything with netbird. Zitadel seems to fully work without issue, at least use a secure version :D. (Even if it's only for a quick trial) (https://github.com/advisories/GHSA-3rmw-76m6-4gjc)

## Issue ticket number and link
"Discussed" in the Slack.

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
