### PR TITLE
[relay client] choose nearest relay based on latency

### DIFF
--- a/relay/client/client.go
+++ b/relay/client/client.go
@@ -123,11 +123,12 @@ func (cc *connContainer) close() {
 // the client can be reused by calling Connect again. When the client is closed, all connections are closed too.
 // While the Connect is in progress, the OpenConn function will block until the connection is established with relay server.
 type Client struct {
-	log            *log.Entry
-	parentCtx      context.Context
-	connectionURL  string
-	authTokenStore *auth.TokenStore
-	hashedID       []byte
+	log                   *log.Entry
+	parentCtx             context.Context
+	connectionURL         string
+	authTokenStore        *auth.TokenStore
+	hashedID              []byte
+	InitialConnectionTime time.Duration
 
 	bufPool *sync.Pool
 
@@ -264,11 +265,12 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) connect() error {
-	conn, err := ws.Dial(c.connectionURL)
+	conn, latency, err := ws.Dial(c.connectionURL)
 	if err != nil {
 		return err
 	}
 	c.relayConn = conn
+	c.InitialConnectionTime = latency
 
 	err = c.handShake()
 	if err != nil {

--- a/relay/client/dialer/ws/ws.go
+++ b/relay/client/dialer/ws/ws.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"nhooyr.io/websocket"
@@ -15,10 +17,10 @@ import (
 	nbnet "github.com/netbirdio/netbird/util/net"
 )
 
-func Dial(address string) (net.Conn, error) {
+func Dial(address string) (net.Conn, time.Duration, error) {
 	wsURL, err := prepareURL(address)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	opts := &websocket.DialOptions{
@@ -27,21 +29,26 @@ func Dial(address string) (net.Conn, error) {
 
 	parsedURL, err := url.Parse(wsURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	parsedURL.Path = ws.URLPath
 
-	wsConn, resp, err := websocket.Dial(context.Background(), parsedURL.String(), opts)
+	var connStart, firstByte time.Time
+	ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+		ConnectStart:         func(network, addr string) { connStart = time.Now() },
+		GotFirstResponseByte: func() { firstByte = time.Now() },
+	})
+	wsConn, resp, err := websocket.Dial(ctx, parsedURL.String(), opts)
 	if err != nil {
 		log.Errorf("failed to dial to Relay server '%s': %s", wsURL, err)
-		return nil, err
+		return nil, 0, err
 	}
 	if resp.Body != nil {
 		_ = resp.Body.Close()
 	}
 
 	conn := NewConn(wsConn, address)
-	return conn, nil
+	return conn, firstByte.Sub(connStart), nil
 }
 
 func prepareURL(address string) (string, error) {

--- a/relay/client/picker.go
+++ b/relay/client/picker.go
@@ -124,7 +124,9 @@ func (sp *ServerPicker) processConnResults(resultChan chan connResult, successCh
 		bestLatencyResult = cr
 	}
 
-	processingCtxCancel()
+	if processingCtxCancel != nil {
+		processingCtxCancel()
+	}
 	if successChan == nil {
 		return
 	}

--- a/relay/client/picker.go
+++ b/relay/client/picker.go
@@ -112,6 +112,8 @@ func (sp *ServerPicker) processConnResults(resultChan chan connResult, successCh
 		bestLatencyResult = cr
 	}
 
-	successChan <- bestLatencyResult
+	if bestLatencyResult.RelayClient != nil {
+		successChan <- bestLatencyResult
+	}
 	close(successChan)
 }


### PR DESCRIPTION
## Describe your changes

Change picker to choose nearest relay based on connection latency.

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/2950

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [X] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
