### PR TITLE
[management] return empty array instead of null on networks endpoints

### DIFF
--- a/management/server/http/handlers/networks/handler.go
+++ b/management/server/http/handlers/networks/handler.go
@@ -289,7 +289,7 @@ func (h *handler) collectIDsInNetwork(ctx context.Context, accountID, userID, ne
 }
 
 func (h *handler) generateNetworkResponse(networks []*types.Network, routers map[string][]*routerTypes.NetworkRouter, resourceIDs map[string][]string, groups map[string]*nbtypes.Group, account *nbtypes.Account) []*api.Network {
-	networkResponse := make([]*api.Network, len(networks))
+	networkResponse := make([]*api.Network, 0, len(networks))
 	for _, network := range networks {
 		routerIDs, peerCounter := getRouterIDs(network, routers, groups)
 		policyIDs := account.GetPoliciesAppliedInNetwork(network.ID)

--- a/management/server/http/handlers/networks/handler.go
+++ b/management/server/http/handlers/networks/handler.go
@@ -289,7 +289,7 @@ func (h *handler) collectIDsInNetwork(ctx context.Context, accountID, userID, ne
 }
 
 func (h *handler) generateNetworkResponse(networks []*types.Network, routers map[string][]*routerTypes.NetworkRouter, resourceIDs map[string][]string, groups map[string]*nbtypes.Group, account *nbtypes.Account) []*api.Network {
-	var networkResponse []*api.Network
+	networkResponse := make([]*api.Network, len(networks))
 	for _, network := range networks {
 		routerIDs, peerCounter := getRouterIDs(network, routers, groups)
 		policyIDs := account.GetPoliciesAppliedInNetwork(network.ID)

--- a/management/server/http/handlers/networks/resources_handler.go
+++ b/management/server/http/handlers/networks/resources_handler.go
@@ -89,7 +89,7 @@ func (h *resourceHandler) getAllResourcesInAccount(w http.ResponseWriter, r *htt
 
 	grpsInfoMap := groups.ToGroupsInfoMap(grps, 0)
 
-	var resourcesResponse []*api.NetworkResource
+	resourcesResponse := make([]*api.NetworkResource, 0, len(resources))
 	for _, resource := range resources {
 		resourcesResponse = append(resourcesResponse, resource.ToAPIResponse(grpsInfoMap[resource.ID]))
 	}

--- a/management/server/http/handlers/networks/routers_handler.go
+++ b/management/server/http/handlers/networks/routers_handler.go
@@ -48,7 +48,7 @@ func (h *routersHandler) getAllRouters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var routersResponse []*api.NetworkRouter
+	routersResponse := make([]*api.NetworkRouter, 0, len(routers))
 	for _, router := range routers {
 		routersResponse = append(routersResponse, router.ToAPIResponse())
 	}


### PR DESCRIPTION
## Describe your changes
The network's endpoints were returning null when a GET request was run on 0 elements. This PR returns an empty array now to keep in sync with the responses of the other endpoints 

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
