### PR TITLE
[client] Android exit node via P2P

### DIFF
--- a/client/iface/bind/control_android.go
+++ b/client/iface/bind/control_android.go
@@ -1,0 +1,12 @@
+package bind
+
+import (
+	wireguard "golang.zx2c4.com/wireguard/conn"
+
+	nbnet "github.com/netbirdio/netbird/util/net"
+)
+
+func init() {
+	// ControlFns is not thread safe and should only be modified during init.
+	*wireguard.ControlFns = append(*wireguard.ControlFns, nbnet.ControlProtectSocket)
+}

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ replace github.com/kardianos/service => github.com/netbirdio/service v0.0.0-2024
 
 replace github.com/getlantern/systray => github.com/netbirdio/systray v0.0.0-20231030152038-ef1ed2a27949
 
-replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go  v0.0.0-20241122164326-9c57ff270274
+replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go v0.0.0-20241122164326-9c57ff270274
 
 replace github.com/cloudflare/circl => github.com/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6
 

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ replace github.com/kardianos/service => github.com/netbirdio/service v0.0.0-2024
 
 replace github.com/getlantern/systray => github.com/netbirdio/systray v0.0.0-20231030152038-ef1ed2a27949
 
-replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go v0.0.0-20241122164326-9c57ff270274
+replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go v0.0.0-20241125150134-f9cdce5e32e9
 
 replace github.com/cloudflare/circl => github.com/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6
 

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ replace github.com/kardianos/service => github.com/netbirdio/service v0.0.0-2024
 
 replace github.com/getlantern/systray => github.com/netbirdio/systray v0.0.0-20231030152038-ef1ed2a27949
 
-replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go v0.0.0-20241107152827-57d8513b5f73
+replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go  v0.0.0-20241122164326-9c57ff270274
 
 replace github.com/cloudflare/circl => github.com/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6
 

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,8 @@ github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502 h1:3tHlFmhTdX9ax
 github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20241010133937-e0df50df217d h1:bRq5TKgC7Iq20pDiuC54yXaWnAVeS5PdGpSokFTlR28=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20241010133937-e0df50df217d/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
-github.com/netbirdio/wireguard-go v0.0.0-20241122164326-9c57ff270274 h1:VOCvDhVGjvBohTbHTT3BGpyJZjDECk6OO2+tqJVe1IA=
-github.com/netbirdio/wireguard-go v0.0.0-20241122164326-9c57ff270274/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
+github.com/netbirdio/wireguard-go v0.0.0-20241125150134-f9cdce5e32e9 h1:Pu/7EukijT09ynHUOzQYW7cC3M/BKU8O4qyN/TvTGoY=
+github.com/netbirdio/wireguard-go v0.0.0-20241125150134-f9cdce5e32e9/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 github.com/nicksnyder/go-i18n/v2 v2.4.0 h1:3IcvPOAvnCKwNm0TB0dLDTuawWEj+ax/RERNC+diLMM=
 github.com/nicksnyder/go-i18n/v2 v2.4.0/go.mod h1:nxYSZE9M0bf3Y70gPQjN9ha7XNHX7gMc814+6wVyEI4=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/go.sum
+++ b/go.sum
@@ -527,6 +527,7 @@ github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502 h1:3tHlFmhTdX9ax
 github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20241010133937-e0df50df217d h1:bRq5TKgC7Iq20pDiuC54yXaWnAVeS5PdGpSokFTlR28=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20241010133937-e0df50df217d/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
+github.com/netbirdio/wireguard-go v0.0.0-20241122164326-9c57ff270274 h1:VOCvDhVGjvBohTbHTT3BGpyJZjDECk6OO2+tqJVe1IA=
 github.com/netbirdio/wireguard-go v0.0.0-20241122164326-9c57ff270274/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 github.com/nicksnyder/go-i18n/v2 v2.4.0 h1:3IcvPOAvnCKwNm0TB0dLDTuawWEj+ax/RERNC+diLMM=
 github.com/nicksnyder/go-i18n/v2 v2.4.0/go.mod h1:nxYSZE9M0bf3Y70gPQjN9ha7XNHX7gMc814+6wVyEI4=

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,7 @@ github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502 h1:3tHlFmhTdX9ax
 github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20241010133937-e0df50df217d h1:bRq5TKgC7Iq20pDiuC54yXaWnAVeS5PdGpSokFTlR28=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20241010133937-e0df50df217d/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
-github.com/netbirdio/wireguard-go v0.0.0-20241107152827-57d8513b5f73 h1:jayg97LH/jJlvpIHVxueTfa+tfQ+FY8fy2sIhCwkz0g=
-github.com/netbirdio/wireguard-go v0.0.0-20241107152827-57d8513b5f73/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
+github.com/netbirdio/wireguard-go v0.0.0-20241122164326-9c57ff270274/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 github.com/nicksnyder/go-i18n/v2 v2.4.0 h1:3IcvPOAvnCKwNm0TB0dLDTuawWEj+ax/RERNC+diLMM=
 github.com/nicksnyder/go-i18n/v2 v2.4.0/go.mod h1:nxYSZE9M0bf3Y70gPQjN9ha7XNHX7gMc814+6wVyEI4=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/util/net/dialer_init_android.go
+++ b/util/net/dialer_init_android.go
@@ -1,25 +1,5 @@
 package net
 
-import (
-	"syscall"
-
-	log "github.com/sirupsen/logrus"
-)
-
 func (d *Dialer) init() {
-	d.Dialer.Control = func(_, _ string, c syscall.RawConn) error {
-		err := c.Control(func(fd uintptr) {
-			androidProtectSocketLock.Lock()
-			f := androidProtectSocket
-			androidProtectSocketLock.Unlock()
-			if f == nil {
-				return
-			}
-			ok := f(int32(fd))
-			if !ok {
-				log.Errorf("failed to protect socket: %d", fd)
-			}
-		})
-		return err
-	}
+	d.Dialer.Control = ControlProtectSocket
 }

--- a/util/net/listener_init_android.go
+++ b/util/net/listener_init_android.go
@@ -1,26 +1,6 @@
 package net
 
-import (
-	"syscall"
-
-	log "github.com/sirupsen/logrus"
-)
-
 // init configures the net.ListenerConfig Control function to set the fwmark on the socket
 func (l *ListenerConfig) init() {
-	l.ListenConfig.Control = func(_, _ string, c syscall.RawConn) error {
-		err := c.Control(func(fd uintptr) {
-			androidProtectSocketLock.Lock()
-			f := androidProtectSocket
-			androidProtectSocketLock.Unlock()
-			if f == nil {
-				return
-			}
-			ok := f(int32(fd))
-			if !ok {
-				log.Errorf("failed to protect listener socket: %d", fd)
-			}
-		})
-		return err
-	}
+	l.ListenConfig.Control = ControlProtectSocket
 }

--- a/util/net/protectsocket_android.go
+++ b/util/net/protectsocket_android.go
@@ -1,14 +1,42 @@
 package net
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+	"syscall"
+)
 
 var (
 	androidProtectSocketLock sync.Mutex
 	androidProtectSocket     func(fd int32) bool
 )
 
-func SetAndroidProtectSocketFn(f func(fd int32) bool) {
+func SetAndroidProtectSocketFn(fn func(fd int32) bool) {
 	androidProtectSocketLock.Lock()
-	androidProtectSocket = f
+	androidProtectSocket = fn
 	androidProtectSocketLock.Unlock()
+}
+
+// ControlProtectSocket is a Control function that sets the fwmark on the socket
+func ControlProtectSocket(_, _ string, c syscall.RawConn) error {
+	var aErr error
+	err := c.Control(func(fd uintptr) {
+		androidProtectSocketLock.Lock()
+		defer androidProtectSocketLock.Unlock()
+
+		if androidProtectSocket == nil {
+			aErr = fmt.Errorf("socket protection function not set")
+			return
+		}
+
+		if !androidProtectSocket(int32(fd)) {
+			aErr = fmt.Errorf("failed to protect socket via Android")
+		}
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return aErr
 }


### PR DESCRIPTION
## Describe your changes
Support exit node feature on Android via P2P communication

Protect the WireGuard UDP listeners with marks.
The implementation can support the VPN permission revocation events in thread safe way. It will be important if we start to support the running time route and DNS update features.

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
