### PR TITLE
install.sh: fix arch install error with empty temporary dependencies

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -154,8 +154,10 @@ add_aur_repo() {
         cd netbird-ui && makepkg -sri --noconfirm
     fi
 
-    # Clean up the installed packages
-    ${SUDO} pacman -Rs "$REMOVE_PKGS" --noconfirm
+    if [ -n "$REMOVE_PKGS" ]; then
+      # Clean up the installed packages
+      ${SUDO} pacman -Rs "$REMOVE_PKGS" --noconfirm
+    fi
 }
 
 prepare_tun_module() {


### PR DESCRIPTION
Used to print:
    (3/3) Updating the desktop file MIME type cache...
    [sudo] password for XXXX:
    error: target not found:
