### PR TITLE
[misc] Enable UDP port for relay service

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -61,6 +61,7 @@ services:
     - NB_AUTH_SECRET=$NETBIRD_RELAY_AUTH_SECRET
     ports:
       - $NETBIRD_RELAY_PORT:$NETBIRD_RELAY_PORT
+      - $NETBIRD_RELAY_PORT:$NETBIRD_RELAY_PORT/udp
     logging:
       driver: "json-file"
       options:

--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -528,7 +528,7 @@ initEnvironment() {
 renderCaddyfile() {
   cat <<EOF
 {
-  debug
+  #debug
 	servers :80,:443 {
     protocols h1 h2c h2 h3
   }


### PR DESCRIPTION

## Describe your changes
- This allows support for QUIC protocol on relay

- Disabled debug logs for Caddy configuration

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
