### PR TITLE
[client] Restrict Unix socket permissions to 0600 for enhanced security

### DIFF
--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -48,7 +48,7 @@ func (p *program) Start(svc service.Service) error {
 		defer listen.Close()
 
 		if split[0] == "unix" {
-			err = os.Chmod(split[1], 0666)
+			err = os.Chmod(split[1], 0600)
 			if err != nil {
 				log.Errorf("failed setting daemon permissions: %v", split[1])
 				return


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
