### PR TITLE
Set signal flags from environment variables

### DIFF
--- a/signal/cmd/env.go
+++ b/signal/cmd/env.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// setFlagsFromEnvVars reads and updates flag values from environment variables with prefix NB_
+func setFlagsFromEnvVars(cmd *cobra.Command) {
+	flags := cmd.PersistentFlags()
+	flags.VisitAll(func(f *pflag.Flag) {
+		newEnvVar := flagNameToEnvVar(f.Name, "NB_")
+		value, present := os.LookupEnv(newEnvVar)
+		if !present {
+			return
+		}
+
+		err := flags.Set(f.Name, value)
+		if err != nil {
+			log.Infof("unable to configure flag %s using variable %s, err: %v", f.Name, newEnvVar, err)
+		}
+	})
+}
+
+// flagNameToEnvVar converts flag name to environment var name adding a prefix,
+// replacing dashes and making all uppercase (e.g. setup-keys is converted to NB_SETUP_KEYS according to the input prefix)
+func flagNameToEnvVar(cmdFlag string, prefix string) string {
+	parsed := strings.ReplaceAll(cmdFlag, "-", "_")
+	upper := strings.ToUpper(parsed)
+	return prefix + upper
+}

--- a/signal/cmd/run.go
+++ b/signal/cmd/run.go
@@ -303,4 +303,5 @@ func init() {
 	runCmd.Flags().StringVar(&signalLetsencryptDomain, "letsencrypt-domain", "", "a domain to issue Let's Encrypt certificate for. Enables TLS using Let's Encrypt. Will fetch and renew certificate, and run the server with TLS")
 	runCmd.Flags().StringVar(&signalCertFile, "cert-file", "", "Location of your SSL certificate. Can be used when you have an existing certificate and don't want a new certificate be generated automatically. If letsencrypt-domain is specified this property has no effect")
 	runCmd.Flags().StringVar(&signalCertKey, "cert-key", "", "Location of your SSL certificate private key. Can be used when you have an existing certificate and don't want a new certificate be generated automatically. If letsencrypt-domain is specified this property has no effect")
+	setFlagsFromEnvVars(runCmd)
 }


### PR DESCRIPTION
## Describe your changes

Hello, I like the idea of being able to configure the services from an env file for the relay service (e.g `NB_LISTEN_PORT`), so I copied this to the relay service.

I did not test nor compile the code, just did what looked correct.

If it happens to be correct, I'll also do it with the other services (management).

Once merged, we should be able to go from:

``` yaml
  signal:
    image: netbirdio/signal:$NETBIRD_SIGNAL_TAG
    command: ["--letsencrypt-domain", "foo.com", "--ssl-dir", "/etc/letsencrypt"]
```

To:

``` yaml
  signal:
    image: netbirdio/signal:$NETBIRD_SIGNAL_TAG
    environment:
      NB_LETSENCRYPT_DOMAIN: foo.com
      NB_SSL_DIR: /etc/letsencrypt
```

Or better use an `env_file` and have better agnosticism in the docker-compose file.

## Issue ticket number and link

## Stack

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
