### PR TITLE
[client] Prevent to block channel writing

### DIFF
--- a/client/server/server.go
+++ b/client/server/server.go
@@ -160,7 +160,7 @@ func (s *Server) Start() error {
 // mechanism to keep the client connected even when the connection is lost.
 // we cancel retry if the client receive a stop or down command, or if disable auto connect is configured.
 func (s *Server) connectWithRetryRuns(ctx context.Context, config *internal.Config, statusRecorder *peer.Status,
-	runningChan chan error,
+	runningChan chan struct{},
 ) {
 	backOff := getConnectWithBackoff(ctx)
 	retryStarted := false
@@ -628,20 +628,21 @@ func (s *Server) Up(callerCtx context.Context, _ *proto.UpRequest) (*proto.UpRes
 	s.statusRecorder.UpdateManagementAddress(s.config.ManagementURL.String())
 	s.statusRecorder.UpdateRosenpass(s.config.RosenpassEnabled, s.config.RosenpassPermissive)
 
-	runningChan := make(chan error)
-	go s.connectWithRetryRuns(ctx, s.config, s.statusRecorder, runningChan)
+	timeoutCtx, cancel := context.WithTimeout(callerCtx, 10*time.Second)
+	defer cancel()
 
+	runningChan := make(chan struct{}, 1) // buffered channel to do not lose the signal
+	go s.connectWithRetryRuns(ctx, s.config, s.statusRecorder, runningChan)
 	for {
 		select {
-		case err := <-runningChan:
-			if err != nil {
-				log.Debugf("waiting for engine to become ready failed: %s", err)
-			} else {
-				return &proto.UpResponse{}, nil
-			}
+		case <-runningChan:
+			return &proto.UpResponse{}, nil
 		case <-callerCtx.Done():
 			log.Debug("context done, stopping the wait for engine to become ready")
 			return nil, callerCtx.Err()
+		case <-timeoutCtx.Done():
+			log.Debug("up is timed out, stopping the wait for engine to become ready")
+			return nil, timeoutCtx.Err()
 		}
 	}
 }


### PR DESCRIPTION
## Describe your changes

The "runningChan" provides feedback to the UI or any client about whether the service is up and running. If the client exits earlier than when the service successfully starts, then this channel causes a block.

- Added timeout for reading the channel to ensure we don't cause blocks for too long for the caller
- Modified channel writing operations to be non-blocking

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
