### PR TITLE
[client] Fix Advanced Setting unable to open on Windows 11 with Chinese Locale Setting

### DIFF
--- a/client/ui/font_windows.go
+++ b/client/ui/font_windows.go
@@ -25,12 +25,12 @@ func (s *serviceClient) getWindowsFontFilePath() string {
 		fontFolder  = "C:/Windows/Fonts"
 		fontMapping = map[string]string{
 			"default":     "Segoeui.ttf",
-			"zh-CN":       "Msyh.ttc",
+			"zh-CN":       "Segoeui.ttf",
 			"am-ET":       "Ebrima.ttf",
 			"nirmala":     "Nirmala.ttf",
 			"chr-CHER-US": "Gadugi.ttf",
-			"zh-HK":       "Msjh.ttc",
-			"zh-TW":       "Msjh.ttc",
+			"zh-HK":       "Segoeui.ttf",
+			"zh-TW":       "Segoeui.ttf",
 			"ja-JP":       "Yugothm.ttc",
 			"km-KH":       "Leelawui.ttf",
 			"ko-KR":       "Malgun.ttf",


### PR DESCRIPTION
Fix #3345 and #2603

## Describe your changes
Fix Advanced Setting cannot open by reverting default font for Windows 10/11/2022 platform. 

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
