### PR TITLE
[client] Fix DNS Nrpt policies

### DIFF
--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -24,8 +24,8 @@ var (
 
 const (
 	dnsPolicyConfigMatchPath    = `SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\DnsPolicyConfig\NetBird-Match`
-	gpoDnsPolicyRoot            = `SOFTWARE\Policies\Microsoft\Windows NT\DNSClient`
-	gpoDnsPolicyConfigMatchPath = gpoDnsPolicyRoot + `\DnsPolicyConfig\NetBird-Match`
+	gpoDnsPolicyRoot            = `SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\DnsPolicyConfig`
+	gpoDnsPolicyConfigMatchPath = gpoDnsPolicyRoot + `\NetBird-Match`
 
 	dnsPolicyConfigVersionKey           = "Version"
 	dnsPolicyConfigVersionValue         = 2
@@ -134,10 +134,6 @@ func (r *registryConfigurator) addDNSMatchPolicy(domains []string, ip string) er
 	if r.gpo {
 		if err := r.configureDNSPolicy(gpoDnsPolicyConfigMatchPath, domains, ip); err != nil {
 			return fmt.Errorf("configure GPO DNS policy: %w", err)
-		}
-
-		if err := r.configureDNSPolicy(dnsPolicyConfigMatchPath, domains, ip); err != nil {
-			return fmt.Errorf("configure local DNS policy: %w", err)
 		}
 
 		if err := refreshGroupPolicy(); err != nil {


### PR DESCRIPTION
## Describe your changes
- The registry key that is currently used to check if the client is in GPO mode or not is not correct. You can have DNSClient key present if you define other DNS settings by GPO (Ex: Disable Netbios, disable mutlicast, ...) but not using GPO to configure Nrpt policies.
- When client is in GPO mode, there is no need to push the local policy configuration as this entry will be discared. The way of Microsoft to check if there is NRPT settings configured by GPO is to check the DnsPolicyConfig key is present (That's why it's coherent to check that key and not the DNSClient key)

> If any NRPT settings are configured in domain Group Policy, then all local Group Policy NRPT settings are ignored
https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/dn593632(v=ws.11)

## Issue ticket number and link
Partial fix https://github.com/netbirdio/netbird/issues/3332

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
