### PR TITLE
[management] Fix duplicate resource routes when routing peer is part of the source group

### DIFF
--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -1330,10 +1330,8 @@ func (a *Account) GetNetworkResourcesRoutesToSync(ctx context.Context, peerID st
 				// routing peer should be able to connect with all source peers
 				if addSourcePeers {
 					allSourcePeers = append(allSourcePeers, group.Peers...)
-				}
-
-				// add routes for the resource if the peer is in the distribution group
-				if slices.Contains(group.Peers, peerID) {
+				} else if slices.Contains(group.Peers, peerID) {
+					// add routes for the resource if the peer is in the distribution group
 					for peerId, router := range networkRoutingPeers {
 						routes = append(routes, a.getNetworkResourcesRoutes(resource, peerId, router, resourcePolicies)...)
 					}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
