### PR TITLE
[management] Sync account peers on network router group changes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: codespell
         uses: codespell-project/actions-codespell@v2
         with:
-          ignore_words_list: erro,clienta,hastable,iif,groupd,testin
+          ignore_words_list: erro,clienta,hastable,iif,groupd,testin,groupe
           skip: go.mod,go.sum
           only_warn: 1
   golangci:

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -6,18 +6,17 @@ import (
 	"fmt"
 	"slices"
 
-	routerTypes "github.com/netbirdio/netbird/management/server/networks/routers/types"
 	"github.com/rs/xid"
 	log "github.com/sirupsen/logrus"
 
 	nbdns "github.com/netbirdio/netbird/dns"
+	"github.com/netbirdio/netbird/management/server/activity"
+	routerTypes "github.com/netbirdio/netbird/management/server/networks/routers/types"
+	"github.com/netbirdio/netbird/management/server/status"
 	"github.com/netbirdio/netbird/management/server/store"
 	"github.com/netbirdio/netbird/management/server/types"
 	"github.com/netbirdio/netbird/management/server/util"
 	"github.com/netbirdio/netbird/route"
-
-	"github.com/netbirdio/netbird/management/server/activity"
-	"github.com/netbirdio/netbird/management/server/status"
 )
 
 type GroupLinkError struct {

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -499,6 +499,10 @@ func validateDeleteGroup(ctx context.Context, transaction store.Store, group *ty
 		return &GroupLinkError{"user", linkedUser.Id}
 	}
 
+	if isLinked, linkedRouter := isGroupLinkedToNetworkRouter(ctx, transaction, group.AccountID, group.ID); isLinked {
+		return &GroupLinkError{"network router", linkedRouter.ID}
+	}
+
 	return checkGroupLinkedToSettings(ctx, transaction, group)
 }
 

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 
+	routerTypes "github.com/netbirdio/netbird/management/server/networks/routers/types"
 	"github.com/rs/xid"
 	log "github.com/sirupsen/logrus"
 
@@ -613,6 +614,22 @@ func isGroupLinkedToUser(ctx context.Context, transaction store.Store, accountID
 	return false, nil
 }
 
+// isGroupLinkedToNetworkRouter checks if a group is linked to any network router in the account.
+func isGroupLinkedToNetworkRouter(ctx context.Context, transaction store.Store, accountID string, groupID string) (bool, *routerTypes.NetworkRouter) {
+	routers, err := transaction.GetNetworkRoutersByAccountID(ctx, store.LockingStrengthShare, accountID)
+	if err != nil {
+		log.WithContext(ctx).Errorf("error retrieving network routers while checking group linkage: %v", err)
+		return false, nil
+	}
+
+	for _, router := range routers {
+		if slices.Contains(router.PeerGroups, groupID) {
+			return true, router
+		}
+	}
+	return false, nil
+}
+
 // areGroupChangesAffectPeers checks if any changes to the specified groups will affect peers.
 func areGroupChangesAffectPeers(ctx context.Context, transaction store.Store, accountID string, groupIDs []string) (bool, error) {
 	if len(groupIDs) == 0 {
@@ -635,6 +652,9 @@ func areGroupChangesAffectPeers(ctx context.Context, transaction store.Store, ac
 			return true, nil
 		}
 		if linked, _ := isGroupLinkedToRoute(ctx, transaction, accountID, groupID); linked {
+			return true, nil
+		}
+		if linked, _ := isGroupLinkedToNetworkRouter(ctx, transaction, accountID, groupID); linked {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
## Describe your changes

- Updates account peers when a group linked to a network router is modified
- Prevents group deletion if it's still being used by any network router

## Issue ticket number and link

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
