### PR TITLE
Update Caddyfile and Docker Compose to support HTTP3

### DIFF
--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -530,7 +530,7 @@ renderCaddyfile() {
 {
   debug
 	servers :80,:443 {
-    protocols h1 h2c
+    protocols h1 h2c h3
   }
 }
 
@@ -788,6 +788,7 @@ services:
     networks: [ netbird ]
     ports:
       - '443:443'
+      - '443:443/udp'
       - '80:80'
       - '8080:8080'
     volumes:


### PR DESCRIPTION
## Describe your changes
Update Caddyfile and Docker Compose to support HTTP3

## Issue ticket number and link
Closes #2785 

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [X ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
