### PR TITLE
[management] check and log on new management version

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -280,7 +280,7 @@ func newServiceClient(addr string, logFile string, a fyne.App, showSettings bool
 
 		showAdvancedSettings: showSettings,
 		showNetworks:         showNetworks,
-		update:               version.NewUpdate(),
+		update:               version.NewUpdate("nb/client-ui"),
 	}
 
 	s.eventHandler = newEventHandler(s)

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -357,6 +357,13 @@ var (
 			log.WithContext(ctx).Infof("running HTTP server and gRPC server on the same port: %s", listener.Addr().String())
 			serveGRPCWithHTTP(ctx, listener, rootHandler, tlsEnabled)
 
+			update := version.NewUpdate("nb/management")
+			update.SetDaemonVersion(version.NetbirdVersion())
+			update.SetOnUpdateListener(func() {
+				log.WithContext(ctx).Infof("your management version, \"%s\", is outdated, a new management version is available. Learn more here: https://github.com/netbirdio/netbird/releases", version.NetbirdVersion())
+			})
+			defer update.StopWatch()
+
 			SetupCloseHandler()
 
 			<-stopCh

--- a/version/update.go
+++ b/version/update.go
@@ -21,6 +21,7 @@ var (
 // Update fetch the version info periodically and notify the onUpdateListener in case the UI version or the
 // daemon version are deprecated
 type Update struct {
+	httpAgent       string
 	uiVersion       *goversion.Version
 	daemonVersion   *goversion.Version
 	latestAvailable *goversion.Version
@@ -34,7 +35,7 @@ type Update struct {
 }
 
 // NewUpdate instantiate Update and start to fetch the new version information
-func NewUpdate() *Update {
+func NewUpdate(httpAgent string) *Update {
 	currentVersion, err := goversion.NewVersion(version)
 	if err != nil {
 		currentVersion, _ = goversion.NewVersion("0.0.0")
@@ -43,6 +44,7 @@ func NewUpdate() *Update {
 	latestAvailable, _ := goversion.NewVersion("0.0.0")
 
 	u := &Update{
+		httpAgent:       httpAgent,
 		latestAvailable: latestAvailable,
 		uiVersion:       currentVersion,
 		fetchTicker:     time.NewTicker(fetchPeriod),
@@ -112,7 +114,15 @@ func (u *Update) startFetcher() {
 func (u *Update) fetchVersion() bool {
 	log.Debugf("fetching version info from %s", versionURL)
 
-	resp, err := http.Get(versionURL)
+	req, err := http.NewRequest("GET", versionURL, nil)
+	if err != nil {
+		log.Errorf("failed to create request for version info: %s", err)
+		return false
+	}
+
+	req.Header.Set("User-Agent", u.httpAgent)
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Errorf("failed to fetch version info: %s", err)
 		return false

--- a/version/update_test.go
+++ b/version/update_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const httpAgent = "pkg/test"
+
 func TestNewUpdate(t *testing.T) {
 	version = "1.0.0"
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +23,7 @@ func TestNewUpdate(t *testing.T) {
 	wg.Add(1)
 
 	onUpdate := false
-	u := NewUpdate()
+	u := NewUpdate(httpAgent)
 	defer u.StopWatch()
 	u.SetOnUpdateListener(func() {
 		onUpdate = true
@@ -46,7 +48,7 @@ func TestDoNotUpdate(t *testing.T) {
 	wg.Add(1)
 
 	onUpdate := false
-	u := NewUpdate()
+	u := NewUpdate(httpAgent)
 	defer u.StopWatch()
 	u.SetOnUpdateListener(func() {
 		onUpdate = true
@@ -71,7 +73,7 @@ func TestDaemonUpdate(t *testing.T) {
 	wg.Add(1)
 
 	onUpdate := false
-	u := NewUpdate()
+	u := NewUpdate(httpAgent)
 	defer u.StopWatch()
 	u.SetOnUpdateListener(func() {
 		onUpdate = true


### PR DESCRIPTION
## Describe your changes
This PR enhances the version checker to send a custom User-Agent header when polling for updates, and configures both the management CLI and client UI to use distinct agents. 

- NewUpdate now takes an `httpAgent` string to set the User-Agent header.
- `fetchVersion` builds a custom HTTP request (instead of `http.Get`) and sets the User-Agent.
- Management CLI and client UI now pass `"nb/management"` and `"nb/client-ui"` respectively to NewUpdate.
- Tests updated to supply an `httpAgent` constant.
- Logs if there is a new version available for management

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
