### PR TITLE
[client] Remove outbound chains

### DIFF
--- a/client/firewall/iptables/acl_linux.go
+++ b/client/firewall/iptables/acl_linux.go
@@ -19,8 +19,7 @@ const (
 	tableName = "filter"
 
 	// rules chains contains the effective ACL rules
-	chainNameInputRules  = "NETBIRD-ACL-INPUT"
-	chainNameOutputRules = "NETBIRD-ACL-OUTPUT"
+	chainNameInputRules = "NETBIRD-ACL-INPUT"
 )
 
 type aclEntries map[string][][]string
@@ -84,7 +83,6 @@ func (m *aclManager) AddPeerFiltering(
 	protocol firewall.Protocol,
 	sPort *firewall.Port,
 	dPort *firewall.Port,
-	direction firewall.RuleDirection,
 	action firewall.Action,
 	ipsetName string,
 ) ([]firewall.Rule, error) {
@@ -97,15 +95,10 @@ func (m *aclManager) AddPeerFiltering(
 		sPortVal = strconv.Itoa(sPort.Values[0])
 	}
 
-	var chain string
-	if direction == firewall.RuleDirectionOUT {
-		chain = chainNameOutputRules
-	} else {
-		chain = chainNameInputRules
-	}
+	chain := chainNameInputRules
 
 	ipsetName = transformIPsetName(ipsetName, sPortVal, dPortVal)
-	specs := filterRuleSpecs(ip, string(protocol), sPortVal, dPortVal, direction, action, ipsetName)
+	specs := filterRuleSpecs(ip, string(protocol), sPortVal, dPortVal, action, ipsetName)
 	if ipsetName != "" {
 		if ipList, ipsetExists := m.ipsetStore.ipset(ipsetName); ipsetExists {
 			if err := ipset.Add(ipsetName, ip.String()); err != nil {
@@ -214,28 +207,7 @@ func (m *aclManager) Reset() error {
 
 // todo write less destructive cleanup mechanism
 func (m *aclManager) cleanChains() error {
-	ok, err := m.iptablesClient.ChainExists(tableName, chainNameOutputRules)
-	if err != nil {
-		log.Debugf("failed to list chains: %s", err)
-		return err
-	}
-	if ok {
-		rules := m.entries["OUTPUT"]
-		for _, rule := range rules {
-			err := m.iptablesClient.DeleteIfExists(tableName, "OUTPUT", rule...)
-			if err != nil {
-				log.Errorf("failed to delete rule: %v, %s", rule, err)
-			}
-		}
-
-		err = m.iptablesClient.ClearAndDeleteChain(tableName, chainNameOutputRules)
-		if err != nil {
-			log.Debugf("failed to clear and delete %s chain: %s", chainNameOutputRules, err)
-			return err
-		}
-	}
-
-	ok, err = m.iptablesClient.ChainExists(tableName, chainNameInputRules)
+	ok, err := m.iptablesClient.ChainExists(tableName, chainNameInputRules)
 	if err != nil {
 		log.Debugf("failed to list chains: %s", err)
 		return err
@@ -295,12 +267,6 @@ func (m *aclManager) createDefaultChains() error {
 		return err
 	}
 
-	// chain netbird-acl-output-rules
-	if err := m.iptablesClient.NewChain(tableName, chainNameOutputRules); err != nil {
-		log.Debugf("failed to create '%s' chain: %s", chainNameOutputRules, err)
-		return err
-	}
-
 	for chainName, rules := range m.entries {
 		for _, rule := range rules {
 			if err := m.iptablesClient.InsertUnique(tableName, chainName, 1, rule...); err != nil {
@@ -329,8 +295,6 @@ func (m *aclManager) createDefaultChains() error {
 
 // The existing FORWARD rules/policies decide outbound traffic towards our interface.
 // In case the FORWARD policy is set to "drop", we add an established/related rule to allow return traffic for the inbound rule.
-
-// The OUTPUT chain gets an extra rule to allow traffic to any set up routes, the return traffic is handled by the INPUT related/established rule.
 func (m *aclManager) seedInitialEntries() {
 	established := getConntrackEstablished()
 
@@ -390,30 +354,18 @@ func (m *aclManager) updateState() {
 }
 
 // filterRuleSpecs returns the specs of a filtering rule
-func filterRuleSpecs(
-	ip net.IP, protocol string, sPort, dPort string, direction firewall.RuleDirection, action firewall.Action, ipsetName string,
-) (specs []string) {
+func filterRuleSpecs(ip net.IP, protocol, sPort, dPort string, action firewall.Action, ipsetName string) (specs []string) {
 	matchByIP := true
 	// don't use IP matching if IP is ip 0.0.0.0
 	if ip.String() == "0.0.0.0" {
 		matchByIP = false
 	}
-	switch direction {
-	case firewall.RuleDirectionIN:
-		if matchByIP {
-			if ipsetName != "" {
-				specs = append(specs, "-m", "set", "--set", ipsetName, "src")
-			} else {
-				specs = append(specs, "-s", ip.String())
-			}
-		}
-	case firewall.RuleDirectionOUT:
-		if matchByIP {
-			if ipsetName != "" {
-				specs = append(specs, "-m", "set", "--set", ipsetName, "dst")
-			} else {
-				specs = append(specs, "-d", ip.String())
-			}
+
+	if matchByIP {
+		if ipsetName != "" {
+			specs = append(specs, "-m", "set", "--set", ipsetName, "src")
+		} else {
+			specs = append(specs, "-s", ip.String())
 		}
 	}
 	if protocol != "all" {

--- a/client/firewall/iptables/manager_linux.go
+++ b/client/firewall/iptables/manager_linux.go
@@ -100,15 +100,14 @@ func (m *Manager) AddPeerFiltering(
 	protocol firewall.Protocol,
 	sPort *firewall.Port,
 	dPort *firewall.Port,
-	direction firewall.RuleDirection,
 	action firewall.Action,
 	ipsetName string,
-	comment string,
+	_ string,
 ) ([]firewall.Rule, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	return m.aclMgr.AddPeerFiltering(ip, protocol, sPort, dPort, direction, action, ipsetName)
+	return m.aclMgr.AddPeerFiltering(ip, protocol, sPort, dPort, action, ipsetName)
 }
 
 func (m *Manager) AddRouteFiltering(
@@ -201,7 +200,6 @@ func (m *Manager) AllowNetbird() error {
 		"all",
 		nil,
 		nil,
-		firewall.RuleDirectionIN,
 		firewall.ActionAccept,
 		"",
 		"",

--- a/client/firewall/iptables/manager_linux_test.go
+++ b/client/firewall/iptables/manager_linux_test.go
@@ -215,11 +215,7 @@ func TestIptablesCreatePerformance(t *testing.T) {
 			start := time.Now()
 			for i := 0; i < testMax; i++ {
 				port := &fw.Port{Values: []int{1000 + i}}
-				if i%2 == 0 {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
-				} else {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
-				}
+				_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
 
 				require.NoError(t, err, "failed to add rule")
 			}

--- a/client/firewall/iptables/manager_linux_test.go
+++ b/client/firewall/iptables/manager_linux_test.go
@@ -68,41 +68,18 @@ func TestIptablesManager(t *testing.T) {
 		time.Sleep(time.Second)
 	}()
 
-	var rule1 []fw.Rule
-	t.Run("add first rule", func(t *testing.T) {
-		ip := net.ParseIP("10.20.0.2")
-		port := &fw.Port{Values: []int{8080}}
-		rule1, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.RuleDirectionOUT, fw.ActionAccept, "", "accept HTTP traffic")
-		require.NoError(t, err, "failed to add rule")
-
-		for _, r := range rule1 {
-			checkRuleSpecs(t, ipv4Client, chainNameOutputRules, true, r.(*Rule).specs...)
-		}
-
-	})
-
 	var rule2 []fw.Rule
 	t.Run("add second rule", func(t *testing.T) {
 		ip := net.ParseIP("10.20.0.3")
 		port := &fw.Port{
 			Values: []int{8043: 8046},
 		}
-		rule2, err = manager.AddPeerFiltering(
-			ip, "tcp", port, nil, fw.RuleDirectionIN, fw.ActionAccept, "", "accept HTTPS traffic from ports range")
+		rule2, err = manager.AddPeerFiltering(ip, "tcp", port, nil, fw.ActionAccept, "", "accept HTTPS traffic from ports range")
 		require.NoError(t, err, "failed to add rule")
 
 		for _, r := range rule2 {
 			rr := r.(*Rule)
 			checkRuleSpecs(t, ipv4Client, rr.chain, true, rr.specs...)
-		}
-	})
-
-	t.Run("delete first rule", func(t *testing.T) {
-		for _, r := range rule1 {
-			err := manager.DeletePeerRule(r)
-			require.NoError(t, err, "failed to delete rule")
-
-			checkRuleSpecs(t, ipv4Client, chainNameOutputRules, false, r.(*Rule).specs...)
 		}
 	})
 
@@ -119,7 +96,7 @@ func TestIptablesManager(t *testing.T) {
 		// add second rule
 		ip := net.ParseIP("10.20.0.3")
 		port := &fw.Port{Values: []int{5353}}
-		_, err = manager.AddPeerFiltering(ip, "udp", nil, port, fw.RuleDirectionOUT, fw.ActionAccept, "", "accept Fake DNS traffic")
+		_, err = manager.AddPeerFiltering(ip, "udp", nil, port, fw.ActionAccept, "", "accept Fake DNS traffic")
 		require.NoError(t, err, "failed to add rule")
 
 		err = manager.Reset(nil)
@@ -135,9 +112,6 @@ func TestIptablesManager(t *testing.T) {
 }
 
 func TestIptablesManagerIPSet(t *testing.T) {
-	ipv4Client, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
-	require.NoError(t, err)
-
 	mock := &iFaceMock{
 		NameFunc: func() string {
 			return "lo"
@@ -167,46 +141,17 @@ func TestIptablesManagerIPSet(t *testing.T) {
 		time.Sleep(time.Second)
 	}()
 
-	var rule1 []fw.Rule
-	t.Run("add first rule with set", func(t *testing.T) {
-		ip := net.ParseIP("10.20.0.2")
-		port := &fw.Port{Values: []int{8080}}
-		rule1, err = manager.AddPeerFiltering(
-			ip, "tcp", nil, port, fw.RuleDirectionOUT,
-			fw.ActionAccept, "default", "accept HTTP traffic",
-		)
-		require.NoError(t, err, "failed to add rule")
-
-		for _, r := range rule1 {
-			checkRuleSpecs(t, ipv4Client, chainNameOutputRules, true, r.(*Rule).specs...)
-			require.Equal(t, r.(*Rule).ipsetName, "default-dport", "ipset name must be set")
-			require.Equal(t, r.(*Rule).ip, "10.20.0.2", "ipset IP must be set")
-		}
-	})
-
 	var rule2 []fw.Rule
 	t.Run("add second rule", func(t *testing.T) {
 		ip := net.ParseIP("10.20.0.3")
 		port := &fw.Port{
 			Values: []int{443},
 		}
-		rule2, err = manager.AddPeerFiltering(
-			ip, "tcp", port, nil, fw.RuleDirectionIN, fw.ActionAccept,
-			"default", "accept HTTPS traffic from ports range",
-		)
+		rule2, err = manager.AddPeerFiltering(ip, "tcp", port, nil, fw.ActionAccept, "default", "accept HTTPS traffic from ports range")
 		for _, r := range rule2 {
 			require.NoError(t, err, "failed to add rule")
 			require.Equal(t, r.(*Rule).ipsetName, "default-sport", "ipset name must be set")
 			require.Equal(t, r.(*Rule).ip, "10.20.0.3", "ipset IP must be set")
-		}
-	})
-
-	t.Run("delete first rule", func(t *testing.T) {
-		for _, r := range rule1 {
-			err := manager.DeletePeerRule(r)
-			require.NoError(t, err, "failed to delete rule")
-
-			require.NotContains(t, manager.aclMgr.ipsetStore.ipsets, r.(*Rule).ruleID, "rule must be removed form the ruleset index")
 		}
 	})
 
@@ -271,9 +216,9 @@ func TestIptablesCreatePerformance(t *testing.T) {
 			for i := 0; i < testMax; i++ {
 				port := &fw.Port{Values: []int{1000 + i}}
 				if i%2 == 0 {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.RuleDirectionOUT, fw.ActionAccept, "", "accept HTTP traffic")
+					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
 				} else {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.RuleDirectionIN, fw.ActionAccept, "", "accept HTTP traffic")
+					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
 				}
 
 				require.NoError(t, err, "failed to add rule")

--- a/client/firewall/manager/firewall.go
+++ b/client/firewall/manager/firewall.go
@@ -69,7 +69,6 @@ type Manager interface {
 		proto Protocol,
 		sPort *Port,
 		dPort *Port,
-		direction RuleDirection,
 		action Action,
 		ipsetName string,
 		comment string,

--- a/client/firewall/nftables/manager_linux.go
+++ b/client/firewall/nftables/manager_linux.go
@@ -117,7 +117,6 @@ func (m *Manager) AddPeerFiltering(
 	proto firewall.Protocol,
 	sPort *firewall.Port,
 	dPort *firewall.Port,
-	direction firewall.RuleDirection,
 	action firewall.Action,
 	ipsetName string,
 	comment string,
@@ -130,10 +129,17 @@ func (m *Manager) AddPeerFiltering(
 		return nil, fmt.Errorf("unsupported IP version: %s", ip.String())
 	}
 
-	return m.aclManager.AddPeerFiltering(ip, proto, sPort, dPort, direction, action, ipsetName, comment)
+	return m.aclManager.AddPeerFiltering(ip, proto, sPort, dPort, action, ipsetName, comment)
 }
 
-func (m *Manager) AddRouteFiltering(sources []netip.Prefix, destination netip.Prefix, proto firewall.Protocol, sPort *firewall.Port, dPort *firewall.Port, action firewall.Action) (firewall.Rule, error) {
+func (m *Manager) AddRouteFiltering(
+	sources []netip.Prefix,
+	destination netip.Prefix,
+	proto firewall.Protocol,
+	sPort *firewall.Port,
+	dPort *firewall.Port,
+	action firewall.Action,
+) (firewall.Rule, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/client/firewall/nftables/manager_linux_test.go
+++ b/client/firewall/nftables/manager_linux_test.go
@@ -201,11 +201,7 @@ func TestNFtablesCreatePerformance(t *testing.T) {
 			start := time.Now()
 			for i := 0; i < testMax; i++ {
 				port := &fw.Port{Values: []int{1000 + i}}
-				if i%2 == 0 {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
-				} else {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
-				}
+				_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
 				require.NoError(t, err, "failed to add rule")
 
 				if i%100 == 0 {

--- a/client/firewall/nftables/manager_linux_test.go
+++ b/client/firewall/nftables/manager_linux_test.go
@@ -74,16 +74,7 @@ func TestNftablesManager(t *testing.T) {
 
 	testClient := &nftables.Conn{}
 
-	rule, err := manager.AddPeerFiltering(
-		ip,
-		fw.ProtocolTCP,
-		nil,
-		&fw.Port{Values: []int{53}},
-		fw.RuleDirectionIN,
-		fw.ActionDrop,
-		"",
-		"",
-	)
+	rule, err := manager.AddPeerFiltering(ip, fw.ProtocolTCP, nil, &fw.Port{Values: []int{53}}, fw.ActionDrop, "", "")
 	require.NoError(t, err, "failed to add rule")
 
 	err = manager.Flush()
@@ -211,9 +202,9 @@ func TestNFtablesCreatePerformance(t *testing.T) {
 			for i := 0; i < testMax; i++ {
 				port := &fw.Port{Values: []int{1000 + i}}
 				if i%2 == 0 {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.RuleDirectionOUT, fw.ActionAccept, "", "accept HTTP traffic")
+					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
 				} else {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.RuleDirectionIN, fw.ActionAccept, "", "accept HTTP traffic")
+					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
 				}
 				require.NoError(t, err, "failed to add rule")
 
@@ -296,16 +287,7 @@ func TestNftablesManagerCompatibilityWithIptables(t *testing.T) {
 	})
 
 	ip := net.ParseIP("100.96.0.1")
-	_, err = manager.AddPeerFiltering(
-		ip,
-		fw.ProtocolTCP,
-		nil,
-		&fw.Port{Values: []int{80}},
-		fw.RuleDirectionIN,
-		fw.ActionAccept,
-		"",
-		"test rule",
-	)
+	_, err = manager.AddPeerFiltering(ip, fw.ProtocolTCP, nil, &fw.Port{Values: []int{80}}, fw.ActionAccept, "", "test rule")
 	require.NoError(t, err, "failed to add peer filtering rule")
 
 	_, err = manager.AddRouteFiltering(

--- a/client/firewall/uspfilter/rule.go
+++ b/client/firewall/uspfilter/rule.go
@@ -4,8 +4,6 @@ import (
 	"net"
 
 	"github.com/google/gopacket"
-
-	firewall "github.com/netbirdio/netbird/client/firewall/manager"
 )
 
 // Rule to handle management of rules
@@ -15,7 +13,6 @@ type Rule struct {
 	ipLayer    gopacket.LayerType
 	matchByIP  bool
 	protoLayer gopacket.LayerType
-	direction  firewall.RuleDirection
 	sPort      uint16
 	dPort      uint16
 	drop       bool

--- a/client/firewall/uspfilter/uspfilter.go
+++ b/client/firewall/uspfilter/uspfilter.go
@@ -578,19 +578,22 @@ func (m *Manager) AddUDPPacketHook(
 
 // RemovePacketHook removes packet hook by given ID
 func (m *Manager) RemovePacketHook(hookID string) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	for _, arr := range m.incomingRules {
 		for _, r := range arr {
 			if r.id == hookID {
-				rule := r
-				return m.DeletePeerRule(&rule)
+				delete(arr, r.id)
+				return nil
 			}
 		}
 	}
 	for _, arr := range m.outgoingRules {
 		for _, r := range arr {
 			if r.id == hookID {
-				rule := r
-				return m.DeletePeerRule(&rule)
+				delete(arr, r.id)
+				return nil
 			}
 		}
 	}

--- a/client/firewall/uspfilter/uspfilter.go
+++ b/client/firewall/uspfilter/uspfilter.go
@@ -39,7 +39,9 @@ type RuleSet map[string]Rule
 
 // Manager userspace firewall manager
 type Manager struct {
-	outgoingRules  map[string]RuleSet
+	// outgoingRules is used for hooks only
+	outgoingRules map[string]RuleSet
+	// incomingRules is used for filtering and hooks
 	incomingRules  map[string]RuleSet
 	wgNetwork      *net.IPNet
 	decoders       sync.Pool
@@ -156,9 +158,8 @@ func (m *Manager) AddPeerFiltering(
 	proto firewall.Protocol,
 	sPort *firewall.Port,
 	dPort *firewall.Port,
-	direction firewall.RuleDirection,
 	action firewall.Action,
-	ipsetName string,
+	_ string,
 	comment string,
 ) ([]firewall.Rule, error) {
 	r := Rule{
@@ -166,7 +167,6 @@ func (m *Manager) AddPeerFiltering(
 		ip:        ip,
 		ipLayer:   layers.LayerTypeIPv6,
 		matchByIP: true,
-		direction: direction,
 		drop:      action == firewall.ActionDrop,
 		comment:   comment,
 	}
@@ -202,17 +202,10 @@ func (m *Manager) AddPeerFiltering(
 	}
 
 	m.mutex.Lock()
-	if direction == firewall.RuleDirectionIN {
-		if _, ok := m.incomingRules[r.ip.String()]; !ok {
-			m.incomingRules[r.ip.String()] = make(RuleSet)
-		}
-		m.incomingRules[r.ip.String()][r.id] = r
-	} else {
-		if _, ok := m.outgoingRules[r.ip.String()]; !ok {
-			m.outgoingRules[r.ip.String()] = make(RuleSet)
-		}
-		m.outgoingRules[r.ip.String()][r.id] = r
+	if _, ok := m.incomingRules[r.ip.String()]; !ok {
+		m.incomingRules[r.ip.String()] = make(RuleSet)
 	}
+	m.incomingRules[r.ip.String()][r.id] = r
 	m.mutex.Unlock()
 	return []firewall.Rule{&r}, nil
 }
@@ -241,19 +234,10 @@ func (m *Manager) DeletePeerRule(rule firewall.Rule) error {
 		return fmt.Errorf("delete rule: invalid rule type: %T", rule)
 	}
 
-	if r.direction == firewall.RuleDirectionIN {
-		_, ok := m.incomingRules[r.ip.String()][r.id]
-		if !ok {
-			return fmt.Errorf("delete rule: no rule with such id: %v", r.id)
-		}
-		delete(m.incomingRules[r.ip.String()], r.id)
-	} else {
-		_, ok := m.outgoingRules[r.ip.String()][r.id]
-		if !ok {
-			return fmt.Errorf("delete rule: no rule with such id: %v", r.id)
-		}
-		delete(m.outgoingRules[r.ip.String()], r.id)
+	if _, ok := m.incomingRules[r.ip.String()][r.id]; !ok {
+		return fmt.Errorf("delete rule: no rule with such id: %v", r.id)
 	}
+	delete(m.incomingRules[r.ip.String()], r.id)
 
 	return nil
 }
@@ -566,7 +550,6 @@ func (m *Manager) AddUDPPacketHook(
 		protoLayer: layers.LayerTypeUDP,
 		dPort:      dPort,
 		ipLayer:    layers.LayerTypeIPv6,
-		direction:  firewall.RuleDirectionOUT,
 		comment:    fmt.Sprintf("UDP Hook direction: %v, ip:%v, dport:%d", in, ip, dPort),
 		udpHook:    hook,
 	}
@@ -577,7 +560,6 @@ func (m *Manager) AddUDPPacketHook(
 
 	m.mutex.Lock()
 	if in {
-		r.direction = firewall.RuleDirectionIN
 		if _, ok := m.incomingRules[r.ip.String()]; !ok {
 			m.incomingRules[r.ip.String()] = make(map[string]Rule)
 		}

--- a/client/firewall/uspfilter/uspfilter_bench_test.go
+++ b/client/firewall/uspfilter/uspfilter_bench_test.go
@@ -91,7 +91,7 @@ func BenchmarkCoreFiltering(b *testing.B) {
 			setupFunc: func(m *Manager) {
 				// Single rule allowing all traffic
 				_, err := m.AddPeerFiltering(net.ParseIP("0.0.0.0"), fw.ProtocolALL, nil, nil,
-					fw.RuleDirectionIN, fw.ActionAccept, "", "allow all")
+					fw.ActionAccept, "", "allow all")
 				require.NoError(b, err)
 			},
 			desc: "Baseline: Single 'allow all' rule without connection tracking",
@@ -114,7 +114,7 @@ func BenchmarkCoreFiltering(b *testing.B) {
 					_, err := m.AddPeerFiltering(ip, fw.ProtocolTCP,
 						&fw.Port{Values: []int{1024 + i}},
 						&fw.Port{Values: []int{80}},
-						fw.RuleDirectionIN, fw.ActionAccept, "", "explicit return")
+						fw.ActionAccept, "", "explicit return")
 					require.NoError(b, err)
 				}
 			},
@@ -126,7 +126,7 @@ func BenchmarkCoreFiltering(b *testing.B) {
 			setupFunc: func(m *Manager) {
 				// Add some basic rules but rely on state for established connections
 				_, err := m.AddPeerFiltering(net.ParseIP("0.0.0.0"), fw.ProtocolTCP, nil, nil,
-					fw.RuleDirectionIN, fw.ActionDrop, "", "default drop")
+					fw.ActionDrop, "", "default drop")
 				require.NoError(b, err)
 			},
 			desc: "Connection tracking with established connections",
@@ -590,7 +590,7 @@ func BenchmarkLongLivedConnections(b *testing.B) {
 				_, err := manager.AddPeerFiltering(net.ParseIP("0.0.0.0"), fw.ProtocolTCP,
 					&fw.Port{Values: []int{80}},
 					nil,
-					fw.RuleDirectionIN, fw.ActionAccept, "", "return traffic")
+					fw.ActionAccept, "", "return traffic")
 				require.NoError(b, err)
 			}
 
@@ -681,7 +681,7 @@ func BenchmarkShortLivedConnections(b *testing.B) {
 				_, err := manager.AddPeerFiltering(net.ParseIP("0.0.0.0"), fw.ProtocolTCP,
 					&fw.Port{Values: []int{80}},
 					nil,
-					fw.RuleDirectionIN, fw.ActionAccept, "", "return traffic")
+					fw.ActionAccept, "", "return traffic")
 				require.NoError(b, err)
 			}
 
@@ -799,7 +799,7 @@ func BenchmarkParallelLongLivedConnections(b *testing.B) {
 				_, err := manager.AddPeerFiltering(net.ParseIP("0.0.0.0"), fw.ProtocolTCP,
 					&fw.Port{Values: []int{80}},
 					nil,
-					fw.RuleDirectionIN, fw.ActionAccept, "", "return traffic")
+					fw.ActionAccept, "", "return traffic")
 				require.NoError(b, err)
 			}
 
@@ -886,7 +886,7 @@ func BenchmarkParallelShortLivedConnections(b *testing.B) {
 				_, err := manager.AddPeerFiltering(net.ParseIP("0.0.0.0"), fw.ProtocolTCP,
 					&fw.Port{Values: []int{80}},
 					nil,
-					fw.RuleDirectionIN, fw.ActionAccept, "", "return traffic")
+					fw.ActionAccept, "", "return traffic")
 				require.NoError(b, err)
 			}
 

--- a/client/firewall/uspfilter/uspfilter_test.go
+++ b/client/firewall/uspfilter/uspfilter_test.go
@@ -298,7 +298,7 @@ func TestNotMatchByIP(t *testing.T) {
 		return
 	}
 
-	if m.dropFilter(buf.Bytes(), m.outgoingRules) {
+	if m.dropFilter(buf.Bytes(), m.incomingRules) {
 		t.Errorf("expected packet to be accepted")
 		return
 	}

--- a/client/firewall/uspfilter/uspfilter_test.go
+++ b/client/firewall/uspfilter/uspfilter_test.go
@@ -70,11 +70,10 @@ func TestManagerAddPeerFiltering(t *testing.T) {
 	ip := net.ParseIP("192.168.1.1")
 	proto := fw.ProtocolTCP
 	port := &fw.Port{Values: []int{80}}
-	direction := fw.RuleDirectionOUT
 	action := fw.ActionDrop
 	comment := "Test rule"
 
-	rule, err := m.AddPeerFiltering(ip, proto, nil, port, direction, action, "", comment)
+	rule, err := m.AddPeerFiltering(ip, proto, nil, port, action, "", comment)
 	if err != nil {
 		t.Errorf("failed to add filtering: %v", err)
 		return
@@ -105,35 +104,13 @@ func TestManagerDeleteRule(t *testing.T) {
 	ip := net.ParseIP("192.168.1.1")
 	proto := fw.ProtocolTCP
 	port := &fw.Port{Values: []int{80}}
-	direction := fw.RuleDirectionOUT
 	action := fw.ActionDrop
-	comment := "Test rule"
+	comment := "Test rule 2"
 
-	rule, err := m.AddPeerFiltering(ip, proto, nil, port, direction, action, "", comment)
+	rule2, err := m.AddPeerFiltering(ip, proto, nil, port, action, "", comment)
 	if err != nil {
 		t.Errorf("failed to add filtering: %v", err)
 		return
-	}
-
-	ip = net.ParseIP("192.168.1.1")
-	proto = fw.ProtocolTCP
-	port = &fw.Port{Values: []int{80}}
-	direction = fw.RuleDirectionIN
-	action = fw.ActionDrop
-	comment = "Test rule 2"
-
-	rule2, err := m.AddPeerFiltering(ip, proto, nil, port, direction, action, "", comment)
-	if err != nil {
-		t.Errorf("failed to add filtering: %v", err)
-		return
-	}
-
-	for _, r := range rule {
-		err = m.DeletePeerRule(r)
-		if err != nil {
-			t.Errorf("failed to delete rule: %v", err)
-			return
-		}
 	}
 
 	for _, r := range rule2 {
@@ -225,10 +202,6 @@ func TestAddUDPPacketHook(t *testing.T) {
 				t.Errorf("expected protoLayer %s, got %s", layers.LayerTypeUDP, addedRule.protoLayer)
 				return
 			}
-			if tt.expDir != addedRule.direction {
-				t.Errorf("expected direction %d, got %d", tt.expDir, addedRule.direction)
-				return
-			}
 			if addedRule.udpHook == nil {
 				t.Errorf("expected udpHook to be set")
 				return
@@ -251,11 +224,10 @@ func TestManagerReset(t *testing.T) {
 	ip := net.ParseIP("192.168.1.1")
 	proto := fw.ProtocolTCP
 	port := &fw.Port{Values: []int{80}}
-	direction := fw.RuleDirectionOUT
 	action := fw.ActionDrop
 	comment := "Test rule"
 
-	_, err = m.AddPeerFiltering(ip, proto, nil, port, direction, action, "", comment)
+	_, err = m.AddPeerFiltering(ip, proto, nil, port, action, "", comment)
 	if err != nil {
 		t.Errorf("failed to add filtering: %v", err)
 		return
@@ -293,7 +265,7 @@ func TestNotMatchByIP(t *testing.T) {
 	action := fw.ActionAccept
 	comment := "Test rule"
 
-	_, err = m.AddPeerFiltering(ip, proto, nil, nil, direction, action, "", comment)
+	_, err = m.AddPeerFiltering(ip, proto, nil, nil, action, "", comment)
 	if err != nil {
 		t.Errorf("failed to add filtering: %v", err)
 		return
@@ -493,11 +465,7 @@ func TestUSPFilterCreatePerformance(t *testing.T) {
 			start := time.Now()
 			for i := 0; i < testMax; i++ {
 				port := &fw.Port{Values: []int{1000 + i}}
-				if i%2 == 0 {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.RuleDirectionOUT, fw.ActionAccept, "", "accept HTTP traffic")
-				} else {
-					_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.RuleDirectionIN, fw.ActionAccept, "", "accept HTTP traffic")
-				}
+				_, err = manager.AddPeerFiltering(ip, "tcp", nil, port, fw.ActionAccept, "", "accept HTTP traffic")
 
 				require.NoError(t, err, "failed to add rule")
 			}

--- a/client/firewall/uspfilter/uspfilter_test.go
+++ b/client/firewall/uspfilter/uspfilter_test.go
@@ -261,7 +261,6 @@ func TestNotMatchByIP(t *testing.T) {
 
 	ip := net.ParseIP("0.0.0.0")
 	proto := fw.ProtocolUDP
-	direction := fw.RuleDirectionOUT
 	action := fw.ActionAccept
 	comment := "Test rule"
 

--- a/client/internal/acl/manager.go
+++ b/client/internal/acl/manager.go
@@ -289,7 +289,7 @@ func (d *DefaultManager) protoRuleToFirewallRule(
 		rules, err = d.addInRules(ip, protocol, port, action, ipsetName, "")
 	case mgmProto.RuleDirection_OUT:
 		// TODO: Remove this soon. Outbound rules are obsolete.
-		// We only maintain this for return traffic (in dir) which is now handled by the stateful firewall already
+		// We only maintain this for return traffic (inbound dir) which is now handled by the stateful firewall already
 		rules, err = d.addOutRules(ip, protocol, port, action, ipsetName, "")
 	default:
 		return "", nil, fmt.Errorf("invalid direction, skipping firewall rule")

--- a/client/internal/acl/manager_test.go
+++ b/client/internal/acl/manager_test.go
@@ -119,8 +119,8 @@ func TestDefaultManager(t *testing.T) {
 
 		networkMap.FirewallRulesIsEmpty = false
 		acl.ApplyFiltering(networkMap)
-		if len(acl.peerRulesPairs) != 2 {
-			t.Errorf("rules should contain 2 rules if FirewallRulesIsEmpty is not set, got: %v", len(acl.peerRulesPairs))
+		if len(acl.peerRulesPairs) != 1 {
+			t.Errorf("rules should contain 1 rules if FirewallRulesIsEmpty is not set, got: %v", len(acl.peerRulesPairs))
 			return
 		}
 	})
@@ -356,8 +356,8 @@ func TestDefaultManagerEnableSSHRules(t *testing.T) {
 
 	acl.ApplyFiltering(networkMap)
 
-	if len(acl.peerRulesPairs) != 4 {
-		t.Errorf("expect 4 rules (last must be SSH), got: %d", len(acl.peerRulesPairs))
+	if len(acl.peerRulesPairs) != 3 {
+		t.Errorf("expect 3 rules (last must be SSH), got: %d", len(acl.peerRulesPairs))
 		return
 	}
 }

--- a/client/internal/dnsfwd/manager.go
+++ b/client/internal/dnsfwd/manager.go
@@ -88,7 +88,7 @@ func (h *Manager) allowDNSFirewall() error {
 		return nil
 	}
 
-	dnsRules, err := h.firewall.AddPeerFiltering(net.IP{0, 0, 0, 0}, firewall.ProtocolUDP, nil, dport, firewall.RuleDirectionIN, firewall.ActionAccept, "", "")
+	dnsRules, err := h.firewall.AddPeerFiltering(net.IP{0, 0, 0, 0}, firewall.ProtocolUDP, nil, dport, firewall.ActionAccept, "", "")
 	if err != nil {
 		log.Errorf("failed to add allow DNS router rules, err: %v", err)
 		return err

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -495,7 +495,6 @@ func (e *Engine) initFirewall() error {
 		manager.ProtocolUDP,
 		nil,
 		&port,
-		manager.RuleDirectionIN,
 		manager.ActionAccept,
 		"",
 		"",


### PR DESCRIPTION
## Describe your changes

`OUTPUT` chains are unused and obsolete, only the userspace filter still uses them for hooks

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
