### PR TITLE
[client] Use the netbird logger for ice and grpc

### DIFF
--- a/client/iface/bind/udp_mux.go
+++ b/client/iface/bind/udp_mux.go
@@ -150,7 +150,7 @@ func isZeros(ip net.IP) bool {
 // NewUDPMuxDefault creates an implementation of UDPMux
 func NewUDPMuxDefault(params UDPMuxParams) *UDPMuxDefault {
 	if params.Logger == nil {
-		params.Logger = logging.NewDefaultLoggerFactory().NewLogger("ice")
+		params.Logger = getLogger()
 	}
 
 	mux := &UDPMuxDefault{
@@ -454,4 +454,10 @@ func newBufferHolder(size int) *bufferHolder {
 	return &bufferHolder{
 		buf: make([]byte, size),
 	}
+}
+
+func getLogger() logging.LeveledLogger {
+	fac := logging.NewDefaultLoggerFactory()
+	fac.Writer = log.StandardLogger().Writer()
+	return fac.NewLogger("ice")
 }

--- a/client/iface/bind/udp_mux_universal.go
+++ b/client/iface/bind/udp_mux_universal.go
@@ -49,7 +49,7 @@ type UniversalUDPMuxParams struct {
 // NewUniversalUDPMuxDefault creates an implementation of UniversalUDPMux embedding UDPMux
 func NewUniversalUDPMuxDefault(params UniversalUDPMuxParams) *UniversalUDPMuxDefault {
 	if params.Logger == nil {
-		params.Logger = logging.NewDefaultLoggerFactory().NewLogger("ice")
+		params.Logger = getLogger()
 	}
 	if params.XORMappedAddrCacheTTL == 0 {
 		params.XORMappedAddrCacheTTL = time.Second * 25

--- a/client/internal/peer/ice/agent.go
+++ b/client/internal/peer/ice/agent.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/pion/ice/v3"
+	"github.com/pion/logging"
 	"github.com/pion/randutil"
 	log "github.com/sirupsen/logrus"
 
@@ -35,6 +36,9 @@ func NewAgent(iFaceDiscover stdnet.ExternalIFaceDiscover, config Config, candida
 		log.Errorf("failed to create pion's stdnet: %s", err)
 	}
 
+	fac := logging.NewDefaultLoggerFactory()
+	fac.Writer = log.StandardLogger().Writer()
+
 	agentConfig := &ice.AgentConfig{
 		MulticastDNSMode:       ice.MulticastDNSModeDisabled,
 		NetworkTypes:           []ice.NetworkType{ice.NetworkTypeUDP4, ice.NetworkTypeUDP6},
@@ -51,6 +55,7 @@ func NewAgent(iFaceDiscover stdnet.ExternalIFaceDiscover, config Config, candida
 		RelayAcceptanceMinWait: &iceRelayAcceptanceMinWait,
 		LocalUfrag:             ufrag,
 		LocalPwd:               pwd,
+		LoggerFactory:          fac,
 	}
 
 	if config.DisableIPv6Discovery {

--- a/formatter/hook/hook.go
+++ b/formatter/hook/hook.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"fmt"
 	"path"
+	"runtime"
 	"runtime/debug"
 	"strings"
 
@@ -40,8 +41,12 @@ func (hook ContextHook) Levels() []logrus.Level {
 
 // Fire extend with the source information the entry.Data
 func (hook ContextHook) Fire(entry *logrus.Entry) error {
-	src := hook.parseSrc(entry.Caller.File)
-	entry.Data[EntryKeySource] = fmt.Sprintf("%s:%v", src, entry.Caller.Line)
+	caller := &runtime.Frame{Line: 0, File: "caller_not_available"}
+	if entry.Caller != nil {
+		caller = entry.Caller
+	}
+	src := hook.parseSrc(caller.File)
+	entry.Data[EntryKeySource] = fmt.Sprintf("%s:%v", src, caller.Line)
 	additionalEntries(entry)
 
 	if entry.Context == nil {

--- a/util/log.go
+++ b/util/log.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/grpclog"
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/netbirdio/netbird/formatter"
@@ -48,7 +49,25 @@ func InitLog(logLevel string, logPath string) error {
 		formatter.SetTextFormatter(log.StandardLogger())
 	}
 	log.SetLevel(level)
+
+	setGRPCLibLogger()
+
 	return nil
+}
+
+func setGRPCLibLogger() {
+	logOut := log.StandardLogger().Writer()
+	if os.Getenv("GRPC_GO_LOG_SEVERITY_LEVEL") != "info" {
+		grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, logOut, logOut))
+	}
+
+	var v int
+	vLevel := os.Getenv("GRPC_GO_LOG_VERBOSITY_LEVEL")
+	if vl, err := strconv.Atoi(vLevel); err == nil {
+		v = vl
+	}
+
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2WithVerbosity(logOut, logOut, logOut, v))
 }
 
 func getLogMaxSize() int {

--- a/util/log.go
+++ b/util/log.go
@@ -59,6 +59,7 @@ func setGRPCLibLogger() {
 	logOut := log.StandardLogger().Writer()
 	if os.Getenv("GRPC_GO_LOG_SEVERITY_LEVEL") != "info" {
 		grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, logOut, logOut))
+		return
 	}
 
 	var v int


### PR DESCRIPTION
## Describe your changes
set default for hook when caller is not set

based on #3585

gRPC logs:
```
2025-03-29T16:05:30+01:00 INFO ./caller_not_available:0: 2025/03/29 16:05:30 INFO: [core] [Channel #3]Channel switches to new LB policy "pick_first"
2025-03-29T16:05:30+01:00 INFO ./caller_not_available:0: 2025/03/29 16:05:30 INFO: [core] [Channel #3 SubChannel #4]Subchannel created
```
ICE logs:
```
2025-03-29T16:07:28+01:00 INFO ./caller_not_available:0: ice WARNING: 2025/03/29 16:07:28 Discard message from (udp4 host 94.237.63.127:51820), unknown TransactionID 0x2aafb8441436fadf118fe929
2025-03-29T16:07:28+01:00 INFO ./caller_not_available:0: ice TRACE: 16:07:28.987802 agent.go:1105: Inbound STUN (Request) from 94.237.63.127:51820 to udp4 srflx 94.134.125.44:12343 related 0.0.0.0:51000, useCandidate: false
2025-03-29T16:07:28+01:00 INFO ./caller_not_available:0: ice TRACE: 16:07:28.988421 selection.go:133: Inbound STUN (SuccessResponse) from udp4 host 209.94.61.253:51820 to udp4 host 198.19.249.3:51000
```

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
