### PR TITLE
[client] Avoid using iota on mixed const block

### DIFF
--- a/client/iface/device/kernel_module_linux.go
+++ b/client/iface/device/kernel_module_linux.go
@@ -27,14 +27,14 @@ import (
 type status int
 
 const (
-	defaultModuleDir        = "/lib/modules"
-	unknown          status = iota
-	unloaded
-	unloading
-	loading
-	live
-	inuse
-	envDisableWireGuardKernel = "NB_WG_KERNEL_DISABLED"
+	unknown                   status = 1
+	unloaded                  status = 2
+	unloading                 status = 3
+	loading                   status = 4
+	live                      status = 5
+	inuse                     status = 6
+	defaultModuleDir                 = "/lib/modules"
+	envDisableWireGuardKernel        = "NB_WG_KERNEL_DISABLED"
 )
 
 type module struct {


### PR DESCRIPTION
## Describe your changes
Used the values as resolved when the first iota value was the second const in the block.

See example: https://go.dev/play/p/bMReMFC9anU

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
