### PR TITLE
[client] Add support for retain existing AllowedIPs when no alternative paths are available

### DIFF
--- a/client/internal/routemanager/client/client.go
+++ b/client/internal/routemanager/client/client.go
@@ -336,6 +336,11 @@ func (w *Watcher) recalculateRoutes(rsn reason, routerPeerStatuses map[route.ID]
 			return nil
 		}
 
+		if isRouteStickyOnFailure() {
+			log.Warnf("No available routes for network [%v], keep current route %s", w.handler, w.currentChosen.Peer)
+			return nil
+		}
+
 		if err := w.removeAllowedIPs(w.currentChosen, rsn); err != nil {
 			return fmt.Errorf("remove obsolete: %w", err)
 		}

--- a/client/internal/routemanager/client/env.go
+++ b/client/internal/routemanager/client/env.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// envRouteStickyOnFailure is used to configure if routes should be kept on failure
+	envRouteStickyOnFailure = "NB_ROUTE_STICKY_ON_FAILURE"
+)
+
+// isRouteStickyOnFailure checks if routes should be kept on failure
+func isRouteStickyOnFailure() bool {
+	stickyOnFailureEnv := os.Getenv(envRouteStickyOnFailure)
+	if stickyOnFailureEnv == "" {
+		return false
+	}
+
+	log.Infof("routes will be kept on failure as %s is set to %s", envRouteStickyOnFailure, stickyOnFailureEnv)
+	return strings.ToLower(stickyOnFailureEnv) == "true"
+}


### PR DESCRIPTION
We are using Netbird to manage our WireGuard network (without relay nodes). Our topology is relatively stable and does not change frequently.

We have analyzed potential network instability issues that may occur when either the ICE connection drops or the management API becomes temporarily unavailable. As noted in [this comment](https://github.com/netbirdio/netbird/issues/1584#issuecomment-2179294070), in such cases, network routes (e.g., 10.0.0.0/24) are removed from AllowedIPs, effectively cutting off connectivity.

In our scenario, we prefer:
	•	When ICE fails or the management service is temporarily down, the existing network connectivity should remain unaffected. The system should not proactively remove AllowedIPs, especially when no alternative paths are available.
	•	Even if the management service remains operational, the temporary unavailability of routes during ICE reconnection is still unacceptable, as it causes unnecessary and avoidable disruptions.

We propose adding an option to enable a failsafe routing mode, where:
	•	Route manager only updates AllowedIPs when a valid, reachable path is available.
	•	If no valid path is detected, the current AllowedIPs are kept unchanged.

This behavior would help prevent unnecessary network disconnections caused by transient ICE or management issues.

Example environment variable:
```
NB_ROUTE_STICKY_ON_FAILURE=true
```

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
