### PR TITLE
fix client unsupported h2 protocol when only 443 activated

### DIFF
--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -530,7 +530,7 @@ renderCaddyfile() {
 {
   debug
 	servers :80,:443 {
-    protocols h1 h2c h3
+    protocols h1 h2c h2 h3
   }
 }
 


### PR DESCRIPTION
## Describe your changes

When I remove 80 http port in Caddyfile, netbird client cannot connect server:443. Logs show error below: {"level":"debug","ts":1733809631.4012625,"logger":"http.stdlib","msg":"http: TLS handshake error from redacted:41580: tls: client requested unsupported application protocols ([h2])"} I wonder here h2 protocol is absent.

## Issue ticket number and link

### Checklist
- [✓] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
