### PR TITLE
[client] Init route selector early

### DIFF
--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -124,6 +124,8 @@ func NewManager(
 
 // Init sets up the routing
 func (m *DefaultManager) Init() (nbnet.AddHookFunc, nbnet.RemoveHookFunc, error) {
+	m.routeSelector = m.initSelector()
+
 	if nbnet.CustomRoutingDisabled() {
 		return nil, nil, nil
 	}
@@ -143,8 +145,6 @@ func (m *DefaultManager) Init() (nbnet.AddHookFunc, nbnet.RemoveHookFunc, error)
 	if err != nil {
 		return nil, nil, fmt.Errorf("setup routing: %w", err)
 	}
-
-	m.routeSelector = m.initSelector()
 
 	log.Info("Routing setup complete")
 	return beforePeerHook, afterPeerHook, nil


### PR DESCRIPTION
## Describe your changes

Makes sure the route selector is initialized even if custom routing is disabled or we error out early.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
