### PR TITLE
Update getting-started-with-zitadel.sh - Fix Zitadel user console access

### DIFF
--- a/infrastructure_files/getting-started-with-zitadel.sh
+++ b/infrastructure_files/getting-started-with-zitadel.sh
@@ -602,6 +602,7 @@ renderCaddyfile() {
     reverse_proxy /debug/* h2c://zitadel:8080
     reverse_proxy /device/* h2c://zitadel:8080
     reverse_proxy /device h2c://zitadel:8080
+    reverse_proxy /zitadel.user.v2.UserService/* h2c://zitadel:8080
     # Dashboard
     reverse_proxy /* dashboard:80
 }


### PR DESCRIPTION
## Fix for Zitadel User Management
With the current Caddy configuration, it is not possible to display the users in the Zitadel console.
This is because the UI uses the endpoints:
- ```/zitadel.user.v2.UserService/ListUsers```
- ```/zitadel.user.v2.UserService/GetUserByID```

to display the users which are currently not handled by Caddy.

The PR adds the necessary configuration.

### Checklist
- [X] Is it a bug fix

