### PR TITLE
[relay] Set InitialPacketSize to the maximum allowable value

### DIFF
--- a/relay/client/dialer/quic/quic.go
+++ b/relay/client/dialer/quic/quic.go
@@ -29,9 +29,10 @@ func (d Dialer) Dial(ctx context.Context, address string) (net.Conn, error) {
 	}
 
 	quicConfig := &quic.Config{
-		KeepAlivePeriod: 30 * time.Second,
-		MaxIdleTimeout:  4 * time.Minute,
-		EnableDatagrams: true,
+		KeepAlivePeriod:   30 * time.Second,
+		MaxIdleTimeout:    4 * time.Minute,
+		EnableDatagrams:   true,
+		InitialPacketSize: 1452,
 	}
 
 	udpConn, err := nbnet.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})

--- a/relay/server/listener/quic/listener.go
+++ b/relay/server/listener/quic/listener.go
@@ -25,7 +25,8 @@ func (l *Listener) Listen(acceptFn func(conn net.Conn)) error {
 	l.acceptFn = acceptFn
 
 	quicCfg := &quic.Config{
-		EnableDatagrams: true,
+		EnableDatagrams:   true,
+		InitialPacketSize: 1452,
 	}
 	listener, err := quic.ListenAddr(l.Address, l.TLSConfig, quicCfg)
 	if err != nil {


### PR DESCRIPTION
Fixes an issue on macOS where the server throws errors with default settings:
`failed to write transport message to: DATAGRAM frame too large.`

Further investigation is required to optimize MTU-related values.

## Describe your changes

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
