### PR TITLE
[management] Enforce max conn of 1 for sqlite setups

### DIFF
--- a/management/server/sql_store.go
+++ b/management/server/sql_store.go
@@ -69,6 +69,14 @@ func NewSqlStore(ctx context.Context, db *gorm.DB, storeEngine StoreEngine, metr
 	if err != nil {
 		conns = runtime.NumCPU()
 	}
+
+	if storeEngine == SqliteStoreEngine {
+		if err == nil {
+			log.Warnf("setting NB_SQL_MAX_OPEN_CONNS is not supported for sqlite, using default value 1")
+		}
+		conns = 1
+	}
+
 	sql.SetMaxOpenConns(conns)
 
 	log.Infof("Set max open db connections to %d", conns)


### PR DESCRIPTION
## Describe your changes
This is needed so that we can migrate to using db locks instead of the in memory locks.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
