### PR TITLE
[relay-client] Fix reconnection

### DIFF
--- a/relay/client/client.go
+++ b/relay/client/client.go
@@ -141,7 +141,6 @@ type Client struct {
 	muInstanceURL    sync.Mutex
 
 	onDisconnectListener func(string)
-	onConnectedListener  func()
 	listenerMutex        sync.Mutex
 }
 
@@ -190,7 +189,6 @@ func (c *Client) Connect() error {
 
 	c.wgReadLoop.Add(1)
 	go c.readLoop(c.relayConn)
-	go c.notifyConnected()
 
 	return nil
 }
@@ -236,12 +234,6 @@ func (c *Client) SetOnDisconnectListener(fn func(string)) {
 	c.listenerMutex.Lock()
 	defer c.listenerMutex.Unlock()
 	c.onDisconnectListener = fn
-}
-
-func (c *Client) SetOnConnectedListener(fn func()) {
-	c.listenerMutex.Lock()
-	defer c.listenerMutex.Unlock()
-	c.onConnectedListener = fn
 }
 
 // HasConns returns true if there are connections.
@@ -557,16 +549,6 @@ func (c *Client) notifyDisconnected() {
 		return
 	}
 	go c.onDisconnectListener(c.connectionURL)
-}
-
-func (c *Client) notifyConnected() {
-	c.listenerMutex.Lock()
-	defer c.listenerMutex.Unlock()
-
-	if c.onConnectedListener == nil {
-		return
-	}
-	go c.onConnectedListener()
 }
 
 func (c *Client) writeCloseMsg() {

--- a/relay/client/guard.go
+++ b/relay/client/guard.go
@@ -124,14 +124,6 @@ func (g *Guard) notifyReconnected() {
 	}
 }
 
-func (g *Guard) isReadyToQuickReconnect(relayClient *Client) bool {
-	if relayClient == nil {
-		return false
-	}
-
-	return g.isServerURLStillValid(relayClient)
-}
-
 func exponentTicker(ctx context.Context) *backoff.Ticker {
 	bo := backoff.WithContext(&backoff.ExponentialBackOff{
 		InitialInterval: 2 * time.Second,


### PR DESCRIPTION
## Describe your changes

After we started to allow the agent to run without an established Relay connection the reconnection and connection definition has been changed. In this PR I fix these incosistency.

- The client structure does not manage the reconnection callback anymore
- If the quick reconnection (to the original home server) is success we will trigger the onReconnection callback

### Original issue:
When you start the agent without a Relay connection, it attempts to reconnect for a while before allowing operation without an active Relay connection. In the background, it periodically tries to establish the connection. If successful, it does not notify peers about the changes.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
