### PR TITLE
[client, relay] The openConn function no longer blocks the relayAddress function call

### DIFF
--- a/relay/client/manager.go
+++ b/relay/client/manager.go
@@ -125,7 +125,7 @@ func (m *Manager) Serve() error {
 // connection to the relay server. It returns back with a net.Conn what represent the remote peer connection.
 func (m *Manager) OpenConn(ctx context.Context, serverAddress, peerKey string) (net.Conn, error) {
 	m.relayClientMu.RLock()
-	defer m.relayClientMu.Unlock()
+	defer m.relayClientMu.RUnlock()
 
 	if m.relayClient == nil {
 		return nil, ErrRelayClientNotConnected
@@ -156,7 +156,7 @@ func (m *Manager) OpenConn(ctx context.Context, serverAddress, peerKey string) (
 // Ready returns true if the home Relay client is connected to the relay server.
 func (m *Manager) Ready() bool {
 	m.relayClientMu.RLock()
-	defer m.relayClientMu.Unlock()
+	defer m.relayClientMu.RUnlock()
 
 	if m.relayClient == nil {
 		return false
@@ -175,7 +175,7 @@ func (m *Manager) SetOnReconnectedListener(f func()) {
 // closed.
 func (m *Manager) AddCloseListener(serverAddress string, onClosedListener OnServerCloseListener) error {
 	m.relayClientMu.RLock()
-	defer m.relayClientMu.Unlock()
+	defer m.relayClientMu.RUnlock()
 
 	if m.relayClient == nil {
 		return ErrRelayClientNotConnected
@@ -200,7 +200,7 @@ func (m *Manager) AddCloseListener(serverAddress string, onClosedListener OnServ
 // lost. This address will be sent to the target peer to choose the common relay server for the communication.
 func (m *Manager) RelayInstanceAddress() (string, error) {
 	m.relayClientMu.RLock()
-	defer m.relayClientMu.Unlock()
+	defer m.relayClientMu.RUnlock()
 
 	if m.relayClient == nil {
 		return "", ErrRelayClientNotConnected

--- a/relay/client/manager.go
+++ b/relay/client/manager.go
@@ -65,7 +65,7 @@ type Manager struct {
 
 	relayClient *Client
 	// the guard logic can overwrite the relayClient variable, this mutex protect the usage of the variable
-	relayClientMu  sync.Mutex
+	relayClientMu  sync.RWMutex
 	reconnectGuard *Guard
 
 	relayClients      map[string]*RelayTrack
@@ -124,7 +124,7 @@ func (m *Manager) Serve() error {
 // established via the relay server. If the peer is on a different relay server, the manager will establish a new
 // connection to the relay server. It returns back with a net.Conn what represent the remote peer connection.
 func (m *Manager) OpenConn(ctx context.Context, serverAddress, peerKey string) (net.Conn, error) {
-	m.relayClientMu.Lock()
+	m.relayClientMu.RLock()
 	defer m.relayClientMu.Unlock()
 
 	if m.relayClient == nil {
@@ -155,7 +155,7 @@ func (m *Manager) OpenConn(ctx context.Context, serverAddress, peerKey string) (
 
 // Ready returns true if the home Relay client is connected to the relay server.
 func (m *Manager) Ready() bool {
-	m.relayClientMu.Lock()
+	m.relayClientMu.RLock()
 	defer m.relayClientMu.Unlock()
 
 	if m.relayClient == nil {
@@ -174,7 +174,7 @@ func (m *Manager) SetOnReconnectedListener(f func()) {
 // AddCloseListener adds a listener to the given server instance address. The listener will be called if the connection
 // closed.
 func (m *Manager) AddCloseListener(serverAddress string, onClosedListener OnServerCloseListener) error {
-	m.relayClientMu.Lock()
+	m.relayClientMu.RLock()
 	defer m.relayClientMu.Unlock()
 
 	if m.relayClient == nil {
@@ -199,7 +199,7 @@ func (m *Manager) AddCloseListener(serverAddress string, onClosedListener OnServ
 // RelayInstanceAddress returns the address of the permanent relay server. It could change if the network connection is
 // lost. This address will be sent to the target peer to choose the common relay server for the communication.
 func (m *Manager) RelayInstanceAddress() (string, error) {
-	m.relayClientMu.Lock()
+	m.relayClientMu.RLock()
 	defer m.relayClientMu.Unlock()
 
 	if m.relayClient == nil {
@@ -300,7 +300,9 @@ func (m *Manager) onServerConnected() {
 func (m *Manager) onServerDisconnected(serverAddress string) {
 	m.relayClientMu.Lock()
 	if serverAddress == m.relayClient.connectionURL {
-		go m.reconnectGuard.StartReconnectTrys(m.ctx, m.relayClient)
+		go func(client *Client) {
+			m.reconnectGuard.StartReconnectTrys(m.ctx, client)
+		}(m.relayClient)
 	}
 	m.relayClientMu.Unlock()
 


### PR DESCRIPTION
## Describe your changes

The openConn function no longer blocks the relayAddress function call in manager layer

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
