### PR TITLE
Env vars improvements

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -46,7 +46,9 @@ services:
       - $NETBIRD_SIGNAL_PORT:80
   #      # port and command for Let's Encrypt validation
   #      - 443:443
-  #    command: ["--letsencrypt-domain", "$NETBIRD_LETSENCRYPT_DOMAIN", "--log-file", "console"]
+    environment:
+      - NB_LETSENCRYPT_DOMAIN=$NETBIRD_LETSENCRYPT_DOMAIN
+      - NB_LOG_FILE=console
 
   # Relay
   relay:
@@ -73,19 +75,17 @@ services:
       - ./management.json:/etc/netbird/management.json
     ports:
       - $NETBIRD_MGMT_API_PORT:443 #API port
-  #    # command for Let's Encrypt validation without dashboard container
-  #    command: ["--letsencrypt-domain", "$NETBIRD_LETSENCRYPT_DOMAIN", "--log-file", "console"]
-    command: [
-      "--port", "443",
-      "--log-file", "console",
-      "--log-level", "info",
-      "--disable-anonymous-metrics=$NETBIRD_DISABLE_ANONYMOUS_METRICS",
-      "--single-account-mode-domain=$NETBIRD_MGMT_SINGLE_ACCOUNT_MODE_DOMAIN",
-      "--dns-domain=$NETBIRD_MGMT_DNS_DOMAIN"
-      ]
     environment:
+        # Let's Encrypt validation without dashboard container
+        # - NB_LETSENCRYPT_DOMAIN=$NETBIRD_LETSENCRYPT_DOMAIN
       - NETBIRD_STORE_ENGINE_POSTGRES_DSN=$NETBIRD_STORE_ENGINE_POSTGRES_DSN
       - NETBIRD_STORE_ENGINE_MYSQL_DSN=$NETBIRD_STORE_ENGINE_MYSQL_DSN
+      - NB_PORT=443
+      - NB_LOG_FILE=console
+      - NB_LOG_LEVEL=info
+      - NB_DISABLE_ANONYMOUS_METRICS=$NETBIRD_DISABLE_ANONYMOUS_METRICS
+      - NB_SINGLE_ACCOUNT_MODE_DOMAIN=$NETBIRD_MGMT_SINGLE_ACCOUNT_MODE_DOMAIN
+      - NB_DNS_DOMAIN=$NETBIRD_MGMT_DNS_DOMAIN
       
   # Coturn
   coturn:

--- a/infrastructure_files/docker-compose.yml.tmpl.traefik
+++ b/infrastructure_files/docker-compose.yml.tmpl.traefik
@@ -74,14 +74,6 @@ services:
       - $MGMT_VOLUMENAME:/var/lib/netbird
       - $LETSENCRYPT_VOLUMENAME:/etc/letsencrypt:ro
       - ./management.json:/etc/netbird/management.json
-    command: [
-      "--port", "33073",
-      "--log-file", "console",
-      "--log-level", "info",
-      "--disable-anonymous-metrics=$NETBIRD_DISABLE_ANONYMOUS_METRICS",
-      "--single-account-mode-domain=$NETBIRD_MGMT_SINGLE_ACCOUNT_MODE_DOMAIN",
-      "--dns-domain=$NETBIRD_MGMT_DNS_DOMAIN"
-      ]
     labels:
     - traefik.enable=true
     - traefik.http.routers.netbird-api.rule=Host(`$NETBIRD_DOMAIN`) && PathPrefix(`/api`)
@@ -95,6 +87,12 @@ services:
     environment:
       - NETBIRD_STORE_ENGINE_POSTGRES_DSN=$NETBIRD_STORE_ENGINE_POSTGRES_DSN
       - NETBIRD_STORE_ENGINE_MYSQL_DSN=$NETBIRD_STORE_ENGINE_MYSQL_DSN
+      - NB_PORT=33073
+      - NB_LOG_FILE=console
+      - NB_LOG_LEVEL=info
+      - NB_DISABLE_ANONYMOUS_METRICS=$NETBIRD_DISABLE_ANONYMOUS_METRICS
+      - NB_SINGLE_ACCOUNT_MODE_DOMAIN=$NETBIRD_MGMT_SINGLE_ACCOUNT_MODE_DOMAIN
+      - NB_DNS_DOMAIN=$NETBIRD_MGMT_DNS_DOMAIN
       
   # Coturn
   coturn:

--- a/management/cmd/env.go
+++ b/management/cmd/env.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// setFlagsFromEnvVars reads and updates flag values from environment variables with prefix NB_
+func setFlagsFromEnvVars(cmd *cobra.Command) {
+	processFlagSet(cmd.PersistentFlags())
+	processFlagSet(cmd.Flags())
+}
+
+func processFlagSet(flags *pflag.FlagSet) {
+	flags.VisitAll(func(f *pflag.Flag) {
+		newEnvVar := flagNameToEnvVar(f.Name, "NB_")
+		value, present := os.LookupEnv(newEnvVar)
+		if !present {
+			return
+		}
+
+		err := flags.Set(f.Name, value)
+		if err != nil {
+			log.Infof("unable to configure flag %s using variable %s, err: %v", f.Name, newEnvVar, err)
+		}
+	})
+}
+
+// flagNameToEnvVar converts flag name to environment var name adding a prefix,
+// replacing dashes and making all uppercase (e.g. setup-keys is converted to NB_SETUP_KEYS according to the input prefix)
+func flagNameToEnvVar(cmdFlag string, prefix string) string {
+	parsed := strings.ReplaceAll(cmdFlag, "-", "_")
+	upper := strings.ToUpper(parsed)
+	return prefix + upper
+}

--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -67,14 +67,17 @@ func init() {
 	mgmtCmd.Flags().BoolVar(&idpSignKeyRefreshEnabled, idpSignKeyRefreshEnabledFlagName, false, "Enable cache headers evaluation to determine signing key rotation period. This will refresh the signing key upon expiry.")
 	mgmtCmd.Flags().BoolVar(&userDeleteFromIDPEnabled, "user-delete-from-idp", false, "Allows to delete user from IDP when user is deleted from account")
 	mgmtCmd.Flags().BoolVar(&disableGeoliteUpdate, "disable-geolite-update", true, "disables automatic updates to the Geolite2 geolocation databases")
+	setFlagsFromEnvVars(mgmtCmd)
 	rootCmd.MarkFlagRequired("config") //nolint
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout")
+	setFlagsFromEnvVars(rootCmd)
 	rootCmd.AddCommand(mgmtCmd)
 
 	migrationCmd.PersistentFlags().StringVar(&mgmtDataDir, "datadir", defaultMgmtDataDir, "server data directory location")
 	migrationCmd.MarkFlagRequired("datadir") //nolint
+	setFlagsFromEnvVars(migrationCmd)
 
 	migrationCmd.AddCommand(upCmd)
 

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -1,4 +1,3 @@
 FROM gcr.io/distroless/base:debug
 ENTRYPOINT [ "/go/bin/netbird-relay" ]
-ENV NB_LOG_FILE=console
 COPY netbird-relay /go/bin/netbird-relay

--- a/signal/cmd/env.go
+++ b/signal/cmd/env.go
@@ -11,7 +11,11 @@ import (
 
 // setFlagsFromEnvVars reads and updates flag values from environment variables with prefix NB_
 func setFlagsFromEnvVars(cmd *cobra.Command) {
-	flags := cmd.PersistentFlags()
+	processFlagSet(cmd.PersistentFlags())
+	processFlagSet(cmd.Flags())
+}
+
+func processFlagSet(flags *pflag.FlagSet) {
 	flags.VisitAll(func(f *pflag.Flag) {
 		newEnvVar := flagNameToEnvVar(f.Name, "NB_")
 		value, present := os.LookupEnv(newEnvVar)

--- a/signal/cmd/root.go
+++ b/signal/cmd/root.go
@@ -48,6 +48,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout")
+	setFlagsFromEnvVars(rootCmd)
 	rootCmd.AddCommand(runCmd)
 }
 


### PR DESCRIPTION
## Describe your changes

- Fixes issues introduced by #3972 (only applied to persistent flags and not all flags).
- Adds env var supports to management service.
- Updates docker compose templates to use env vars.
- Remove redundant "console" flag in relay.

Please verify the commit that adds env vars to management, I didn't test it.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
