### PR TITLE
[management] exclude self from network map if self is routing peer

### DIFF
--- a/management/server/http/testing/integration/setupkeys_handler_integration_test.go
+++ b/management/server/http/testing/integration/setupkeys_handler_integration_test.go
@@ -925,7 +925,7 @@ func Test_SetupKeys_GetAll(t *testing.T) {
 					return tc.expectedResponse[i].UsageLimit < tc.expectedResponse[j].UsageLimit
 				})
 
-				for i, _ := range tc.expectedResponse {
+				for i := range tc.expectedResponse {
 					validateCreatedKey(t, tc.expectedResponse[i], &got[i])
 
 					key, err := am.GetSetupKey(context.Background(), testing_tools.TestAccountId, testing_tools.TestUserId, got[i].Id)

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -335,6 +335,9 @@ func (a *Account) addNetworksRoutingPeers(
 		}
 	}
 	for p := range networkRoutesPeers {
+		if p == peer.ID {
+			continue
+		}
 		missingPeers[p] = struct{}{}
 	}
 

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -317,8 +317,6 @@ func (a *Account) addNetworksRoutingPeers(
 		networkRoutesPeers[r.PeerID] = struct{}{}
 	}
 
-	delete(sourcePeers, peer.ID)
-
 	for _, existingPeer := range peersToConnect {
 		delete(sourcePeers, existingPeer.ID)
 		delete(networkRoutesPeers, existingPeer.ID)
@@ -335,14 +333,11 @@ func (a *Account) addNetworksRoutingPeers(
 		}
 	}
 	for p := range networkRoutesPeers {
-		if p == peer.ID {
-			continue
-		}
 		missingPeers[p] = struct{}{}
 	}
 
 	for p := range missingPeers {
-		if missingPeer := a.Peers[p]; missingPeer != nil {
+		if missingPeer := a.Peers[p]; missingPeer != nil && missingPeer.ID != peer.ID {
 			peersToConnect = append(peersToConnect, missingPeer)
 		}
 	}

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -317,6 +317,9 @@ func (a *Account) addNetworksRoutingPeers(
 		networkRoutesPeers[r.PeerID] = struct{}{}
 	}
 
+	delete(sourcePeers, peer.ID)
+	delete(networkRoutesPeers, peer.ID)
+
 	for _, existingPeer := range peersToConnect {
 		delete(sourcePeers, existingPeer.ID)
 		delete(networkRoutesPeers, existingPeer.ID)
@@ -337,7 +340,7 @@ func (a *Account) addNetworksRoutingPeers(
 	}
 
 	for p := range missingPeers {
-		if missingPeer := a.Peers[p]; missingPeer != nil && missingPeer.ID != peer.ID {
+		if missingPeer := a.Peers[p]; missingPeer != nil {
 			peersToConnect = append(peersToConnect, missingPeer)
 		}
 	}

--- a/management/server/types/account_test.go
+++ b/management/server/types/account_test.go
@@ -336,12 +336,12 @@ func Test_AddNetworksRoutingPeersAddsMissingPeers(t *testing.T) {
 
 func Test_AddNetworksRoutingPeersIgnoresExistingPeers(t *testing.T) {
 	account := setupTestAccount()
-	peer := &nbpeer.Peer{Key: "peer1"}
+	peer := &nbpeer.Peer{Key: "peer1Key", ID: "peer1"}
 	networkResourcesRoutes := []*route.Route{
 		{Peer: "peer2Key"},
 	}
 	peersToConnect := []*nbpeer.Peer{
-		{Key: "peer2Key"},
+		{Key: "peer2Key", ID: "peer2"},
 	}
 	expiredPeers := []*nbpeer.Peer{}
 
@@ -352,16 +352,16 @@ func Test_AddNetworksRoutingPeersIgnoresExistingPeers(t *testing.T) {
 
 func Test_AddNetworksRoutingPeersAddsExpiredPeers(t *testing.T) {
 	account := setupTestAccount()
-	peer := &nbpeer.Peer{Key: "peer1Key"}
+	peer := &nbpeer.Peer{Key: "peer1Key", ID: "peer1"}
 	networkResourcesRoutes := []*route.Route{
-		{Peer: "peer2Key"},
-		{Peer: "peer3Key"},
+		{Peer: "peer2Key", PeerID: "peer2"},
+		{Peer: "peer3Key", PeerID: "peer3"},
 	}
 	peersToConnect := []*nbpeer.Peer{
-		{Key: "peer2Key"},
+		{Key: "peer2Key", ID: "peer2"},
 	}
 	expiredPeers := []*nbpeer.Peer{
-		{Key: "peer3Key"},
+		{Key: "peer3Key", ID: "peer3"},
 	}
 
 	result := account.addNetworksRoutingPeers(networkResourcesRoutes, peer, peersToConnect, expiredPeers, false, map[string]struct{}{})
@@ -369,9 +369,24 @@ func Test_AddNetworksRoutingPeersAddsExpiredPeers(t *testing.T) {
 	require.Equal(t, "peer2Key", result[0].Key)
 }
 
+func Test_AddNetworksRoutingPeersExcludesSelf(t *testing.T) {
+	account := setupTestAccount()
+	peer := &nbpeer.Peer{Key: "peer1Key", ID: "peer1"}
+	networkResourcesRoutes := []*route.Route{
+		{Peer: "peer1Key", PeerID: "peer1"},
+		{Peer: "peer2Key", PeerID: "peer2"},
+	}
+	peersToConnect := []*nbpeer.Peer{}
+	expiredPeers := []*nbpeer.Peer{}
+
+	result := account.addNetworksRoutingPeers(networkResourcesRoutes, peer, peersToConnect, expiredPeers, true, map[string]struct{}{})
+	require.Len(t, result, 1)
+	require.Equal(t, "peer2Key", result[0].Key)
+}
+
 func Test_AddNetworksRoutingPeersHandlesNoMissingPeers(t *testing.T) {
 	account := setupTestAccount()
-	peer := &nbpeer.Peer{Key: "peer1"}
+	peer := &nbpeer.Peer{Key: "peer1key", ID: "peer1"}
 	networkResourcesRoutes := []*route.Route{}
 	peersToConnect := []*nbpeer.Peer{}
 	expiredPeers := []*nbpeer.Peer{}

--- a/management/server/types/account_test.go
+++ b/management/server/types/account_test.go
@@ -770,3 +770,21 @@ func Test_NetworksNetMapGenWithTwoPostureChecks(t *testing.T) {
 		t.Errorf("%s should not have source range of peer2 %s", rules[0].SourceRanges, accNetResourcePeer2IP.String())
 	}
 }
+
+func Test_NetworksNetMapGenShouldExcludeOtherRouters(t *testing.T) {
+	account := getBasicAccountsWithResource()
+
+	account.Peers["router2Id"] = &nbpeer.Peer{Key: "router2Key", ID: "router2Id", AccountID: accID, IP: net.IP{192, 168, 1, 4}}
+	account.NetworkRouters = append(account.NetworkRouters, &routerTypes.NetworkRouter{
+		ID:        "router2Id",
+		NetworkID: network1ID,
+		AccountID: accID,
+		Peer:      "router2Id",
+	})
+
+	// validate routes for router1
+	isRouter, networkResourcesRoutes, sourcePeers := account.GetNetworkResourcesRoutesToSync(context.Background(), accNetResourceRouter1ID, account.GetResourcePoliciesMap(), account.GetResourceRoutersMap())
+	assert.True(t, isRouter, "should be router")
+	assert.Len(t, networkResourcesRoutes, 1, "expected network resource route don't match")
+	assert.Len(t, sourcePeers, 2, "expected source peers don't match")
+}


### PR DESCRIPTION
## Describe your changes
If the peer is a router and it would be added to the accessible peers part of the network map. This PR excludes a peer so it is not shown as connecting to itself.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
