### PR TITLE
[client] Do not reconnect to mgm server in case of handler error

### DIFF
--- a/client/internal/netflow/manager.go
+++ b/client/internal/netflow/manager.go
@@ -123,10 +123,14 @@ func (m *Manager) disableFlow() error {
 
 	m.logger.Close()
 
-	if m.receiverClient != nil {
-		clientErr := m.receiverClient.Close()
-		m.receiverClient = nil
-		return clientErr
+	if m.receiverClient == nil {
+		return nil
+	}
+
+	err := m.receiverClient.Close()
+	m.receiverClient = nil
+	if err != nil {
+		return fmt.Errorf("close: %w", err)
 	}
 
 	return nil

--- a/client/internal/netflow/manager.go
+++ b/client/internal/netflow/manager.go
@@ -124,7 +124,9 @@ func (m *Manager) disableFlow() error {
 	m.logger.Close()
 
 	if m.receiverClient != nil {
-		return m.receiverClient.Close()
+		clientErr := m.receiverClient.Close()
+		m.receiverClient = nil
+		return clientErr
 	}
 
 	return nil

--- a/management/client/grpc.go
+++ b/management/client/grpc.go
@@ -260,8 +260,6 @@ func (c *GrpcClient) receiveEvents(stream proto.ManagementService_SyncClient, se
 
 		if err := msgHandler(decryptedResp); err != nil {
 			log.Errorf("failed handling an update message received from Management Service: %v", err.Error())
-			// hide any grpc error code that is not relevant for management
-			return fmt.Errorf("msg handler error: %v", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
## Describe your changes

- Do not reconnect to mgm server in case of handler error
- Set to nil the flow grpc client to prevent double close call

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
