### PR TITLE
fix: reformat IPv6 ICE addresses when hole punching

### DIFF
--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -264,7 +264,13 @@ func (w *WorkerICE) closeAgent(cancel context.CancelFunc) {
 func (w *WorkerICE) punchRemoteWGPort(pair *ice.CandidatePair, remoteWgPort int) {
 	// wait local endpoint configuration
 	time.Sleep(time.Second)
-	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", pair.Remote.Address(), remoteWgPort))
+	addrString := pair.Remote.Address()
+	parsed, err := netip.ParseAddr(addrString)
+	if (err == nil) && (parsed.Is6()) {
+		addrString = fmt.Sprintf("[%s]", addrString)
+		//IPv6 Literals need to be wrapped in brackets for Resolve*Addr()
+	}
+	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", addrString, remoteWgPort))
 	if err != nil {
 		w.log.Warnf("got an error while resolving the udp address, err: %s", err)
 		return


### PR DESCRIPTION
## Describe your changes
Check for IPv6 addresses during hole punching, adding brackets around them as needed

## Issue ticket number and link
#2327 and #2606

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
