### PR TITLE
[client] Manage the IP forwarding sysctl setting in global way

### DIFF
--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -586,7 +586,7 @@ func (r *router) updateState() {
 }
 
 func (r *router) AddDNATRule(rule firewall.ForwardRule) (firewall.Rule, error) {
-	if err := r.ipFwdState.ReleaseForwarding(); err != nil {
+	if err := r.ipFwdState.RequestForwarding(); err != nil {
 		return nil, err
 	}
 

--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -16,6 +16,7 @@ import (
 	nberrors "github.com/netbirdio/netbird/client/errors"
 	firewall "github.com/netbirdio/netbird/client/firewall/manager"
 	"github.com/netbirdio/netbird/client/internal/acl/id"
+	"github.com/netbirdio/netbird/client/internal/routemanager/ipfwdstate"
 	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
 	"github.com/netbirdio/netbird/client/internal/statemanager"
 	nbnet "github.com/netbirdio/netbird/util/net"
@@ -76,6 +77,7 @@ type router struct {
 	legacyManagement bool
 
 	stateManager *statemanager.Manager
+	ipFwdState   *ipfwdstate.IPForwardingState
 }
 
 func newRouter(iptablesClient *iptables.IPTables, wgIface iFaceMapper) (*router, error) {
@@ -83,6 +85,7 @@ func newRouter(iptablesClient *iptables.IPTables, wgIface iFaceMapper) (*router,
 		iptablesClient: iptablesClient,
 		rules:          make(map[string][]string),
 		wgIface:        wgIface,
+		ipFwdState:     ipfwdstate.NewIPForwardingState(),
 	}
 
 	r.ipsetCounter = refcounter.New(
@@ -217,6 +220,10 @@ func (r *router) deleteIpSet(setName string) error {
 
 // AddNatRule inserts an iptables rule pair into the nat chain
 func (r *router) AddNatRule(pair firewall.RouterPair) error {
+	if err := r.ipFwdState.RequestForwarding(); err != nil {
+		return err
+	}
+
 	if r.legacyManagement {
 		log.Warnf("This peer is connected to a NetBird Management service with an older version. Allowing all traffic for %s", pair.Destination)
 		if err := r.addLegacyRouteRule(pair); err != nil {
@@ -243,6 +250,10 @@ func (r *router) AddNatRule(pair firewall.RouterPair) error {
 
 // RemoveNatRule removes an iptables rule pair from forwarding and nat chains
 func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
+	if err := r.ipFwdState.ReleaseForwarding(); err != nil {
+		log.Errorf("failed to disable sysctl IP forwarding: %v", err)
+	}
+
 	if err := r.removeNatRule(pair); err != nil {
 		return fmt.Errorf("remove nat rule: %w", err)
 	}
@@ -575,6 +586,10 @@ func (r *router) updateState() {
 }
 
 func (r *router) AddDNATRule(rule firewall.ForwardRule) (firewall.Rule, error) {
+	if err := r.ipFwdState.ReleaseForwarding(); err != nil {
+		return nil, err
+	}
+
 	ruleKey := rule.ID()
 	if _, exists := r.rules[ruleKey+dnatSuffix]; exists {
 		return rule, nil
@@ -669,6 +684,10 @@ func (r *router) rollbackRules(rules map[string]ruleInfo) error {
 }
 
 func (r *router) DeleteDNATRule(rule firewall.Rule) error {
+	if err := r.ipFwdState.ReleaseForwarding(); err != nil {
+		log.Errorf("failed to disable sysctl IP forwarding: %v", err)
+	}
+
 	ruleKey := rule.ID()
 
 	var merr *multierror.Error

--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -251,7 +251,7 @@ func (r *router) AddNatRule(pair firewall.RouterPair) error {
 // RemoveNatRule removes an iptables rule pair from forwarding and nat chains
 func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
 	if err := r.ipFwdState.ReleaseForwarding(); err != nil {
-		log.Errorf("failed to disable sysctl IP forwarding: %v", err)
+		log.Errorf("%v", err)
 	}
 
 	if err := r.removeNatRule(pair); err != nil {
@@ -685,7 +685,7 @@ func (r *router) rollbackRules(rules map[string]ruleInfo) error {
 
 func (r *router) DeleteDNATRule(rule firewall.Rule) error {
 	if err := r.ipFwdState.ReleaseForwarding(); err != nil {
-		log.Errorf("failed to disable sysctl IP forwarding: %v", err)
+		log.Errorf("%v", err)
 	}
 
 	ruleKey := rule.ID()

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -898,7 +898,7 @@ func (r *router) removeAcceptForwardRulesIptables(ipt *iptables.IPTables) error 
 // RemoveNatRule removes the prerouting mark rule
 func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
 	if err := r.ipFwdState.ReleaseForwarding(); err != nil {
-		log.Errorf("failed to disable sysctl IP forwarding: %v", err)
+		log.Errorf("%v", err)
 	}
 
 	if err := r.refreshRulesMap(); err != nil {
@@ -1190,7 +1190,7 @@ func (r *router) addDnatMasq(rule firewall.ForwardRule, protoNum uint8, ruleKey 
 
 func (r *router) DeleteDNATRule(rule firewall.Rule) error {
 	if err := r.ipFwdState.ReleaseForwarding(); err != nil {
-		log.Errorf("failed to disable sysctl IP forwarding: %v", err)
+		log.Errorf("%v", err)
 	}
 
 	ruleKey := rule.ID()

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -962,7 +962,7 @@ func (r *router) refreshRulesMap() error {
 }
 
 func (r *router) AddDNATRule(rule firewall.ForwardRule) (firewall.Rule, error) {
-	if err := r.ipFwdState.ReleaseForwarding(); err != nil {
+	if err := r.ipFwdState.RequestForwarding(); err != nil {
 		return nil, err
 	}
 

--- a/client/internal/routemanager/ipfwdstate/ipfwdstate.go
+++ b/client/internal/routemanager/ipfwdstate/ipfwdstate.go
@@ -2,6 +2,9 @@ package ipfwdstate
 
 import (
 	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
 	"github.com/netbirdio/netbird/client/internal/routemanager/systemops"
 )
 
@@ -23,6 +26,7 @@ func (f *IPForwardingState) RequestForwarding() error {
 		return fmt.Errorf("failed to enable IP forwarding with sysctl: %w", err)
 	}
 	f.enabledCounter = 1
+	log.Info("IP forwarding enabled")
 
 	return nil
 }
@@ -43,5 +47,7 @@ func (f *IPForwardingState) ReleaseForwarding() error {
 	if err := systemops.DisableIPForwarding(); err != nil {
 		return fmt.Errorf("failed to disable IP forwarding with sysctl: %w", err)
 	}
+	log.Info("IP forwarding disabled")
+
 	return nil
 }

--- a/client/internal/routemanager/ipfwdstate/ipfwdstate.go
+++ b/client/internal/routemanager/ipfwdstate/ipfwdstate.go
@@ -1,0 +1,46 @@
+package ipfwdstate
+
+import (
+	"github.com/netbirdio/netbird/client/internal/routemanager/systemops"
+)
+
+type IPForwardingState struct {
+	enabledCounter int
+}
+
+func NewIPForwardingState() *IPForwardingState {
+	return &IPForwardingState{}
+}
+
+func (f *IPForwardingState) RequestForwarding() error {
+	if f.enabledCounter != 0 {
+		f.enabledCounter++
+		return nil
+	}
+
+	if err := systemops.EnableIPForwarding(); err != nil {
+		return err
+	}
+	f.enabledCounter = 1
+
+	return nil
+}
+
+func (f *IPForwardingState) ReleaseForwarding() error {
+	if f.enabledCounter == 0 {
+		return nil
+	}
+
+	if f.enabledCounter > 1 {
+		f.enabledCounter--
+		return nil
+	}
+
+	// if failed to disable IP forwarding we anyway decrement the counter
+	f.enabledCounter = 0
+
+	if err := systemops.DisableIPForwarding(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/client/internal/routemanager/ipfwdstate/ipfwdstate.go
+++ b/client/internal/routemanager/ipfwdstate/ipfwdstate.go
@@ -8,6 +8,8 @@ import (
 	"github.com/netbirdio/netbird/client/internal/routemanager/systemops"
 )
 
+// IPForwardingState is a struct that keeps track of the IP forwarding state.
+// todo: read initial state of the IP forwarding from the system and reset the state based on it
 type IPForwardingState struct {
 	enabledCounter int
 }
@@ -44,10 +46,6 @@ func (f *IPForwardingState) ReleaseForwarding() error {
 	// if failed to disable IP forwarding we anyway decrement the counter
 	f.enabledCounter = 0
 
-	if err := systemops.DisableIPForwarding(); err != nil {
-		return fmt.Errorf("failed to disable IP forwarding with sysctl: %w", err)
-	}
-	log.Info("IP forwarding disabled")
-
+	// todo call systemops.DisableIPForwarding()
 	return nil
 }

--- a/client/internal/routemanager/ipfwdstate/ipfwdstate.go
+++ b/client/internal/routemanager/ipfwdstate/ipfwdstate.go
@@ -1,6 +1,7 @@
 package ipfwdstate
 
 import (
+	"fmt"
 	"github.com/netbirdio/netbird/client/internal/routemanager/systemops"
 )
 
@@ -19,7 +20,7 @@ func (f *IPForwardingState) RequestForwarding() error {
 	}
 
 	if err := systemops.EnableIPForwarding(); err != nil {
-		return err
+		return fmt.Errorf("failed to enable IP forwarding with sysctl: %w", err)
 	}
 	f.enabledCounter = 1
 
@@ -40,7 +41,7 @@ func (f *IPForwardingState) ReleaseForwarding() error {
 	f.enabledCounter = 0
 
 	if err := systemops.DisableIPForwarding(); err != nil {
-		return err
+		return fmt.Errorf("failed to disable IP forwarding with sysctl: %w", err)
 	}
 	return nil
 }

--- a/client/internal/routemanager/server_nonandroid.go
+++ b/client/internal/routemanager/server_nonandroid.go
@@ -13,7 +13,6 @@ import (
 	firewall "github.com/netbirdio/netbird/client/firewall/manager"
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/internal/peer"
-	"github.com/netbirdio/netbird/client/internal/routemanager/systemops"
 	"github.com/netbirdio/netbird/route"
 )
 
@@ -68,13 +67,6 @@ func (m *serverRouter) updateRoutes(routesMap map[route.ID]*route.Route) error {
 			continue
 		}
 		m.routes[id] = newRoute
-	}
-
-	if len(m.routes) > 0 {
-		err := systemops.EnableIPForwarding()
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/client/internal/routemanager/systemops/systemops_linux.go
+++ b/client/internal/routemanager/systemops/systemops_linux.go
@@ -375,6 +375,11 @@ func EnableIPForwarding() error {
 	return err
 }
 
+func DisableIPForwarding() error {
+	_, err := sysctl.Set(ipv4ForwardingPath, 0, false)
+	return err
+}
+
 // entryExists checks if the specified ID or name already exists in the rt_tables file
 // and verifies if existing names start with "netbird_".
 func entryExists(file *os.File, id int) (bool, error) {

--- a/client/internal/routemanager/systemops/systemops_linux.go
+++ b/client/internal/routemanager/systemops/systemops_linux.go
@@ -375,11 +375,6 @@ func EnableIPForwarding() error {
 	return err
 }
 
-func DisableIPForwarding() error {
-	_, err := sysctl.Set(ipv4ForwardingPath, 0, false)
-	return err
-}
-
 // entryExists checks if the specified ID or name already exists in the rt_tables file
 // and verifies if existing names start with "netbird_".
 func entryExists(file *os.File, id int) (bool, error) {


### PR DESCRIPTION
## Describe your changes

Add new package ipfwdstate that implements reference counting for IP forwarding 
state management. This allows multiple usage to safely request IP forwarding
without interfering with each other.

TODO:
- Read initial state from system config
- Implement DisableIPForwarding call

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
