### PR TITLE
add missing relay to docker-compose.yml.tmpl.traefik

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl.traefik
+++ b/infrastructure_files/docker-compose.yml.tmpl.traefik
@@ -50,6 +50,24 @@ services:
     - traefik.http.services.netbird-signal.loadbalancer.server.port=80
     - traefik.http.services.netbird-signal.loadbalancer.server.scheme=h2c
 
+  # Relay
+  relay:
+    image: netbirdio/relay:$NETBIRD_RELAY_TAG
+    restart: unless-stopped
+    environment:
+    - NB_LOG_LEVEL=info
+    - NB_LISTEN_ADDRESS=:$NETBIRD_RELAY_PORT
+    - NB_EXPOSED_ADDRESS=$NETBIRD_RELAY_DOMAIN:$NETBIRD_RELAY_PORT
+    # todo: change to a secure secret
+    - NB_AUTH_SECRET=$NETBIRD_RELAY_AUTH_SECRET
+    ports:
+      - $NETBIRD_RELAY_PORT:$NETBIRD_RELAY_PORT
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "500m"
+        max-file: "2"
+
   # Management
   management:
     image: netbirdio/management:$NETBIRD_MANAGEMENT_TAG


### PR DESCRIPTION
## Describe your changes

the traefik template for docker-compose doesnt include the relay

so a default setup using the traefik template for docker-compose , add in a relay to the management.json,
but the relay cant be used because no relay server is running

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
