### PR TITLE
Fix typo

### DIFF
--- a/client/iface/netstack/tun.go
+++ b/client/iface/netstack/tun.go
@@ -55,7 +55,7 @@ func (t *NetStackTun) Create() (tun.Device, *netstack.Net, error) {
 
 	skipProxy, err := strconv.ParseBool(os.Getenv(EnvSkipProxy))
 	if err != nil {
-		log.Errorf("failed to parse NB_ETSTACK_SKIP_PROXY: %s", err)
+		log.Errorf("failed to parse %s: %s", EnvSkipProxy, err)
 	}
 	if skipProxy {
 		return nsTunDev, tunNet, nil


### PR DESCRIPTION
## Describe your changes

This fixes a typo. It'd be `NB_NETSTACK_SKIP_PROXY` instead of `NB_ETSTACK_SKIP_PROXY`, but even better is to simply use the variable name.

### Checklist
- [ ] Is it a bug fix
- [X] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
