### PR TITLE
Add missing parentheses on iphone hostname generation condition

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -477,7 +477,7 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, setupKey, userID s
 			setupKeyName = sk.Name
 		}
 
-		if strings.ToLower(peer.Meta.Hostname) == "iphone" || strings.ToLower(peer.Meta.Hostname) == "ipad" && userID != "" {
+		if (strings.ToLower(peer.Meta.Hostname) == "iphone" || strings.ToLower(peer.Meta.Hostname) == "ipad") && userID != "" {
 			if am.idpManager != nil {
 				userdata, err := am.idpManager.GetUserDataByID(ctx, userID, idp.AppMetadata{WTAccountID: accountID})
 				if err == nil && userdata != nil {


### PR DESCRIPTION
## Describe your changes

Add missing parentheses around the comparison to fill the hostname field from the IdP user data when using iphone.

## Issue ticket number and link

No ticket. Found this apparent bug when browsing the code for something completely unrelated, I don't believe this will affect anything in real world usage.

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
