### PR TITLE
Improve Base62 encoding/decoding performance and robustness

### DIFF
--- a/base62/base62.go
+++ b/base62/base62.go
@@ -3,21 +3,41 @@ package base62
 import (
 	"fmt"
 	"math"
-	"strings"
 )
 
 const (
-	alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	base     = uint32(len(alphabet))
+	alphabet        = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	base            = uint32(len(alphabet))
+	maxBase62Digits = 6 // max number of digits required to encode MaxUint32
+
 )
 
+var (
+	ErrEmptyString = fmt.Errorf("empty string")
+	ErrInvalidChar = fmt.Errorf("invalid character")
+	ErrOverflow    = fmt.Errorf("integer overflow")
+)
+
+// Fixed-size arrays have better performance and lower memory overhead compared to maps for small static sets of data
+var charToIndex [123]int8 // Assuming ASCII from '\0' - 'z'
+
+func init() {
+	for i := range charToIndex {
+		charToIndex[i] = -1
+	}
+	for i, c := range alphabet {
+		charToIndex[c] = int8(i)
+	}
+}
+
 // Encode encodes a uint32 value to a base62 string.
+// The returned string will be between 1-6 characters long.
 func Encode(n uint32) string {
 	if n < base {
 		return string(alphabet[n])
 	}
 	// avoid dynamic memory usage for small, fixed size data
-	buf := [6]byte{} // 6 is max number of digits required to encode MaxUint32
+	buf := [maxBase62Digits]byte{}
 	idx := len(buf)
 
 	for n > 0 {
@@ -30,19 +50,24 @@ func Encode(n uint32) string {
 }
 
 // Decode decodes a base62 string to a uint32 value.
+// Returns an error if the input string is empty, contains invalid characters,
+// or would result in integer overflow.
 func Decode(encoded string) (uint32, error) {
 	if len(encoded) == 0 {
-		return 0, fmt.Errorf("empty string")
+		return 0, ErrEmptyString
 	}
 	var decoded uint32
 	for _, char := range encoded {
-		index := strings.IndexRune(alphabet, char)
+		index := int8(-1)
+		if int(char) < len(charToIndex) {
+			index = charToIndex[char]
+		}
 		if index < 0 {
-			return 0, fmt.Errorf("invalid character: %c", char)
+			return 0, fmt.Errorf("%w: %c", ErrInvalidChar, char)
 		}
 		// Add overflow check when calculating the decoded value to prevent silent overflow of uint32
 		if decoded > (math.MaxUint32-uint32(index))/base {
-			return 0, fmt.Errorf("integer overflow")
+			return 0, fmt.Errorf("%w: %s", ErrOverflow, encoded)
 		}
 
 		decoded = decoded*base + uint32(index)

--- a/base62/base62_test.go
+++ b/base62/base62_test.go
@@ -1,6 +1,7 @@
 package base62
 
 import (
+	"errors"
 	"math"
 	"testing"
 )
@@ -48,19 +49,19 @@ func TestEncodeDecode(t *testing.T) {
 
 // Decode handles empty string input with appropriate error
 func TestDecodeEmptyString(t *testing.T) {
-	if _, err := Decode(""); err == nil {
-		t.Error("Expected error for empty string, got nil")
+	if _, err := Decode(""); !errors.Is(err, ErrEmptyString) {
+		t.Errorf("Expected error %v, got %v", ErrEmptyString, err)
 	}
 }
 
 func TestDecodeOverflow(t *testing.T) {
-	if _, err := Decode("4gfFC4"); err == nil {
-		t.Error("Expected error overflow , got nil")
+	if _, err := Decode("4gfFC4"); !errors.Is(err, ErrOverflow) {
+		t.Errorf("Expected error %v, got %v", ErrOverflow, err)
 	}
 }
 
 func TestDecodeInvalid(t *testing.T) {
-	if _, err := Decode("/"); err == nil {
-		t.Error("Expected error invalid character, got nil")
+	if _, err := Decode("/"); !errors.Is(err, ErrInvalidChar) {
+		t.Errorf("Expected error %v, got %v", ErrInvalidChar, err)
 	}
 }


### PR DESCRIPTION
## Describe your changes

### Performance & Robustness Enhancements
- Optimize Base62 decoding by replacing strings.IndexRune with a fixed-size array for O(1) lookups, reducing memory overhead.
- Reduce heap allocations and improve Base62.Encode performance by avoiding dynamic memory usage for small, fixed-size data.
- Use iterative multiplication instead of math.Pow() to avoid floating-point precision issues.
- Add an overflow check when calculating the decoded value to prevent silent overflow of uint32, ensuring correctness for long input strings.

### Testing Improvements:
- Enhance unit tests by explicitly verifying encoding and decoding accuracy.
- Add unit tests for Base62 decoding: one for overflow handling and another for empty strings.
- Add a unit test for input strings containing invalid characters.

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
