### PR TITLE
Update install.sh - remove hardcoded google dns 8.8.8.8

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -72,7 +72,7 @@ download_release_binary() {
     if [ -n "$GITHUB_TOKEN" ]; then
       cd /tmp && curl -H  "Authorization: token ${GITHUB_TOKEN}" -LO "$DOWNLOAD_URL"
     else
-      cd /tmp && curl -LO "$DOWNLOAD_URL" || curl -LO --dns-servers 8.8.8.8 "$DOWNLOAD_URL"
+      cd /tmp && curl -LO "$DOWNLOAD_URL" || curl -LO "$DOWNLOAD_URL"
     fi
 
 


### PR DESCRIPTION
Enterprise environments may limit access to DNS to internal servers, allowing for centralized DNS monitoring and DNS security solutions. Hardcoding a google DNS server may fail in those environments.

Using the curl param does not seem necessary to me, but i may be wrong. Please check wether my patch introduces new problems

## Describe your changes

removing hard-coded dns server 8.8.8.8 from curl command

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
