### PR TITLE
Dockerfile: pin gopls to v0.18.1 (latest that supports golang 1.23)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         libayatana-appindicator3-dev=0.5.5-2+deb11u2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && go install -v golang.org/x/tools/gopls@latest
+    && go install -v golang.org/x/tools/gopls@v0.18.1
 
 
 WORKDIR /app


### PR DESCRIPTION
Container will fail to build with newer versions of gopls unless golang is updated to 1.24. The latest stable version supporting 1.23 is gopls v0.18.1

## Describe your changes
Changed gopls@latest to gopls@v0.18.1 in .devcontainer/Dockerfile

## Issue ticket number and link
github.com/netbirdio/netbird/issues/4238
## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
