### PR TITLE
[client] Fix a panic on shutdown if dns host manager failed to initialize

### DIFF
--- a/client/internal/dns/host_unix.go
+++ b/client/internal/dns/host_unix.go
@@ -48,11 +48,17 @@ type restoreHostManager interface {
 func newHostManager(wgInterface string) (hostManager, error) {
 	osManager, err := getOSDNSManagerType()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get os dns manager type: %w", err)
 	}
 
 	log.Infof("System DNS manager discovered: %s", osManager)
-	return newHostManagerFromType(wgInterface, osManager)
+	mgr, err := newHostManagerFromType(wgInterface, osManager)
+	// need to explicitly return nil mgr on error to avoid returning a non-nil interface containing a nil value
+	if err != nil {
+		return nil, fmt.Errorf("create host manager: %w", err)
+	}
+
+	return mgr, nil
 }
 
 func newHostManagerFromType(wgInterface string, osManager osManagerType) (restoreHostManager, error) {


### PR DESCRIPTION
## Describe your changes

If the inner host manager init fails, we will be left with a non-nil `s.hostManager` despite the inner value being nil. Any `s.hostManager != nil` check will pass, but method calls on this struct will panic.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
