### PR TITLE
[client] Add macOS .pkg installer support to installation script

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -209,9 +209,9 @@ install_pkg() {
 
   PKG_URL=$(curl -sIL -o /dev/null -w '%{url_effective}' "https://pkgs.netbird.io/macos/${ARCH}")
   echo "Downloading NetBird macOS installer from https://pkgs.netbird.io/macos/${ARCH}"
-  ${SUDO} curl -fsSL -o /tmp/netbird.pkg "${PKG_URL}"
+  curl -fsSL -o /tmp/netbird.pkg "${PKG_URL}"
   ${SUDO} installer -pkg /tmp/netbird.pkg -target /
-  ${SUDO} rm -f /tmp/netbird.pkg
+  rm -f /tmp/netbird.pkg
 }
 
 check_use_bin_variable() {

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -208,7 +208,7 @@ install_pkg() {
   esac
 
   PKG_URL=$(curl -sIL -o /dev/null -w '%{url_effective}' "https://pkgs.netbird.io/macos/${ARCH}")
-  echo "Downloading NetBird macOS installer from ${PKG_URL}"
+  echo "Downloading NetBird macOS installer from https://pkgs.netbird.io/macos/${ARCH}"
   ${SUDO} curl -fsSL -o /tmp/netbird.pkg "${PKG_URL}"
   ${SUDO} installer -pkg /tmp/netbird.pkg -target /
   ${SUDO} rm -f /tmp/netbird.pkg

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -337,7 +337,7 @@ install_netbird() {
     echo "package_manager=$PACKAGE_MANAGER" | ${SUDO} tee "$CONFIG_FILE" > /dev/null
 
     # Load and start netbird service
-    if [ "$PACKAGE_MANAGER" != "rpm-ostree" ]; then
+    if [ "$PACKAGE_MANAGER" != "rpm-ostree" ] && [ "$PACKAGE_MANAGER" != "pkg" ]; then
         if ! ${SUDO} netbird service install 2>&1; then
             echo "NetBird service has already been loaded"
         fi

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -199,6 +199,21 @@ install_native_binaries() {
     fi
 }
 
+# Handle macOS .pkg installer
+install_pkg() {
+  case "$(uname -m)" in
+    x86_64) ARCH="amd64" ;;
+    arm64|aarch64) ARCH="arm64" ;;
+    *) echo "Unsupported macOS arch: $(uname -m)" >&2; exit 1 ;;
+  esac
+
+  PKG_URL=$(curl -sIL -o /dev/null -w '%{url_effective}' "https://pkgs.netbird.io/macos/${ARCH}")
+  echo "Downloading NetBird macOS installer from ${PKG_URL}"
+  ${SUDO} curl -fsSL -o /tmp/netbird.pkg "${PKG_URL}"
+  ${SUDO} installer -pkg /tmp/netbird.pkg -target /
+  ${SUDO} rm -f /tmp/netbird.pkg
+}
+
 check_use_bin_variable() {
     if [ "${USE_BIN_INSTALL}-x" = "true-x" ]; then
       echo "The installation will be performed using binary files"
@@ -265,6 +280,16 @@ install_netbird() {
         ${SUDO} pacman -Syy
         add_aur_repo
     ;;
+    pkg)
+        # Check if the package is already installed
+        if [ -f /Library/Receipts/netbird.pkg ]; then
+            echo "NetBird is already installed. Please remove it before proceeding."
+            exit 1
+        fi
+
+        # Install the package
+        install_pkg
+    ;;
     brew)
         # Remove Netbird if it had been installed using Homebrew before
         if brew ls --versions netbird >/dev/null 2>&1; then
@@ -274,7 +299,7 @@ install_netbird() {
             netbird service stop
             netbird service uninstall
 
-            # Unlik the app
+            # Unlink the app
             brew unlink netbird
         fi
 
@@ -451,9 +476,8 @@ if type uname >/dev/null 2>&1; then
             # Check the availability of a compatible package manager
             if check_use_bin_variable; then
                 PACKAGE_MANAGER="bin"
-            elif [ -x "$(command -v brew)" ]; then
-                PACKAGE_MANAGER="brew"
-                echo "The installation will be performed using brew package manager"
+            else
+              PACKAGE_MANAGER="pkg"
             fi
 		;;
 	esac


### PR DESCRIPTION
## Describe your changes
[client] Add macOS .pkg installer support to installation script and use .pkg installer default
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
