### PR TITLE
[client] Improve userspace filter logging performance

### DIFF
--- a/client/firewall/uspfilter/conntrack/icmp.go
+++ b/client/firewall/uspfilter/conntrack/icmp.go
@@ -221,7 +221,7 @@ func (t *ICMPTracker) track(
 
 	// non echo requests don't need tracking
 	if typ != uint8(layers.ICMPv4TypeEchoRequest) {
-		t.logger.Trace("New %s ICMP connection %s - %s", direction, key, icmpInfo)
+		t.logger.Trace3("New %s ICMP connection %s - %s", direction, key, icmpInfo)
 		t.sendStartEvent(direction, srcIP, dstIP, typ, code, ruleId, size)
 		return
 	}
@@ -243,7 +243,7 @@ func (t *ICMPTracker) track(
 	t.connections[key] = conn
 	t.mutex.Unlock()
 
-	t.logger.Trace("New %s ICMP connection %s - %s", direction, key, icmpInfo)
+	t.logger.Trace3("New %s ICMP connection %s - %s", direction, key, icmpInfo)
 	t.sendEvent(nftypes.TypeStart, conn, ruleId)
 }
 
@@ -294,7 +294,7 @@ func (t *ICMPTracker) cleanup() {
 		if conn.timeoutExceeded(t.timeout) {
 			delete(t.connections, key)
 
-			t.logger.Trace("Removed ICMP connection %s (timeout) [in: %d Pkts/%d B out: %d Pkts/%d B]",
+			t.logger.Trace5("Removed ICMP connection %s (timeout) [in: %d Pkts/%d B out: %d Pkts/%d B]",
 				key, conn.PacketsRx.Load(), conn.BytesRx.Load(), conn.PacketsTx.Load(), conn.BytesTx.Load())
 			t.sendEvent(nftypes.TypeEnd, conn, nil)
 		}

--- a/client/firewall/uspfilter/conntrack/udp.go
+++ b/client/firewall/uspfilter/conntrack/udp.go
@@ -116,7 +116,7 @@ func (t *UDPTracker) track(srcIP netip.Addr, dstIP netip.Addr, srcPort uint16, d
 	t.connections[key] = conn
 	t.mutex.Unlock()
 
-	t.logger.Trace("New %s UDP connection: %s", direction, key)
+	t.logger.Trace2("New %s UDP connection: %s", direction, key)
 	t.sendEvent(nftypes.TypeStart, conn, ruleID)
 }
 
@@ -165,7 +165,7 @@ func (t *UDPTracker) cleanup() {
 		if conn.timeoutExceeded(t.timeout) {
 			delete(t.connections, key)
 
-			t.logger.Trace("Removed UDP connection %s (timeout) [in: %d Pkts/%d B, out: %d Pkts/%d B]",
+			t.logger.Trace5("Removed UDP connection %s (timeout) [in: %d Pkts/%d B, out: %d Pkts/%d B]",
 				key, conn.PacketsRx.Load(), conn.BytesRx.Load(), conn.PacketsTx.Load(), conn.BytesTx.Load())
 			t.sendEvent(nftypes.TypeEnd, conn, nil)
 		}

--- a/client/firewall/uspfilter/forwarder/endpoint.go
+++ b/client/firewall/uspfilter/forwarder/endpoint.go
@@ -57,7 +57,7 @@ func (e *endpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Error) 
 		address := netHeader.DestinationAddress()
 		err := e.device.CreateOutboundPacket(data.AsSlice(), address.AsSlice())
 		if err != nil {
-			e.logger.Error("CreateOutboundPacket: %v", err)
+			e.logger.Error1("CreateOutboundPacket: %v", err)
 			continue
 		}
 		written++

--- a/client/firewall/uspfilter/forwarder/tcp.go
+++ b/client/firewall/uspfilter/forwarder/tcp.go
@@ -38,7 +38,7 @@ func (f *Forwarder) handleTCP(r *tcp.ForwarderRequest) {
 	outConn, err := (&net.Dialer{}).DialContext(f.ctx, "tcp", dialAddr)
 	if err != nil {
 		r.Complete(true)
-		f.logger.Trace("forwarder: dial error for %v: %v", epID(id), err)
+		f.logger.Trace2("forwarder: dial error for %v: %v", epID(id), err)
 		return
 	}
 
@@ -47,9 +47,9 @@ func (f *Forwarder) handleTCP(r *tcp.ForwarderRequest) {
 
 	ep, epErr := r.CreateEndpoint(&wq)
 	if epErr != nil {
-		f.logger.Error("forwarder: failed to create TCP endpoint: %v", epErr)
+		f.logger.Error1("forwarder: failed to create TCP endpoint: %v", epErr)
 		if err := outConn.Close(); err != nil {
-			f.logger.Debug("forwarder: outConn close error: %v", err)
+			f.logger.Debug1("forwarder: outConn close error: %v", err)
 		}
 		r.Complete(true)
 		return
@@ -61,7 +61,7 @@ func (f *Forwarder) handleTCP(r *tcp.ForwarderRequest) {
 	inConn := gonet.NewTCPConn(&wq, ep)
 
 	success = true
-	f.logger.Trace("forwarder: established TCP connection %v", epID(id))
+	f.logger.Trace1("forwarder: established TCP connection %v", epID(id))
 
 	go f.proxyTCP(id, inConn, outConn, ep, flowID)
 }
@@ -75,10 +75,10 @@ func (f *Forwarder) proxyTCP(id stack.TransportEndpointID, inConn *gonet.TCPConn
 		<-ctx.Done()
 		// Close connections and endpoint.
 		if err := inConn.Close(); err != nil && !isClosedError(err) {
-			f.logger.Debug("forwarder: inConn close error: %v", err)
+			f.logger.Debug1("forwarder: inConn close error: %v", err)
 		}
 		if err := outConn.Close(); err != nil && !isClosedError(err) {
-			f.logger.Debug("forwarder: outConn close error: %v", err)
+			f.logger.Debug1("forwarder: outConn close error: %v", err)
 		}
 
 		ep.Close()
@@ -111,12 +111,12 @@ func (f *Forwarder) proxyTCP(id stack.TransportEndpointID, inConn *gonet.TCPConn
 
 	if errInToOut != nil {
 		if !isClosedError(errInToOut) {
-			f.logger.Error("proxyTCP: copy error (in → out) for %s: %v", epID(id), errInToOut)
+			f.logger.Error2("proxyTCP: copy error (in → out) for %s: %v", epID(id), errInToOut)
 		}
 	}
 	if errOutToIn != nil {
 		if !isClosedError(errOutToIn) {
-			f.logger.Error("proxyTCP: copy error (out → in) for %s: %v", epID(id), errOutToIn)
+			f.logger.Error2("proxyTCP: copy error (out → in) for %s: %v", epID(id), errOutToIn)
 		}
 	}
 
@@ -127,7 +127,7 @@ func (f *Forwarder) proxyTCP(id stack.TransportEndpointID, inConn *gonet.TCPConn
 		txPackets = tcpStats.SegmentsReceived.Value()
 	}
 
-	f.logger.Trace("forwarder: Removed TCP connection %s [in: %d Pkts/%d B, out: %d Pkts/%d B]", epID(id), rxPackets, bytesFromOutToIn, txPackets, bytesFromInToOut)
+	f.logger.Trace5("forwarder: Removed TCP connection %s [in: %d Pkts/%d B, out: %d Pkts/%d B]", epID(id), rxPackets, bytesFromOutToIn, txPackets, bytesFromInToOut)
 
 	f.sendTCPEvent(nftypes.TypeEnd, flowID, id, uint64(bytesFromOutToIn), uint64(bytesFromInToOut), rxPackets, txPackets)
 }

--- a/client/firewall/uspfilter/log/log.go
+++ b/client/firewall/uspfilter/log/log.go
@@ -246,31 +246,43 @@ func (l *Logger) formatMessage(buf *[]byte, msg logMessage) {
 	*buf = append(*buf, levelStrings[msg.level]...)
 	*buf = append(*buf, ' ')
 
-	args := make([]any, 0, 6)
+	// Count non-nil arguments for switch
+	argCount := 0
 	if msg.arg1 != nil {
-		args = append(args, msg.arg1)
-	}
-	if msg.arg2 != nil {
-		args = append(args, msg.arg2)
-	}
-	if msg.arg3 != nil {
-		args = append(args, msg.arg3)
-	}
-	if msg.arg4 != nil {
-		args = append(args, msg.arg4)
-	}
-	if msg.arg5 != nil {
-		args = append(args, msg.arg5)
-	}
-	if msg.arg6 != nil {
-		args = append(args, msg.arg6)
+		argCount++
+		if msg.arg2 != nil {
+			argCount++
+			if msg.arg3 != nil {
+				argCount++
+				if msg.arg4 != nil {
+					argCount++
+					if msg.arg5 != nil {
+						argCount++
+						if msg.arg6 != nil {
+							argCount++
+						}
+					}
+				}
+			}
+		}
 	}
 
 	var formatted string
-	if len(args) > 0 {
-		formatted = fmt.Sprintf(msg.format, args...)
-	} else {
+	switch argCount {
+	case 0:
 		formatted = msg.format
+	case 1:
+		formatted = fmt.Sprintf(msg.format, msg.arg1)
+	case 2:
+		formatted = fmt.Sprintf(msg.format, msg.arg1, msg.arg2)
+	case 3:
+		formatted = fmt.Sprintf(msg.format, msg.arg1, msg.arg2, msg.arg3)
+	case 4:
+		formatted = fmt.Sprintf(msg.format, msg.arg1, msg.arg2, msg.arg3, msg.arg4)
+	case 5:
+		formatted = fmt.Sprintf(msg.format, msg.arg1, msg.arg2, msg.arg3, msg.arg4, msg.arg5)
+	case 6:
+		formatted = fmt.Sprintf(msg.format, msg.arg1, msg.arg2, msg.arg3, msg.arg4, msg.arg5, msg.arg6)
 	}
 
 	*buf = append(*buf, formatted...)

--- a/client/firewall/uspfilter/log/log.go
+++ b/client/firewall/uspfilter/log/log.go
@@ -44,7 +44,12 @@ var levelStrings = map[Level]string{
 type logMessage struct {
 	level  Level
 	format string
-	args   []any
+	arg1   any
+	arg2   any
+	arg3   any
+	arg4   any
+	arg5   any
+	arg6   any
 }
 
 // Logger is a high-performance, non-blocking logger
@@ -89,62 +94,186 @@ func (l *Logger) SetLevel(level Level) {
 	log.Debugf("Set uspfilter logger loglevel to %v", levelStrings[level])
 }
 
-func (l *Logger) log(level Level, format string, args ...any) {
-	select {
-	case l.msgChannel <- logMessage{level: level, format: format, args: args}:
-	default:
-	}
-}
 
-// Error logs a message at error level
-func (l *Logger) Error(format string, args ...any) {
+func (l *Logger) Error(format string) {
 	if l.level.Load() >= uint32(LevelError) {
-		l.log(LevelError, format, args...)
+		select {
+		case l.msgChannel <- logMessage{level: LevelError, format: format}:
+		default:
+		}
 	}
 }
 
-// Warn logs a message at warning level
-func (l *Logger) Warn(format string, args ...any) {
+func (l *Logger) Warn(format string) {
 	if l.level.Load() >= uint32(LevelWarn) {
-		l.log(LevelWarn, format, args...)
+		select {
+		case l.msgChannel <- logMessage{level: LevelWarn, format: format}:
+		default:
+		}
 	}
 }
 
-// Info logs a message at info level
-func (l *Logger) Info(format string, args ...any) {
+func (l *Logger) Info(format string) {
 	if l.level.Load() >= uint32(LevelInfo) {
-		l.log(LevelInfo, format, args...)
+		select {
+		case l.msgChannel <- logMessage{level: LevelInfo, format: format}:
+		default:
+		}
 	}
 }
 
-// Debug logs a message at debug level
-func (l *Logger) Debug(format string, args ...any) {
+func (l *Logger) Debug(format string) {
 	if l.level.Load() >= uint32(LevelDebug) {
-		l.log(LevelDebug, format, args...)
+		select {
+		case l.msgChannel <- logMessage{level: LevelDebug, format: format}:
+		default:
+		}
 	}
 }
 
-// Trace logs a message at trace level
-func (l *Logger) Trace(format string, args ...any) {
+func (l *Logger) Trace(format string) {
 	if l.level.Load() >= uint32(LevelTrace) {
-		l.log(LevelTrace, format, args...)
+		select {
+		case l.msgChannel <- logMessage{level: LevelTrace, format: format}:
+		default:
+		}
 	}
 }
 
-func (l *Logger) formatMessage(buf *[]byte, level Level, format string, args ...any) {
+func (l *Logger) Error1(format string, arg1 any) {
+	if l.level.Load() >= uint32(LevelError) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelError, format: format, arg1: arg1}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Error2(format string, arg1, arg2 any) {
+	if l.level.Load() >= uint32(LevelError) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelError, format: format, arg1: arg1, arg2: arg2}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Warn3(format string, arg1, arg2, arg3 any) {
+	if l.level.Load() >= uint32(LevelWarn) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelWarn, format: format, arg1: arg1, arg2: arg2, arg3: arg3}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Debug1(format string, arg1 any) {
+	if l.level.Load() >= uint32(LevelDebug) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelDebug, format: format, arg1: arg1}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Debug2(format string, arg1, arg2 any) {
+	if l.level.Load() >= uint32(LevelDebug) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelDebug, format: format, arg1: arg1, arg2: arg2}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Trace1(format string, arg1 any) {
+	if l.level.Load() >= uint32(LevelTrace) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelTrace, format: format, arg1: arg1}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Trace2(format string, arg1, arg2 any) {
+	if l.level.Load() >= uint32(LevelTrace) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelTrace, format: format, arg1: arg1, arg2: arg2}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Trace3(format string, arg1, arg2, arg3 any) {
+	if l.level.Load() >= uint32(LevelTrace) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelTrace, format: format, arg1: arg1, arg2: arg2, arg3: arg3}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Trace4(format string, arg1, arg2, arg3, arg4 any) {
+	if l.level.Load() >= uint32(LevelTrace) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelTrace, format: format, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Trace5(format string, arg1, arg2, arg3, arg4, arg5 any) {
+	if l.level.Load() >= uint32(LevelTrace) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelTrace, format: format, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) Trace6(format string, arg1, arg2, arg3, arg4, arg5, arg6 any) {
+	if l.level.Load() >= uint32(LevelTrace) {
+		select {
+		case l.msgChannel <- logMessage{level: LevelTrace, format: format, arg1: arg1, arg2: arg2, arg3: arg3, arg4: arg4, arg5: arg5, arg6: arg6}:
+		default:
+		}
+	}
+}
+
+func (l *Logger) formatMessage(buf *[]byte, msg logMessage) {
 	*buf = (*buf)[:0]
 	*buf = time.Now().AppendFormat(*buf, "2006-01-02T15:04:05-07:00")
 	*buf = append(*buf, ' ')
-	*buf = append(*buf, levelStrings[level]...)
+	*buf = append(*buf, levelStrings[msg.level]...)
 	*buf = append(*buf, ' ')
 
-	var msg string
-	if len(args) > 0 {
-		msg = fmt.Sprintf(format, args...)
-	} else {
-		msg = format
+	args := make([]any, 0, 6)
+	if msg.arg1 != nil {
+		args = append(args, msg.arg1)
 	}
-	*buf = append(*buf, msg...)
+	if msg.arg2 != nil {
+		args = append(args, msg.arg2)
+	}
+	if msg.arg3 != nil {
+		args = append(args, msg.arg3)
+	}
+	if msg.arg4 != nil {
+		args = append(args, msg.arg4)
+	}
+	if msg.arg5 != nil {
+		args = append(args, msg.arg5)
+	}
+	if msg.arg6 != nil {
+		args = append(args, msg.arg6)
+	}
+
+	var formatted string
+	if len(args) > 0 {
+		formatted = fmt.Sprintf(msg.format, args...)
+	} else {
+		formatted = msg.format
+	}
+
+	*buf = append(*buf, formatted...)
 	*buf = append(*buf, '\n')
 
 	if len(*buf) > maxMessageSize {
@@ -157,7 +286,7 @@ func (l *Logger) processMessage(msg logMessage, buffer *[]byte) {
 	bufp := l.bufPool.Get().(*[]byte)
 	defer l.bufPool.Put(bufp)
 
-	l.formatMessage(bufp, msg.level, msg.format, msg.args...)
+	l.formatMessage(bufp, msg)
 
 	if len(*buffer)+len(*bufp) > maxBatchSize {
 		_, _ = l.output.Write(*buffer)

--- a/client/firewall/uspfilter/log/log_test.go
+++ b/client/firewall/uspfilter/log/log_test.go
@@ -19,22 +19,17 @@ func (d *discard) Write(p []byte) (n int, err error) {
 func BenchmarkLogger(b *testing.B) {
 	simpleMessage := "Connection established"
 
-	conntrackMessage := "TCP connection %s:%d -> %s:%d state changed to %d"
 	srcIP := "192.168.1.1"
 	srcPort := uint16(12345)
 	dstIP := "10.0.0.1"
 	dstPort := uint16(443)
 	state := 4 // TCPStateEstablished
 
-	complexMessage := "Packet inspection result: protocol=%s, direction=%s, flags=0x%x, sequence=%d, acknowledged=%d, payload_size=%d, fragmented=%v, connection_id=%s"
 	protocol := "TCP"
 	direction := "outbound"
 	flags := uint16(0x18) // ACK + PSH
 	sequence := uint32(123456789)
 	acknowledged := uint32(987654321)
-	payloadSize := 1460
-	fragmented := false
-	connID := "f7a12b3e-c456-7890-d123-456789abcdef"
 
 	b.Run("SimpleMessage", func(b *testing.B) {
 		logger := createTestLogger()
@@ -52,7 +47,7 @@ func BenchmarkLogger(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			logger.Trace(conntrackMessage, srcIP, srcPort, dstIP, dstPort, state)
+			logger.Trace5("TCP connection %s:%d → %s:%d state %d", srcIP, srcPort, dstIP, dstPort, state)
 		}
 	})
 
@@ -62,7 +57,7 @@ func BenchmarkLogger(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			logger.Trace(complexMessage, protocol, direction, flags, sequence, acknowledged, payloadSize, fragmented, connID)
+			logger.Trace6("Complex trace: proto=%s dir=%s flags=%d seq=%d ack=%d size=%d", protocol, direction, flags, sequence, acknowledged, 1460)
 		}
 	})
 }
@@ -72,7 +67,6 @@ func BenchmarkLoggerParallel(b *testing.B) {
 	logger := createTestLogger()
 	defer cleanupLogger(logger)
 
-	conntrackMessage := "TCP connection %s:%d -> %s:%d state changed to %d"
 	srcIP := "192.168.1.1"
 	srcPort := uint16(12345)
 	dstIP := "10.0.0.1"
@@ -82,7 +76,7 @@ func BenchmarkLoggerParallel(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			logger.Trace(conntrackMessage, srcIP, srcPort, dstIP, dstPort, state)
+			logger.Trace5("TCP connection %s:%d → %s:%d state %d", srcIP, srcPort, dstIP, dstPort, state)
 		}
 	})
 }
@@ -92,7 +86,6 @@ func BenchmarkLoggerBurst(b *testing.B) {
 	logger := createTestLogger()
 	defer cleanupLogger(logger)
 
-	conntrackMessage := "TCP connection %s:%d -> %s:%d state changed to %d"
 	srcIP := "192.168.1.1"
 	srcPort := uint16(12345)
 	dstIP := "10.0.0.1"
@@ -102,7 +95,7 @@ func BenchmarkLoggerBurst(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 100; j++ {
-			logger.Trace(conntrackMessage, srcIP, srcPort, dstIP, dstPort, state)
+			logger.Trace5("TCP connection %s:%d → %s:%d state %d", srcIP, srcPort, dstIP, dstPort, state)
 		}
 	}
 }

--- a/client/firewall/uspfilter/nat.go
+++ b/client/firewall/uspfilter/nat.go
@@ -211,11 +211,11 @@ func (m *Manager) translateOutboundDNAT(packetData []byte, d *decoder) bool {
 	}
 
 	if err := m.rewritePacketDestination(packetData, d, translatedIP); err != nil {
-		m.logger.Error("Failed to rewrite packet destination: %v", err)
+		m.logger.Error1("Failed to rewrite packet destination: %v", err)
 		return false
 	}
 
-	m.logger.Trace("DNAT: %s -> %s", dstIP, translatedIP)
+	m.logger.Trace2("DNAT: %s -> %s", dstIP, translatedIP)
 	return true
 }
 
@@ -237,11 +237,11 @@ func (m *Manager) translateInboundReverse(packetData []byte, d *decoder) bool {
 	}
 
 	if err := m.rewritePacketSource(packetData, d, originalIP); err != nil {
-		m.logger.Error("Failed to rewrite packet source: %v", err)
+		m.logger.Error1("Failed to rewrite packet source: %v", err)
 		return false
 	}
 
-	m.logger.Trace("Reverse DNAT: %s -> %s", srcIP, originalIP)
+	m.logger.Trace2("Reverse DNAT: %s -> %s", srcIP, originalIP)
 	return true
 }
 


### PR DESCRIPTION
## Describe your changes

This improves logging performance when logs are off by eliminating the variadic function call.

  | Test Case      | Variadic         |  LogN   | Improvement |
  |-------------------|-----------------------|-----------------------------|-------------|
  | 2 Args - Disabled | 72.75ns, 32B, 1 alloc | 0.85ns, 0B, 0 allocs        | 86x faster  |
  | 2 Args - Enabled  | 102.2ns, 35B, 1 alloc | 23.45ns, 0B, 0 allocs       | 4.4x faster |
  | 6 Args - Disabled | 112.5ns, 96B, 1 alloc | 0.85ns, 0B, 0 allocs      | 132x faster |
  | 6 Args - Enabled  | 124.9ns, 97B, 1 alloc | 38ns, 0B, 0 allocs        | 3.3x faster |


## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
