### PR TITLE
Handle IPv6 addresses in X-Real-IP header on relay service

### DIFF
--- a/relay/server/listener/ws/listener.go
+++ b/relay/server/listener/ws/listener.go
@@ -96,5 +96,5 @@ func remoteAddr(r *http.Request) string {
 	if r.Header.Get("X-Real-Ip") == "" || r.Header.Get("X-Real-Port") == "" {
 		return r.RemoteAddr
 	}
-	return fmt.Sprintf("%s:%s", r.Header.Get("X-Real-Ip"), r.Header.Get("X-Real-Port"))
+	return net.JoinHostPort(r.Header.Get("X-Real-Ip"), r.Header.Get("X-Real-Port"))
 }


### PR DESCRIPTION
## Describe your changes

Properly format IPv6 addresses found in `X-Real-IP` headers to avoid errors on the call to `net.ResolveTCPAddr`. IPv6 addresses need to be formatted `[1234::abcd]:443`, which is handled automatically by `net.JoinHostPort`.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
