### PR TITLE
[management] Fix always enabling of NetworkResource in createResource()

### DIFF
--- a/management/server/http/handlers/networks/resources_handler.go
+++ b/management/server/http/handlers/networks/resources_handler.go
@@ -118,7 +118,6 @@ func (h *resourceHandler) createResource(w http.ResponseWriter, r *http.Request)
 
 	resource.NetworkID = mux.Vars(r)["networkId"]
 	resource.AccountID = accountID
-	resource.Enabled = true
 	resource, err = h.resourceManager.CreateResource(r.Context(), userID, resource)
 	if err != nil {
 		util.WriteError(r.Context(), err, w)


### PR DESCRIPTION
## Describe your changes
When creating a network resource, the "Enabled" field in the NetworkResourceRequest was forced to true, thus not respecting the requested state of the "Enabled" field. This PR removes the forced true state of the "Enabled" field.

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
