### PR TITLE
[misc] update gpt file permissions in install.sh

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -110,7 +110,7 @@ add_apt_repo() {
     | ${SUDO} gpg --dearmor -o /usr/share/keyrings/netbird-archive-keyring.gpg
 
     # Explicitly set the file permission
-    chmod 0644 /usr/share/keyrings/netbird-archive-keyring.gpg
+    ${SUDO} chmod 0644 /usr/share/keyrings/netbird-archive-keyring.gpg
 
     echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' \
     | ${SUDO} tee /etc/apt/sources.list.d/netbird.list

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -109,6 +109,9 @@ add_apt_repo() {
     curl -sSL https://pkgs.netbird.io/debian/public.key \
     | ${SUDO} gpg --dearmor -o /usr/share/keyrings/netbird-archive-keyring.gpg
 
+    # Explicitly set the file permission
+    chmod 0644 /usr/share/keyrings/netbird-archive-keyring.gpg
+
     echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' \
     | ${SUDO} tee /etc/apt/sources.list.d/netbird.list
 


### PR DESCRIPTION
Fix install.sh for some installations by explicitly setting the file permissions correctly.

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/1168

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
