### PR TITLE
[management] Preserve jwt groups when accessing API with PAT

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1252,6 +1252,12 @@ func (am *DefaultAccountManager) GetAccountIDFromToken(ctx context.Context, clai
 // syncJWTGroups processes the JWT groups for a user, updates the account based on the groups,
 // and propagates changes to peers if group propagation is enabled.
 func (am *DefaultAccountManager) syncJWTGroups(ctx context.Context, accountID string, claims jwtclaims.AuthorizationClaims) error {
+	if claim, exists := claims.Raw[jwtclaims.IsToken]; exists {
+		if isToken, ok := claim.(bool); ok && isToken {
+			return nil
+		}
+	}
+
 	settings, err := am.Store.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
 	if err != nil {
 		return err

--- a/management/server/http/middleware/auth_middleware.go
+++ b/management/server/http/middleware/auth_middleware.go
@@ -175,6 +175,7 @@ func (m *AuthMiddleware) checkPATFromRequest(w http.ResponseWriter, r *http.Requ
 	claimMaps[m.audience+jwtclaims.AccountIDSuffix] = account.Id
 	claimMaps[m.audience+jwtclaims.DomainIDSuffix] = account.Domain
 	claimMaps[m.audience+jwtclaims.DomainCategorySuffix] = account.DomainCategory
+	claimMaps[jwtclaims.IsToken] = true
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claimMaps)
 	newRequest := r.WithContext(context.WithValue(r.Context(), jwtclaims.TokenUserProperty, jwtToken)) //nolint
 	// Update the current request with the new context information.

--- a/management/server/jwtclaims/extractor.go
+++ b/management/server/jwtclaims/extractor.go
@@ -22,6 +22,8 @@ const (
 	LastLoginSuffix = "nb_last_login"
 	// Invited claim indicates that an incoming JWT is from a user that just accepted an invitation
 	Invited = "nb_invited"
+	// IsToken claim indicates that auth type from the user is a token
+	IsToken = "is_token"
 )
 
 // ExtractClaims Extract function type


### PR DESCRIPTION
## Describe your changes

Fix unintended removal of synced JWT groups when accessing the API with PAT.

## Issue ticket number and link

Fixes #3127

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
