### PR TITLE
remove error causing dnf config-manager add

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -262,13 +262,6 @@ install_netbird() {
     ;;
     dnf)
         add_rpm_repo
-        ${SUDO} dnf -y install dnf-plugin-config-manager
-        if [[ "$(dnf --version | head -n1 | cut -d. -f1)" > "4" ]];
-        then
-          ${SUDO} dnf config-manager addrepo --from-repofile=/etc/yum.repos.d/netbird.repo
-        else
-          ${SUDO} dnf config-manager --add-repo /etc/yum.repos.d/netbird.repo
-        fi
         ${SUDO} dnf -y install netbird
 
         if ! $SKIP_UI_APP; then


### PR DESCRIPTION
## Describe your changes

This PR fixes the issue https://github.com/netbirdio/netbird/issues/3014.

`dnf config-manager` is useful for adding a remote  `repo` file but the `add_rpm_repo` function called on line 264 already writes the `repo` to the appropriate location and therefore when `dnf config-manager` is ran it raises an error stating that the repo already exists. This causes the script to stop and prevents the installation from completing. Users have found adding `--overwrite` to `dnf config-manager` works (https://github.com/netbirdio/netbird/issues/3014#issuecomment-2621112511) but this is unnecessary to begin with.

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/3014.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
