### PR TITLE
chore: remove duplicate labels for services.relay in docker-compose.y…

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl.traefik
+++ b/infrastructure_files/docker-compose.yml.tmpl.traefik
@@ -71,10 +71,6 @@ services:
     - NB_AUTH_SECRET=$NETBIRD_RELAY_AUTH_SECRET
     # ports:
     #   - $NETBIRD_RELAY_PORT:$NETBIRD_RELAY_PORT
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.netbird-relay.rule=Host(`$NETBIRD_DOMAIN`) && PathPrefix(`/relay`)
-    - traefik.http.services.netbird-relay.loadbalancer.server.port=33080
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
…ml.tmpl.traefik

## Describe your changes
Remove duplicate label section for services.relay in file infrastructure_files/docker-compose.yml.tmpl.traefik

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ x ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
