### PR TITLE
[client] Cleanup status resources on engine stop

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -276,6 +276,10 @@ func (e *Engine) Stop() error {
 		e.srWatcher.Close()
 	}
 
+	e.statusRecorder.ReplaceOfflinePeers([]peer.State{})
+	e.statusRecorder.UpdateDNSStates([]peer.NSGroupState{})
+	e.statusRecorder.UpdateRelayStates([]relay.ProbeResult{})
+
 	err := e.removeAllPeers()
 	if err != nil {
 		return fmt.Errorf("failed to remove all peers: %s", err)

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -2998,10 +2998,10 @@ func BenchmarkSyncAndMarkPeer(b *testing.B) {
 		minMsPerOpCICD  float64
 		maxMsPerOpCICD  float64
 	}{
-		{"Small", 50, 5, 1, 3, 4, 10},
+		{"Small", 50, 5, 1, 3, 3, 10},
 		{"Medium", 500, 100, 7, 13, 10, 60},
 		{"Large", 5000, 200, 65, 80, 60, 170},
-		{"Small single", 50, 10, 1, 3, 4, 60},
+		{"Small single", 50, 10, 1, 3, 3, 60},
 		{"Medium single", 500, 10, 7, 13, 10, 26},
 		{"Large 5", 5000, 15, 65, 80, 60, 170},
 	}
@@ -3141,10 +3141,10 @@ func BenchmarkLoginPeer_NewPeer(b *testing.B) {
 	}{
 		{"Small", 50, 5, 107, 120, 107, 140},
 		{"Medium", 500, 100, 105, 140, 105, 170},
-		{"Large", 5000, 200, 180, 220, 180, 320},
+		{"Large", 5000, 200, 180, 220, 180, 340},
 		{"Small single", 50, 10, 107, 120, 105, 140},
 		{"Medium single", 500, 10, 105, 140, 105, 170},
-		{"Large 5", 5000, 15, 180, 220, 180, 320},
+		{"Large 5", 5000, 15, 180, 220, 180, 340},
 	}
 
 	log.SetOutput(io.Discard)


### PR DESCRIPTION

## Describe your changes
cleanup leftovers from status recorder when stopping the engine

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
