### PR TITLE
[client] Account different policiy rules for routes firewall rules

### DIFF
--- a/management/server/route.go
+++ b/management/server/route.go
@@ -430,7 +430,7 @@ func (a *Account) getPeerRoutesFirewallRules(ctx context.Context, peerID string,
 }
 
 func (a *Account) getRouteFirewallRules(ctx context.Context, peerID string, policies []*Policy, route *route.Route, validatedPeersMap map[string]struct{}, distributionPeers map[string]struct{}) []*RouteFirewallRule {
-	fwRules := make([]*RouteFirewallRule, 0)
+	var fwRules []*RouteFirewallRule
 	for _, policy := range policies {
 		if !policy.Enabled {
 			continue

--- a/management/server/route_test.go
+++ b/management/server/route_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"sort"
 	"testing"
 	"time"
 
@@ -1487,6 +1488,8 @@ func TestAccount_getPeersRoutesFirewall(t *testing.T) {
 		peerBIp = "100.65.80.39"
 		peerCIp = "100.65.254.139"
 		peerHIp = "100.65.29.55"
+		peerJIp = "100.65.29.65"
+		peerKIp = "100.65.29.66"
 	)
 
 	account := &Account{
@@ -1542,6 +1545,16 @@ func TestAccount_getPeersRoutesFirewall(t *testing.T) {
 				IP:     net.ParseIP(peerHIp),
 				Status: &nbpeer.PeerStatus{},
 			},
+			"peerJ": {
+				ID:     "peerJ",
+				IP:     net.ParseIP(peerJIp),
+				Status: &nbpeer.PeerStatus{},
+			},
+			"peerK": {
+				ID:     "peerK",
+				IP:     net.ParseIP(peerKIp),
+				Status: &nbpeer.PeerStatus{},
+			},
 		},
 		Groups: map[string]*nbgroup.Group{
 			"routingPeer1": {
@@ -1568,6 +1581,11 @@ func TestAccount_getPeersRoutesFirewall(t *testing.T) {
 				Name:  "Route2",
 				Peers: []string{},
 			},
+			"route4": {
+				ID:    "route4",
+				Name:  "route4",
+				Peers: []string{},
+			},
 			"finance": {
 				ID:   "finance",
 				Name: "Finance",
@@ -1583,6 +1601,28 @@ func TestAccount_getPeersRoutesFirewall(t *testing.T) {
 					"peerC",
 					"peerH",
 					"peerB",
+				},
+			},
+			"qa": {
+				ID:   "qa",
+				Name: "QA",
+				Peers: []string{
+					"peerJ",
+					"peerK",
+				},
+			},
+			"restrictQA": {
+				ID:   "restrictQA",
+				Name: "restrictQA",
+				Peers: []string{
+					"peerJ",
+				},
+			},
+			"unrestrictedQA": {
+				ID:   "unrestrictedQA",
+				Name: "unrestrictedQA",
+				Peers: []string{
+					"peerK",
 				},
 			},
 			"contractors": {
@@ -1631,6 +1671,19 @@ func TestAccount_getPeersRoutesFirewall(t *testing.T) {
 				Enabled:             true,
 				Groups:              []string{"contractors"},
 				AccessControlGroups: []string{},
+			},
+			"route4": {
+				ID:                  "route4",
+				Network:             netip.MustParsePrefix("192.168.10.0/16"),
+				NetID:               "route4",
+				NetworkType:         route.IPv4Network,
+				PeerGroups:          []string{"routingPeer1"},
+				Description:         "Route4",
+				Masquerade:          false,
+				Metric:              9999,
+				Enabled:             true,
+				Groups:              []string{"qa"},
+				AccessControlGroups: []string{"route4"},
 			},
 		},
 		Policies: []*Policy{
@@ -1686,6 +1739,49 @@ func TestAccount_getPeersRoutesFirewall(t *testing.T) {
 					},
 				},
 			},
+			{
+				ID:      "RuleRoute4",
+				Name:    "RuleRoute4",
+				Enabled: true,
+				Rules: []*PolicyRule{
+					{
+						ID:            "RuleRoute4",
+						Name:          "RuleRoute4",
+						Bidirectional: true,
+						Enabled:       true,
+						Protocol:      PolicyRuleProtocolTCP,
+						Action:        PolicyTrafficActionAccept,
+						Ports:         []string{"80"},
+						Sources: []string{
+							"restrictQA",
+						},
+						Destinations: []string{
+							"route4",
+						},
+					},
+				},
+			},
+			{
+				ID:      "RuleRoute5",
+				Name:    "RuleRoute5",
+				Enabled: true,
+				Rules: []*PolicyRule{
+					{
+						ID:            "RuleRoute5",
+						Name:          "RuleRoute5",
+						Bidirectional: true,
+						Enabled:       true,
+						Protocol:      PolicyRuleProtocolALL,
+						Action:        PolicyTrafficActionAccept,
+						Sources: []string{
+							"unrestrictedQA",
+						},
+						Destinations: []string{
+							"route4",
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -1710,7 +1806,7 @@ func TestAccount_getPeersRoutesFirewall(t *testing.T) {
 
 	t.Run("check peer routes firewall rules", func(t *testing.T) {
 		routesFirewallRules := account.getPeerRoutesFirewallRules(context.Background(), "peerA", validatedPeers)
-		assert.Len(t, routesFirewallRules, 2)
+		assert.Len(t, routesFirewallRules, 4)
 
 		expectedRoutesFirewallRules := []*RouteFirewallRule{
 			{
@@ -1736,12 +1832,32 @@ func TestAccount_getPeersRoutesFirewall(t *testing.T) {
 				Port:        320,
 			},
 		}
-		assert.ElementsMatch(t, routesFirewallRules, expectedRoutesFirewallRules)
+		additionalFirewallRule := []*RouteFirewallRule{
+			{
+				SourceRanges: []string{
+					fmt.Sprintf(AllowedIPsFormat, peerJIp),
+				},
+				Action:      "accept",
+				Destination: "192.168.10.0/16",
+				Protocol:    "tcp",
+				Port:        80,
+			},
+			{
+				SourceRanges: []string{
+					fmt.Sprintf(AllowedIPsFormat, peerKIp),
+				},
+				Action:      "accept",
+				Destination: "192.168.10.0/16",
+				Protocol:    "all",
+			},
+		}
+
+		assert.ElementsMatch(t, orderRuleSourceRanges(routesFirewallRules), orderRuleSourceRanges(append(expectedRoutesFirewallRules, additionalFirewallRule...)))
 
 		// peerD is also the routing peer for route1, should contain same routes firewall rules as peerA
 		routesFirewallRules = account.getPeerRoutesFirewallRules(context.Background(), "peerD", validatedPeers)
 		assert.Len(t, routesFirewallRules, 2)
-		assert.ElementsMatch(t, routesFirewallRules, expectedRoutesFirewallRules)
+		assert.ElementsMatch(t, orderRuleSourceRanges(routesFirewallRules), orderRuleSourceRanges(expectedRoutesFirewallRules))
 
 		// peerE is a single routing peer for route 2 and route 3
 		routesFirewallRules = account.getPeerRoutesFirewallRules(context.Background(), "peerE", validatedPeers)
@@ -1770,13 +1886,21 @@ func TestAccount_getPeersRoutesFirewall(t *testing.T) {
 				IsDynamic:    true,
 			},
 		}
-		assert.ElementsMatch(t, routesFirewallRules, expectedRoutesFirewallRules)
+		assert.ElementsMatch(t, orderRuleSourceRanges(routesFirewallRules), orderRuleSourceRanges(expectedRoutesFirewallRules))
 
 		// peerC is part of route1 distribution groups but should not receive the routes firewall rules
 		routesFirewallRules = account.getPeerRoutesFirewallRules(context.Background(), "peerC", validatedPeers)
 		assert.Len(t, routesFirewallRules, 0)
 	})
 
+}
+
+// orderList is a helper function to sort a list of strings
+func orderRuleSourceRanges(ruleList []*RouteFirewallRule) []*RouteFirewallRule {
+	for _, rule := range ruleList {
+		sort.Strings(rule.SourceRanges)
+	}
+	return ruleList
 }
 
 func TestRouteAccountPeersUpdate(t *testing.T) {


### PR DESCRIPTION
## Describe your changes
This fixes the behavior where multiple policies with different access levels were applied to all distribution group peers. 

Now, we ensure that route firewall rules generation will consider source group peers of access control policies and apply rules to peers from these groups. Peers from the distribution group that don't belong to any source group will have their traffic dropped.

This will change behavior for existing and valid policies benefiting from this flaw. 

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
