### PR TITLE
[client] Disable the dns host manager properly if disabled through management

### DIFF
--- a/client/internal/dns/handler_chain.go
+++ b/client/internal/dns/handler_chain.go
@@ -15,7 +15,7 @@ const (
 	PriorityDNSRoute = 75
 	PriorityUpstream = 50
 	PriorityDefault  = 1
-	PriorityFallback    = -100
+	PriorityFallback = -100
 )
 
 type SubdomainMatcher interface {


### PR DESCRIPTION
## Describe your changes


  This PR fixes several DNS manager cleanup issues:

  1. DNS not cleaned up when disabled via management
  - Start with DNS enabled in management
  - Run netbird up
  - Disable DNS in management
  - Result: Host DNS still points to NetBird's IP instead of being restored (e.g., /etc/resolv.conf on Linux, but varies by system)

  2. Invalid IP in host DNS when starting with DNS disabled
  - Start with DNS disabled in management
  - Run netbird up
  - Result: Host DNS configuration gets an invalid IP address

  3. Deadlock during shutdown after DNS disable/enable cycle
  - Start with DNS disabled in management
  - Run netbird up
  - Enable DNS, then disable it again via management
  - Run netbird down
  - Result: DNS cleanup hangs and blocks shutdown

  4. Client DNS flags ignored after management DNS toggle
  - Start with DNS disabled on client (via --disable-dns flag or netstack mode)
  - Management has DNS enabled
  - Run netbird up - correctly no host DNS changes
  - Toggle DNS off then on again in management
  - Result: Client DNS becomes active, ignoring the client-side disable flag

## Issue ticket number and link

#4236

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
