### PR TITLE
[management] remove regex check from validateDomain()

### DIFF
--- a/management/server/nameserver.go
+++ b/management/server/nameserver.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"regexp"
 	"unicode/utf8"
 
 	"github.com/miekg/dns"
@@ -17,8 +16,6 @@ import (
 	"github.com/netbirdio/netbird/management/server/store"
 	"github.com/netbirdio/netbird/management/server/types"
 )
-
-const domainPattern = `^(?i)[a-z0-9]+([\-\.]{1}[a-z0-9]+)*[*.a-z]{1,}$`
 
 var invalidDomainName = errors.New("invalid domain name")
 
@@ -314,13 +311,7 @@ func validateGroups(list []string, groups map[string]*types.Group) error {
 	return nil
 }
 
-var domainMatcher = regexp.MustCompile(domainPattern)
-
 func validateDomain(domain string) error {
-	if !domainMatcher.MatchString(domain) {
-		return errors.New("domain should consists of only letters, numbers, and hyphens with no leading, trailing hyphens, or spaces")
-	}
-
 	_, valid := dns.IsDomainName(domain)
 	if !valid {
 		return invalidDomainName


### PR DESCRIPTION
The regex blocked labels that are allowed by rfc1035 like "x", "x1", "x--x" and possibly some more.

The regex check was also redundant because it is directly followed by dns.IsDomainName(domain)

## Describe your changes

I only removed the regex check from validateDomain().

This change still requires an update to management/server/nameserver_test.go because it tests for the too strict domain validation.

## Issue ticket number and link

#3996

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
