### PR TITLE
[client] Add peer conn init limit

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -172,7 +172,7 @@ func NewConn(engineCtx context.Context, config ConnConfig, statusRecorder *Statu
 // It will try to establish a connection using ICE and in parallel with relay. The higher priority connection type will
 // be used.
 func (conn *Conn) Open() {
-	conn.semaphore.Add()
+	conn.semaphore.Add(conn.ctx)
 	conn.log.Debugf("open connection to peer")
 
 	conn.mu.Lock()
@@ -195,7 +195,7 @@ func (conn *Conn) Open() {
 }
 
 func (conn *Conn) startHandshakeAndReconnect(ctx context.Context) {
-	defer conn.semaphore.Done()
+	defer conn.semaphore.Done(conn.ctx)
 	conn.waitInitialRandomSleepTime(ctx)
 
 	err := conn.handshaker.sendOffer()

--- a/client/internal/peer/conn_test.go
+++ b/client/internal/peer/conn_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/peer/ice"
 	"github.com/netbirdio/netbird/client/internal/stdnet"
 	"github.com/netbirdio/netbird/util"
+	semaphoregroup "github.com/netbirdio/netbird/util/semaphore-group"
 )
 
 var connConf = ConnConfig{
@@ -46,7 +47,7 @@ func TestNewConn_interfaceFilter(t *testing.T) {
 
 func TestConn_GetKey(t *testing.T) {
 	swWatcher := guard.NewSRWatcher(nil, nil, nil, connConf.ICEConfig)
-	conn, err := NewConn(context.Background(), connConf, nil, nil, nil, nil, swWatcher)
+	conn, err := NewConn(context.Background(), connConf, nil, nil, nil, nil, swWatcher, semaphoregroup.NewSemaphoreGroup(1))
 	if err != nil {
 		return
 	}
@@ -58,7 +59,7 @@ func TestConn_GetKey(t *testing.T) {
 
 func TestConn_OnRemoteOffer(t *testing.T) {
 	swWatcher := guard.NewSRWatcher(nil, nil, nil, connConf.ICEConfig)
-	conn, err := NewConn(context.Background(), connConf, NewRecorder("https://mgm"), nil, nil, nil, swWatcher)
+	conn, err := NewConn(context.Background(), connConf, NewRecorder("https://mgm"), nil, nil, nil, swWatcher, semaphoregroup.NewSemaphoreGroup(1))
 	if err != nil {
 		return
 	}
@@ -92,7 +93,7 @@ func TestConn_OnRemoteOffer(t *testing.T) {
 
 func TestConn_OnRemoteAnswer(t *testing.T) {
 	swWatcher := guard.NewSRWatcher(nil, nil, nil, connConf.ICEConfig)
-	conn, err := NewConn(context.Background(), connConf, NewRecorder("https://mgm"), nil, nil, nil, swWatcher)
+	conn, err := NewConn(context.Background(), connConf, NewRecorder("https://mgm"), nil, nil, nil, swWatcher, semaphoregroup.NewSemaphoreGroup(1))
 	if err != nil {
 		return
 	}
@@ -125,7 +126,7 @@ func TestConn_OnRemoteAnswer(t *testing.T) {
 }
 func TestConn_Status(t *testing.T) {
 	swWatcher := guard.NewSRWatcher(nil, nil, nil, connConf.ICEConfig)
-	conn, err := NewConn(context.Background(), connConf, NewRecorder("https://mgm"), nil, nil, nil, swWatcher)
+	conn, err := NewConn(context.Background(), connConf, NewRecorder("https://mgm"), nil, nil, nil, swWatcher, semaphoregroup.NewSemaphoreGroup(1))
 	if err != nil {
 		return
 	}

--- a/util/semaphore-group/semaphore_group.go
+++ b/util/semaphore-group/semaphore_group.go
@@ -1,0 +1,39 @@
+package semaphoregroup
+
+import (
+	"sync"
+)
+
+// SemaphoreGroup is a custom type that combines sync.WaitGroup and a semaphore.
+type SemaphoreGroup struct {
+	waitGroup sync.WaitGroup
+	semaphore chan struct{}
+}
+
+// NewSemaphoreGroup creates a new SemaphoreGroup with the specified semaphore limit.
+func NewSemaphoreGroup(limit int) *SemaphoreGroup {
+	return &SemaphoreGroup{
+		semaphore: make(chan struct{}, limit),
+	}
+}
+
+// Add increments the internal WaitGroup counter and acquires a semaphore slot.
+func (sg *SemaphoreGroup) Add() {
+	sg.waitGroup.Add(1)
+
+	// Acquire semaphore slot
+	sg.semaphore <- struct{}{}
+}
+
+// Done decrements the internal WaitGroup counter and releases a semaphore slot.
+func (sg *SemaphoreGroup) Done() {
+	sg.waitGroup.Done()
+
+	// Release semaphore slot
+	<-sg.semaphore
+}
+
+// Wait waits until the internal WaitGroup counter is zero.
+func (sg *SemaphoreGroup) Wait() {
+	sg.waitGroup.Wait()
+}

--- a/util/semaphore-group/semaphore_group_test.go
+++ b/util/semaphore-group/semaphore_group_test.go
@@ -1,6 +1,7 @@
 package semaphoregroup
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -9,9 +10,9 @@ func TestSemaphoreGroup(t *testing.T) {
 	semGroup := NewSemaphoreGroup(2)
 
 	for i := 0; i < 5; i++ {
-		semGroup.Add()
+		semGroup.Add(context.Background())
 		go func(id int) {
-			defer semGroup.Done()
+			defer semGroup.Done(context.Background())
 
 			got := len(semGroup.semaphore)
 			if got == 0 {
@@ -29,5 +30,37 @@ func TestSemaphoreGroup(t *testing.T) {
 	got := len(semGroup.semaphore)
 	if got != want {
 		t.Errorf("Expected semaphore length %d, got %d", want, got)
+	}
+}
+
+func TestSemaphoreGroupContext(t *testing.T) {
+	semGroup := NewSemaphoreGroup(1)
+	semGroup.Add(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	t.Cleanup(cancel)
+	rChan := make(chan struct{})
+
+	go func() {
+		semGroup.Add(ctx)
+		rChan <- struct{}{}
+	}()
+	select {
+	case <-rChan:
+	case <-time.NewTimer(2 * time.Second).C:
+		t.Error("Adding to semaphore group should not block when context is not done")
+	}
+
+	semGroup.Done(context.Background())
+
+	ctxDone, cancelDone := context.WithTimeout(context.Background(), 1*time.Second)
+	t.Cleanup(cancelDone)
+	go func() {
+		semGroup.Done(ctxDone)
+		rChan <- struct{}{}
+	}()
+	select {
+	case <-rChan:
+	case <-time.NewTimer(2 * time.Second).C:
+		t.Error("Releasing from semaphore group should not block when context is not done")
 	}
 }

--- a/util/semaphore-group/semaphore_group_test.go
+++ b/util/semaphore-group/semaphore_group_test.go
@@ -1,0 +1,33 @@
+package semaphoregroup
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSemaphoreGroup(t *testing.T) {
+	semGroup := NewSemaphoreGroup(2)
+
+	for i := 0; i < 5; i++ {
+		semGroup.Add()
+		go func(id int) {
+			defer semGroup.Done()
+
+			got := len(semGroup.semaphore)
+			if got == 0 {
+				t.Errorf("Expected semaphore length > 0 , got 0")
+			}
+
+			time.Sleep(time.Millisecond)
+			t.Logf("Goroutine %d is running\n", id)
+		}(i)
+	}
+
+	semGroup.Wait()
+
+	want := 0
+	got := len(semGroup.semaphore)
+	if got != want {
+		t.Errorf("Expected semaphore length %d, got %d", want, got)
+	}
+}


### PR DESCRIPTION
## Describe your changes
Limit the peer connection initialization at 200 peers at the same time

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
