### PR TITLE
Added regex-capabilities to process posture checks

### DIFF
--- a/management/server/posture/process.go
+++ b/management/server/posture/process.go
@@ -61,31 +61,27 @@ func (p *ProcessCheck) Validate() error {
 // It returns true if all processes are running, otherwise false.
 func (p *ProcessCheck) areAllProcessesRunning(activeProcesses []string, pathSelector func(Process) string) bool {
 	for _, process := range p.Processes {
-		pattern := pathSelector(process)
-		if pattern == "" {
-			return false
-		}
-
-		matched := false
-
-		if re, err := regexp.Compile(pattern); err == nil {
-			for _, ap := range activeProcesses {
-				if loc := re.FindStringIndex(ap); loc != nil && loc[0] == 0 && loc[1] == len(ap) {
-					matched = true
-					break
-				}
-			}
-		} else {
-			if slices.Contains(activeProcesses, pattern) {
-				matched = true
-			}
-		}
-
-		if !matched {
+		path := pathSelector(process)
+		if path == "" || !matchesProcess(path, activeProcesses) {
 			return false
 		}
 	}
 	return true
+}
+
+// matchesProcess checks for a given pattern to match against the list of processes
+// returns true if the posture-check is successful, otherwise false
+func matchesProcess(pattern string, processes []string) bool {
+	if re, err := regexp.Compile(pattern); err == nil {
+		for _, ap := range processes {
+			if loc := re.FindStringIndex(ap); loc != nil && loc[0] == 0 && loc[1] == len(ap) {
+				return true
+			}
+		}
+		return false
+	}
+
+	return slices.Contains(processes, pattern)
 }
 
 // extractPeerActiveProcesses extracts the paths of running processes from the peer meta.

--- a/management/server/posture/process_test.go
+++ b/management/server/posture/process_test.go
@@ -118,6 +118,26 @@ func TestProcessCheck_Check(t *testing.T) {
 			isValid: false,
 		},
 		{
+			name: "linux with regex processes",
+			input: peer.Peer{
+				Meta: peer.PeerSystemMeta{
+					GoOS: "linux",
+					Files: []peer.File{
+						{Path: "/usr/bin/proc1", ProcessIsRunning: true},
+						{Path: "/usr/bin/proc2", ProcessIsRunning: true},
+					},
+				},
+			},
+			check: ProcessCheck{
+				Processes: []Process{
+					{LinuxPath: "/usr/bin/proc[0-9]"},
+					{LinuxPath: "/usr/bin/proc2"},
+				},
+			},
+			wantErr: false,
+			isValid: true,
+		},
+		{
 			name: "linux with non-matching processes",
 			input: peer.Peer{
 				Meta: peer.PeerSystemMeta{
@@ -196,6 +216,24 @@ func TestProcessCheck_Check(t *testing.T) {
 			},
 			wantErr: false,
 			isValid: false,
+		},
+		{
+			name: "windows with regex processes",
+			input: peer.Peer{
+				Meta: peer.PeerSystemMeta{
+					GoOS: "windows",
+					Files: []peer.File{
+						{Path: "C:\\Program Files\\App\\proc.exe", ProcessIsRunning: true},
+					},
+				},
+			},
+			check: ProcessCheck{
+				Processes: []Process{
+					{WindowsPath: `C:\\Program Files\\.*\\proc\.exe`},
+				},
+			},
+			wantErr: false,
+			isValid: true,
 		},
 		{
 			name: "unsupported ios operating system",


### PR DESCRIPTION
## Describe your changes
This PR aims at giving more flexibility for process-type posture checks by allowing the users to use regex in the process path.

## Issue ticket number and link
Potentially also helps with https://github.com/netbirdio/netbird/issues/3760

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
