### PR TITLE
[client] close windows when process needs to exit

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -879,7 +879,7 @@ func (s *serviceClient) onUpdateAvailable() {
 func (s *serviceClient) onSessionExpire() {
 	s.sendNotification = true
 	if s.sendNotification {
-		s.eventHandler.runSelfCommand("login-url", "true")
+		s.eventHandler.runSelfCommand(s.ctx, "login-url", "true")
 		s.sendNotification = false
 	}
 }

--- a/client/ui/event_handler.go
+++ b/client/ui/event_handler.go
@@ -122,7 +122,7 @@ func (h *eventHandler) handleAdvancedSettingsClick() {
 	go func() {
 		defer h.client.mAdvancedSettings.Enable()
 		defer h.client.getSrvConfig()
-		h.runSelfCommand("settings", "true")
+		h.runSelfCommand(h.client.ctx, "settings", "true")
 	}()
 }
 
@@ -130,7 +130,7 @@ func (h *eventHandler) handleCreateDebugBundleClick() {
 	h.client.mCreateDebugBundle.Disable()
 	go func() {
 		defer h.client.mCreateDebugBundle.Enable()
-		h.runSelfCommand("debug", "true")
+		h.runSelfCommand(h.client.ctx, "debug", "true")
 	}()
 }
 
@@ -154,7 +154,7 @@ func (h *eventHandler) handleNetworksClick() {
 	h.client.mNetworks.Disable()
 	go func() {
 		defer h.client.mNetworks.Enable()
-		h.runSelfCommand("networks", "true")
+		h.runSelfCommand(h.client.ctx, "networks", "true")
 	}()
 }
 
@@ -172,14 +172,14 @@ func (h *eventHandler) updateConfigWithErr() {
 	}
 }
 
-func (h *eventHandler) runSelfCommand(command, arg string) {
+func (h *eventHandler) runSelfCommand(ctx context.Context, command, arg string) {
 	proc, err := os.Executable()
 	if err != nil {
 		log.Errorf("error getting executable path: %v", err)
 		return
 	}
 
-	cmd := exec.Command(proc,
+	cmd := exec.CommandContext(ctx, proc,
 		fmt.Sprintf("--%s=%s", command, arg),
 		fmt.Sprintf("--daemon-addr=%s", h.client.addr),
 	)


### PR DESCRIPTION

## Describe your changes
Use CommandContext to close advanced settings and re-authentication windows When the main GUI process exits

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
