### PR TITLE
[client] make ICE failed timeout configurable

### DIFF
--- a/client/internal/peer/ice/agent.go
+++ b/client/internal/peer/ice/agent.go
@@ -18,17 +18,15 @@ const (
 
 	iceKeepAliveDefault           = 4 * time.Second
 	iceDisconnectedTimeoutDefault = 6 * time.Second
+	iceFailedTimeoutDefault       = 6 * time.Second
 	// iceRelayAcceptanceMinWaitDefault is the same as in the Pion ICE package
 	iceRelayAcceptanceMinWaitDefault = 2 * time.Second
-)
-
-var (
-	failedTimeout = 6 * time.Second
 )
 
 func NewAgent(iFaceDiscover stdnet.ExternalIFaceDiscover, config Config, candidateTypes []ice.CandidateType, ufrag string, pwd string) (*ice.Agent, error) {
 	iceKeepAlive := iceKeepAlive()
 	iceDisconnectedTimeout := iceDisconnectedTimeout()
+	iceFailedTimeout := iceFailedTimeout()
 	iceRelayAcceptanceMinWait := iceRelayAcceptanceMinWait()
 
 	transportNet, err := newStdNet(iFaceDiscover, config.InterfaceBlackList)
@@ -50,7 +48,7 @@ func NewAgent(iFaceDiscover stdnet.ExternalIFaceDiscover, config Config, candida
 		UDPMuxSrflx:            config.UDPMuxSrflx,
 		NAT1To1IPs:             config.NATExternalIPs,
 		Net:                    transportNet,
-		FailedTimeout:          &failedTimeout,
+		FailedTimeout:          &iceFailedTimeout,
 		DisconnectedTimeout:    &iceDisconnectedTimeout,
 		KeepaliveInterval:      &iceKeepAlive,
 		RelayAcceptanceMinWait: &iceRelayAcceptanceMinWait,

--- a/client/internal/peer/ice/env.go
+++ b/client/internal/peer/ice/env.go
@@ -13,6 +13,7 @@ const (
 	envICEForceRelayConn            = "NB_ICE_FORCE_RELAY_CONN"
 	envICEKeepAliveIntervalSec      = "NB_ICE_KEEP_ALIVE_INTERVAL_SEC"
 	envICEDisconnectedTimeoutSec    = "NB_ICE_DISCONNECTED_TIMEOUT_SEC"
+	envICEFailedTimeoutSec          = "NB_ICE_FAILED_TIMEOUT_SEC"
 	envICERelayAcceptanceMinWaitSec = "NB_ICE_RELAY_ACCEPTANCE_MIN_WAIT_SEC"
 
 	msgWarnInvalidValue = "invalid value %s set for %s, using default %v"
@@ -53,6 +54,22 @@ func iceDisconnectedTimeout() time.Duration {
 	}
 
 	return time.Duration(disconnectedTimeoutSec) * time.Second
+}
+
+func iceFailedTimeout() time.Duration {
+	failedTimeoutEnv := os.Getenv(envICEFailedTimeoutSec)
+	if failedTimeoutEnv == "" {
+		return iceFailedTimeoutDefault
+	}
+
+	log.Infof("setting ICE failed timeout to %s seconds", failedTimeoutEnv)
+	failedTimeoutSec, err := strconv.Atoi(failedTimeoutEnv)
+	if err != nil {
+		log.Warnf(msgWarnInvalidValue, failedTimeoutEnv, envICEFailedTimeoutSec, iceFailedTimeoutDefault)
+		return iceFailedTimeoutDefault
+	}
+
+	return time.Duration(failedTimeoutSec) * time.Second
 }
 
 func iceRelayAcceptanceMinWait() time.Duration {


### PR DESCRIPTION
## Describe your changes
Make ICE failed timeout configurable via NB_ICE_FAILED_TIMEOUT_SEC

We want the NetBird agent to tolerate longer periods of ICE failure. Currently, only the disconnection timeout can be adjusted. However, setting the disconnection timeout longer than the ICE failed timeout is meaningless from ICE’s perspective.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
