### PR TITLE
[client] Remove loop after route calculation

### DIFF
--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -257,7 +257,6 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 		return nil
 	}
 
-	d.notifyPeerStateChangeListeners(receivedState.PubKey)
 	d.notifyPeerListChanged()
 	return nil
 }

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -237,10 +237,6 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 		peerState.IP = receivedState.IP
 	}
 
-	if receivedState.GetRoutes() != nil {
-		peerState.SetRoutes(receivedState.GetRoutes())
-	}
-
 	skipNotification := shouldSkipNotify(receivedState.ConnStatus, peerState)
 
 	if receivedState.ConnStatus != peerState.ConnStatus {
@@ -261,12 +257,33 @@ func (d *Status) UpdatePeerState(receivedState State) error {
 		return nil
 	}
 
-	ch, found := d.changeNotify[receivedState.PubKey]
-	if found && ch != nil {
-		close(ch)
-		d.changeNotify[receivedState.PubKey] = nil
+	d.notifyPeerStateChangeListeners(receivedState.PubKey)
+	d.notifyPeerListChanged()
+	return nil
+}
+
+// UpdatePeerRouteState updates peer's route state. It operates with routes only, ignore other fields
+func (d *Status) UpdatePeerRouteState(receivedState State) error {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+
+	peerState, ok := d.peers[receivedState.PubKey]
+	if !ok {
+		return errors.New("peer doesn't exist")
 	}
 
+	if receivedState.GetRoutes() != nil {
+		peerState.SetRoutes(receivedState.GetRoutes())
+	}
+
+	skipNotification := shouldSkipNotify(receivedState.ConnStatus, peerState)
+
+	d.peers[receivedState.PubKey] = peerState
+
+	if skipNotification {
+		return nil
+	}
+	// todo: consider to make sense of this notification or not
 	d.notifyPeerListChanged()
 	return nil
 }
@@ -301,12 +318,6 @@ func (d *Status) UpdatePeerICEState(receivedState State) error {
 		return nil
 	}
 
-	ch, found := d.changeNotify[receivedState.PubKey]
-	if found && ch != nil {
-		close(ch)
-		d.changeNotify[receivedState.PubKey] = nil
-	}
-
 	d.notifyPeerListChanged()
 	return nil
 }
@@ -334,12 +345,7 @@ func (d *Status) UpdatePeerRelayedState(receivedState State) error {
 		return nil
 	}
 
-	ch, found := d.changeNotify[receivedState.PubKey]
-	if found && ch != nil {
-		close(ch)
-		d.changeNotify[receivedState.PubKey] = nil
-	}
-
+	d.notifyPeerStateChangeListeners(receivedState.PubKey)
 	d.notifyPeerListChanged()
 	return nil
 }
@@ -366,12 +372,7 @@ func (d *Status) UpdatePeerRelayedStateToDisconnected(receivedState State) error
 		return nil
 	}
 
-	ch, found := d.changeNotify[receivedState.PubKey]
-	if found && ch != nil {
-		close(ch)
-		d.changeNotify[receivedState.PubKey] = nil
-	}
-
+	d.notifyPeerStateChangeListeners(receivedState.PubKey)
 	d.notifyPeerListChanged()
 	return nil
 }
@@ -401,12 +402,7 @@ func (d *Status) UpdatePeerICEStateToDisconnected(receivedState State) error {
 		return nil
 	}
 
-	ch, found := d.changeNotify[receivedState.PubKey]
-	if found && ch != nil {
-		close(ch)
-		d.changeNotify[receivedState.PubKey] = nil
-	}
-
+	d.notifyPeerStateChangeListeners(receivedState.PubKey)
 	d.notifyPeerListChanged()
 	return nil
 }
@@ -477,11 +473,14 @@ func (d *Status) FinishPeerListModifications() {
 func (d *Status) GetPeerStateChangeNotifier(peer string) <-chan struct{} {
 	d.mux.Lock()
 	defer d.mux.Unlock()
+
 	ch, found := d.changeNotify[peer]
-	if !found || ch == nil {
-		ch = make(chan struct{})
-		d.changeNotify[peer] = ch
+	if found {
+		return ch
 	}
+
+	ch = make(chan struct{})
+	d.changeNotify[peer] = ch
 	return ch
 }
 
@@ -753,6 +752,17 @@ func (d *Status) RemoveConnectionListener() {
 
 func (d *Status) onConnectionChanged() {
 	d.notifier.updateServerStates(d.managementState, d.signalState)
+}
+
+// notifyPeerStateChangeListeners notifies route manager about the change in peer state
+func (d *Status) notifyPeerStateChangeListeners(peerID string) {
+	ch, found := d.changeNotify[peerID]
+	if !found {
+		return
+	}
+
+	close(ch)
+	delete(d.changeNotify, peerID)
 }
 
 func (d *Status) notifyPeerListChanged() {

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -325,6 +325,7 @@ func (d *Status) UpdatePeerICEState(receivedState State) error {
 		return nil
 	}
 
+	d.notifyPeerStateChangeListeners(receivedState.PubKey)
 	d.notifyPeerListChanged()
 	return nil
 }

--- a/client/internal/peer/status_test.go
+++ b/client/internal/peer/status_test.go
@@ -93,7 +93,7 @@ func TestGetPeerStateChangeNotifierLogic(t *testing.T) {
 
 	peerState.IP = ip
 
-	err := status.UpdatePeerState(peerState)
+	err := status.UpdatePeerRelayedStateToDisconnected(peerState)
 	assert.NoError(t, err, "shouldn't return error")
 
 	select {

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -227,11 +227,7 @@ func (w *WorkerICE) reCreateAgent(agentCancel context.CancelFunc, candidates []i
 				w.lastKnownState = ice.ConnectionStateDisconnected
 				w.conn.OnStatusChanged(StatusDisconnected)
 			}
-			w.muxAgent.Lock()
-			agentCancel()
-			_ = w.agent.Close()
-			w.agent = nil
-			w.muxAgent.Unlock()
+			w.closeAgent(agentCancel)
 		default:
 			return
 		}
@@ -257,6 +253,15 @@ func (w *WorkerICE) reCreateAgent(agentCancel context.CancelFunc, candidates []i
 	}
 
 	return agent, nil
+}
+
+func (w *WorkerICE) closeAgent(cancel context.CancelFunc) {
+	w.muxAgent.Lock()
+	defer w.muxAgent.Unlock()
+
+	cancel()
+	_ = w.agent.Close()
+	w.agent = nil
 }
 
 func (w *WorkerICE) punchRemoteWGPort(pair *ice.CandidatePair, remoteWgPort int) {

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -218,6 +218,10 @@ func (w *WorkerICE) reCreateAgent(agentCancel context.CancelFunc, candidates []i
 
 	err = agent.OnConnectionStateChange(func(state ice.ConnectionState) {
 		w.log.Debugf("ICE ConnectionState has changed to %s", state.String())
+		if state == ice.ConnectionStateConnected {
+			w.lastKnownState = ice.ConnectionStateConnected
+			return
+		}
 		if state != ice.ConnectionStateFailed && state != ice.ConnectionStateDisconnected {
 			return
 		}

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -197,8 +197,7 @@ func (w *WorkerICE) Close() {
 		return
 	}
 
-	err := w.agent.Close()
-	if err != nil {
+	if err := w.agent.Close(); err != nil {
 		w.log.Warnf("failed to close ICE agent: %s", err)
 	}
 }
@@ -260,7 +259,9 @@ func (w *WorkerICE) closeAgent(cancel context.CancelFunc) {
 	defer w.muxAgent.Unlock()
 
 	cancel()
-	_ = w.agent.Close()
+	if err := w.agent.Close(); err != nil {
+		w.log.Warnf("failed to close ICE agent: %s", err)
+	}
 	w.agent = nil
 }
 

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -130,10 +130,12 @@ func (c *clientNetwork) getBestRouteFromStatuses(routePeerStatuses map[route.ID]
 			log.Infof("peer %s has 0 latency, range %s", r.Peer, c.handler)
 		}
 
+		// avoid negative tempScore on the higher latency calculation
 		if latency > 1*time.Second {
 			latency = 999 * time.Millisecond
 		}
 
+		// higher latency is worse score
 		tempScore += 1 - latency.Seconds()
 
 		if !peerStatus.relayed {

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -127,7 +127,7 @@ func (c *clientNetwork) getBestRouteFromStatuses(routePeerStatuses map[route.ID]
 		if peerStatus.latency != 0 {
 			latency = peerStatus.latency
 		} else {
-			log.Infof("peer %s has 0 latency, range %s", r.Peer, c.handler)
+			log.Tracef("peer %s has 0 latency, range %s", r.Peer, c.handler)
 		}
 
 		// avoid negative tempScore on the higher latency calculation

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -122,13 +122,18 @@ func (c *clientNetwork) getBestRouteFromStatuses(routePeerStatuses map[route.ID]
 			tempScore = float64(metricDiff) * 10
 		}
 
-		// in some temporal cases, latency can be 0, so we set it to 1s to not block but try to avoid this route
-		latency := time.Second
+		// in some temporal cases, latency can be 0, so we set it to 999ms to not block but try to avoid this route
+		latency := 999 * time.Millisecond
 		if peerStatus.latency != 0 {
 			latency = peerStatus.latency
 		} else {
-			log.Warnf("peer %s has 0 latency", r.Peer)
+			log.Infof("peer %s has 0 latency, range %s", r.Peer, c.handler)
 		}
+
+		if latency > 1*time.Second {
+			latency = 999 * time.Millisecond
+		}
+
 		tempScore += 1 - latency.Seconds()
 
 		if !peerStatus.relayed {

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -215,15 +215,14 @@ func (c *clientNetwork) startPeersStatusChangeWatcher() {
 }
 
 func (c *clientNetwork) removeRouteFromWireGuardPeer() error {
-	var multiErr *multierror.Error
 	if err := c.statusRecorder.RemovePeerStateRoute(c.currentChosen.Peer, c.handler.String()); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("remove peer state route: %w", err))
+		log.Warnf("Failed to update peer state: %v", err)
 	}
 
 	if err := c.handler.RemoveAllowedIPs(); err != nil {
-		multiErr = multierror.Append(multiErr, fmt.Errorf("remove allowed IPs: %w", err))
+		return fmt.Errorf("remove allowed IPs: %w", err)
 	}
-	return nberrors.FormatErrorOrNil(multiErr)
+	return nil
 }
 
 func (c *clientNetwork) removeRouteFromPeerAndSystem() error {

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -281,10 +281,6 @@ func (c *clientNetwork) recalculateRouteAndUpdatePeerAndSystem() error {
 	return nil
 }
 
-func (c *clientNetwork) removeStateRoute() {
-
-}
-
 func (c *clientNetwork) sendUpdateToClientNetworkWatcher(update routesUpdate) {
 	go func() {
 		c.routeUpdate <- update

--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -150,6 +150,8 @@ func (c *clientNetwork) getBestRouteFromStatuses(routePeerStatuses map[route.ID]
 		}
 	}
 
+	log.Debugf("chosen route: %s, chosen score: %f, current route: %s, current score: %f", chosen, chosenScore, currID, currScore)
+
 	switch {
 	case chosen == "":
 		var peers []string

--- a/client/internal/routemanager/refcounter/refcounter.go
+++ b/client/internal/routemanager/refcounter/refcounter.go
@@ -217,13 +217,19 @@ func (rm *Counter[Key, I, O]) Clear() {
 
 // MarshalJSON implements the json.Marshaler interface for Counter.
 func (rm *Counter[Key, I, O]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
+	rm.refCountMu.Lock()
+	defer rm.refCountMu.Unlock()
+	rm.idMu.Lock()
+	defer rm.idMu.Unlock()
+
+	b, err := json.Marshal(struct {
 		RefCountMap map[Key]Ref[O]   `json:"refCountMap"`
 		IDMap       map[string][]Key `json:"idMap"`
 	}{
 		RefCountMap: rm.refCountMap,
 		IDMap:       rm.idMap,
 	})
+	return b, err
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for Counter.

--- a/client/internal/routemanager/refcounter/refcounter.go
+++ b/client/internal/routemanager/refcounter/refcounter.go
@@ -222,14 +222,13 @@ func (rm *Counter[Key, I, O]) MarshalJSON() ([]byte, error) {
 	rm.idMu.Lock()
 	defer rm.idMu.Unlock()
 
-	b, err := json.Marshal(struct {
+	return json.Marshal(struct {
 		RefCountMap map[Key]Ref[O]   `json:"refCountMap"`
 		IDMap       map[string][]Key `json:"idMap"`
 	}{
 		RefCountMap: rm.refCountMap,
 		IDMap:       rm.idMap,
 	})
-	return b, err
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for Counter.


### PR DESCRIPTION
## Describe your changes

- ICE do not trigger disconnect callbacks if the stated did not change
- Fix route calculation callback loop
- Move route state updates into protected scope by mutex
- Do not calculate routes in case of peer.Open() and peer.Close()

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
