### PR TITLE
[client] Fix race condition with systray ready

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -572,6 +572,7 @@ func (s *serviceClient) onTrayReady() {
 	s.update.SetOnUpdateListener(s.onUpdateAvailable)
 	go func() {
 		s.getSrvConfig()
+		time.Sleep(100 * time.Millisecond) // To prevent race condition caused by systray not being fully initialized and ignoring setIcon
 		for {
 			err := s.updateStatus()
 			if err != nil {


### PR DESCRIPTION
## Describe your changes
fyne.io/systray package [calls onTrayReady before fully initializing](https://github.com/fyne-io/systray/blob/v1.11.0/systray_unix.go#L161), causing some calls (e.g SetIcon) to [fail silently](https://github.com/fyne-io/systray/blob/v1.11.0/systray_unix.go#L58-L60) because `props` global variable inside systray package is not yet set, while the [MenuItems can be updated normally without failure](https://github.com/fyne-io/systray/blob/v1.11.0/systray.go#L213-L223).

This causes netbird-ui icon to stay stuck on Disconnected if netbird service was running and connected before netbird-ui starts up.

This is mainly a workaround since the [issue in systray is not responsive](https://github.com/fyne-io/systray/issues/35).

## Issue ticket number and link

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
