### PR TITLE
[management] provide clear error message about mismatched logins

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -838,7 +838,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 		if login.UserID != "" {
 			if peer.UserID != login.UserID {
 				log.Warnf("user mismatch when logging in peer %s: peer user %s, login user %s ", peer.ID, peer.UserID, login.UserID)
-				return status.Errorf(status.Unauthenticated, "invalid user")
+				return status.NewPeerLoginMismatchError()
 			}
 
 			changed, err := am.handleUserPeer(ctx, transaction, peer, settings)
@@ -1087,7 +1087,7 @@ func checkAuth(ctx context.Context, loginUserID string, peer *nbpeer.Peer) error
 	}
 	if peer.UserID != loginUserID {
 		log.WithContext(ctx).Warnf("user mismatch when logging in peer %s: peer user %s, login user %s ", peer.ID, peer.UserID, loginUserID)
-		return status.Errorf(status.Unauthenticated, "can't login with this credentials")
+		return status.NewPeerLoginMismatchError()
 	}
 	return nil
 }

--- a/management/server/status/error.go
+++ b/management/server/status/error.go
@@ -105,9 +105,14 @@ func NewUserBlockedError() error {
 	return Errorf(PermissionDenied, "user is blocked")
 }
 
-// NewPeerNotRegisteredError creates a new Error with NotFound type for a missing peer
+// NewPeerNotRegisteredError creates a new Error with Unauthenticated type unregistered peer
 func NewPeerNotRegisteredError() error {
 	return Errorf(Unauthenticated, "peer is not registered")
+}
+
+// NewPeerLoginMismatchError creates a new Error with Unauthenticated type for a peer that is already registered for another user
+func NewPeerLoginMismatchError() error {
+	return Errorf(Unauthenticated, "peer is already registered by a different User or a Setup Key")
 }
 
 // NewPeerLoginExpiredError creates a new Error with PermissionDenied type for an expired peer


### PR DESCRIPTION
## Describe your changes

management: replace `invalid user` with a clear error message about mismatched logins

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
