### PR TITLE
[client] Automatically start the connection if exclude list is changing

### DIFF
--- a/client/internal/conn_mgr.go
+++ b/client/internal/conn_mgr.go
@@ -95,7 +95,7 @@ func (e *ConnMgr) SetExcludeList(peerIDs []string) {
 		var peerConn *peer.Conn
 		var exists bool
 		if peerConn, exists = e.peerStore.PeerConn(peerID); !exists {
-			// if the peer not exist in the store, it means that the engine will call the AddPeerConn
+			// if the peer not exist in the store, it means that the engine will call the AddPeerConn in next step
 			continue
 		}
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -995,9 +995,6 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 		log.Errorf("failed to update forward rules, err: %v", err)
 	}
 
-	excludedLazyPeers := e.toExcludedLazyPeers(routes, forwardingRules, networkMap.GetRemotePeers())
-	e.connMgr.SetExcludeList(excludedLazyPeers)
-
 	log.Debugf("got peers update from Management Service, total peers to connect to = %d", len(networkMap.GetRemotePeers()))
 
 	e.updateOfflinePeers(networkMap.GetOfflinePeers())
@@ -1039,6 +1036,9 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 			}
 		}
 	}
+
+	excludedLazyPeers := e.toExcludedLazyPeers(routes, forwardingRules, networkMap.GetRemotePeers())
+	e.connMgr.SetExcludeList(excludedLazyPeers)
 
 	protoDNSConfig := networkMap.GetDNSConfig()
 	if protoDNSConfig == nil {
@@ -1245,12 +1245,12 @@ func (e *Engine) createPeerConn(pubKey string, allowedIPs []netip.Prefix, agentV
 	// randomize connection timeout
 	timeout := time.Duration(rand.Intn(PeerConnectionTimeoutMax-PeerConnectionTimeoutMin)+PeerConnectionTimeoutMin) * time.Millisecond
 	config := peer.ConnConfig{
-		Key:         pubKey,
-		LocalKey:    e.config.WgPrivateKey.PublicKey().String(),
-		AgentVersion:    agentVersion,
-		Timeout:     timeout,
-		WgConfig:    wgConfig,
-		LocalWgPort: e.config.WgPort,
+		Key:          pubKey,
+		LocalKey:     e.config.WgPrivateKey.PublicKey().String(),
+		AgentVersion: agentVersion,
+		Timeout:      timeout,
+		WgConfig:     wgConfig,
+		LocalWgPort:  e.config.WgPort,
 		RosenpassConfig: peer.RosenpassConfig{
 			PubKey:         e.getRosenpassPubKey(),
 			Addr:           e.getRosenpassAddr(),

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -995,6 +995,9 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 		log.Errorf("failed to update forward rules, err: %v", err)
 	}
 
+	excludedLazyPeers := e.toExcludedLazyPeers(routes, forwardingRules, networkMap.GetRemotePeers())
+	e.connMgr.SetExcludeList(excludedLazyPeers)
+
 	log.Debugf("got peers update from Management Service, total peers to connect to = %d", len(networkMap.GetRemotePeers()))
 
 	e.updateOfflinePeers(networkMap.GetOfflinePeers())
@@ -1036,9 +1039,6 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 			}
 		}
 	}
-
-	excludedLazyPeers := e.toExcludedLazyPeers(routes, forwardingRules, networkMap.GetRemotePeers())
-	e.connMgr.SetExcludeList(excludedLazyPeers)
 
 	protoDNSConfig := networkMap.GetDNSConfig()
 	if protoDNSConfig == nil {

--- a/client/internal/lazyconn/manager/manager.go
+++ b/client/internal/lazyconn/manager/manager.go
@@ -98,6 +98,10 @@ func (m *Manager) Start(ctx context.Context, activeFn func(peerID string), inact
 }
 
 // ExcludePeer marks peers for a permanent connection
+// It removes peers from the managed list if they are added to the exclude list
+// Adds them back to the managed list and start the inactivity listener if they are removed from the exclude list. In
+// this case, we suppose that the connection status is connected or connecting.
+// If the peer is not exists yet in the managed list then the responsibility is the upper layer to call the AddPeer function
 func (m *Manager) ExcludePeer(ctx context.Context, peerConfigs []lazyconn.PeerConfig) []string {
 	m.managedPeersMu.Lock()
 	defer m.managedPeersMu.Unlock()
@@ -106,7 +110,7 @@ func (m *Manager) ExcludePeer(ctx context.Context, peerConfigs []lazyconn.PeerCo
 	excludes := make(map[string]lazyconn.PeerConfig, len(peerConfigs))
 
 	for _, peerCfg := range peerConfigs {
-		log.Infof("update excluded peers from lazy connection: %s", peerCfg.PublicKey)
+		log.Infof("update excluded lazy connection list with peer: %s", peerCfg.PublicKey)
 		excludes[peerCfg.PublicKey] = peerCfg
 	}
 

--- a/client/internal/lazyconn/manager/manager.go
+++ b/client/internal/lazyconn/manager/manager.go
@@ -121,7 +121,7 @@ func (m *Manager) ExcludePeer(ctx context.Context, peerConfigs []lazyconn.PeerCo
 		}
 
 		added = append(added, pubKey)
-		peerCfg.Log.Infof("exclude peer from lazy connection managment")
+		peerCfg.Log.Infof("peer newly added to lazy connection exclude list")
 		m.removePeer(pubKey)
 	}
 
@@ -130,6 +130,8 @@ func (m *Manager) ExcludePeer(ctx context.Context, peerConfigs []lazyconn.PeerCo
 		if _, stillExcluded := excludes[pubKey]; stillExcluded {
 			continue
 		}
+
+		peerCfg.Log.Infof("peer removed from lazy connection exclude list")
 
 		if err := m.addActivePeer(ctx, peerCfg); err != nil {
 			log.Errorf("failed to add peer to lazy connection manager: %s", err)

--- a/client/internal/lazyconn/manager/manager.go
+++ b/client/internal/lazyconn/manager/manager.go
@@ -43,7 +43,7 @@ type Manager struct {
 	connStateListener    *dispatcher.ConnectionListener
 	managedPeers         map[string]*lazyconn.PeerConfig
 	managedPeersByConnID map[peerid.ConnID]*managedPeer
-	excludes             map[string]struct{}
+	excludes             map[string]lazyconn.PeerConfig
 	managedPeersMu       sync.Mutex
 
 	activityManager    *activity.Manager
@@ -60,7 +60,7 @@ func NewManager(config Config, wgIface lazyconn.WGIface, connStateDispatcher *di
 		inactivityThreshold:  inactivity.DefaultInactivityThreshold,
 		managedPeers:         make(map[string]*lazyconn.PeerConfig),
 		managedPeersByConnID: make(map[peerid.ConnID]*managedPeer),
-		excludes:             make(map[string]struct{}),
+		excludes:             make(map[string]lazyconn.PeerConfig),
 		activityManager:      activity.NewManager(wgIface),
 		inactivityMonitors:   make(map[peerid.ConnID]*inactivity.Monitor),
 		onInactive:           make(chan peerid.ConnID),
@@ -98,15 +98,43 @@ func (m *Manager) Start(ctx context.Context, activeFn func(peerID string), inact
 }
 
 // ExcludePeer marks peers for a permanent connection
-func (m *Manager) ExcludePeer(peerIDs []string) {
+func (m *Manager) ExcludePeer(ctx context.Context, peerConfigs []lazyconn.PeerConfig) []string {
 	m.managedPeersMu.Lock()
 	defer m.managedPeersMu.Unlock()
-	log.Infof("update excluded peers from lazy connection: %v", peerIDs)
 
-	m.excludes = make(map[string]struct{})
-	for _, peerID := range peerIDs {
-		m.excludes[peerID] = struct{}{}
+	added := make([]string, 0)
+	excludes := make(map[string]lazyconn.PeerConfig, len(peerConfigs))
+
+	for _, peerCfg := range peerConfigs {
+		log.Infof("update excluded peers from lazy connection: %s", peerCfg.PublicKey)
+		excludes[peerCfg.PublicKey] = peerCfg
 	}
+
+	// if a peer is newly added to the exclude list, remove from the managed peers list
+	for pubKey, peerCfg := range excludes {
+		if _, wasExcluded := m.excludes[pubKey]; wasExcluded {
+			continue
+		}
+
+		added = append(added, pubKey)
+		peerCfg.Log.Infof("exclude peer from lazy connection managment")
+		m.removePeer(pubKey)
+	}
+
+	// if a peer has been removed from exclude list then it should be added to the managed peers
+	for pubKey, peerCfg := range m.excludes {
+		if _, stillExcluded := excludes[pubKey]; stillExcluded {
+			continue
+		}
+
+		if err := m.addActivePeer(ctx, peerCfg); err != nil {
+			log.Errorf("failed to add peer to lazy connection manager: %s", err)
+			continue
+		}
+	}
+
+	m.excludes = excludes
+	return added
 }
 
 func (m *Manager) AddPeer(peerCfg lazyconn.PeerConfig) (bool, error) {
@@ -144,22 +172,7 @@ func (m *Manager) RemovePeer(peerID string) {
 	m.managedPeersMu.Lock()
 	defer m.managedPeersMu.Unlock()
 
-	cfg, ok := m.managedPeers[peerID]
-	if !ok {
-		return
-	}
-
-	cfg.Log.Infof("removing lazy peer")
-
-	if im, ok := m.inactivityMonitors[cfg.PeerConnID]; ok {
-		im.Stop()
-		delete(m.inactivityMonitors, cfg.PeerConnID)
-		cfg.Log.Debugf("inactivity monitor stopped")
-	}
-
-	m.activityManager.RemovePeer(cfg.Log, cfg.PeerConnID)
-	delete(m.managedPeers, peerID)
-	delete(m.managedPeersByConnID, cfg.PeerConnID)
+	m.removePeer(peerID)
 }
 
 // ActivatePeer activates a peer connection when a signal message is received
@@ -189,6 +202,45 @@ func (m *Manager) ActivatePeer(peerID string) (found bool) {
 	cfg.Log.Debugf("reset inactivity monitor timer")
 	m.inactivityMonitors[cfg.PeerConnID].ResetTimer()
 	return true
+}
+
+func (m *Manager) addActivePeer(ctx context.Context, peerCfg lazyconn.PeerConfig) error {
+	if _, ok := m.managedPeers[peerCfg.PublicKey]; ok {
+		peerCfg.Log.Warnf("peer already managed")
+		return nil
+	}
+
+	im := inactivity.NewInactivityMonitor(peerCfg.PeerConnID, m.inactivityThreshold)
+	m.inactivityMonitors[peerCfg.PeerConnID] = im
+
+	m.managedPeers[peerCfg.PublicKey] = &peerCfg
+	m.managedPeersByConnID[peerCfg.PeerConnID] = &managedPeer{
+		peerCfg:         &peerCfg,
+		expectedWatcher: watcherInactivity,
+	}
+
+	peerCfg.Log.Infof("starting inactivity monitor on peer that has been removed from exclude list")
+	go im.Start(ctx, m.onInactive)
+	return nil
+}
+
+func (m *Manager) removePeer(peerID string) {
+	cfg, ok := m.managedPeers[peerID]
+	if !ok {
+		return
+	}
+
+	cfg.Log.Infof("removing lazy peer")
+
+	if im, ok := m.inactivityMonitors[cfg.PeerConnID]; ok {
+		im.Stop()
+		delete(m.inactivityMonitors, cfg.PeerConnID)
+		cfg.Log.Debugf("inactivity monitor stopped")
+	}
+
+	m.activityManager.RemovePeer(cfg.Log, cfg.PeerConnID)
+	delete(m.managedPeers, peerID)
+	delete(m.managedPeersByConnID, cfg.PeerConnID)
 }
 
 func (m *Manager) close() {


### PR DESCRIPTION
## Describe your changes
Fix the exclude list handling. When the agent gets a new network map, it manages the changes in the excluded peers.

Cases:
- Extend the exclude list with a new peer: start permanent peer connection
- Remove a peer from the exclude list: we do not know the actual state of the peer connection, so we must suppose it is not in "**idle**". Start the `inactivity listener` for peer.
- If a peer is newly created in the management server and it will be in exclude list (i.e. it is a router) then the manager can not start the connection immediately because the `peer.Conn` is not exist yet. It is normal and the engine code will create the peer and start the connection in the next step.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
