### PR TITLE
Add peer traffic rule IDs to allowed connections in flows

### DIFF
--- a/client/firewall/uspfilter/conntrack/icmp.go
+++ b/client/firewall/uspfilter/conntrack/icmp.go
@@ -90,17 +90,17 @@ func (t *ICMPTracker) updateIfExists(srcIP net.IP, dstIP net.IP, id uint16, seq 
 func (t *ICMPTracker) TrackOutbound(srcIP net.IP, dstIP net.IP, id uint16, seq uint16, typecode layers.ICMPv4TypeCode) {
 	if _, exists := t.updateIfExists(dstIP, srcIP, id, seq); !exists {
 		// if (inverted direction) conn is not tracked, track this direction
-		t.track(srcIP, dstIP, id, seq, typecode, nftypes.Egress)
+		t.track(srcIP, dstIP, id, seq, typecode, nftypes.Egress, nil)
 	}
 }
 
 // TrackInbound records an inbound ICMP Echo Request
-func (t *ICMPTracker) TrackInbound(srcIP net.IP, dstIP net.IP, id uint16, seq uint16, typecode layers.ICMPv4TypeCode) {
-	t.track(srcIP, dstIP, id, seq, typecode, nftypes.Ingress)
+func (t *ICMPTracker) TrackInbound(srcIP net.IP, dstIP net.IP, id uint16, seq uint16, typecode layers.ICMPv4TypeCode, ruleId []byte) {
+	t.track(srcIP, dstIP, id, seq, typecode, nftypes.Ingress, ruleId)
 }
 
 // track is the common implementation for tracking both inbound and outbound ICMP connections
-func (t *ICMPTracker) track(srcIP net.IP, dstIP net.IP, id uint16, seq uint16, typecode layers.ICMPv4TypeCode, direction nftypes.Direction) {
+func (t *ICMPTracker) track(srcIP net.IP, dstIP net.IP, id uint16, seq uint16, typecode layers.ICMPv4TypeCode, direction nftypes.Direction, ruleId []byte) {
 	// TODO: icmp doesn't need to extend the timeout
 	key, exists := t.updateIfExists(srcIP, dstIP, id, seq)
 	if exists {
@@ -112,7 +112,7 @@ func (t *ICMPTracker) track(srcIP net.IP, dstIP net.IP, id uint16, seq uint16, t
 	// non echo requests don't need tracking
 	if typ != uint8(layers.ICMPv4TypeEchoRequest) {
 		t.logger.Trace("New %s ICMP connection %s type %d code %d", direction, key, typ, code)
-		t.sendStartEvent(direction, key, typ, code)
+		t.sendStartEvent(direction, key, typ, code, ruleId)
 		return
 	}
 
@@ -133,7 +133,7 @@ func (t *ICMPTracker) track(srcIP net.IP, dstIP net.IP, id uint16, seq uint16, t
 	t.mutex.Unlock()
 
 	t.logger.Trace("New %s ICMP connection %s type %d code %d", direction, key, typ, code)
-	t.sendEvent(nftypes.TypeStart, key, conn)
+	t.sendEvent(nftypes.TypeStart, key, conn, ruleId)
 }
 
 // IsValidInbound checks if an inbound ICMP Echo Reply matches a tracked request
@@ -177,7 +177,7 @@ func (t *ICMPTracker) cleanup() {
 			delete(t.connections, key)
 
 			t.logger.Debug("Removed ICMP connection %s (timeout)", &key)
-			t.sendEvent(nftypes.TypeEnd, key, conn)
+			t.sendEvent(nftypes.TypeEnd, key, conn, nil)
 		}
 	}
 }
@@ -192,10 +192,11 @@ func (t *ICMPTracker) Close() {
 	t.mutex.Unlock()
 }
 
-func (t *ICMPTracker) sendEvent(typ nftypes.Type, key ICMPConnKey, conn *ICMPConnTrack) {
+func (t *ICMPTracker) sendEvent(typ nftypes.Type, key ICMPConnKey, conn *ICMPConnTrack, ruleID []byte) {
 	t.flowLogger.StoreEvent(nftypes.EventFields{
 		FlowID:    conn.FlowId,
 		Type:      typ,
+		RuleID:    ruleID,
 		Direction: conn.Direction,
 		Protocol:  nftypes.ICMP, // TODO: adjust for IPv6/icmpv6
 		SourceIP:  key.SrcIP,
@@ -205,10 +206,11 @@ func (t *ICMPTracker) sendEvent(typ nftypes.Type, key ICMPConnKey, conn *ICMPCon
 	})
 }
 
-func (t *ICMPTracker) sendStartEvent(direction nftypes.Direction, key ICMPConnKey, typ, code uint8) {
+func (t *ICMPTracker) sendStartEvent(direction nftypes.Direction, key ICMPConnKey, typ, code uint8, RuleID []byte) {
 	t.flowLogger.StoreEvent(nftypes.EventFields{
 		FlowID:    uuid.New(),
 		Type:      nftypes.TypeStart,
+		RuleID:    RuleID,
 		Direction: direction,
 		Protocol:  nftypes.ICMP,
 		SourceIP:  key.SrcIP,

--- a/client/firewall/uspfilter/conntrack/tcp.go
+++ b/client/firewall/uspfilter/conntrack/tcp.go
@@ -167,17 +167,17 @@ func (t *TCPTracker) updateIfExists(srcIP net.IP, dstIP net.IP, srcPort uint16, 
 func (t *TCPTracker) TrackOutbound(srcIP net.IP, dstIP net.IP, srcPort uint16, dstPort uint16, flags uint8) {
 	if _, exists := t.updateIfExists(dstIP, srcIP, dstPort, srcPort, flags); !exists {
 		// if (inverted direction) conn is not tracked, track this direction
-		t.track(srcIP, dstIP, srcPort, dstPort, flags, nftypes.Egress)
+		t.track(srcIP, dstIP, srcPort, dstPort, flags, nftypes.Egress, nil)
 	}
 }
 
 // TrackInbound processes an inbound TCP packet and updates connection state
-func (t *TCPTracker) TrackInbound(srcIP net.IP, dstIP net.IP, srcPort uint16, dstPort uint16, flags uint8) {
-	t.track(srcIP, dstIP, srcPort, dstPort, flags, nftypes.Ingress)
+func (t *TCPTracker) TrackInbound(srcIP net.IP, dstIP net.IP, srcPort uint16, dstPort uint16, flags uint8, ruleID []byte) {
+	t.track(srcIP, dstIP, srcPort, dstPort, flags, nftypes.Ingress, ruleID)
 }
 
 // track is the common implementation for tracking both inbound and outbound connections
-func (t *TCPTracker) track(srcIP net.IP, dstIP net.IP, srcPort uint16, dstPort uint16, flags uint8, direction nftypes.Direction) {
+func (t *TCPTracker) track(srcIP net.IP, dstIP net.IP, srcPort uint16, dstPort uint16, flags uint8, direction nftypes.Direction, ruleID []byte) {
 	key, exists := t.updateIfExists(srcIP, dstIP, srcPort, dstPort, flags)
 	if exists {
 		return
@@ -205,7 +205,7 @@ func (t *TCPTracker) track(srcIP net.IP, dstIP net.IP, srcPort uint16, dstPort u
 	t.connections[key] = conn
 	t.mutex.Unlock()
 
-	t.sendEvent(nftypes.TypeStart, key, conn)
+	t.sendEvent(nftypes.TypeStart, key, conn, ruleID)
 }
 
 // IsValidInbound checks if an inbound TCP packet matches a tracked connection
@@ -233,7 +233,7 @@ func (t *TCPTracker) IsValidInbound(srcIP net.IP, dstIP net.IP, srcPort uint16, 
 		conn.Unlock()
 
 		t.logger.Trace("TCP connection reset: %s", key)
-		t.sendEvent(nftypes.TypeEnd, key, conn)
+		t.sendEvent(nftypes.TypeEnd, key, conn, nil)
 		return true
 	}
 
@@ -305,7 +305,7 @@ func (t *TCPTracker) updateState(key ConnKey, conn *TCPConnTrack, flags uint8, i
 			conn.State = TCPStateTimeWait
 
 			t.logger.Trace("TCP connection %s completed", key)
-			t.sendEvent(nftypes.TypeEnd, key, conn)
+			t.sendEvent(nftypes.TypeEnd, key, conn, nil)
 		}
 
 	case TCPStateClosing:
@@ -314,7 +314,7 @@ func (t *TCPTracker) updateState(key ConnKey, conn *TCPConnTrack, flags uint8, i
 			// Keep established = false from previous state
 
 			t.logger.Trace("TCP connection %s closed (simultaneous)", key)
-			t.sendEvent(nftypes.TypeEnd, key, conn)
+			t.sendEvent(nftypes.TypeEnd, key, conn, nil)
 		}
 
 	case TCPStateCloseWait:
@@ -328,7 +328,7 @@ func (t *TCPTracker) updateState(key ConnKey, conn *TCPConnTrack, flags uint8, i
 			conn.SetTombstone()
 
 			// Send close event for gracefully closed connections
-			t.sendEvent(nftypes.TypeEnd, key, conn)
+			t.sendEvent(nftypes.TypeEnd, key, conn, nil)
 			t.logger.Trace("TCP connection %s closed gracefully", key)
 		}
 	}
@@ -415,7 +415,7 @@ func (t *TCPTracker) cleanup() {
 
 			// event already handled by state change
 			if conn.State != TCPStateTimeWait {
-				t.sendEvent(nftypes.TypeEnd, key, conn)
+				t.sendEvent(nftypes.TypeEnd, key, conn, nil)
 			}
 		}
 	}
@@ -446,10 +446,11 @@ func isValidFlagCombination(flags uint8) bool {
 	return true
 }
 
-func (t *TCPTracker) sendEvent(typ nftypes.Type, key ConnKey, conn *TCPConnTrack) {
+func (t *TCPTracker) sendEvent(typ nftypes.Type, key ConnKey, conn *TCPConnTrack, ruleID []byte) {
 	t.flowLogger.StoreEvent(nftypes.EventFields{
 		FlowID:     conn.FlowId,
 		Type:       typ,
+		RuleID:     ruleID,
 		Direction:  conn.Direction,
 		Protocol:   nftypes.TCP,
 		SourceIP:   key.SrcIP,


### PR DESCRIPTION
## Describe your changes

We already have rule IDs in blocked events, this one adds rule IDs to allowed events for peer traffic

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
