### PR TITLE
[management] Fix add peer all group network map update

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -589,6 +589,12 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, setupKey, userID s
 		return nil, nil, nil, fmt.Errorf("error getting account: %w", err)
 	}
 
+	allGroup, err := account.GetGroupAll()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error getting all group ID: %w", err)
+	}
+
+	groupsToAdd = append(groupsToAdd, allGroup.ID)
 	if areGroupChangesAffectPeers(account, groupsToAdd) {
 		am.updateAccountPeers(ctx, account)
 	}


### PR DESCRIPTION
## Describe your changes
When adding a peer the participation in the all group was not checked and could cause issues that a network map was not send.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
