### PR TITLE
Reduce max wait time to initialize peer connections

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -598,7 +598,7 @@ func (conn *Conn) doOnConnected(remoteRosenpassPubKey []byte, remoteRosenpassAdd
 
 func (conn *Conn) waitInitialRandomSleepTime(ctx context.Context) {
 	minWait := 100
-	maxWait := 800
+	maxWait := 300
 	duration := time.Duration(rand.Intn(maxWait-minWait)+minWait) * time.Millisecond
 
 	timeout := time.NewTimer(duration)

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -597,9 +597,8 @@ func (conn *Conn) doOnConnected(remoteRosenpassPubKey []byte, remoteRosenpassAdd
 }
 
 func (conn *Conn) waitInitialRandomSleepTime(ctx context.Context) {
-	minWait := 100
 	maxWait := 300
-	duration := time.Duration(rand.Intn(maxWait-minWait)+minWait) * time.Millisecond
+	duration := time.Duration(rand.Intn(maxWait)) * time.Millisecond
 
 	timeout := time.NewTimer(duration)
 	defer timeout.Stop()


### PR DESCRIPTION

## Describe your changes
setting rand time range to 100-300ms instead of 100-800ms

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
