### PR TITLE
Set -p 1 for management tests

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -183,7 +183,7 @@ jobs:
         run: git --no-pager diff --exit-code
 
       - name: Test
-        run: CGO_ENABLED=1 GOARCH=${{ matrix.arch }} NETBIRD_STORE_ENGINE=${{ matrix.store }} CI=true go test -exec 'sudo --preserve-env=CI,NETBIRD_STORE_ENGINE' -timeout 10m $(go list ./... | grep /management)
+        run: CGO_ENABLED=1 GOARCH=${{ matrix.arch }} NETBIRD_STORE_ENGINE=${{ matrix.store }} CI=true go test -exec 'sudo --preserve-env=CI,NETBIRD_STORE_ENGINE' -timeout 10m -p 1 $(go list ./... | grep /management)
 
   benchmark:
     needs: [ build-cache ]

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -3039,10 +3039,10 @@ func BenchmarkSyncAndMarkPeer(b *testing.B) {
 	}{
 		{"Small", 50, 5, 1, 3, 3, 10},
 		{"Medium", 500, 100, 7, 13, 10, 60},
-		{"Large", 5000, 200, 65, 80, 60, 170},
+		{"Large", 5000, 200, 65, 80, 60, 175},
 		{"Small single", 50, 10, 1, 3, 3, 60},
 		{"Medium single", 500, 10, 7, 13, 10, 26},
-		{"Large 5", 5000, 15, 65, 80, 60, 170},
+		{"Large 5", 5000, 15, 65, 80, 60, 175},
 	}
 
 	log.SetOutput(io.Discard)


### PR DESCRIPTION
## Describe your changes
We still have some client tests that can lock other tests within the management code

for now, I am adding back the -p 1 flag
## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
