### PR TITLE
[client] Get static system info once

### DIFF
--- a/client/system/info.go
+++ b/client/system/info.go
@@ -61,6 +61,14 @@ type Info struct {
 	Files              []File // for posture checks
 }
 
+// StaticInfo is an object that contains machine information that does not change
+type StaticInfo struct {
+	SystemSerialNumber string
+	SystemProductName  string
+	SystemManufacturer string
+	Environment        Environment
+}
+
 // extractUserAgent extracts Netbird's agent (client) name and version from the outgoing context
 func extractUserAgent(ctx context.Context) string {
 	md, hasMeta := metadata.FromOutgoingContext(ctx)

--- a/client/system/info_darwin.go
+++ b/client/system/info_darwin.go
@@ -10,50 +10,14 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/sys/unix"
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/netbirdio/netbird/client/system/detect_cloud"
-	"github.com/netbirdio/netbird/client/system/detect_platform"
 	"github.com/netbirdio/netbird/version"
 )
-
-var (
-	staticInfo StaticInfo
-	once       sync.Once
-)
-
-func init() {
-	go func() {
-		_ = updateStaticInfo()
-	}()
-}
-
-func updateStaticInfo() StaticInfo {
-	once.Do(func() {
-		ctx := context.Background()
-		wg := sync.WaitGroup{}
-		wg.Add(3)
-		go func() {
-			staticInfo.SystemSerialNumber, staticInfo.SystemProductName, staticInfo.SystemManufacturer = sysInfo()
-			wg.Done()
-		}()
-		go func() {
-			staticInfo.Environment.Cloud = detect_cloud.Detect(ctx)
-			wg.Done()
-		}()
-		go func() {
-			staticInfo.Environment.Platform = detect_platform.Detect(ctx)
-			wg.Done()
-		}()
-		wg.Wait()
-	})
-	return staticInfo
-}
 
 // GetInfo retrieves and parses the system information
 func GetInfo(ctx context.Context) *Info {

--- a/client/system/info_darwin.go
+++ b/client/system/info_darwin.go
@@ -43,7 +43,7 @@ func GetInfo(ctx context.Context) *Info {
 	start := time.Now()
 	si := updateStaticInfo()
 	if time.Since(start) > 1*time.Second {
-		log.Infof("updateStaticInfo took %s", time.Since(start))
+		log.Warnf("updateStaticInfo took %s", time.Since(start))
 	}
 
 	gio := &Info{

--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -72,7 +72,7 @@ func GetInfo(ctx context.Context) *Info {
 	start := time.Now()
 	si := updateStaticInfo()
 	if time.Since(start) > 1*time.Second {
-		log.Infof("updateStaticInfo took %s", time.Since(start))
+		log.Warnf("updateStaticInfo took %s", time.Since(start))
 	}
 
 	gio := &Info{

--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -21,10 +21,6 @@ import (
 
 var sisInfoWrapper SysInfoWrapper
 
-type SysInfoGetter interface {
-	GetSysInfo() SysInfo
-}
-
 type SysInfoWrapper struct {
 	providedInfo *SysInfo
 	si           sysinfo.SysInfo

--- a/client/system/info_windows.go
+++ b/client/system/info_windows.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/yusufpapurcu/wmi"
 	"golang.org/x/sys/windows/registry"
 
 	"github.com/netbirdio/netbird/version"
@@ -44,7 +43,7 @@ func GetInfo(ctx context.Context) *Info {
 	start := time.Now()
 	si := updateStaticInfo()
 	if time.Since(start) > 1*time.Second {
-		log.Infof("updateStaticInfo took %s", time.Since(start))
+		log.Warnf("updateStaticInfo took %s", time.Since(start))
 	}
 
 	gio := &Info{

--- a/client/system/info_windows.go
+++ b/client/system/info_windows.go
@@ -6,15 +6,11 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/yusufpapurcu/wmi"
 	"golang.org/x/sys/windows/registry"
 
-	"github.com/netbirdio/netbird/client/system/detect_cloud"
-	"github.com/netbirdio/netbird/client/system/detect_platform"
 	"github.com/netbirdio/netbird/version"
 )
 
@@ -32,39 +28,6 @@ type Win32_ComputerSystemProduct struct {
 
 type Win32_BIOS struct {
 	SerialNumber string
-}
-
-var (
-	staticInfo StaticInfo
-	once       sync.Once
-)
-
-func init() {
-	go func() {
-		_ = updateStaticInfo()
-	}()
-}
-
-func updateStaticInfo() StaticInfo {
-	once.Do(func() {
-		ctx := context.Background()
-		wg := sync.WaitGroup{}
-		wg.Add(3)
-		go func() {
-			staticInfo.SystemSerialNumber, staticInfo.SystemProductName, staticInfo.SystemManufacturer = sysInfo()
-			wg.Done()
-		}()
-		go func() {
-			staticInfo.Environment.Cloud = detect_cloud.Detect(ctx)
-			wg.Done()
-		}()
-		go func() {
-			staticInfo.Environment.Platform = detect_platform.Detect(ctx)
-			wg.Done()
-		}()
-		wg.Wait()
-	})
-	return staticInfo
 }
 
 // GetInfo retrieves and parses the system information

--- a/client/system/info_windows.go
+++ b/client/system/info_windows.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/yusufpapurcu/wmi"
 	"golang.org/x/sys/windows/registry"
 
 	"github.com/netbirdio/netbird/version"

--- a/client/system/static_info.go
+++ b/client/system/static_info.go
@@ -1,4 +1,4 @@
-//go:build (linux && !android) || windows || darwin
+//go:build (linux && !android) || windows || (darwin && !ios)
 
 package system
 

--- a/client/system/static_info.go
+++ b/client/system/static_info.go
@@ -1,0 +1,46 @@
+//go:build (linux && !android) || windows || darwin
+
+package system
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/netbirdio/netbird/client/system/detect_cloud"
+	"github.com/netbirdio/netbird/client/system/detect_platform"
+)
+
+var (
+	staticInfo StaticInfo
+	once       sync.Once
+)
+
+func init() {
+	go func() {
+		_ = updateStaticInfo()
+	}()
+}
+
+func updateStaticInfo() StaticInfo {
+	once.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		wg := sync.WaitGroup{}
+		wg.Add(3)
+		go func() {
+			staticInfo.SystemSerialNumber, staticInfo.SystemProductName, staticInfo.SystemManufacturer = sysInfo()
+			wg.Done()
+		}()
+		go func() {
+			staticInfo.Environment.Cloud = detect_cloud.Detect(ctx)
+			wg.Done()
+		}()
+		go func() {
+			staticInfo.Environment.Platform = detect_platform.Detect(ctx)
+			wg.Done()
+		}()
+		wg.Wait()
+	})
+	return staticInfo
+}

--- a/client/system/sysinfo_linux_test.go
+++ b/client/system/sysinfo_linux_test.go
@@ -183,7 +183,8 @@ func Test_sysInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSerialNum, gotProdName, gotManufacturer := sysInfo(tt.sysInfo)
+			sisInfoWrapper = tt.sysInfo
+			gotSerialNum, gotProdName, gotManufacturer := sysInfo()
 			if gotSerialNum != tt.wantSerialNum {
 				t.Errorf("sysInfo() gotSerialNum = %v, want %v", gotSerialNum, tt.wantSerialNum)
 			}

--- a/client/system/sysinfo_linux_test.go
+++ b/client/system/sysinfo_linux_test.go
@@ -183,7 +183,7 @@ func Test_sysInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sisInfoWrapper = tt.sysInfo
+			sisInfoWrapper.providedInfo = &tt.sysInfo
 			gotSerialNum, gotProdName, gotManufacturer := sysInfo()
 			if gotSerialNum != tt.wantSerialNum {
 				t.Errorf("sysInfo() gotSerialNum = %v, want %v", gotSerialNum, tt.wantSerialNum)

--- a/client/system/sysinfo_linux_test.go
+++ b/client/system/sysinfo_linux_test.go
@@ -183,7 +183,9 @@ func Test_sysInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sisInfoWrapper.providedInfo = &tt.sysInfo
+			getSystemInfo = func() SysInfo {
+				return tt.sysInfo
+			}
 			gotSerialNum, gotProdName, gotManufacturer := sysInfo()
 			if gotSerialNum != tt.wantSerialNum {
 				t.Errorf("sysInfo() gotSerialNum = %v, want %v", gotSerialNum, tt.wantSerialNum)


### PR DESCRIPTION
## Describe your changes
Get static system info once for Windows, Darwin, and Linux nodes

This should improve startup and peer authentication times
## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
