### PR TITLE
[client] Ignore candidates that are part of the the wireguard subnet

### DIFF
--- a/client/firewall/iface.go
+++ b/client/firewall/iface.go
@@ -4,12 +4,13 @@ import (
 	wgdevice "golang.zx2c4.com/wireguard/device"
 
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 // IFaceMapper defines subset methods of interface required for manager
 type IFaceMapper interface {
 	Name() string
-	Address() device.WGAddress
+	Address() wgaddr.Address
 	IsUserspaceBind() bool
 	SetFilter(device.PacketFilter) error
 	GetDevice() *device.FilteredDevice

--- a/client/firewall/iptables/manager_linux.go
+++ b/client/firewall/iptables/manager_linux.go
@@ -13,7 +13,7 @@ import (
 
 	nberrors "github.com/netbirdio/netbird/client/errors"
 	firewall "github.com/netbirdio/netbird/client/firewall/manager"
-	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/internal/statemanager"
 )
 
@@ -31,7 +31,7 @@ type Manager struct {
 // iFaceMapper defines subset methods of interface required for manager
 type iFaceMapper interface {
 	Name() string
-	Address() iface.WGAddress
+	Address() wgaddr.Address
 	IsUserspaceBind() bool
 }
 

--- a/client/firewall/iptables/manager_linux_test.go
+++ b/client/firewall/iptables/manager_linux_test.go
@@ -10,15 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fw "github.com/netbirdio/netbird/client/firewall/manager"
-	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 var ifaceMock = &iFaceMock{
 	NameFunc: func() string {
 		return "lo"
 	},
-	AddressFunc: func() iface.WGAddress {
-		return iface.WGAddress{
+	AddressFunc: func() wgaddr.Address {
+		return wgaddr.Address{
 			IP: net.ParseIP("10.20.0.1"),
 			Network: &net.IPNet{
 				IP:   net.ParseIP("10.20.0.0"),
@@ -31,7 +31,7 @@ var ifaceMock = &iFaceMock{
 // iFaceMapper defines subset methods of interface required for manager
 type iFaceMock struct {
 	NameFunc    func() string
-	AddressFunc func() iface.WGAddress
+	AddressFunc func() wgaddr.Address
 }
 
 func (i *iFaceMock) Name() string {
@@ -41,7 +41,7 @@ func (i *iFaceMock) Name() string {
 	panic("NameFunc is not set")
 }
 
-func (i *iFaceMock) Address() iface.WGAddress {
+func (i *iFaceMock) Address() wgaddr.Address {
 	if i.AddressFunc != nil {
 		return i.AddressFunc()
 	}
@@ -117,8 +117,8 @@ func TestIptablesManagerIPSet(t *testing.T) {
 		NameFunc: func() string {
 			return "lo"
 		},
-		AddressFunc: func() iface.WGAddress {
-			return iface.WGAddress{
+		AddressFunc: func() wgaddr.Address {
+			return wgaddr.Address{
 				IP: net.ParseIP("10.20.0.1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("10.20.0.0"),
@@ -184,8 +184,8 @@ func TestIptablesCreatePerformance(t *testing.T) {
 		NameFunc: func() string {
 			return "lo"
 		},
-		AddressFunc: func() iface.WGAddress {
-			return iface.WGAddress{
+		AddressFunc: func() wgaddr.Address {
+			return wgaddr.Address{
 				IP: net.ParseIP("10.20.0.1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("10.20.0.0"),

--- a/client/firewall/iptables/state_linux.go
+++ b/client/firewall/iptables/state_linux.go
@@ -4,21 +4,20 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/netbirdio/netbird/client/iface"
-	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type InterfaceState struct {
-	NameStr       string          `json:"name"`
-	WGAddress     iface.WGAddress `json:"wg_address"`
-	UserspaceBind bool            `json:"userspace_bind"`
+	NameStr       string         `json:"name"`
+	WGAddress     wgaddr.Address `json:"wg_address"`
+	UserspaceBind bool           `json:"userspace_bind"`
 }
 
 func (i *InterfaceState) Name() string {
 	return i.NameStr
 }
 
-func (i *InterfaceState) Address() device.WGAddress {
+func (i *InterfaceState) Address() wgaddr.Address {
 	return i.WGAddress
 }
 

--- a/client/firewall/nftables/manager_linux.go
+++ b/client/firewall/nftables/manager_linux.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	firewall "github.com/netbirdio/netbird/client/firewall/manager"
-	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/internal/statemanager"
 )
 
@@ -29,7 +29,7 @@ const (
 // iFaceMapper defines subset methods of interface required for manager
 type iFaceMapper interface {
 	Name() string
-	Address() iface.WGAddress
+	Address() wgaddr.Address
 	IsUserspaceBind() bool
 }
 

--- a/client/firewall/nftables/manager_linux_test.go
+++ b/client/firewall/nftables/manager_linux_test.go
@@ -16,15 +16,15 @@ import (
 	"golang.org/x/sys/unix"
 
 	fw "github.com/netbirdio/netbird/client/firewall/manager"
-	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 var ifaceMock = &iFaceMock{
 	NameFunc: func() string {
 		return "lo"
 	},
-	AddressFunc: func() iface.WGAddress {
-		return iface.WGAddress{
+	AddressFunc: func() wgaddr.Address {
+		return wgaddr.Address{
 			IP: net.ParseIP("100.96.0.1"),
 			Network: &net.IPNet{
 				IP:   net.ParseIP("100.96.0.0"),
@@ -37,7 +37,7 @@ var ifaceMock = &iFaceMock{
 // iFaceMapper defines subset methods of interface required for manager
 type iFaceMock struct {
 	NameFunc    func() string
-	AddressFunc func() iface.WGAddress
+	AddressFunc func() wgaddr.Address
 }
 
 func (i *iFaceMock) Name() string {
@@ -47,7 +47,7 @@ func (i *iFaceMock) Name() string {
 	panic("NameFunc is not set")
 }
 
-func (i *iFaceMock) Address() iface.WGAddress {
+func (i *iFaceMock) Address() wgaddr.Address {
 	if i.AddressFunc != nil {
 		return i.AddressFunc()
 	}
@@ -171,8 +171,8 @@ func TestNFtablesCreatePerformance(t *testing.T) {
 		NameFunc: func() string {
 			return "lo"
 		},
-		AddressFunc: func() iface.WGAddress {
-			return iface.WGAddress{
+		AddressFunc: func() wgaddr.Address {
+			return wgaddr.Address{
 				IP: net.ParseIP("100.96.0.1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("100.96.0.0"),

--- a/client/firewall/nftables/state_linux.go
+++ b/client/firewall/nftables/state_linux.go
@@ -3,21 +3,20 @@ package nftables
 import (
 	"fmt"
 
-	"github.com/netbirdio/netbird/client/iface"
-	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type InterfaceState struct {
-	NameStr       string          `json:"name"`
-	WGAddress     iface.WGAddress `json:"wg_address"`
-	UserspaceBind bool            `json:"userspace_bind"`
+	NameStr       string         `json:"name"`
+	WGAddress     wgaddr.Address `json:"wg_address"`
+	UserspaceBind bool           `json:"userspace_bind"`
 }
 
 func (i *InterfaceState) Name() string {
 	return i.NameStr
 }
 
-func (i *InterfaceState) Address() device.WGAddress {
+func (i *InterfaceState) Address() wgaddr.Address {
 	return i.WGAddress
 }
 

--- a/client/firewall/uspfilter/common/iface.go
+++ b/client/firewall/uspfilter/common/iface.go
@@ -3,14 +3,14 @@ package common
 import (
 	wgdevice "golang.zx2c4.com/wireguard/device"
 
-	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 // IFaceMapper defines subset methods of interface required for manager
 type IFaceMapper interface {
 	SetFilter(device.PacketFilter) error
-	Address() iface.WGAddress
+	Address() wgaddr.Address
 	GetWGDevice() *wgdevice.Device
 	GetDevice() *device.FilteredDevice
 }

--- a/client/firewall/uspfilter/localip_test.go
+++ b/client/firewall/uspfilter/localip_test.go
@@ -6,19 +6,19 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 func TestLocalIPManager(t *testing.T) {
 	tests := []struct {
 		name      string
-		setupAddr iface.WGAddress
+		setupAddr wgaddr.Address
 		testIP    net.IP
 		expected  bool
 	}{
 		{
 			name: "Localhost range",
-			setupAddr: iface.WGAddress{
+			setupAddr: wgaddr.Address{
 				IP: net.ParseIP("192.168.1.1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("192.168.1.0"),
@@ -30,7 +30,7 @@ func TestLocalIPManager(t *testing.T) {
 		},
 		{
 			name: "Localhost standard address",
-			setupAddr: iface.WGAddress{
+			setupAddr: wgaddr.Address{
 				IP: net.ParseIP("192.168.1.1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("192.168.1.0"),
@@ -42,7 +42,7 @@ func TestLocalIPManager(t *testing.T) {
 		},
 		{
 			name: "Localhost range edge",
-			setupAddr: iface.WGAddress{
+			setupAddr: wgaddr.Address{
 				IP: net.ParseIP("192.168.1.1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("192.168.1.0"),
@@ -54,7 +54,7 @@ func TestLocalIPManager(t *testing.T) {
 		},
 		{
 			name: "Local IP matches",
-			setupAddr: iface.WGAddress{
+			setupAddr: wgaddr.Address{
 				IP: net.ParseIP("192.168.1.1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("192.168.1.0"),
@@ -66,7 +66,7 @@ func TestLocalIPManager(t *testing.T) {
 		},
 		{
 			name: "Local IP doesn't match",
-			setupAddr: iface.WGAddress{
+			setupAddr: wgaddr.Address{
 				IP: net.ParseIP("192.168.1.1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("192.168.1.0"),
@@ -78,7 +78,7 @@ func TestLocalIPManager(t *testing.T) {
 		},
 		{
 			name: "IPv6 address",
-			setupAddr: iface.WGAddress{
+			setupAddr: wgaddr.Address{
 				IP: net.ParseIP("fe80::1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("fe80::"),
@@ -95,7 +95,7 @@ func TestLocalIPManager(t *testing.T) {
 			manager := newLocalIPManager()
 
 			mock := &IFaceMock{
-				AddressFunc: func() iface.WGAddress {
+				AddressFunc: func() wgaddr.Address {
 					return tt.setupAddr
 				},
 			}

--- a/client/firewall/uspfilter/uspfilter_filter_test.go
+++ b/client/firewall/uspfilter/uspfilter_filter_test.go
@@ -12,9 +12,9 @@ import (
 	wgdevice "golang.zx2c4.com/wireguard/device"
 
 	fw "github.com/netbirdio/netbird/client/firewall/manager"
-	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/device"
 	"github.com/netbirdio/netbird/client/iface/mocks"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 func TestPeerACLFiltering(t *testing.T) {
@@ -26,8 +26,8 @@ func TestPeerACLFiltering(t *testing.T) {
 
 	ifaceMock := &IFaceMock{
 		SetFilterFunc: func(device.PacketFilter) error { return nil },
-		AddressFunc: func() iface.WGAddress {
-			return iface.WGAddress{
+		AddressFunc: func() wgaddr.Address {
+			return wgaddr.Address{
 				IP:      localIP,
 				Network: wgNet,
 			}
@@ -288,8 +288,8 @@ func setupRoutedManager(tb testing.TB, network string) *Manager {
 
 	ifaceMock := &IFaceMock{
 		SetFilterFunc: func(device.PacketFilter) error { return nil },
-		AddressFunc: func() iface.WGAddress {
-			return iface.WGAddress{
+		AddressFunc: func() wgaddr.Address {
+			return wgaddr.Address{
 				IP:      localIP,
 				Network: wgNet,
 			}

--- a/client/firewall/uspfilter/uspfilter_test.go
+++ b/client/firewall/uspfilter/uspfilter_test.go
@@ -16,15 +16,15 @@ import (
 	fw "github.com/netbirdio/netbird/client/firewall/manager"
 	"github.com/netbirdio/netbird/client/firewall/uspfilter/conntrack"
 	"github.com/netbirdio/netbird/client/firewall/uspfilter/log"
-	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 var logger = log.NewFromLogrus(logrus.StandardLogger())
 
 type IFaceMock struct {
 	SetFilterFunc   func(device.PacketFilter) error
-	AddressFunc     func() iface.WGAddress
+	AddressFunc     func() wgaddr.Address
 	GetWGDeviceFunc func() *wgdevice.Device
 	GetDeviceFunc   func() *device.FilteredDevice
 }
@@ -50,9 +50,9 @@ func (i *IFaceMock) SetFilter(iface device.PacketFilter) error {
 	return i.SetFilterFunc(iface)
 }
 
-func (i *IFaceMock) Address() iface.WGAddress {
+func (i *IFaceMock) Address() wgaddr.Address {
 	if i.AddressFunc == nil {
-		return iface.WGAddress{}
+		return wgaddr.Address{}
 	}
 	return i.AddressFunc()
 }
@@ -268,8 +268,8 @@ func TestManagerReset(t *testing.T) {
 func TestNotMatchByIP(t *testing.T) {
 	ifaceMock := &IFaceMock{
 		SetFilterFunc: func(device.PacketFilter) error { return nil },
-		AddressFunc: func() iface.WGAddress {
-			return iface.WGAddress{
+		AddressFunc: func() wgaddr.Address {
+			return wgaddr.Address{
 				IP: net.ParseIP("100.10.0.100"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("100.10.0.0"),

--- a/client/iface/bind/udp_mux_universal.go
+++ b/client/iface/bind/udp_mux_universal.go
@@ -165,8 +165,8 @@ func (u *udpConn) performFilterCheck(addr net.Addr) error {
 	}
 
 	if u.address.Network.Contains(a.AsSlice()) {
-		log.Warnf("Address %s is part of the wireguard network %s, refusing to write", addr, u.address)
-		return fmt.Errorf("address %s is part of the wireguard network %s, refusing to write", addr, u.address)
+		log.Warnf("Address %s is part of the NetBird network %s, refusing to write", addr, u.address)
+		return fmt.Errorf("address %s is part of the NetBird network %s, refusing to write", addr, u.address)
 	}
 
 	if isRouted, prefix, err := u.filterFn(a); err != nil {

--- a/client/iface/bind/udp_mux_universal.go
+++ b/client/iface/bind/udp_mux_universal.go
@@ -17,6 +17,8 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v2"
 	"github.com/pion/transport/v3"
+
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 // FilterFn is a function that filters out candidates based on the address.
@@ -41,6 +43,7 @@ type UniversalUDPMuxParams struct {
 	XORMappedAddrCacheTTL time.Duration
 	Net                   transport.Net
 	FilterFn              FilterFn
+	WGAddress             wgaddr.Address
 }
 
 // NewUniversalUDPMuxDefault creates an implementation of UniversalUDPMux embedding UDPMux
@@ -64,6 +67,7 @@ func NewUniversalUDPMuxDefault(params UniversalUDPMuxParams) *UniversalUDPMuxDef
 		mux:        m,
 		logger:     params.Logger,
 		filterFn:   params.FilterFn,
+		address:    params.WGAddress,
 	}
 
 	// embed UDPMux
@@ -118,6 +122,7 @@ type udpConn struct {
 	filterFn FilterFn
 	// TODO: reset cache on route changes
 	addrCache sync.Map
+	address   wgaddr.Address
 }
 
 func (u *udpConn) WriteTo(b []byte, addr net.Addr) (int, error) {
@@ -157,6 +162,11 @@ func (u *udpConn) performFilterCheck(addr net.Addr) error {
 	if err != nil {
 		log.Errorf("Failed to parse address %s: %v", addr, err)
 		return nil
+	}
+
+	if u.address.Network.Contains(a.AsSlice()) {
+		log.Warnf("Address %s is part of the wireguard network %s, refusing to write", addr, u.address)
+		return fmt.Errorf("address %s is part of the wireguard network %s, refusing to write", addr, u.address)
 	}
 
 	if isRouted, prefix, err := u.filterFn(a); err != nil {

--- a/client/iface/device.go
+++ b/client/iface/device.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type WGTunDevice interface {
 	Create() (device.WGConfigurer, error)
 	Up() (*bind.UniversalUDPMuxDefault, error)
-	UpdateAddr(address WGAddress) error
-	WgAddress() WGAddress
+	UpdateAddr(address wgaddr.Address) error
+	WgAddress() wgaddr.Address
 	DeviceName() string
 	Close() error
 	FilteredDevice() *device.FilteredDevice

--- a/client/iface/device/device_android.go
+++ b/client/iface/device/device_android.go
@@ -13,11 +13,12 @@ import (
 
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/configurer"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 // WGTunDevice ignore the WGTunDevice interface on Android because the creation of the tun device is different on this platform
 type WGTunDevice struct {
-	address    WGAddress
+	address    wgaddr.Address
 	port       int
 	key        string
 	mtu        int
@@ -31,7 +32,7 @@ type WGTunDevice struct {
 	configurer     WGConfigurer
 }
 
-func NewTunDevice(address WGAddress, port int, key string, mtu int, iceBind *bind.ICEBind, tunAdapter TunAdapter) *WGTunDevice {
+func NewTunDevice(address wgaddr.Address, port int, key string, mtu int, iceBind *bind.ICEBind, tunAdapter TunAdapter) *WGTunDevice {
 	return &WGTunDevice{
 		address:    address,
 		port:       port,
@@ -93,7 +94,7 @@ func (t *WGTunDevice) Up() (*bind.UniversalUDPMuxDefault, error) {
 	return udpMux, nil
 }
 
-func (t *WGTunDevice) UpdateAddr(addr WGAddress) error {
+func (t *WGTunDevice) UpdateAddr(addr wgaddr.Address) error {
 	// todo implement
 	return nil
 }
@@ -123,7 +124,7 @@ func (t *WGTunDevice) DeviceName() string {
 	return t.name
 }
 
-func (t *WGTunDevice) WgAddress() WGAddress {
+func (t *WGTunDevice) WgAddress() wgaddr.Address {
 	return t.address
 }
 

--- a/client/iface/device/device_darwin.go
+++ b/client/iface/device/device_darwin.go
@@ -13,11 +13,12 @@ import (
 
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/configurer"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type TunDevice struct {
 	name    string
-	address WGAddress
+	address wgaddr.Address
 	port    int
 	key     string
 	mtu     int
@@ -29,7 +30,7 @@ type TunDevice struct {
 	configurer     WGConfigurer
 }
 
-func NewTunDevice(name string, address WGAddress, port int, key string, mtu int, iceBind *bind.ICEBind) *TunDevice {
+func NewTunDevice(name string, address wgaddr.Address, port int, key string, mtu int, iceBind *bind.ICEBind) *TunDevice {
 	return &TunDevice{
 		name:    name,
 		address: address,
@@ -85,7 +86,7 @@ func (t *TunDevice) Up() (*bind.UniversalUDPMuxDefault, error) {
 	return udpMux, nil
 }
 
-func (t *TunDevice) UpdateAddr(address WGAddress) error {
+func (t *TunDevice) UpdateAddr(address wgaddr.Address) error {
 	t.address = address
 	return t.assignAddr()
 }
@@ -106,7 +107,7 @@ func (t *TunDevice) Close() error {
 	return nil
 }
 
-func (t *TunDevice) WgAddress() WGAddress {
+func (t *TunDevice) WgAddress() wgaddr.Address {
 	return t.address
 }
 

--- a/client/iface/device/device_ios.go
+++ b/client/iface/device/device_ios.go
@@ -14,11 +14,12 @@ import (
 
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/configurer"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type TunDevice struct {
 	name    string
-	address WGAddress
+	address wgaddr.Address
 	port    int
 	key     string
 	iceBind *bind.ICEBind
@@ -30,7 +31,7 @@ type TunDevice struct {
 	configurer     WGConfigurer
 }
 
-func NewTunDevice(name string, address WGAddress, port int, key string, iceBind *bind.ICEBind, tunFd int) *TunDevice {
+func NewTunDevice(name string, address wgaddr.Address, port int, key string, iceBind *bind.ICEBind, tunFd int) *TunDevice {
 	return &TunDevice{
 		name:    name,
 		address: address,
@@ -120,11 +121,11 @@ func (t *TunDevice) Close() error {
 	return nil
 }
 
-func (t *TunDevice) WgAddress() WGAddress {
+func (t *TunDevice) WgAddress() wgaddr.Address {
 	return t.address
 }
 
-func (t *TunDevice) UpdateAddr(addr WGAddress) error {
+func (t *TunDevice) UpdateAddr(_ wgaddr.Address) error {
 	// todo implement
 	return nil
 }

--- a/client/iface/device/device_netstack.go
+++ b/client/iface/device/device_netstack.go
@@ -13,12 +13,13 @@ import (
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	nbnetstack "github.com/netbirdio/netbird/client/iface/netstack"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	nbnet "github.com/netbirdio/netbird/util/net"
 )
 
 type TunNetstackDevice struct {
 	name          string
-	address       WGAddress
+	address       wgaddr.Address
 	port          int
 	key           string
 	mtu           int
@@ -34,7 +35,7 @@ type TunNetstackDevice struct {
 	net *netstack.Net
 }
 
-func NewNetstackDevice(name string, address WGAddress, wgPort int, key string, mtu int, iceBind *bind.ICEBind, listenAddress string) *TunNetstackDevice {
+func NewNetstackDevice(name string, address wgaddr.Address, wgPort int, key string, mtu int, iceBind *bind.ICEBind, listenAddress string) *TunNetstackDevice {
 	return &TunNetstackDevice{
 		name:          name,
 		address:       address,
@@ -97,7 +98,7 @@ func (t *TunNetstackDevice) Up() (*bind.UniversalUDPMuxDefault, error) {
 	return udpMux, nil
 }
 
-func (t *TunNetstackDevice) UpdateAddr(WGAddress) error {
+func (t *TunNetstackDevice) UpdateAddr(wgaddr.Address) error {
 	return nil
 }
 
@@ -116,7 +117,7 @@ func (t *TunNetstackDevice) Close() error {
 	return nil
 }
 
-func (t *TunNetstackDevice) WgAddress() WGAddress {
+func (t *TunNetstackDevice) WgAddress() wgaddr.Address {
 	return t.address
 }
 

--- a/client/iface/device/device_usp_unix.go
+++ b/client/iface/device/device_usp_unix.go
@@ -12,11 +12,12 @@ import (
 
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/configurer"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type USPDevice struct {
 	name    string
-	address WGAddress
+	address wgaddr.Address
 	port    int
 	key     string
 	mtu     int
@@ -28,7 +29,7 @@ type USPDevice struct {
 	configurer     WGConfigurer
 }
 
-func NewUSPDevice(name string, address WGAddress, port int, key string, mtu int, iceBind *bind.ICEBind) *USPDevice {
+func NewUSPDevice(name string, address wgaddr.Address, port int, key string, mtu int, iceBind *bind.ICEBind) *USPDevice {
 	log.Infof("using userspace bind mode")
 
 	return &USPDevice{
@@ -93,7 +94,7 @@ func (t *USPDevice) Up() (*bind.UniversalUDPMuxDefault, error) {
 	return udpMux, nil
 }
 
-func (t *USPDevice) UpdateAddr(address WGAddress) error {
+func (t *USPDevice) UpdateAddr(address wgaddr.Address) error {
 	t.address = address
 	return t.assignAddr()
 }
@@ -113,7 +114,7 @@ func (t *USPDevice) Close() error {
 	return nil
 }
 
-func (t *USPDevice) WgAddress() WGAddress {
+func (t *USPDevice) WgAddress() wgaddr.Address {
 	return t.address
 }
 

--- a/client/iface/device/device_windows.go
+++ b/client/iface/device/device_windows.go
@@ -13,13 +13,14 @@ import (
 
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/configurer"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 const defaultWindowsGUIDSTring = "{f2f29e61-d91f-4d76-8151-119b20c4bdeb}"
 
 type TunDevice struct {
 	name    string
-	address WGAddress
+	address wgaddr.Address
 	port    int
 	key     string
 	mtu     int
@@ -32,7 +33,7 @@ type TunDevice struct {
 	configurer      WGConfigurer
 }
 
-func NewTunDevice(name string, address WGAddress, port int, key string, mtu int, iceBind *bind.ICEBind) *TunDevice {
+func NewTunDevice(name string, address wgaddr.Address, port int, key string, mtu int, iceBind *bind.ICEBind) *TunDevice {
 	return &TunDevice{
 		name:    name,
 		address: address,
@@ -118,7 +119,7 @@ func (t *TunDevice) Up() (*bind.UniversalUDPMuxDefault, error) {
 	return udpMux, nil
 }
 
-func (t *TunDevice) UpdateAddr(address WGAddress) error {
+func (t *TunDevice) UpdateAddr(address wgaddr.Address) error {
 	t.address = address
 	return t.assignAddr()
 }
@@ -139,7 +140,7 @@ func (t *TunDevice) Close() error {
 	}
 	return nil
 }
-func (t *TunDevice) WgAddress() WGAddress {
+func (t *TunDevice) WgAddress() wgaddr.Address {
 	return t.address
 }
 

--- a/client/iface/device/wg_link_freebsd.go
+++ b/client/iface/device/wg_link_freebsd.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/netbirdio/netbird/client/iface/freebsd"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type wgLink struct {
@@ -56,7 +57,7 @@ func (l *wgLink) up() error {
 	return nil
 }
 
-func (l *wgLink) assignAddr(address WGAddress) error {
+func (l *wgLink) assignAddr(address wgaddr.Address) error {
 	link, err := freebsd.LinkByName(l.name)
 	if err != nil {
 		return fmt.Errorf("link by name: %w", err)

--- a/client/iface/device/wg_link_linux.go
+++ b/client/iface/device/wg_link_linux.go
@@ -8,6 +8,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type wgLink struct {
@@ -90,7 +92,7 @@ func (l *wgLink) up() error {
 	return nil
 }
 
-func (l *wgLink) assignAddr(address WGAddress) error {
+func (l *wgLink) assignAddr(address wgaddr.Address) error {
 	//delete existing addresses
 	list, err := netlink.AddrList(l, 0)
 	if err != nil {

--- a/client/iface/device_android.go
+++ b/client/iface/device_android.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type WGTunDevice interface {
 	Create(routes []string, dns string, searchDomains []string) (device.WGConfigurer, error)
 	Up() (*bind.UniversalUDPMuxDefault, error)
-	UpdateAddr(address WGAddress) error
-	WgAddress() WGAddress
+	UpdateAddr(address wgaddr.Address) error
+	WgAddress() wgaddr.Address
 	DeviceName() string
 	Close() error
 	FilteredDevice() *device.FilteredDevice

--- a/client/iface/iface.go
+++ b/client/iface/iface.go
@@ -19,6 +19,7 @@ import (
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
 )
 
@@ -27,8 +28,6 @@ const (
 	DefaultWgPort      = 51820
 	WgInterfaceDefault = configurer.WgInterfaceDefault
 )
-
-type WGAddress = device.WGAddress
 
 type wgProxyFactory interface {
 	GetProxy() wgproxy.Proxy
@@ -72,7 +71,7 @@ func (w *WGIface) Name() string {
 }
 
 // Address returns the interface address
-func (w *WGIface) Address() device.WGAddress {
+func (w *WGIface) Address() wgaddr.Address {
 	return w.tun.WgAddress()
 }
 
@@ -103,7 +102,7 @@ func (w *WGIface) UpdateAddr(newAddr string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	addr, err := device.ParseWGAddress(newAddr)
+	addr, err := wgaddr.ParseWGAddress(newAddr)
 	if err != nil {
 		return err
 	}

--- a/client/iface/iface_new_android.go
+++ b/client/iface/iface_new_android.go
@@ -3,17 +3,18 @@ package iface
 import (
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
 )
 
 // NewWGIFace Creates a new WireGuard interface instance
 func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
-	wgAddress, err := device.ParseWGAddress(opts.Address)
+	wgAddress, err := wgaddr.ParseWGAddress(opts.Address)
 	if err != nil {
 		return nil, err
 	}
 
-	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn)
+	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, wgAddress)
 
 	wgIFace := &WGIface{
 		userspaceBind:  true,

--- a/client/iface/iface_new_darwin.go
+++ b/client/iface/iface_new_darwin.go
@@ -6,17 +6,18 @@ import (
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/device"
 	"github.com/netbirdio/netbird/client/iface/netstack"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
 )
 
 // NewWGIFace Creates a new WireGuard interface instance
 func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
-	wgAddress, err := device.ParseWGAddress(opts.Address)
+	wgAddress, err := wgaddr.ParseWGAddress(opts.Address)
 	if err != nil {
 		return nil, err
 	}
 
-	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn)
+	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, wgAddress)
 
 	var tun WGTunDevice
 	if netstack.IsEnabled() {

--- a/client/iface/iface_new_ios.go
+++ b/client/iface/iface_new_ios.go
@@ -5,17 +5,18 @@ package iface
 import (
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
 )
 
 // NewWGIFace Creates a new WireGuard interface instance
 func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
-	wgAddress, err := device.ParseWGAddress(opts.Address)
+	wgAddress, err := wgaddr.ParseWGAddress(opts.Address)
 	if err != nil {
 		return nil, err
 	}
 
-	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn)
+	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, wgAddress)
 
 	wgIFace := &WGIface{
 		tun:            device.NewTunDevice(opts.IFaceName, wgAddress, opts.WGPort, opts.WGPrivKey, iceBind, opts.MobileArgs.TunFd),

--- a/client/iface/iface_new_unix.go
+++ b/client/iface/iface_new_unix.go
@@ -8,12 +8,13 @@ import (
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/device"
 	"github.com/netbirdio/netbird/client/iface/netstack"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
 )
 
 // NewWGIFace Creates a new WireGuard interface instance
 func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
-	wgAddress, err := device.ParseWGAddress(opts.Address)
+	wgAddress, err := wgaddr.ParseWGAddress(opts.Address)
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +22,7 @@ func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
 	wgIFace := &WGIface{}
 
 	if netstack.IsEnabled() {
-		iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn)
+		iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, wgAddress)
 		wgIFace.tun = device.NewNetstackDevice(opts.IFaceName, wgAddress, opts.WGPort, opts.WGPrivKey, opts.MTU, iceBind, netstack.ListenAddr())
 		wgIFace.userspaceBind = true
 		wgIFace.wgProxyFactory = wgproxy.NewUSPFactory(iceBind)
@@ -34,7 +35,7 @@ func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
 		return wgIFace, nil
 	}
 	if device.ModuleTunIsLoaded() {
-		iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn)
+		iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, wgAddress)
 		wgIFace.tun = device.NewUSPDevice(opts.IFaceName, wgAddress, opts.WGPort, opts.WGPrivKey, opts.MTU, iceBind)
 		wgIFace.userspaceBind = true
 		wgIFace.wgProxyFactory = wgproxy.NewUSPFactory(iceBind)

--- a/client/iface/iface_new_windows.go
+++ b/client/iface/iface_new_windows.go
@@ -4,16 +4,17 @@ import (
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/device"
 	"github.com/netbirdio/netbird/client/iface/netstack"
+	wgaddr "github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
 )
 
 // NewWGIFace Creates a new WireGuard interface instance
 func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
-	wgAddress, err := device.ParseWGAddress(opts.Address)
+	wgAddress, err := wgaddr.ParseWGAddress(opts.Address)
 	if err != nil {
 		return nil, err
 	}
-	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn)
+	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, wgAddress)
 
 	var tun WGTunDevice
 	if netstack.IsEnabled() {

--- a/client/iface/wgaddr/address.go
+++ b/client/iface/wgaddr/address.go
@@ -1,29 +1,29 @@
-package device
+package wgaddr
 
 import (
 	"fmt"
 	"net"
 )
 
-// WGAddress WireGuard parsed address
-type WGAddress struct {
+// Address WireGuard parsed address
+type Address struct {
 	IP      net.IP
 	Network *net.IPNet
 }
 
 // ParseWGAddress parse a string ("1.2.3.4/24") address to WG Address
-func ParseWGAddress(address string) (WGAddress, error) {
+func ParseWGAddress(address string) (Address, error) {
 	ip, network, err := net.ParseCIDR(address)
 	if err != nil {
-		return WGAddress{}, err
+		return Address{}, err
 	}
-	return WGAddress{
+	return Address{
 		IP:      ip,
 		Network: network,
 	}, nil
 }
 
-func (addr WGAddress) String() string {
+func (addr Address) String() string {
 	maskSize, _ := addr.Network.Mask.Size()
 	return fmt.Sprintf("%s/%d", addr.IP.String(), maskSize)
 }

--- a/client/internal/acl/manager_test.go
+++ b/client/internal/acl/manager_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/netbirdio/netbird/client/firewall"
 	"github.com/netbirdio/netbird/client/firewall/manager"
-	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/internal/acl/mocks"
 	mgmProto "github.com/netbirdio/netbird/management/proto"
 )
@@ -45,7 +45,7 @@ func TestDefaultManager(t *testing.T) {
 	}
 
 	ifaceMock.EXPECT().Name().Return("lo").AnyTimes()
-	ifaceMock.EXPECT().Address().Return(iface.WGAddress{
+	ifaceMock.EXPECT().Address().Return(wgaddr.Address{
 		IP:      ip,
 		Network: network,
 	}).AnyTimes()
@@ -339,7 +339,7 @@ func TestDefaultManagerEnableSSHRules(t *testing.T) {
 	}
 
 	ifaceMock.EXPECT().Name().Return("lo").AnyTimes()
-	ifaceMock.EXPECT().Address().Return(iface.WGAddress{
+	ifaceMock.EXPECT().Address().Return(wgaddr.Address{
 		IP:      ip,
 		Network: network,
 	}).AnyTimes()

--- a/client/internal/acl/mocks/iface_mapper.go
+++ b/client/internal/acl/mocks/iface_mapper.go
@@ -10,8 +10,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	wgdevice "golang.zx2c4.com/wireguard/device"
 
-	iface "github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 // MockIFaceMapper is a mock of IFaceMapper interface.
@@ -38,10 +38,10 @@ func (m *MockIFaceMapper) EXPECT() *MockIFaceMapperMockRecorder {
 }
 
 // Address mocks base method.
-func (m *MockIFaceMapper) Address() iface.WGAddress {
+func (m *MockIFaceMapper) Address() wgaddr.Address {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Address")
-	ret0, _ := ret[0].(iface.WGAddress)
+	ret0, _ := ret[0].(wgaddr.Address)
 	return ret0
 }
 

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	"github.com/netbirdio/netbird/client/iface/device"
 	pfmock "github.com/netbirdio/netbird/client/iface/mocks"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/statemanager"
 	"github.com/netbirdio/netbird/client/internal/stdnet"
@@ -37,9 +38,9 @@ func (w *mocWGIface) Name() string {
 	panic("implement me")
 }
 
-func (w *mocWGIface) Address() iface.WGAddress {
+func (w *mocWGIface) Address() wgaddr.Address {
 	ip, network, _ := net.ParseCIDR("100.66.100.0/24")
-	return iface.WGAddress{
+	return wgaddr.Address{
 		IP:      ip,
 		Network: network,
 	}

--- a/client/internal/dns/wgiface.go
+++ b/client/internal/dns/wgiface.go
@@ -5,15 +5,15 @@ package dns
 import (
 	"net"
 
-	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 // WGIface defines subset methods of interface required for manager
 type WGIface interface {
 	Name() string
-	Address() iface.WGAddress
+	Address() wgaddr.Address
 	ToInterface() *net.Interface
 	IsUserspaceBind() bool
 	GetFilter() device.PacketFilter

--- a/client/internal/dns/wgiface_windows.go
+++ b/client/internal/dns/wgiface_windows.go
@@ -1,15 +1,15 @@
 package dns
 
 import (
-	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 // WGIface defines subset methods of interface required for manager
 type WGIface interface {
 	Name() string
-	Address() iface.WGAddress
+	Address() wgaddr.Address
 	IsUserspaceBind() bool
 	GetFilter() device.PacketFilter
 	GetDevice() *device.FilteredDevice

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
 	"github.com/netbirdio/netbird/client/internal/dns"
 	"github.com/netbirdio/netbird/client/internal/peer"
@@ -74,7 +75,7 @@ type MockWGIface struct {
 	CreateOnAndroidFunc        func(routeRange []string, ip string, domains []string) error
 	IsUserspaceBindFunc        func() bool
 	NameFunc                   func() string
-	AddressFunc                func() device.WGAddress
+	AddressFunc                func() wgaddr.Address
 	ToInterfaceFunc            func() *net.Interface
 	UpFunc                     func() (*bind.UniversalUDPMuxDefault, error)
 	UpdateAddrFunc             func(newAddr string) error
@@ -113,7 +114,7 @@ func (m *MockWGIface) Name() string {
 	return m.NameFunc()
 }
 
-func (m *MockWGIface) Address() device.WGAddress {
+func (m *MockWGIface) Address() wgaddr.Address {
 	return m.AddressFunc()
 }
 
@@ -363,8 +364,8 @@ func TestEngine_UpdateNetworkMap(t *testing.T) {
 		RemovePeerFunc: func(peerKey string) error {
 			return nil
 		},
-		AddressFunc: func() iface.WGAddress {
-			return iface.WGAddress{
+		AddressFunc: func() wgaddr.Address {
+			return wgaddr.Address{
 				IP: net.ParseIP("10.20.0.1"),
 				Network: &net.IPNet{
 					IP:   net.ParseIP("10.20.0.0"),

--- a/client/internal/iface_common.go
+++ b/client/internal/iface_common.go
@@ -12,6 +12,7 @@ import (
 	"github.com/netbirdio/netbird/client/iface/bind"
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
 )
 
@@ -20,7 +21,7 @@ type wgIfaceBase interface {
 	CreateOnAndroid(routeRange []string, ip string, domains []string) error
 	IsUserspaceBind() bool
 	Name() string
-	Address() device.WGAddress
+	Address() wgaddr.Address
 	ToInterface() *net.Interface
 	Up() (*bind.UniversalUDPMuxDefault, error)
 	UpdateAddr(newAddr string) error

--- a/client/internal/peer/iface.go
+++ b/client/internal/peer/iface.go
@@ -8,6 +8,7 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/netbirdio/netbird/client/iface/configurer"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
 )
 
@@ -16,4 +17,5 @@ type WGIface interface {
 	RemovePeer(peerKey string) error
 	GetStats(peerKey string) (configurer.WGStats, error)
 	GetProxy() wgproxy.Proxy
+	Address() wgaddr.Address
 }

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -358,6 +358,12 @@ func extraSrflxCandidate(candidate ice.Candidate) (*ice.CandidateServerReflexive
 }
 
 func candidateViaRoutes(candidate ice.Candidate, clientRoutes route.HAMap) bool {
+	addr, err := netip.ParseAddr(candidate.Address())
+	if err != nil {
+		log.Errorf("Failed to parse IP address %s: %v", candidate.Address(), err)
+		return false
+	}
+
 	var routePrefixes []netip.Prefix
 	for _, routes := range clientRoutes {
 		if len(routes) > 0 && routes[0] != nil {
@@ -365,14 +371,8 @@ func candidateViaRoutes(candidate ice.Candidate, clientRoutes route.HAMap) bool 
 		}
 	}
 
-	addr, err := netip.ParseAddr(candidate.Address())
-	if err != nil {
-		log.Errorf("Failed to parse IP address %s: %v", candidate.Address(), err)
-		return false
-	}
-
 	for _, prefix := range routePrefixes {
-		// default route is
+		// default route is handled by route exclusion / ip rules
 		if prefix.Bits() == 0 {
 			continue
 		}

--- a/client/internal/routemanager/iface/iface_common.go
+++ b/client/internal/routemanager/iface/iface_common.go
@@ -3,9 +3,9 @@ package iface
 import (
 	"net"
 
-	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
 
 type wgIfaceBase interface {
@@ -13,7 +13,7 @@ type wgIfaceBase interface {
 	RemoveAllowedIP(peerKey string, allowedIP string) error
 
 	Name() string
-	Address() iface.WGAddress
+	Address() wgaddr.Address
 	ToInterface() *net.Interface
 	IsUserspaceBind() bool
 	GetFilter() device.PacketFilter


### PR DESCRIPTION
## Describe your changes

Candidates with an IP from the overlay network are never valid, hence we block it in the mux. Not blocking it in `OnCandidate` instead since this wouldn't catch `prflx` candidates.


## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
