### PR TITLE
[management] Fix invalid port range sync

### DIFF
--- a/management/server/policy.go
+++ b/management/server/policy.go
@@ -262,7 +262,6 @@ func toProtocolFirewallRules(rules []*types.FirewallRule) []*proto.FirewallRule 
 			Action:    getProtoAction(rule.Action),
 			Protocol:  getProtoProtocol(rule.Protocol),
 			Port:      rule.Port,
-			PortInfo:  rule.PortRange.ToProto(),
 		}
 
 		if shouldUsePortRange(fwRule) {

--- a/management/server/policy.go
+++ b/management/server/policy.go
@@ -255,7 +255,7 @@ func toProtocolFirewallRules(rules []*types.FirewallRule) []*proto.FirewallRule 
 	for i := range rules {
 		rule := rules[i]
 
-		result[i] = &proto.FirewallRule{
+		fwRule := &proto.FirewallRule{
 			PolicyID:  []byte(rule.PolicyID),
 			PeerIP:    rule.PeerIP,
 			Direction: getProtoDirection(rule.Direction),
@@ -264,6 +264,16 @@ func toProtocolFirewallRules(rules []*types.FirewallRule) []*proto.FirewallRule 
 			Port:      rule.Port,
 			PortInfo:  rule.PortRange.ToProto(),
 		}
+
+		if shouldUsePortRange(fwRule) {
+			fwRule.PortInfo = rule.PortRange.ToProto()
+		}
+
+		result[i] = fwRule
 	}
 	return result
+}
+
+func shouldUsePortRange(rule *proto.FirewallRule) bool {
+	return rule.Port == "" && (rule.Protocol == proto.RuleProtocol_UDP || rule.Protocol == proto.RuleProtocol_TCP)
 }


### PR DESCRIPTION
## Describe your changes
We should not send port range when a port is set or when protocol is all or icmp

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
