### PR TITLE
[client] avoid parsing NB_NETSTACK_SKIP_PROXY if empty

### DIFF
--- a/client/iface/netstack/tun.go
+++ b/client/iface/netstack/tun.go
@@ -41,9 +41,12 @@ func (t *NetStackTun) Create() (tun.Device, *netstack.Net, error) {
 	}
 	t.tundev = nsTunDev
 
-	skipProxy, err := strconv.ParseBool(os.Getenv(EnvSkipProxy))
-	if err != nil {
-		log.Errorf("failed to parse %s: %s", EnvSkipProxy, err)
+	var skipProxy bool
+	if val := os.Getenv(EnvSkipProxy); val != "" {
+		skipProxy, err = strconv.ParseBool(val)
+		if err != nil {
+			log.Errorf("failed to parse %s: %s", EnvSkipProxy, err)
+		}
 	}
 	if skipProxy {
 		return nsTunDev, tunNet, nil


### PR DESCRIPTION
This avoids to have in the logs:
```
ERRO client/iface/netstack/tun.go:46: failed to parse NB_NETSTACK_SKIP_PROXY: strconv.ParseBool: parsing "": invalid syntax
```

## Describe your changes
When you run netbird client in rootless mode and in the absence of the var `NB_NETSTACK_SKIP_PROXY`, you get a parsing error in the logs. People would need to set the variable explicitly to avoid the parsing error in the logs which I don't think it was left like this on purpose?

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
