### PR TITLE
Remove connecting status filter from route manager

### DIFF
--- a/client/internal/routemanager/client.go
+++ b/client/internal/routemanager/client.go
@@ -232,7 +232,7 @@ func (c *clientNetwork) watchPeerStatusChanges(ctx context.Context, peerKey stri
 			return
 		case <-c.statusRecorder.GetPeerStateChangeNotifier(peerKey):
 			state, err := c.statusRecorder.GetPeer(peerKey)
-			if err != nil || state.ConnStatus == peer.StatusConnecting {
+			if err != nil {
 				continue
 			}
 			peerStateUpdate <- struct{}{}


### PR DESCRIPTION
Before lazy connection, when the peer disconnected, the status switched to disconnected.

After implementing lazy connection, the peer state is connecting, so we did not decrease the reference counters on the routes.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
