### PR TITLE
[client, android] Do not propagate empty routes

### DIFF
--- a/client/internal/routemanager/notifier/notifier.go
+++ b/client/internal/routemanager/notifier/notifier.go
@@ -33,7 +33,7 @@ func (n *Notifier) SetInitialClientRoutes(clientRoutes []*route.Route) {
 	nets := make([]string, 0)
 	for _, r := range clientRoutes {
 		// filter out domain routes
-		if !r.Network.IsValid() {
+		if r.IsDynamic() {
 			continue
 		}
 		nets = append(nets, r.Network.String())

--- a/client/internal/routemanager/notifier/notifier.go
+++ b/client/internal/routemanager/notifier/notifier.go
@@ -32,6 +32,10 @@ func (n *Notifier) SetListener(listener listener.NetworkChangeListener) {
 func (n *Notifier) SetInitialClientRoutes(clientRoutes []*route.Route) {
 	nets := make([]string, 0)
 	for _, r := range clientRoutes {
+		// filter out domain routes
+		if !r.Network.IsValid() {
+			continue
+		}
 		nets = append(nets, r.Network.String())
 	}
 	sort.Strings(nets)


### PR DESCRIPTION
## Describe your changes

If we get domain routes the Network prefix variable in route structure will be invalid (engine.go:1057). When we handower to Android the routes, we must to filter out the domain routes. If we do not do it the Android code will get "invalid prefix" string as a route.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
