### PR TITLE
[client] Support wildcard DNS on iOS

### DIFF
--- a/client/internal/dns/upstream_android.go
+++ b/client/internal/dns/upstream_android.go
@@ -84,3 +84,10 @@ func (u *upstreamResolver) isLocalResolver(upstream string) bool {
 	}
 	return false
 }
+
+func GetClientPrivate(ip netip.Addr, interfaceName string, dialTimeout time.Duration) (*dns.Client, error) {
+	return &dns.Client{
+		Timeout: dialTimeout,
+		Net:     "udp",
+	}, nil
+}

--- a/client/internal/dns/upstream_general.go
+++ b/client/internal/dns/upstream_general.go
@@ -36,3 +36,10 @@ func newUpstreamResolver(
 func (u *upstreamResolver) exchange(ctx context.Context, upstream string, r *dns.Msg) (rm *dns.Msg, t time.Duration, err error) {
 	return ExchangeWithFallback(ctx, &dns.Client{}, r, upstream)
 }
+
+func GetClientPrivate(ip netip.Addr, interfaceName string, dialTimeout time.Duration) (*dns.Client, error) {
+	return &dns.Client{
+		Timeout: dialTimeout,
+		Net:     "udp",
+	}, nil
+}

--- a/client/internal/routemanager/client/client.go
+++ b/client/internal/routemanager/client/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"runtime"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -23,7 +22,7 @@ import (
 
 const (
 	handlerTypeDynamic = iota
-	handlerTypeDomain
+	handlerTypeDnsInterceptor
 	handlerTypeStatic
 )
 
@@ -566,13 +565,14 @@ func HandlerFromRoute(
 	useNewDNSRoute bool,
 ) RouteHandler {
 	switch handlerType(rt, useNewDNSRoute) {
-	case handlerTypeDomain:
+	case handlerTypeDnsInterceptor:
 		return dnsinterceptor.New(
 			rt,
 			routeRefCounter,
 			allowedIPsRefCounter,
 			statusRecorder,
 			dnsServer,
+			wgInterface,
 			peerStore,
 		)
 	case handlerTypeDynamic:
@@ -596,8 +596,8 @@ func handlerType(rt *route.Route, useNewDNSRoute bool) int {
 		return handlerTypeStatic
 	}
 
-	if useNewDNSRoute && runtime.GOOS != "ios" {
-		return handlerTypeDomain
+	if useNewDNSRoute {
+		return handlerTypeDnsInterceptor
 	}
 	return handlerTypeDynamic
 }


### PR DESCRIPTION
## Describe your changes

This makes iOS use the private dialer, which is required for dns traffic into the tunnel. DNS interceptor upstream traffic always is, so we use it unconditionally.
Addtionally, this switches the hardcoded old dns approach (pre-resolve) to depend on whatever setting is configured in the management.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
