### PR TITLE
[client] Refactor showLoginURL to improve error handling and connection status checks

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -992,21 +992,6 @@ func (s *serviceClient) restartClient(loginRequest *proto.LoginRequest) error {
 // showLoginURL creates a borderless window styled like a pop-up in the top-right corner using s.wLoginURL.
 func (s *serviceClient) showLoginURL() {
 
-	resp, err := s.login(false)
-	if err != nil {
-		log.Errorf("failed to fetch login URL: %v", err)
-		return
-	}
-	verificationURL := resp.VerificationURIComplete
-	if verificationURL == "" {
-		verificationURL = resp.VerificationURI
-	}
-
-	if verificationURL == "" {
-		log.Error("no verification URL provided in the login response")
-		return
-	}
-
 	resIcon := fyne.NewStaticResource("netbird.png", iconAbout)
 
 	if s.wLoginURL == nil {
@@ -1025,6 +1010,21 @@ func (s *serviceClient) showLoginURL() {
 			return
 		}
 
+		resp, err := s.login(false)
+		if err != nil {
+			log.Errorf("failed to fetch login URL: %v", err)
+			return
+		}
+		verificationURL := resp.VerificationURIComplete
+		if verificationURL == "" {
+			verificationURL = resp.VerificationURI
+		}
+
+		if verificationURL == "" {
+			log.Error("no verification URL provided in the login response")
+			return
+		}
+
 		if err := openURL(verificationURL); err != nil {
 			log.Errorf("failed to open login URL: %v", err)
 			return
@@ -1038,7 +1038,19 @@ func (s *serviceClient) showLoginURL() {
 		}
 
 		label.SetText("Re-authentication successful.\nReconnecting")
-		time.Sleep(300 * time.Millisecond)
+		status, err := conn.Status(s.ctx, &proto.StatusRequest{})
+		if err != nil {
+			log.Errorf("get service status: %v", err)
+			return
+		}
+
+		if status.Status == string(internal.StatusConnected) {
+			label.SetText("Already connected.\nClosing this window.")
+			time.Sleep(2 * time.Second)
+			s.wLoginURL.Close()
+			return
+		}
+
 		_, err = conn.Up(s.ctx, &proto.UpRequest{})
 		if err != nil {
 			label.SetText("Reconnecting failed, please create \na debug bundle in the settings and contact support.")


### PR DESCRIPTION
## Describe your changes
This PR refactors showLoginURL to improve error handling and connection status checks by delaying the login fetch until user interaction and closing the pop-up if already connected.

- Moved s.login(false) call into the click handler to defer network I/O.
- Added a conn.Status check after opening the URL to skip reconnection if already connected.
- Enhanced error logs for missing verification URLs and service status failures.
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
