### PR TITLE
[management/client/rest] Fix panic on unknown errors

### DIFF
--- a/management/client/rest/accounts_test.go
+++ b/management/client/rest/accounts_test.go
@@ -66,6 +66,15 @@ func TestAccounts_List_Err(t *testing.T) {
 	})
 }
 
+func TestAccounts_List_ConnErr(t *testing.T) {
+	withMockClient(func(c *rest.Client, mux *http.ServeMux) {
+		ret, err := c.Accounts.List(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+		assert.Empty(t, ret)
+	})
+}
+
 func TestAccounts_Update_200(t *testing.T) {
 	withMockClient(func(c *rest.Client, mux *http.ServeMux) {
 		mux.HandleFunc("/api/accounts/Test", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Describe your changes

Fixes panic when response has no body or body does not conform to `management/server/http/util.(ErrorResponse)`

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
