### PR TITLE
add NB_SKIP_SOCKET_MARK & fix crash instead of returing an error

### DIFF
--- a/util/grpc/dialer.go
+++ b/util/grpc/dialer.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"os/user"
 	"runtime"
@@ -20,24 +21,27 @@ import (
 
 func WithCustomDialer() grpc.DialOption {
 	return grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+		log.Infof("Custom dialer called for address: %s", addr)
 		if runtime.GOOS == "linux" {
 			currentUser, err := user.Current()
 			if err != nil {
-				log.Fatalf("failed to get current user: %v", err)
+				return nil, fmt.Errorf("failed to get current user: %w", err)
 			}
 
-			// the custom dialer requires root permissions which are not required for use cases run as non-root
+			log.Infof("Current user UID: %s", currentUser.Uid)
 			if currentUser.Uid != "0" {
+				log.Debug("Not running as root, using standard dialer")
 				dialer := &net.Dialer{}
 				return dialer.DialContext(ctx, "tcp", addr)
 			}
 		}
 
+		log.Debug("Using nbnet.NewDialer()")
 		conn, err := nbnet.NewDialer().DialContext(ctx, "tcp", addr)
 		if err != nil {
-			log.Errorf("Failed to dial: %s", err)
-			return nil, err
+			return nil, fmt.Errorf("nbnet.NewDialer().DialContext failed: %v", err)
 		}
+		log.Debug("nbnet.NewDialer().DialContext succeeded")
 		return conn, nil
 	})
 }

--- a/util/net/dialer_nonios.go
+++ b/util/net/dialer_nonios.go
@@ -67,10 +67,12 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 		}
 	}
 
+	log.Infof("Dialing %s %s", network, address)
 	conn, err := d.Dialer.DialContext(ctx, network, address)
 	if err != nil {
-		return nil, fmt.Errorf("dial: %w", err)
+		return nil, fmt.Errorf("d.Dialer.DialContext failed: %w", err)
 	}
+	log.Debug("d.Dialer.DialContext succeeded")
 
 	// Wrap the connection in Conn to handle Close with hooks
 	return &Conn{Conn: conn, ID: connID}, nil

--- a/util/net/net_linux.go
+++ b/util/net/net_linux.go
@@ -4,8 +4,13 @@ package net
 
 import (
 	"fmt"
+	"os"
 	"syscall"
+
+	log "github.com/sirupsen/logrus"
 )
+
+const envSkipSocketMark = "NB_SKIP_SOCKET_MARK"
 
 // SetSocketMark sets the SO_MARK option on the given socket connection
 func SetSocketMark(conn syscall.Conn) error {
@@ -28,16 +33,28 @@ func SetRawSocketMark(conn syscall.RawConn) error {
 	}
 
 	if setErr != nil {
-		return fmt.Errorf("set SO_MARK: %w", setErr)
+		return fmt.Errorf("set SO_MARK failed: %w", setErr)
 	}
 
 	return nil
 }
 
 func SetSocketOpt(fd int) error {
+	log.Debugf("Attempting to set SO_MARK on fd %d", fd)
 	if CustomRoutingDisabled() {
+		log.Infof("Custom routing is disabled, skipping SO_MARK")
 		return nil
 	}
 
-	return syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_MARK, NetbirdFwmark)
+	// Check for the new environment variable
+	if skipSocketMark := os.Getenv(envSkipSocketMark); skipSocketMark == "true" {
+		log.Info("NB_SKIP_SOCKET_MARK is set to true, skipping SO_MARK")
+		return nil
+	}
+
+	err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_MARK, NetbirdFwmark)
+	if err == nil {
+		log.Debugf("Successfully set SO_MARK to %d", NetbirdFwmark)
+	}
+	return err
 }


### PR DESCRIPTION
## Describe your changes

I found some changes laying around on my computer when asked about #2530 (debugging my mobile router), can as well upstream those:
- allows disabling `SO_MARK` without disabling other custom routing features
- makes dialer return an error instead of crashing the process with `log.Fatalf`

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/2530

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
