### PR TITLE
Fix multiple peer name filtering in netbird status command

### DIFF
--- a/client/cmd/status.go
+++ b/client/cmd/status.go
@@ -680,7 +680,7 @@ func parsePeers(peers peersStateOutput, rosenpassEnabled, rosenpassPermissive bo
 func skipDetailByFilters(peerState *proto.PeerState, isConnected bool) bool {
 	statusEval := false
 	ipEval := false
-	nameEval := false
+	nameEval := true
 
 	if statusFilter != "" {
 		lowerStatusFilter := strings.ToLower(statusFilter)
@@ -700,8 +700,8 @@ func skipDetailByFilters(peerState *proto.PeerState, isConnected bool) bool {
 
 	if len(prefixNamesFilter) > 0 {
 		for prefixNameFilter := range prefixNamesFilterMap {
-			if !strings.HasPrefix(peerState.Fqdn, prefixNameFilter) {
-				nameEval = true
+			if strings.HasPrefix(peerState.Fqdn, prefixNameFilter) {
+				nameEval = false
 				break
 			}
 		}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

## Description
The current implementation of peer name filtering in the `skipDetailByFilters` function has a logic issue that prevents filtering by multiple peer names. This PR fixes the issue by:

Changing the initial value of `nameEval` to `true` (meaning skip by default)
Inverting the logic to look for matches instead of non-matches
Setting `nameEval = false` when a match is found (meaning don't skip)

### Before the fix:
- When using `--filter-by-names peer-01,peer-02.netbird.cloud`, the command would fail to show both peers because:
1) The function would set nameEval = true if **ANY** name didn't match
2) This caused peers to be skipped even if they matched one of the filters

### After the fix:
- The new logic starts with `nameEval = true` (skip by default)
- When a peer's FQDN matches **ANY** of the provided filters, `nameEval` is set to false
- This allows the command to properly show all peers that match any of the provided name filters

## Example:

**Bash**
```
netbird status -d --filter-by-names peer-01,peer-02.netbird.cloud
```
Now correctly shows both peers that match either name.

## Testing:
- Tested with single peer name filter
- Tested with multiple peer name filters
- Tested in combination with other filters (status, IPs)

This fix maintains compatibility with existing functionality while correctly implementing the intended multiple peer name filtering behavior.
