### PR TITLE
[client] Ensure dst-type local marks can overwrite nat marks

### DIFF
--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -631,7 +631,9 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 		"-j", "MARK", "--set-mark", fmt.Sprintf("%#x", markValue),
 	)
 
-	if err := r.iptablesClient.Append(tableMangle, chainRTPRE, rule...); err != nil {
+	// Ensure nat rules come first, so the mark can be overwritten.
+	// Currently overwritten by the dst-type LOCAL rules for redirected traffic.
+	if err := r.iptablesClient.Insert(tableMangle, chainRTPRE, 1, rule...); err != nil {
 		// TODO: rollback ipset counter
 		return fmt.Errorf("error while adding marking rule for %s: %v", pair.Destination, err)
 	}

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -666,7 +666,9 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 		}
 	}
 
-	r.rules[ruleKey] = r.conn.AddRule(&nftables.Rule{
+	// Ensure nat rules come first, so the mark can be overwritten.
+	// Currently overwritten by the dst-type LOCAL rules for redirected traffic.
+	r.rules[ruleKey] = r.conn.InsertRule(&nftables.Rule{
 		Table:    r.workTable,
 		Chain:    r.chains[chainNameManglePrerouting],
 		Exprs:    exprs,


### PR DESCRIPTION
## Describe your changes

In some cases there is a conflict between to-be-masqueraded and to-be-redirected packets (e.g. by Docker). In that case we need to make sure the redirect mark is applied. So these rules always go last while nat rules always go first.


## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
