### PR TITLE
client: make /var/lib/netbird paths configurable

### DIFF
--- a/client/configs/configs.go
+++ b/client/configs/configs.go
@@ -1,0 +1,24 @@
+package configs
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var StateDir string
+
+func init() {
+	StateDir = os.Getenv("NB_STATE_DIR")
+	if StateDir != "" {
+		return
+	}
+	switch runtime.GOOS {
+	case "windows":
+		StateDir = filepath.Join(os.Getenv("PROGRAMDATA"), "Netbird")
+	case "darwin", "linux":
+		StateDir = "/var/lib/netbird"
+	case "freebsd", "openbsd", "netbsd", "dragonfly":
+		StateDir = "/var/db/netbird"
+	}
+}

--- a/client/internal/dns/consts.go
+++ b/client/internal/dns/consts.go
@@ -1,0 +1,18 @@
+//go:build !android
+
+package dns
+
+import (
+	"github.com/netbirdio/netbird/client/configs"
+	"os"
+	"path/filepath"
+)
+
+var fileUncleanShutdownResolvConfLocation string
+
+func init() {
+	fileUncleanShutdownResolvConfLocation = os.Getenv("NB_UNCLEAN_SHUTDOWN_RESOLV_FILE")
+	if fileUncleanShutdownResolvConfLocation == "" {
+		fileUncleanShutdownResolvConfLocation = filepath.Join(configs.StateDir, "resolv.conf")
+	}
+}

--- a/client/internal/dns/consts_freebsd.go
+++ b/client/internal/dns/consts_freebsd.go
@@ -1,5 +1,0 @@
-package dns
-
-const (
-	fileUncleanShutdownResolvConfLocation = "/var/db/netbird/resolv.conf"
-)

--- a/client/internal/dns/consts_linux.go
+++ b/client/internal/dns/consts_linux.go
@@ -1,7 +1,0 @@
-//go:build !android
-
-package dns
-
-const (
-	fileUncleanShutdownResolvConfLocation = "/var/lib/netbird/resolv.conf"
-)

--- a/client/internal/statemanager/path.go
+++ b/client/internal/statemanager/path.go
@@ -1,23 +1,16 @@
 package statemanager
 
 import (
+	"github.com/netbirdio/netbird/client/configs"
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
 // GetDefaultStatePath returns the path to the state file based on the operating system
 // It returns an empty string if the path cannot be determined.
 func GetDefaultStatePath() string {
-	switch runtime.GOOS {
-	case "windows":
-		return filepath.Join(os.Getenv("PROGRAMDATA"), "Netbird", "state.json")
-	case "darwin", "linux":
-		return "/var/lib/netbird/state.json"
-	case "freebsd", "openbsd", "netbsd", "dragonfly":
-		return "/var/db/netbird/state.json"
+	if path := os.Getenv("NB_DNS_STATE_FILE"); path != "" {
+		return path
 	}
-
-	return ""
-
+	return filepath.Join(configs.StateDir, "state.json")
 }


### PR DESCRIPTION
## Describe your changes

made the change as small as possible to prevent conflicts throughout rest of the codebase:

- NB_STATE_DIR
- NB_UNCLEAN_SHUTDOWN_RESOLV_FILE
- NB_DNS_STATE_FILE

## Issue ticket number and link

related to missing `state.json` & `resolv.conf` configurability for my NixOS module https://github.com/NixOS/nixpkgs/pull/287236

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
