### PR TITLE
[management] Add backward compatibility for older clients without firewall rules port range support

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -92,7 +92,7 @@ func (am *DefaultAccountManager) getUserAccessiblePeers(ctx context.Context, acc
 
 	// fetch all the peers that have access to the user's peers
 	for _, peer := range peers {
-		aclPeers, _ := account.GetPeerConnectionResources(ctx, peer.ID, approvedPeersMap)
+		aclPeers, _ := account.GetPeerConnectionResources(ctx, peer, approvedPeersMap)
 		for _, p := range aclPeers {
 			peersMap[p.ID] = p
 		}
@@ -1149,7 +1149,7 @@ func (am *DefaultAccountManager) checkIfUserOwnsPeer(ctx context.Context, accoun
 	}
 
 	for _, p := range userPeers {
-		aclPeers, _ := account.GetPeerConnectionResources(ctx, p.ID, approvedPeersMap)
+		aclPeers, _ := account.GetPeerConnectionResources(ctx, p, approvedPeersMap)
 		for _, aclPeer := range aclPeers {
 			if aclPeer.ID == peer.ID {
 				return peer, nil

--- a/management/server/policy_test.go
+++ b/management/server/policy_test.go
@@ -411,69 +411,7 @@ func TestAccount_getPeersByPolicy(t *testing.T) {
 		peers, firewallRules := account.GetPeerConnectionResources(context.Background(), account.Peers["peerK"], validatedPeers)
 		assert.Len(t, peers, 1)
 		assert.Contains(t, peers, account.Peers["peerI"])
-
-		expectedFirewallRules := []*types.FirewallRule{
-			{
-				PeerIP:    "100.65.31.2",
-				Direction: types.FirewallRuleDirectionIN,
-				Action:    "accept",
-				Protocol:  "tcp",
-				Port:      "9090",
-				PolicyID:  "RuleWorkflow",
-			},
-			{
-				PeerIP:    "100.65.31.2",
-				Direction: types.FirewallRuleDirectionIN,
-				Action:    "accept",
-				Protocol:  "tcp",
-				Port:      "9091",
-				PolicyID:  "RuleWorkflow",
-			},
-			{
-				PeerIP:    "100.65.31.2",
-				Direction: types.FirewallRuleDirectionIN,
-				Action:    "accept",
-				Protocol:  "tcp",
-				Port:      "9092",
-				PolicyID:  "RuleWorkflow",
-			},
-			{
-				PeerIP:    "100.65.31.2",
-				Direction: types.FirewallRuleDirectionOUT,
-				Action:    "accept",
-				Protocol:  "tcp",
-				Port:      "9090",
-				PolicyID:  "RuleWorkflow",
-			},
-			{
-				PeerIP:    "100.65.31.2",
-				Direction: types.FirewallRuleDirectionOUT,
-				Action:    "accept",
-				Protocol:  "tcp",
-				Port:      "9091",
-				PolicyID:  "RuleWorkflow",
-			},
-			{
-				PeerIP:    "100.65.31.2",
-				Direction: types.FirewallRuleDirectionOUT,
-				Action:    "accept",
-				Protocol:  "tcp",
-				Port:      "9092",
-				PolicyID:  "RuleWorkflow",
-			},
-		}
-		assert.Len(t, firewallRules, len(expectedFirewallRules))
-
-		for _, rule := range firewallRules {
-			contains := false
-			for _, expectedRule := range expectedFirewallRules {
-				if rule.Equal(expectedRule) {
-					contains = true
-					break
-				}
-			}
-			assert.True(t, contains, "rule not found in expected rules %#v", rule)
-		}
+		assert.Len(t, firewallRules, 0)
 	})
 }
 

--- a/management/server/policy_test.go
+++ b/management/server/policy_test.go
@@ -27,6 +27,7 @@ func TestAccount_getPeersByPolicy(t *testing.T) {
 				ID:     "peerB",
 				IP:     net.ParseIP("100.65.80.39"),
 				Status: &nbpeer.PeerStatus{},
+				Meta:   nbpeer.PeerSystemMeta{WtVersion: "0.48.0"},
 			},
 			"peerC": {
 				ID:     "peerC",

--- a/management/server/policy_test.go
+++ b/management/server/policy_test.go
@@ -241,9 +241,13 @@ func TestAccount_getPeersByPolicy(t *testing.T) {
 
 	t.Run("check that all peers get map", func(t *testing.T) {
 		for _, p := range account.Peers {
+			if p.ID == "peerK" {
+				// skip peerK, it has no connections(old peer with no port range support)
+				continue
+			}
 			peers, firewallRules := account.GetPeerConnectionResources(context.Background(), p, validatedPeers)
-			assert.GreaterOrEqual(t, len(peers), 1, "minimum number peers should present")
-			assert.GreaterOrEqual(t, len(firewallRules), 1, "minimum number of firewall rules should present")
+			assert.GreaterOrEqual(t, len(peers), 2, "minimum number peers should present")
+			assert.GreaterOrEqual(t, len(firewallRules), 2, "minimum number of firewall rules should present")
 		}
 	})
 

--- a/management/server/posture/nb_version.go
+++ b/management/server/posture/nb_version.go
@@ -24,20 +24,12 @@ func sanitizeVersion(version string) string {
 }
 
 func (n *NBVersionCheck) Check(ctx context.Context, peer nbpeer.Peer) (bool, error) {
-	peerVersion := sanitizeVersion(peer.Meta.WtVersion)
-	minVersion := sanitizeVersion(n.MinVersion)
-
-	peerNBVersion, err := version.NewVersion(peerVersion)
+	meetsMin, err := MeetsMinVersion(n.MinVersion, peer.Meta.WtVersion)
 	if err != nil {
 		return false, err
 	}
 
-	constraints, err := version.NewConstraint(">= " + minVersion)
-	if err != nil {
-		return false, err
-	}
-
-	if constraints.Check(peerNBVersion) {
+	if meetsMin {
 		return true, nil
 	}
 
@@ -59,4 +51,22 @@ func (n *NBVersionCheck) Validate() error {
 		return fmt.Errorf("%s version: %s is not valid", n.Name(), n.MinVersion)
 	}
 	return nil
+}
+
+// MeetsMinVersion checks if the peer's version meets or exceeds the minimum required version
+func MeetsMinVersion(minVer, peerVer string) (bool, error) {
+	peerVer = sanitizeVersion(peerVer)
+	minVer = sanitizeVersion(minVer)
+
+	peerNBVersion, err := version.NewVersion(peerVer)
+	if err != nil {
+		return false, err
+	}
+
+	constraints, err := version.NewConstraint(">= " + minVer)
+	if err != nil {
+		return false, err
+	}
+
+	return constraints.Check(peerNBVersion), nil
 }

--- a/management/server/posture/nb_version.go
+++ b/management/server/posture/nb_version.go
@@ -58,7 +58,7 @@ func MeetsMinVersion(minVer, peerVer string) (bool, error) {
 	peerVer = sanitizeVersion(peerVer)
 	minVer = sanitizeVersion(minVer)
 
-	peerNBVersion, err := version.NewVersion(peerVer)
+	peerNBVer, err := version.NewVersion(peerVer)
 	if err != nil {
 		return false, err
 	}
@@ -68,5 +68,5 @@ func MeetsMinVersion(minVer, peerVer string) (bool, error) {
 		return false, err
 	}
 
-	return constraints.Check(peerNBVersion), nil
+	return constraints.Check(peerNBVer), nil
 }

--- a/management/server/posture/nb_version_test.go
+++ b/management/server/posture/nb_version_test.go
@@ -139,3 +139,68 @@ func TestNBVersionCheck_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestMeetsMinVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		minVer  string
+		peerVer string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "Peer version greater than min version",
+			minVer:  "0.26.0",
+			peerVer: "0.60.1",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "Peer version equals min version",
+			minVer:  "1.0.0",
+			peerVer: "1.0.0",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "Peer version less than min version",
+			minVer:  "1.0.0",
+			peerVer: "0.9.9",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "Peer version with pre-release tag greater than min version",
+			minVer:  "1.0.0",
+			peerVer: "1.0.1-alpha",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "Invalid peer version format",
+			minVer:  "1.0.0",
+			peerVer: "dev",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid min version format",
+			minVer:  "invalid.version",
+			peerVer: "1.0.0",
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MeetsMinVersion(tt.minVer, tt.peerVer)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -1598,17 +1598,11 @@ func expandPortsAndRanges(base FirewallRule, rule *PolicyRule, peer *nbpeer.Peer
 		return expanded
 	}
 
-	var peerSupportsPortRanges bool
-
-	meetMinVer, err := posture.MeetsMinVersion(firewallRuleMinPortRangesVer, peer.Meta.WtVersion)
-	if err == nil && meetMinVer {
-		peerSupportsPortRanges = true
-	}
-
+	supportPortRanges := peerSupportsPortRanges(peer.Meta.WtVersion)
 	for _, portRange := range rule.PortRanges {
 		fr := base
 
-		if peerSupportsPortRanges {
+		if supportPortRanges {
 			fr.PortRange = portRange
 		} else {
 			// Peer doesn't support port ranges, only allow single-port ranges
@@ -1621,4 +1615,14 @@ func expandPortsAndRanges(base FirewallRule, rule *PolicyRule, peer *nbpeer.Peer
 	}
 
 	return expanded
+}
+
+// peerSupportsPortRanges checks if the peer version supports port ranges.
+func peerSupportsPortRanges(peerVer string) bool {
+	if strings.Contains(peerVer, "dev") {
+		return true
+	}
+
+	meetMinVer, err := posture.MeetsMinVersion(firewallRuleMinPortRangesVer, peerVer)
+	return err == nil && meetMinVer
 }

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -1055,7 +1055,7 @@ func (a *Account) connResourcesGenerator(ctx context.Context, targetPeer *nbpeer
 					continue
 				}
 
-				rules = append(rules, expandPortsAndRanges(ctx, fr, rule, targetPeer)...)
+				rules = append(rules, expandPortsAndRanges(fr, rule, targetPeer)...)
 			}
 		}, func() ([]*nbpeer.Peer, []*FirewallRule) {
 			return peers, rules
@@ -1586,7 +1586,7 @@ func (a *Account) AddAllGroup() error {
 }
 
 // expandPortsAndRanges expands Ports and PortRanges of a rule into individual firewall rules
-func expandPortsAndRanges(ctx context.Context, base FirewallRule, rule *PolicyRule, peer *nbpeer.Peer) []*FirewallRule {
+func expandPortsAndRanges(base FirewallRule, rule *PolicyRule, peer *nbpeer.Peer) []*FirewallRule {
 	var expanded []*FirewallRule
 
 	if len(rule.Ports) > 0 {
@@ -1600,9 +1600,8 @@ func expandPortsAndRanges(ctx context.Context, base FirewallRule, rule *PolicyRu
 
 	var peerSupportsPortRanges bool
 
-	// skip processing the port ranges if the peer version doesn't support it
-	meetMin, err := posture.MeetsMinVersion(firewallRuleMinPortRangesVer, peer.Meta.WtVersion)
-	if err == nil && meetMin {
+	meetMinVer, err := posture.MeetsMinVersion(firewallRuleMinPortRangesVer, peer.Meta.WtVersion)
+	if err == nil && meetMinVer {
 		peerSupportsPortRanges = true
 	}
 
@@ -1618,7 +1617,6 @@ func expandPortsAndRanges(ctx context.Context, base FirewallRule, rule *PolicyRu
 			}
 			fr.Port = strconv.FormatUint(uint64(portRange.Start), 10)
 		}
-
 		expanded = append(expanded, &fr)
 	}
 

--- a/management/server/types/firewall_rule.go
+++ b/management/server/types/firewall_rule.go
@@ -76,7 +76,6 @@ func generateRouteFirewallRules(ctx context.Context, route *nbroute.Route, rule 
 		rules = append(rules, generateRulesWithPortRanges(baseRule, rule, rulesExists)...)
 	} else {
 		rules = append(rules, generateRulesWithPorts(ctx, baseRule, rule, rulesExists)...)
-
 	}
 
 	// TODO: generate IPv6 rules for dynamic routes


### PR DESCRIPTION
## Describe your changes

This PR adds backward compatibility for clients with versions prior to `v0.48.0` that do not support port range firewall rules. For these older clients, port ranges are expanded into individual ports during network map generation.


## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
