### PR TITLE
[client] Support random wireguard port on client

### DIFF
--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -319,10 +319,6 @@ func (config *Config) apply(input ConfigInput) (updated bool, err error) {
 			*input.WireguardPort, config.WgPort)
 		config.WgPort = *input.WireguardPort
 		updated = true
-	} else if config.WgPort == 0 {
-		config.WgPort = iface.DefaultWgPort
-		log.Infof("using default Wireguard port %d", config.WgPort)
-		updated = true
 	}
 
 	if input.InterfaceName != nil && *input.InterfaceName != config.WgIface {

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -525,14 +525,13 @@ func statusRecorderToSignalConnStateNotifier(statusRecorder *peer.Status) signal
 
 // freePort attempts to determine if the provided port is available, if not it will ask the system for a free port.
 func freePort(initPort int) (int, error) {
-	addr := net.UDPAddr{}
-
-	addr.Port = initPort
+	addr := net.UDPAddr{Port: initPort}
 
 	conn, err := net.ListenUDP("udp", &addr)
 	if err == nil {
+		returnPort := conn.LocalAddr().(*net.UDPAddr).Port
 		closeConnWithLog(conn)
-		return initPort, nil
+		return returnPort, nil
 	}
 
 	// if the port is already in use, ask the system for a free port

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
 
-	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/device"
 	"github.com/netbirdio/netbird/client/internal/dns"
 	"github.com/netbirdio/netbird/client/internal/listener"
@@ -527,9 +526,6 @@ func statusRecorderToSignalConnStateNotifier(statusRecorder *peer.Status) signal
 // freePort attempts to determine if the provided port is available, if not it will ask the system for a free port.
 func freePort(initPort int) (int, error) {
 	addr := net.UDPAddr{}
-	if initPort == 0 {
-		initPort = iface.DefaultWgPort
-	}
 
 	addr.Port = initPort
 

--- a/client/internal/connect_test.go
+++ b/client/internal/connect_test.go
@@ -13,10 +13,10 @@ func Test_freePort(t *testing.T) {
 		shouldMatch bool
 	}{
 		{
-			name:        "not provided, fallback to default",
+			name:        "when port is 0 use random port",
 			port:        0,
-			want:        51820,
-			shouldMatch: true,
+			want:        0,
+			shouldMatch: false,
 		},
 		{
 			name:        "provided and available",
@@ -31,13 +31,21 @@ func Test_freePort(t *testing.T) {
 			shouldMatch: false,
 		},
 	}
-	c1, err := net.ListenUDP("udp", &net.UDPAddr{Port: 51830})
+	c1, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
 	if err != nil {
 		t.Errorf("freePort error = %v", err)
 	}
 	defer func(c1 *net.UDPConn) {
 		_ = c1.Close()
 	}(c1)
+
+	if tests[1].port == c1.LocalAddr().(*net.UDPAddr).Port {
+		tests[1].port++
+		tests[1].want++
+	}
+
+	tests[2].port = c1.LocalAddr().(*net.UDPAddr).Port
+	tests[2].want = c1.LocalAddr().(*net.UDPAddr).Port
 
 	for _, tt := range tests {
 


### PR DESCRIPTION
## Describe your changes

Support for random WireGuard ports has been added. You can now run:
```shell
netbird up --wireguard-port 0
```
to let the system automatically select a random available port.

This option can be helpful when running multiple devices in some NATed networks to achieve P2P connections. 

Note: When upgrading from clients older than [v0.25.4](https://github.com/netbirdio/netbird/releases/tag/v0.25.4), the WireGuard connection port will be replaced with a randomly assigned port.



## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
