### PR TITLE
Fix exclude list handling

### DIFF
--- a/client/internal/conn_mgr.go
+++ b/client/internal/conn_mgr.go
@@ -78,6 +78,7 @@ func (e *ConnMgr) SetExcludeList(peerIDs []string) {
 		var peerConn *peer.Conn
 		var exists bool
 		if peerConn, exists = e.peerStore.PeerConn(peerID); !exists {
+			log.Warnf("failed to find peer conn for peerID: %s", peerID)
 			continue
 		}
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -997,9 +997,6 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 		log.Errorf("failed to update forward rules, err: %v", err)
 	}
 
-	excludedLazyPeers := e.toExcludedLazyPeers(routes, forwardingRules, networkMap.GetRemotePeers())
-	e.connMgr.SetExcludeList(excludedLazyPeers)
-
 	log.Debugf("got peers update from Management Service, total peers to connect to = %d", len(networkMap.GetRemotePeers()))
 
 	e.updateOfflinePeers(networkMap.GetOfflinePeers())
@@ -1041,6 +1038,10 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 			}
 		}
 	}
+
+	// must set the exclude list after the peers are added. Without it the manager can not figure out the peers parameters from the store
+	excludedLazyPeers := e.toExcludedLazyPeers(routes, forwardingRules, networkMap.GetRemotePeers())
+	e.connMgr.SetExcludeList(excludedLazyPeers)
 
 	protoDNSConfig := networkMap.GetDNSConfig()
 	if protoDNSConfig == nil {


### PR DESCRIPTION
## Describe your changes

This is a chicken-and-egg problem. The exclude list depends on the peer store. So we must fill the peer store, and because of it, the engine creates the lazy activity listeners. Just in the next step, when we update the exclude list, update the connection to permanent state.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
