### PR TITLE
Fix: JWT Token Processing Uses Too Much Memory in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cunicu.li/go-rosenpass v0.4.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudflare/circl v1.3.3 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** golang-jwt/jwt: jwt-go allows excessive memory allocation during header parsing
- **Rule ID:** CVE-2025-30204-go.mod
- **Severity:** HIGH
- **File:** go.mod
- **Lines Affected:** None - None

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `go.mod` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.