### PR TITLE
[client] Run registerdns before flushing

### DIFF
--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -45,9 +45,9 @@ const (
 	interfaceConfigSearchListKey = "SearchList"
 
 	// Network interface DNS registration settings
-	disableDynamicUpdateKey             = "DisableDynamicUpdate"
-	registrationEnabledKey              = "RegistrationEnabled"
-	maxNumberOfAddressesToRegisterKey   = "MaxNumberOfAddressesToRegister"
+	disableDynamicUpdateKey           = "DisableDynamicUpdate"
+	registrationEnabledKey            = "RegistrationEnabled"
+	maxNumberOfAddressesToRegisterKey = "MaxNumberOfAddressesToRegister"
 
 	// NetBIOS/WINS settings
 	netbtInterfacePath = `SYSTEM\CurrentControlSet\Services\NetBT\Parameters\Interfaces`
@@ -279,6 +279,7 @@ func (r *registryConfigurator) registerDNS() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
+	// nolint:misspell
 	cmd := exec.CommandContext(ctx, "ipconfig", "/registerdns")
 	out, err := cmd.CombinedOutput()
 
@@ -303,7 +304,7 @@ func (r *registryConfigurator) flushDNSCache() {
 	ret, _, err := dnsFlushResolverCacheFn.Call()
 	if ret == 0 {
 		if err != nil && !errors.Is(err, syscall.Errno(0)) {
-			log.Errorf("DnsFlushResolverCache failed: %w", err)
+			log.Errorf("DnsFlushResolverCache failed: %v", err)
 			return
 		}
 		log.Errorf("DnsFlushResolverCache failed")


### PR DESCRIPTION
## Describe your changes

- run ipconfig /registerdns before flushing
- disable WINS on the netbird interface
- disable "dynamic updates" and "registration enabled" on the interface

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
