### PR TITLE
[client] allow relay leader on iOS

### DIFF
--- a/client/internal/peer/ice/agent.go
+++ b/client/internal/peer/ice/agent.go
@@ -1,13 +1,14 @@
 package ice
 
 import (
-	"github.com/netbirdio/netbird/client/internal/stdnet"
+	"time"
+
 	"github.com/pion/ice/v3"
 	"github.com/pion/randutil"
 	"github.com/pion/stun/v2"
 	log "github.com/sirupsen/logrus"
-	"runtime"
-	"time"
+
+	"github.com/netbirdio/netbird/client/internal/stdnet"
 )
 
 const (
@@ -77,10 +78,7 @@ func CandidateTypes() []ice.CandidateType {
 	if hasICEForceRelayConn() {
 		return []ice.CandidateType{ice.CandidateTypeRelay}
 	}
-	// TODO: remove this once we have refactored userspace proxy into the bind package
-	if runtime.GOOS == "ios" {
-		return []ice.CandidateType{ice.CandidateTypeHost, ice.CandidateTypeServerReflexive}
-	}
+
 	return []ice.CandidateType{ice.CandidateTypeHost, ice.CandidateTypeServerReflexive, ice.CandidateTypeRelay}
 }
 


### PR DESCRIPTION
## Describe your changes
In the previous versions, iOS had some limitations regarding relay. We worked around those issues by never allowing an iOS app to be a leader in a relay connection. This was causing some connections to never be established. With the new relay and the removal of the proxy we can now fully use relay on iOS.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
