### PR TITLE
Feature/lazy connection fix inactivity

### DIFF
--- a/client/internal/conn_mgr.go
+++ b/client/internal/conn_mgr.go
@@ -175,7 +175,7 @@ func (e *ConnMgr) RemovePeerConn(peerKey string) {
 	conn.Log.Infof("removed peer from lazy conn manager")
 }
 
-func (e *ConnMgr) OnSignalMsg(peerKey string) (*peer.Conn, bool) {
+func (e *ConnMgr) OnSignalMsg(ctx context.Context, peerKey string) (*peer.Conn, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -188,7 +188,7 @@ func (e *ConnMgr) OnSignalMsg(peerKey string) (*peer.Conn, bool) {
 		return conn, true
 	}
 
-	if found := e.lazyConnMgr.ActivatePeer(peerKey); found {
+	if found := e.lazyConnMgr.ActivatePeer(ctx, peerKey); found {
 		conn.Log.Infof("activated peer from inactive state")
 		if err := conn.Open(e.ctx); err != nil {
 			conn.Log.Errorf("failed to open connection: %v", err)

--- a/client/internal/conn_mgr.go
+++ b/client/internal/conn_mgr.go
@@ -78,6 +78,7 @@ func (e *ConnMgr) SetExcludeList(peerIDs []string) {
 		var peerConn *peer.Conn
 		var exists bool
 		if peerConn, exists = e.peerStore.PeerConn(peerID); !exists {
+			log.Warnf("failed to find peer conn for peerID: %s", peerID)
 			continue
 		}
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -997,9 +997,6 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 		log.Errorf("failed to update forward rules, err: %v", err)
 	}
 
-	excludedLazyPeers := e.toExcludedLazyPeers(routes, forwardingRules, networkMap.GetRemotePeers())
-	e.connMgr.SetExcludeList(excludedLazyPeers)
-
 	log.Debugf("got peers update from Management Service, total peers to connect to = %d", len(networkMap.GetRemotePeers()))
 
 	e.updateOfflinePeers(networkMap.GetOfflinePeers())
@@ -1041,6 +1038,10 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 			}
 		}
 	}
+
+	// must set the exclude list after the peers are added. Without it the manager can not figure out the peers parameters from the store
+	excludedLazyPeers := e.toExcludedLazyPeers(routes, forwardingRules, networkMap.GetRemotePeers())
+	e.connMgr.SetExcludeList(excludedLazyPeers)
 
 	protoDNSConfig := networkMap.GetDNSConfig()
 	if protoDNSConfig == nil {

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1299,7 +1299,7 @@ func (e *Engine) receiveSignalEvents() {
 			e.syncMsgMux.Lock()
 			defer e.syncMsgMux.Unlock()
 
-			conn, ok := e.connMgr.OnSignalMsg(msg.Key)
+			conn, ok := e.connMgr.OnSignalMsg(e.ctx, msg.Key)
 			if !ok {
 				return fmt.Errorf("wrongly addressed message %s", msg.Key)
 			}

--- a/client/internal/lazyconn/inactivity/inactivity.go
+++ b/client/internal/lazyconn/inactivity/inactivity.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	DefaultInactivityThreshold = 60 * time.Minute // idle after 1 hour inactivity
+	MinimumInactivityThreshold = 3 * time.Minute
 )
 
 type Monitor struct {


### PR DESCRIPTION
## Describe your changes

- fix idle state managmenet
- Validate the threshold env variable

If the remote peer initiates the connection, we just reset the inactivity listener, but do not start it. As a result, after a disconnection, our peer never switches back to the idle state.

For every peer, we instantiate an inactivity listener. It is a reusable timer, but it must start on a go routine after it has been stopped. The key challenge is to ensure that we never start the timer multiple times and always clean it up properly when the peer is in the idle state or it has been set to the exclusion list.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
