### PR TITLE
[client] client: container: support CLI with entrypoint addition

### DIFF
--- a/.dockerignore-client
+++ b/.dockerignore-client
@@ -1,0 +1,3 @@
+*
+!client/netbird-entrypoint.sh
+!netbird

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ infrastructure_files/setup-*.env
 .vscode
 .DS_Store
 vendor/
+/netbird

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -155,13 +155,15 @@ dockers:
     goarch: amd64
     use: buildx
     dockerfile: client/Dockerfile
+    extra_files:
+      - client/netbird-entrypoint.sh
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://github.com/netbirdio/{{.ProjectName}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
       - netbirdio/netbird:{{ .Version }}-arm64v8
@@ -171,6 +173,8 @@ dockers:
     goarch: arm64
     use: buildx
     dockerfile: client/Dockerfile
+    extra_files:
+      - client/netbird-entrypoint.sh
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -188,6 +192,8 @@ dockers:
     goarm: 6
     use: buildx
     dockerfile: client/Dockerfile
+    extra_files:
+      - client/netbird-entrypoint.sh
     build_flag_templates:
       - "--platform=linux/arm"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -205,6 +211,8 @@ dockers:
     goarch: amd64
     use: buildx
     dockerfile: client/Dockerfile-rootless
+    extra_files:
+      - client/netbird-entrypoint.sh
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -221,6 +229,8 @@ dockers:
     goarch: arm64
     use: buildx
     dockerfile: client/Dockerfile-rootless
+    extra_files:
+      - client/netbird-entrypoint.sh
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -238,6 +248,8 @@ dockers:
     goarm: 6
     use: buildx
     dockerfile: client/Dockerfile-rootless
+    extra_files:
+      - client/netbird-entrypoint.sh
     build_flag_templates:
       - "--platform=linux/arm"
       - "--label=org.opencontainers.image.created={{.Date}}"

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,5 +1,0 @@
-*
-!Dockerfile
-!Dockerfile-rootless
-!netbird
-!netbird-entrypoint.sh

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,5 @@
+*
+!Dockerfile
+!Dockerfile-rootless
+!netbird
+!netbird-entrypoint.sh

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,1 @@
+/netbird

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,1 +1,0 @@
-/netbird

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,8 @@
-# build locally with:
+# build & run locally with:
 #   cd "$(git rev-parse --show-toplevel)"
 #   CGO_ENABLED=0 go build -o netbird ./client
-#   podman build -t localhost/netbird:latest -f client/Dockerfile --ignorefile .dockerignore-client .
+#   sudo podman build -t localhost/netbird:latest -f client/Dockerfile --ignorefile .dockerignore-client .
+#   sudo podman run --rm -it --cap-add={BPF,NET_ADMIN,NET_RAW} localhost/netbird:latest
 
 FROM alpine:3.22.0
 # iproute2: busybox doesn't display ip rules properly

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,9 +1,22 @@
-FROM alpine:3.21.3
+FROM alpine:3.22.0
 # iproute2: busybox doesn't display ip rules properly
-RUN apk add --no-cache ca-certificates ip6tables iproute2 iptables
+RUN apk add --no-cache \
+    bash \
+    ca-certificates \
+    ip6tables \
+    iproute2 \
+    iptables
+
+ENV \
+    NETBIRD_BIN="/usr/local/bin/netbird" \
+    NB_LOG_FILE="/var/log/netbird/client.log" \
+    NB_DAEMON_ADDR="unix:///var/run/netbird.sock" \
+    NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
+    NB_ENTRYPOINT_LOGIN_TIMEOUT="1" \
+    NB_ENTRYPOINT_TAIL_LOG_FILE="1"
+
+ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 
 ARG NETBIRD_BINARY=netbird
-COPY ${NETBIRD_BINARY} /usr/local/bin/netbird
-
-ENV NB_FOREGROUND_MODE=true
-ENTRYPOINT [ "/usr/local/bin/netbird","up"]
+COPY netbird-entrypoint.sh /usr/local/bin/netbird-entrypoint.sh
+COPY "${NETBIRD_BINARY}"  /usr/local/bin/netbird

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
 
 ENV \
     NETBIRD_BIN="/usr/local/bin/netbird" \
-    NB_LOG_FILE="/var/log/netbird/client.log" \
+    NB_LOG_FILE="console:/var/log/netbird/client.log" \
     NB_DAEMON_ADDR="unix:///var/run/netbird.sock" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
     NB_ENTRYPOINT_LOGIN_TIMEOUT="1"

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
 
 ENV \
     NETBIRD_BIN="/usr/local/bin/netbird" \
-    NB_LOG_FILE="console:/var/log/netbird/client.log" \
+    NB_LOG_FILE="console,/var/log/netbird/client.log" \
     NB_DAEMON_ADDR="unix:///var/run/netbird.sock" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
     NB_ENTRYPOINT_LOGIN_TIMEOUT="1"

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,3 +1,8 @@
+# build locally with:
+#   cd "$(git rev-parse --show-toplevel)"
+#   CGO_ENABLED=0 go build -o netbird ./client
+#   podman build -t localhost/netbird:latest -f client/Dockerfile --ignorefile .dockerignore-client .
+
 FROM alpine:3.22.0
 # iproute2: busybox doesn't display ip rules properly
 RUN apk add --no-cache \

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -13,7 +13,7 @@ ENV \
     NB_DAEMON_ADDR="unix:///var/run/netbird.sock" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
     NB_ENTRYPOINT_LOGIN_TIMEOUT="1" \
-    NB_ENTRYPOINT_TAIL_LOG_FILE="1"
+    NB_ENTRYPOINT_TAIL_LOG_FILE="true"
 
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,5 +18,5 @@ ENV \
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 
 ARG NETBIRD_BINARY=netbird
-COPY netbird-entrypoint.sh /usr/local/bin/netbird-entrypoint.sh
+COPY client/netbird-entrypoint.sh /usr/local/bin/netbird-entrypoint.sh
 COPY "${NETBIRD_BINARY}"  /usr/local/bin/netbird

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,8 +18,7 @@ ENV \
     NB_LOG_FILE="/var/log/netbird/client.log" \
     NB_DAEMON_ADDR="unix:///var/run/netbird.sock" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
-    NB_ENTRYPOINT_LOGIN_TIMEOUT="1" \
-    NB_ENTRYPOINT_TAIL_LOG_FILE="true"
+    NB_ENTRYPOINT_LOGIN_TIMEOUT="1"
 
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 

--- a/client/Dockerfile-rootless
+++ b/client/Dockerfile-rootless
@@ -1,18 +1,28 @@
-FROM alpine:3.21.0
+FROM alpine:3.22.0
 
-ARG NETBIRD_BINARY=netbird
-COPY ${NETBIRD_BINARY} /usr/local/bin/netbird
-
-RUN apk add --no-cache ca-certificates \
+RUN apk add --no-cache \
+      bash \
+      ca-certificates \
     && adduser -D -h /var/lib/netbird netbird
+
 WORKDIR /var/lib/netbird
 USER netbird:netbird
 
-ENV NB_FOREGROUND_MODE=true
-ENV NB_USE_NETSTACK_MODE=true
-ENV NB_ENABLE_NETSTACK_LOCAL_FORWARDING=true
-ENV NB_CONFIG=config.json
-ENV NB_DAEMON_ADDR=unix://netbird.sock
-ENV NB_DISABLE_DNS=true
+ENV \
+    NETBIRD_BIN="/usr/local/bin/netbird" \
+    NB_USE_NETSTACK_MODE="true" \
+    NB_ENABLE_NETSTACK_LOCAL_FORWARDING="true" \
+    NB_CONFIG="/var/lib/netbird/config.json" \
+    NB_STATE_DIR="/var/lib/netbird" \
+    NB_DAEMON_ADDR="unix:///var/lib/netbird/netbird.sock" \
+    NB_LOG_FILE="/var/lib/netbird/client.log" \
+    NB_DISABLE_DNS="true" \
+    NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
+    NB_ENTRYPOINT_LOGIN_TIMEOUT="1" \
+    NB_ENTRYPOINT_TAIL_LOG_FILE="1"
 
-ENTRYPOINT [ "/usr/local/bin/netbird", "up" ]
+ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
+
+ARG NETBIRD_BINARY=netbird
+COPY netbird-entrypoint.sh /usr/local/bin/netbird-entrypoint.sh
+COPY "${NETBIRD_BINARY}"  /usr/local/bin/netbird

--- a/client/Dockerfile-rootless
+++ b/client/Dockerfile-rootless
@@ -24,5 +24,5 @@ ENV \
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 
 ARG NETBIRD_BINARY=netbird
-COPY netbird-entrypoint.sh /usr/local/bin/netbird-entrypoint.sh
+COPY client/netbird-entrypoint.sh /usr/local/bin/netbird-entrypoint.sh
 COPY "${NETBIRD_BINARY}"  /usr/local/bin/netbird

--- a/client/Dockerfile-rootless
+++ b/client/Dockerfile-rootless
@@ -1,3 +1,8 @@
+# build locally with:
+#   cd "$(git rev-parse --show-toplevel)"
+#   CGO_ENABLED=0 go build -o netbird ./client
+#   podman build -t localhost/netbird:latest -f client/Dockerfile --ignorefile .dockerignore-client .
+
 FROM alpine:3.22.0
 
 RUN apk add --no-cache \

--- a/client/Dockerfile-rootless
+++ b/client/Dockerfile-rootless
@@ -24,8 +24,7 @@ ENV \
     NB_LOG_FILE="/var/lib/netbird/client.log" \
     NB_DISABLE_DNS="true" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
-    NB_ENTRYPOINT_LOGIN_TIMEOUT="1" \
-    NB_ENTRYPOINT_TAIL_LOG_FILE="true"
+    NB_ENTRYPOINT_LOGIN_TIMEOUT="1"
 
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 

--- a/client/Dockerfile-rootless
+++ b/client/Dockerfile-rootless
@@ -1,7 +1,8 @@
-# build locally with:
+# build & run locally with:
 #   cd "$(git rev-parse --show-toplevel)"
 #   CGO_ENABLED=0 go build -o netbird ./client
 #   podman build -t localhost/netbird:latest -f client/Dockerfile --ignorefile .dockerignore-client .
+#   podman run --rm -it --cap-add={BPF,NET_ADMIN,NET_RAW} localhost/netbird:latest
 
 FROM alpine:3.22.0
 

--- a/client/Dockerfile-rootless
+++ b/client/Dockerfile-rootless
@@ -21,7 +21,7 @@ ENV \
     NB_CONFIG="/var/lib/netbird/config.json" \
     NB_STATE_DIR="/var/lib/netbird" \
     NB_DAEMON_ADDR="unix:///var/lib/netbird/netbird.sock" \
-    NB_LOG_FILE="/var/lib/netbird/client.log" \
+    NB_LOG_FILE="console:/var/lib/netbird/client.log" \
     NB_DISABLE_DNS="true" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
     NB_ENTRYPOINT_LOGIN_TIMEOUT="1"

--- a/client/Dockerfile-rootless
+++ b/client/Dockerfile-rootless
@@ -19,7 +19,7 @@ ENV \
     NB_DISABLE_DNS="true" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
     NB_ENTRYPOINT_LOGIN_TIMEOUT="1" \
-    NB_ENTRYPOINT_TAIL_LOG_FILE="1"
+    NB_ENTRYPOINT_TAIL_LOG_FILE="true"
 
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 

--- a/client/Dockerfile-rootless
+++ b/client/Dockerfile-rootless
@@ -21,7 +21,7 @@ ENV \
     NB_CONFIG="/var/lib/netbird/config.json" \
     NB_STATE_DIR="/var/lib/netbird" \
     NB_DAEMON_ADDR="unix:///var/lib/netbird/netbird.sock" \
-    NB_LOG_FILE="console:/var/lib/netbird/client.log" \
+    NB_LOG_FILE="console,/var/lib/netbird/client.log" \
     NB_DISABLE_DNS="true" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
     NB_ENTRYPOINT_LOGIN_TIMEOUT="1"

--- a/client/cmd/down.go
+++ b/client/cmd/down.go
@@ -20,7 +20,7 @@ var downCmd = &cobra.Command{
 
 		cmd.SetOut(cmd.OutOrStdout())
 
-		err := util.InitLog(logLevel, "console")
+		err := util.InitLog(logLevel, util.LogConsole)
 		if err != nil {
 			log.Errorf("failed initializing log %v", err)
 			return err

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -50,7 +50,7 @@ var loginCmd = &cobra.Command{
 		}
 
 		// workaround to run without service
-		if util.FindFirstLogPath(logFiles) == "" {
+		if util.FindFirstLogPath(logFiles...) == "" {
 			err = handleRebrand(cmd)
 			if err != nil {
 				return err

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -50,7 +50,7 @@ var loginCmd = &cobra.Command{
 		}
 
 		// workaround to run without service
-		if util.FindFirstLogPath(logFiles...) == "" {
+		if util.FindFirstLogPath(logFiles) == "" {
 			err = handleRebrand(cmd)
 			if err != nil {
 				return err

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -32,7 +32,7 @@ var loginCmd = &cobra.Command{
 
 		cmd.SetOut(cmd.OutOrStdout())
 
-		err := util.InitLog(logLevel, "console")
+		err := util.InitLog(logLevel, util.LogConsole)
 		if err != nil {
 			return fmt.Errorf("failed initializing log %v", err)
 		}
@@ -50,7 +50,7 @@ var loginCmd = &cobra.Command{
 		}
 
 		// workaround to run without service
-		if logFile == "console" {
+		if util.FindFirstLogPath(logFiles) == "" {
 			err = handleRebrand(cmd)
 			if err != nil {
 				return err

--- a/client/cmd/login_test.go
+++ b/client/cmd/login_test.go
@@ -21,7 +21,7 @@ func TestLogin(t *testing.T) {
 		"--config",
 		confPath,
 		"--log-file",
-		"console",
+		util.LogConsole,
 		"--setup-key",
 		strings.ToUpper("a2c8e62b-38f5-4553-b31e-dd66c696cebb"),
 		"--management-url",

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -120,7 +120,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&adminURL, "admin-url", "", fmt.Sprintf("Admin Panel URL [http|https]://[host]:[port] (default \"%s\")", internal.DefaultAdminURL))
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", defaultConfigPath, "Netbird config file location")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "sets Netbird log level")
-	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout. If syslog is specified the log will be sent to syslog daemon.")
+	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout. If syslog is specified the log will be sent to syslog daemon. You can separate multiple entries by `:` character")
 	rootCmd.PersistentFlags().StringVarP(&setupKey, "setup-key", "k", "", "Setup key obtained from the Management Service Dashboard (used to register peer)")
 	rootCmd.PersistentFlags().StringVar(&setupKeyPath, "setup-key-file", "", "The path to a setup key obtained from the Management Service Dashboard (used to register peer) This is ignored if the setup-key flag is provided.")
 	rootCmd.MarkFlagsMutuallyExclusive("setup-key", "setup-key-file")

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path"
 	"runtime"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -51,7 +52,7 @@ var (
 	defaultLogFile          string
 	oldDefaultLogFileDir    string
 	oldDefaultLogFile       string
-	logFile                 string
+	logFiles                []string
 	daemonAddr              string
 	managementURL           string
 	adminURL                string
@@ -120,7 +121,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&adminURL, "admin-url", "", fmt.Sprintf("Admin Panel URL [http|https]://[host]:[port] (default \"%s\")", internal.DefaultAdminURL))
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", defaultConfigPath, "Netbird config file location")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "sets Netbird log level")
-	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", defaultLogFile, "sets Netbird log path. If console is specified the log will be output to stdout. If syslog is specified the log will be sent to syslog daemon. You can separate multiple entries by `:` character")
+	rootCmd.PersistentFlags().StringSliceVar(&logFiles, "log-file", []string{defaultLogFile}, "sets Netbird log paths written to simultaneously. If `console` is specified the log will be output to stdout. If `syslog` is specified the log will be sent to syslog daemon. You can pass the flag multiple times or separate entries by `,` character")
 	rootCmd.PersistentFlags().StringVarP(&setupKey, "setup-key", "k", "", "Setup key obtained from the Management Service Dashboard (used to register peer)")
 	rootCmd.PersistentFlags().StringVar(&setupKeyPath, "setup-key-file", "", "The path to a setup key obtained from the Management Service Dashboard (used to register peer) This is ignored if the setup-key flag is provided.")
 	rootCmd.MarkFlagsMutuallyExclusive("setup-key", "setup-key-file")
@@ -265,7 +266,7 @@ func getSetupKeyFromFile(setupKeyPath string) (string, error) {
 
 func handleRebrand(cmd *cobra.Command) error {
 	var err error
-	if logFile == defaultLogFile {
+	if slices.Contains(logFiles, defaultLogFile) {
 		if migrateToNetbird(oldDefaultLogFile, defaultLogFile) {
 			cmd.Printf("will copy Log dir %s and its content to %s\n", oldDefaultLogFileDir, defaultLogFileDir)
 			err = cpDir(oldDefaultLogFileDir, defaultLogFileDir)

--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -61,7 +61,7 @@ func (p *program) Start(svc service.Service) error {
 			}
 		}
 
-		serverInstance := server.New(p.ctx, configPath, logFile)
+		serverInstance := server.New(p.ctx, configPath, util.FindFirstLogPath(logFiles))
 		if err := serverInstance.Start(); err != nil {
 			log.Fatalf("failed to start daemon: %v", err)
 		}
@@ -136,7 +136,7 @@ var runCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(cmd.Context())
 
 		SetupCloseHandler(ctx, cancel)
-		SetupDebugHandler(ctx, nil, nil, nil, logFile)
+		SetupDebugHandler(ctx, nil, nil, nil, util.FindFirstLogPath(logFiles))
 
 		s, err := setupServiceControlCommand(cmd, ctx, cancel)
 		if err != nil {

--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -61,7 +61,7 @@ func (p *program) Start(svc service.Service) error {
 			}
 		}
 
-		serverInstance := server.New(p.ctx, configPath, util.FindFirstLogPath(logFiles...))
+		serverInstance := server.New(p.ctx, configPath, util.FindFirstLogPath(logFiles))
 		if err := serverInstance.Start(); err != nil {
 			log.Fatalf("failed to start daemon: %v", err)
 		}
@@ -136,7 +136,7 @@ var runCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(cmd.Context())
 
 		SetupCloseHandler(ctx, cancel)
-		SetupDebugHandler(ctx, nil, nil, nil, util.FindFirstLogPath(logFiles...))
+		SetupDebugHandler(ctx, nil, nil, nil, util.FindFirstLogPath(logFiles))
 
 		s, err := setupServiceControlCommand(cmd, ctx, cancel)
 		if err != nil {

--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -112,7 +112,7 @@ func setupServiceControlCommand(cmd *cobra.Command, ctx context.Context, cancel 
 		return nil, err
 	}
 
-	if err := util.InitLog(logLevel, logFile); err != nil {
+	if err := util.InitLog(logLevel, logFiles...); err != nil {
 		return nil, fmt.Errorf("init log: %w", err)
 	}
 

--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -61,7 +61,7 @@ func (p *program) Start(svc service.Service) error {
 			}
 		}
 
-		serverInstance := server.New(p.ctx, configPath, util.FindFirstLogPath(logFiles))
+		serverInstance := server.New(p.ctx, configPath, util.FindFirstLogPath(logFiles...))
 		if err := serverInstance.Start(); err != nil {
 			log.Fatalf("failed to start daemon: %v", err)
 		}
@@ -136,7 +136,7 @@ var runCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(cmd.Context())
 
 		SetupCloseHandler(ctx, cancel)
-		SetupDebugHandler(ctx, nil, nil, nil, util.FindFirstLogPath(logFiles))
+		SetupDebugHandler(ctx, nil, nil, nil, util.FindFirstLogPath(logFiles...))
 
 		s, err := setupServiceControlCommand(cmd, ctx, cancel)
 		if err != nil {

--- a/client/cmd/service_installer.go
+++ b/client/cmd/service_installer.go
@@ -56,7 +56,7 @@ func configurePlatformSpecificSettings(svcConfig *service.Config) error {
 		// Respected only by systemd systems
 		svcConfig.Dependencies = []string{"After=network.target syslog.target"}
 
-		if logFile := util.FindFirstLogPath(logFiles); logFile != "" {
+		if logFile := util.FindFirstLogPath(logFiles...); logFile != "" {
 			setStdLogPath := true
 			dir := filepath.Dir(logFile)
 

--- a/client/cmd/service_installer.go
+++ b/client/cmd/service_installer.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/kardianos/service"
 	"github.com/spf13/cobra"
+
+	"github.com/netbirdio/netbird/util"
 )
 
 var ErrGetServiceStatus = fmt.Errorf("failed to get service status")
@@ -41,7 +43,7 @@ func buildServiceArguments() []string {
 		args = append(args, "--management-url", managementURL)
 	}
 
-	if logFile != "" {
+	for _, logFile := range logFiles {
 		args = append(args, "--log-file", logFile)
 	}
 
@@ -54,7 +56,7 @@ func configurePlatformSpecificSettings(svcConfig *service.Config) error {
 		// Respected only by systemd systems
 		svcConfig.Dependencies = []string{"After=network.target syslog.target"}
 
-		if logFile != "console" {
+		if logFile := util.FindFirstLogPath(logFiles); logFile != "" {
 			setStdLogPath := true
 			dir := filepath.Dir(logFile)
 

--- a/client/cmd/service_installer.go
+++ b/client/cmd/service_installer.go
@@ -56,7 +56,7 @@ func configurePlatformSpecificSettings(svcConfig *service.Config) error {
 		// Respected only by systemd systems
 		svcConfig.Dependencies = []string{"After=network.target syslog.target"}
 
-		if logFile := util.FindFirstLogPath(logFiles...); logFile != "" {
+		if logFile := util.FindFirstLogPath(logFiles); logFile != "" {
 			setStdLogPath := true
 			dir := filepath.Dir(logFile)
 

--- a/client/cmd/ssh.go
+++ b/client/cmd/ssh.go
@@ -46,7 +46,7 @@ var sshCmd = &cobra.Command{
 
 		cmd.SetOut(cmd.OutOrStdout())
 
-		err := util.InitLog(logLevel, "console")
+		err := util.InitLog(logLevel, util.LogConsole)
 		if err != nil {
 			return fmt.Errorf("failed initializing log %v", err)
 		}

--- a/client/cmd/status.go
+++ b/client/cmd/status.go
@@ -59,7 +59,7 @@ func statusFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = util.InitLog(logLevel, "console")
+	err = util.InitLog(logLevel, util.LogConsole)
 	if err != nil {
 		return fmt.Errorf("failed initializing log %v", err)
 	}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -79,7 +79,7 @@ func upFunc(cmd *cobra.Command, args []string) error {
 
 	cmd.SetOut(cmd.OutOrStdout())
 
-	err := util.InitLog(logLevel, "console")
+	err := util.InitLog(logLevel, util.LogConsole)
 	if err != nil {
 		return fmt.Errorf("failed initializing log %v", err)
 	}
@@ -484,7 +484,7 @@ func parseCustomDNSAddress(modified bool) ([]byte, error) {
 		if !isValidAddrPort(customDNSAddress) {
 			return nil, fmt.Errorf("%s is invalid, it should be formatted as IP:Port string or as an empty string like \"\"", customDNSAddress)
 		}
-		if customDNSAddress == "" && logFile != "console" {
+		if customDNSAddress == "" && util.FindFirstLogPath(logFiles) != "" {
 			parsed = []byte("empty")
 		} else {
 			parsed = []byte(customDNSAddress)

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -484,7 +484,7 @@ func parseCustomDNSAddress(modified bool) ([]byte, error) {
 		if !isValidAddrPort(customDNSAddress) {
 			return nil, fmt.Errorf("%s is invalid, it should be formatted as IP:Port string or as an empty string like \"\"", customDNSAddress)
 		}
-		if customDNSAddress == "" && util.FindFirstLogPath(logFiles...) != "" {
+		if customDNSAddress == "" && util.FindFirstLogPath(logFiles) != "" {
 			parsed = []byte("empty")
 		} else {
 			parsed = []byte(customDNSAddress)

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -484,7 +484,7 @@ func parseCustomDNSAddress(modified bool) ([]byte, error) {
 		if !isValidAddrPort(customDNSAddress) {
 			return nil, fmt.Errorf("%s is invalid, it should be formatted as IP:Port string or as an empty string like \"\"", customDNSAddress)
 		}
-		if customDNSAddress == "" && util.FindFirstLogPath(logFiles) != "" {
+		if customDNSAddress == "" && util.FindFirstLogPath(logFiles...) != "" {
 			parsed = []byte("empty")
 		} else {
 			parsed = []byte(customDNSAddress)

--- a/client/iface/wgproxy/proxy_test.go
+++ b/client/iface/wgproxy/proxy_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	_ = util.InitLog("trace", "console")
+	_ = util.InitLog("trace", util.LogConsole)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/client/internal/debug/debug.go
+++ b/client/internal/debug/debug.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -28,6 +29,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/statemanager"
 	mgmProto "github.com/netbirdio/netbird/management/proto"
+	"github.com/netbirdio/netbird/util"
 )
 
 const readmeContent = `Netbird debug bundle
@@ -283,7 +285,7 @@ func (g *BundleGenerator) createArchive() error {
 		log.Errorf("Failed to add wg show output: %v", err)
 	}
 
-	if g.logFile != "console" && g.logFile != "" {
+	if g.logFile != "" && !slices.Contains(util.SpecialLogs, g.logFile) {
 		if err := g.addLogfile(); err != nil {
 			log.Errorf("Failed to add log file to debug bundle: %v", err)
 			if err := g.trySystemdLogFallback(); err != nil {

--- a/client/internal/dns/file_repair_unix_test.go
+++ b/client/internal/dns/file_repair_unix_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	_ = util.InitLog("debug", "console")
+	_ = util.InitLog("debug", util.LogConsole)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -196,7 +196,7 @@ func (m *MockWGIface) LastActivities() map[string]monotime.Time {
 }
 
 func TestMain(m *testing.M) {
-	_ = util.InitLog("debug", "console")
+	_ = util.InitLog("debug", util.LogConsole)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/client/internal/peer/conn_test.go
+++ b/client/internal/peer/conn_test.go
@@ -31,7 +31,7 @@ var connConf = ConnConfig{
 }
 
 func TestMain(m *testing.M) {
-	_ = util.InitLog("trace", "console")
+	_ = util.InitLog("trace", util.LogConsole)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -3,7 +3,6 @@ set -eEuo pipefail
 
 : ${NB_ENTRYPOINT_SERVICE_TIMEOUT:="5"}
 : ${NB_ENTRYPOINT_LOGIN_TIMEOUT:="1"}
-: ${NB_ENTRYPOINT_TAIL_LOG_FILE:="true"}
 NETBIRD_BIN="${NETBIRD_BIN:-"netbird"}"
 export NB_LOG_FILE="${NB_LOG_FILE:-"/var/log/netbird/client.log"}"
 service_pids=()
@@ -79,12 +78,6 @@ main() {
     ;;
   *)
     has_logfile="true"
-    if test "${NB_ENTRYPOINT_TAIL_LOG_FILE}" = "true"; then
-      info "tailing ${NB_LOG_FILE}..."
-      tail -F "${NB_LOG_FILE}" >&2 &
-      extra_pids+=("$!")
-      info "registered new extra process 'tail', currently running: ${extra_pids[*]}"
-    fi
 
     if ! wait_for_message "${NB_ENTRYPOINT_SERVICE_TIMEOUT}" "started daemon server"; then
       warn "log line containing 'started daemon server' not found after ${NB_ENTRYPOINT_SERVICE_TIMEOUT} seconds"

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -59,9 +59,6 @@ main() {
   pids+=("${SERVICE_PID}")
 
   trap 'signal_cleanup' SIGTERM SIGINT EXIT
-  # TODO: do we actually handle any signals in `netbird service run`?
-  #trap 'signal_propagate USR1' SIGUSR1
-  #trap 'signal_propagate USR2' SIGUSR2
 
   case "${NB_LOG_FILE}" in
   console | syslog)

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -25,7 +25,7 @@ warn() {
 on_exit() {
   info "Shutting down NetBird daemon..."
   if test "${#service_pids[@]}" -gt 0; then
-    info "terminating service process PIDs: ${service_pids[*]}"
+    info "terminating service process IDs: ${service_pids[*]}"
     kill -TERM "${service_pids[@]}" 2>/dev/null || true
     wait "${service_pids[@]}" 2>/dev/null || true
   else
@@ -36,10 +36,10 @@ on_exit() {
 wait_for_message() {
   local timeout="${1}" message="${2}"
   if test "${timeout}" -eq 0; then
-    info "not waiting for info message '${message}' due to zero timeout."
+    info "not waiting for log line '${message}' due to zero timeout."
   elif test -n "${log_file_path}"; then
-    info "waiting for info message '${message}' for ${timeout} seconds..."
-    timeout "${timeout}" grep -q "${message}" <(tail -F "${log_file_path}" 2>/dev/null)
+    info "waiting for log line '${message}' for ${timeout} seconds..."
+    grep -q "${message}" <(timeout "${timeout}" tail -F "${log_file_path}" 2>/dev/null)
   else
     info "log file unsupported, sleeping for ${timeout} seconds..."
     sleep "${timeout}"

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -4,9 +4,9 @@ set -eEuo pipefail
 : ${NB_ENTRYPOINT_SERVICE_TIMEOUT:="5"}
 : ${NB_ENTRYPOINT_LOGIN_TIMEOUT:="1"}
 NETBIRD_BIN="${NETBIRD_BIN:-"netbird"}"
-export NB_LOG_FILE="${NB_LOG_FILE:-"/var/log/netbird/client.log"}"
+export NB_LOG_FILE="${NB_LOG_FILE:-"console:/var/log/netbird/client.log"}"
 service_pids=()
-extra_pids=()
+log_file_path=""
 
 _log() {
   # mimic Go logger's output for easier parsing
@@ -31,14 +31,6 @@ on_exit() {
   else
     info "there are no service processes to terminate"
   fi
-  if test "${#extra_pids[@]}" -gt 0; then
-    info "terminating extra process PIDs: ${extra_pids[*]}"
-    kill -TERM "${extra_pids[@]}" 2>/dev/null || true
-    wait "${extra_pids[@]}" 2>/dev/null || true
-  else
-    info "there are no extra processes to terminate"
-  fi
-  exit 0
 }
 
 on_signal_propagate() {
@@ -53,46 +45,65 @@ wait_for_message() {
   local timeout="${1}" message="${2}"
   if test "${timeout}" -eq 0; then
     info "not waiting for info message '${message}' due to zero timeout."
-  elif test "${has_logfile}" = "true"; then
+  elif test -n "${log_file_path}"; then
     info "waiting for info message '${message}' for ${timeout} seconds..."
-    timeout "${timeout}" grep -q "${message}" <(tail -F "${NB_LOG_FILE}" 2>/dev/null)
+    timeout "${timeout}" grep -q "${message}" <(tail -F "${log_file_path}" 2>/dev/null)
   else
     info "log file unsupported, sleeping for ${timeout} seconds..."
     sleep "${timeout}"
   fi
 }
 
-main() {
-  has_logfile="false"
-  "${NETBIRD_BIN}" service run &
-  service_pids+=("$!")
-  info "registered new service process 'netbird service run', currently running: ${service_pids[*]}"
-
-  trap 'signal_cleanup' SIGTERM SIGINT EXIT
-
-  case "${NB_LOG_FILE}" in
-  console | syslog)
-    warn "\$NB_LOG_FILE='${NB_LOG_FILE}' parsing is not supported, sleeping for ${NB_ENTRYPOINT_SERVICE_TIMEOUT} instead."
-    warn "please consider removing the \$NB_LOG_FILE or setting it to real file, before gathering debug bundles."
-    sleep "${NB_ENTRYPOINT_SERVICE_TIMEOUT}"
-    ;;
-  *)
-    has_logfile="true"
-
-    if ! wait_for_message "${NB_ENTRYPOINT_SERVICE_TIMEOUT}" "started daemon server"; then
-      warn "log line containing 'started daemon server' not found after ${NB_ENTRYPOINT_SERVICE_TIMEOUT} seconds"
-      warn "daemon failed to start, exiting..."
-      exit 1
+wait_for_daemon_startup() {
+  local timeout="${1}" log_files_string="${2}"
+  local log_file daemon_started=false
+  while read -r log_file; do
+    if test "${daemon_started}" = "true"; then
+      continue
     fi
-    ;;
-  esac
+    case "${log_file}" in
+    console | syslog | docker | stderr)
+      warn "log file '${log_file}' parsing is not supported by debug bundles"
+      warn "please consider removing the \$NB_LOG_FILE or setting it to real file, before gathering debug bundles."
+      ;;
+    *)
+      log_file_path="${log_file}"
 
-  if test "${has_logfile}" = "true" && wait_for_message "${NB_ENTRYPOINT_LOGIN_TIMEOUT}" 'peer has been successfully registered'; then
+      if ! wait_for_message "${timeout}" "started daemon server"; then
+        warn "log line containing 'started daemon server' not found after ${timeout} seconds"
+        warn "daemon failed to start, exiting..."
+        exit 1
+      fi
+      daemon_started=true
+      ;;
+    esac
+  done < <(sed 's#:#\n#g' <<<"${log_files_string}")
+
+  if test "${daemon_started}" != "true"; then
+    warn "daemon service startup not discovered, sleeping ${timeout} instead"
+    sleep "${timeout}"
+  fi
+}
+
+login_if_needed() {
+  local timeout="${1}"
+
+  if test -n "${log_file_path}" && wait_for_message "${timeout}" 'peer has been successfully registered'; then
     info "already logged in, skipping 'netbird up'..."
   else
     info "logging in..."
     "${NETBIRD_BIN}" up
   fi
+}
+
+main() {
+  trap 'on_exit' SIGTERM SIGINT EXIT
+  "${NETBIRD_BIN}" service run &
+  service_pids+=("$!")
+  info "registered new service process 'netbird service run', currently running: ${service_pids[*]}"
+
+  wait_for_daemon_startup "${NB_ENTRYPOINT_SERVICE_TIMEOUT}" "${NB_LOG_FILE}"
+  login_if_needed "${NB_ENTRYPOINT_LOGIN_TIMEOUT}"
 
   wait "${service_pids[@]}"
 }

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -4,7 +4,7 @@ set -eEuo pipefail
 : ${NB_ENTRYPOINT_SERVICE_TIMEOUT:="5"}
 : ${NB_ENTRYPOINT_LOGIN_TIMEOUT:="1"}
 NETBIRD_BIN="${NETBIRD_BIN:-"netbird"}"
-export NB_LOG_FILE="${NB_LOG_FILE:-"console:/var/log/netbird/client.log"}"
+export NB_LOG_FILE="${NB_LOG_FILE:-"console,/var/log/netbird/client.log"}"
 service_pids=()
 log_file_path=""
 
@@ -65,7 +65,7 @@ locate_log_file() {
       return
       ;;
     esac
-  done < <(sed 's#:#\n#g' <<<"${log_files_string}")
+  done < <(sed 's#,#\n#g' <<<"${log_files_string}")
 
   warn "log files parsing parsing for '${log_files_string}' is not supported by debug bundles"
   warn "please consider removing the \$NB_LOG_FILE or setting it to real file, before gathering debug bundles."

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -51,7 +51,7 @@ locate_log_file() {
 
   while read -r log_file; do
     case "${log_file}" in
-    console | syslog | docker | stderr) ;;
+    console | syslog) ;;
     *)
       log_file_path="${log_file}"
       return

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+: ${NB_ENTRYPOINT_SERVICE_TIMEOUT:="5"}
+: ${NB_ENTRYPOINT_LOGIN_TIMEOUT:="1"}
+: ${NB_ENTRYPOINT_TAIL_LOG_FILE:="1"}
+NETBIRD_BIN="${NETBIRD_BIN:-"netbird"}"
+export NB_LOG_FILE="${NB_LOG_FILE:-"/var/log/netbird/client.log"}"
+pids=()
+
+_log() {
+  # mimic Go logger's output for easier parsing
+  # 2025-04-15T21:32:00+08:00 INFO client/internal/config.go:495: setting notifications to disabled by default
+  printf "$(date -Isec) ${1} ${BASH_SOURCE[1]}:${BASH_LINENO[1]}: ${2}\n" "${@:3}" >&2
+}
+
+info() {
+  _log INFO "$@"
+}
+
+warn() {
+  _log WARN "$@"
+}
+
+signal_cleanup() {
+  info "Shutting down NetBird daemon..."
+  if test "${#pids[@]}" -gt 0; then
+    kill -TERM "${pids[@]}" 2>/dev/null || true
+    wait "${pids[@]}" 2>/dev/null || true
+  fi
+  exit 0
+}
+
+signal_propagate() {
+  local signal="${1}"
+  if test -n "${SERVICE_PID}"; then
+    info "Propagating ${signal} to NetBird daemon..."
+    kill -"${signal}" "${SERVICE_PID}"
+  fi
+}
+
+wait_for_message() {
+  local timeout="${1}" message="${2}"
+  if test "${timeout}" == 0; then
+    info "not waiting for info message '${message}' due to zero timeout."
+  elif test "${has_logfile}" = 1; then
+    info "waiting for info message '${message}' for ${timeout} seconds..."
+    timeout "${timeout}" grep -q "${message}" <(tail -F "${NB_LOG_FILE}" 2>/dev/null)
+  else
+    info "log file unsupported, sleeping for ${timeout} seconds..."
+    sleep "${timeout}"
+  fi
+}
+
+main() {
+  has_logfile="0"
+  "${NETBIRD_BIN}" service run &
+  SERVICE_PID="$!"
+  pids+=("${SERVICE_PID}")
+
+  trap 'signal_cleanup' SIGTERM SIGINT EXIT
+  # TODO: do we actually handle any signals in `netbird service run`?
+  #trap 'signal_propagate USR1' SIGUSR1
+  #trap 'signal_propagate USR2' SIGUSR2
+
+  case "${NB_LOG_FILE}" in
+  console | syslog)
+    warn "\$NB_LOG_FILE=='${NB_LOG_FILE}' parsing is not supported, sleeping for ${NB_ENTRYPOINT_SERVICE_TIMEOUT} instead."
+    warn "please consider removing the \$NB_LOG_FILE to before gathering debug bundles."
+    sleep "${NB_ENTRYPOINT_SERVICE_TIMEOUT}"
+    ;;
+  *)
+    has_logfile=1
+    if test "${NB_ENTRYPOINT_TAIL_LOG_FILE}" == 1; then
+      info "tailing ${NB_LOG_FILE}..."
+      tail -F "${NB_LOG_FILE}" >&2 &
+      pids+=("$!")
+    fi
+
+    if ! wait_for_message "${NB_ENTRYPOINT_SERVICE_TIMEOUT}" "started daemon server"; then
+      warn "log line containing 'started daemon server' not found after ${NB_ENTRYPOINT_SERVICE_TIMEOUT} seconds"
+      warn "daemon failed to start, exiting..."
+      exit 1
+    fi
+    ;;
+  esac
+
+  if test "${has_logfile}" = 1 && wait_for_message "${NB_ENTRYPOINT_LOGIN_TIMEOUT}" 'peer has been successfully registered'; then
+    info "already logged in, skipping 'netbird up'..."
+  else
+    info "logging in..."
+    "${NETBIRD_BIN}" up
+  fi
+
+  wait "${SERVICE_PID}"
+  signal_cleanup || true
+}
+
+main "$@"

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -33,14 +33,6 @@ on_exit() {
   fi
 }
 
-on_signal_propagate() {
-  local signal="${1}"
-  if test "${#service_pids[@]}" -gt 0; then
-    info "Propagating ${signal} to NetBird daemon..."
-    kill -"${signal}" "${#service_pids[@]}"
-  fi
-}
-
 wait_for_message() {
   local timeout="${1}" message="${2}"
   if test "${timeout}" -eq 0; then

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -25,7 +25,7 @@ warn() {
 on_exit() {
   info "Shutting down NetBird daemon..."
   if test "${#service_pids[@]}" -gt 0; then
-    info "terminating service process IDs: ${service_pids[*]}"
+    info "terminating service process IDs: ${service_pids[@]@Q}"
     kill -TERM "${service_pids[@]}" 2>/dev/null || true
     wait "${service_pids[@]}" 2>/dev/null || true
   else
@@ -36,9 +36,9 @@ on_exit() {
 wait_for_message() {
   local timeout="${1}" message="${2}"
   if test "${timeout}" -eq 0; then
-    info "not waiting for log line '${message}' due to zero timeout."
+    info "not waiting for log line ${message@Q} due to zero timeout."
   elif test -n "${log_file_path}"; then
-    info "waiting for log line '${message}' for ${timeout} seconds..."
+    info "waiting for log line ${message@Q} for ${timeout} seconds..."
     grep -q "${message}" <(timeout "${timeout}" tail -F "${log_file_path}" 2>/dev/null)
   else
     info "log file unsupported, sleeping for ${timeout} seconds..."
@@ -59,7 +59,7 @@ locate_log_file() {
     esac
   done < <(sed 's#,#\n#g' <<<"${log_files_string}")
 
-  warn "log files parsing parsing for '${log_files_string}' is not supported by debug bundles"
+  warn "log files parsing for ${log_files_string@Q} is not supported by debug bundles"
   warn "please consider removing the \$NB_LOG_FILE or setting it to real file, before gathering debug bundles."
 }
 
@@ -93,7 +93,7 @@ main() {
   trap 'on_exit' SIGTERM SIGINT EXIT
   "${NETBIRD_BIN}" service run &
   service_pids+=("$!")
-  info "registered new service process 'netbird service run', currently running: ${service_pids[*]}"
+  info "registered new service process 'netbird service run', currently running: ${service_pids[@]@Q}"
 
   locate_log_file "${NB_LOG_FILE}"
   wait_for_daemon_startup "${NB_ENTRYPOINT_SERVICE_TIMEOUT}"

--- a/client/server/server_test.go
+++ b/client/server/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/netbirdio/netbird/management/server/types"
 	"github.com/netbirdio/netbird/signal/proto"
 	signalServer "github.com/netbirdio/netbird/signal/server"
+	"github.com/netbirdio/netbird/util"
 )
 
 var (
@@ -92,7 +93,7 @@ func TestConnectWithRetryRuns(t *testing.T) {
 func TestServer_Up(t *testing.T) {
 	ctx := internal.CtxInitState(context.Background())
 
-	s := New(ctx, t.TempDir()+"/config.json", "console")
+	s := New(ctx, t.TempDir()+"/config.json", util.LogConsole)
 
 	err := s.Start()
 	require.NoError(t, err)
@@ -130,7 +131,7 @@ func (m *mockSubscribeEventsServer) Context() context.Context {
 func TestServer_SubcribeEvents(t *testing.T) {
 	ctx := internal.CtxInitState(context.Background())
 
-	s := New(ctx, t.TempDir()+"/config.json", "console")
+	s := New(ctx, t.TempDir()+"/config.json", util.LogConsole)
 
 	err := s.Start()
 	require.NoError(t, err)

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -66,7 +66,7 @@ func main() {
 		}
 		logFile = file
 	} else {
-		_ = util.InitLog("trace", "console")
+		_ = util.InitLog("trace", util.LogConsole)
 	}
 
 	// Create the Fyne application.

--- a/management/client/client_test.go
+++ b/management/client/client_test.go
@@ -41,7 +41,7 @@ import (
 const ValidKey = "A2C8E62B-38F5-4553-B31E-DD66C696CEBB"
 
 func TestMain(m *testing.M) {
-	_ = util.InitLog("debug", "console")
+	_ = util.InitLog("debug", util.LogConsole)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/relay/client/client_test.go
+++ b/relay/client/client_test.go
@@ -30,7 +30,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	_ = util.InitLog("debug", "console")
+	_ = util.InitLog("debug", util.LogConsole)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/relay/cmd/root.go
+++ b/relay/cmd/root.go
@@ -73,7 +73,7 @@ var (
 )
 
 func init() {
-	_ = util.InitLog("trace", "console")
+	_ = util.InitLog("trace", util.LogConsole)
 	cobraConfig = &Config{}
 	rootCmd.PersistentFlags().StringVarP(&cobraConfig.ListenAddress, "listen-address", "l", ":443", "listen address")
 	rootCmd.PersistentFlags().StringVarP(&cobraConfig.ExposedAddress, "exposed-address", "e", "", "instance domain address (or ip) and port, it will be distributes between peers")

--- a/relay/test/benchmark_test.go
+++ b/relay/test/benchmark_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	_ = util.InitLog("error", "console")
+	_ = util.InitLog("error", util.LogConsole)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/relay/testec2/main.go
+++ b/relay/testec2/main.go
@@ -233,7 +233,7 @@ func TURNReaderMain() []testResult {
 func main() {
 	var mode string
 
-	_ = util.InitLog("debug", "console")
+	_ = util.InitLog("debug", util.LogConsole)
 	flag.StringVar(&mode, "mode", "sender", "sender or receiver mode")
 	flag.Parse()
 

--- a/upload-server/main.go
+++ b/upload-server/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	err := util.InitLog("info", "console")
+	err := util.InitLog("info", util.LogConsole)
 	if err != nil {
 		log.Fatalf("Failed to initialize logger: %v", err)
 	}

--- a/util/log.go
+++ b/util/log.go
@@ -74,7 +74,7 @@ func InitLog(logLevel string, logs ...string) error {
 }
 
 // FindFirstLogPath returns the first logs entry that could be a log path, that is neither empty, nor a special value
-func FindFirstLogPath(logs ...string) string {
+func FindFirstLogPath(logs []string) string {
 	for _, logFile := range logs {
 		if logFile != "" && !slices.Contains(SpecialLogs, logFile) {
 			return logFile

--- a/util/log.go
+++ b/util/log.go
@@ -2,12 +2,10 @@ package util
 
 import (
 	"io"
-	"iter"
 	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/grpclog"
@@ -19,10 +17,8 @@ import (
 const defaultLogSize = 15
 
 const (
-	// LogSeparator preserves compatibility with cobra's StringSliceVar() by using `,`
-	LogSeparator = ","
-	LogConsole   = "console"
-	LogSyslog    = "syslog"
+	LogConsole = "console"
+	LogSyslog  = "syslog"
 )
 
 var (
@@ -42,7 +38,7 @@ func InitLog(logLevel string, logs ...string) error {
 	var writers []io.Writer
 	logFmt := os.Getenv("NB_LOG_FORMAT")
 
-	for logPath := range IterateLogs(logs) {
+	for _, logPath := range logs {
 		switch logPath {
 		case LogSyslog:
 			AddSyslogHook()
@@ -77,22 +73,10 @@ func InitLog(logLevel string, logs ...string) error {
 	return nil
 }
 
-// IterateLogs parses and iterates over logging entries
-func IterateLogs(logs []string) iter.Seq[string] {
-	return func(yield func(string) bool) {
-		parts := strings.Split(strings.Join(logs, LogSeparator), LogSeparator)
-		for _, part := range parts {
-			if !yield(strings.TrimSpace(part)) {
-				return
-			}
-		}
-	}
-}
-
-// FindFirstLogPath locates the first non-special logfile, assumed to be a valid path
-func FindFirstLogPath(logs []string) string {
-	for logFile := range IterateLogs(logs) {
-		if !slices.Contains(SpecialLogs, logFile) {
+// FindFirstLogPath returns the first logs entry that could be a log path, that is neither empty, nor a special value
+func FindFirstLogPath(logs ...string) string {
+	for _, logFile := range logs {
+		if logFile != "" && !slices.Contains(SpecialLogs, logFile) {
 			return logFile
 		}
 	}


### PR DESCRIPTION
## Describe your changes

This will allow running netbird commands (including debugging) against the daemon and provide a flow similar to non-container usages.

It will by default both log to file and `stderr` so it can be handled more uniformly in container-native environments.

## Issue ticket number and link

fixes https://github.com/netbirdio/netbird/issues/2345

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
