### PR TITLE
fix: privacy warning on macOS

### DIFF
--- a/client/system/static_info.go
+++ b/client/system/static_info.go
@@ -4,6 +4,8 @@ package system
 
 import (
 	"context"
+	"os"
+	"runtime"
 	"sync"
 	"time"
 
@@ -17,9 +19,16 @@ var (
 )
 
 func init() {
+	if runtime.GOOS == "Darwin" && !isRoot() {
+		return
+	}
 	go func() {
 		_ = updateStaticInfo()
 	}()
+}
+
+func isRoot() bool {
+	return os.Geteuid() == 0
 }
 
 func updateStaticInfo() StaticInfo {


### PR DESCRIPTION
## Describe your changes
On macOS, detect cloud and detect platform reach out to broadcast address, thus triggering the network privacy warning. This patch ensures that init is only called by programs running as root, i.e. the daemon.

This will ensure user programs like netbird-ui do not access broadcast address triggering privacy warnings.

static_info is unused by netbird-ui.

fixes #3326

## Issue ticket number and link
#3326 

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
