### PR TITLE
[management] do not add ephemeral peer to deletion queue on logout

### DIFF
--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -937,6 +937,12 @@ func (s *GRPCServer) Logout(ctx context.Context, req *proto.EncryptedMessage) (*
 		userID = activity.SystemInitiator
 	}
 
+	// if peer is ephemeral, we need to set it to false to prevent adding it to ephemeral deletion queue
+	if peer.Ephemeral {
+		peer.Ephemeral = false
+	}
+	s.cancelPeerRoutines(ctx, peer.AccountID, peer)
+
 	if err = s.accountManager.DeletePeer(ctx, peer.AccountID, peer.ID, userID); err != nil {
 		log.WithContext(ctx).Errorf("failed to logout peer %s: %v", peerKey.String(), err)
 		return nil, mapError(ctx, err)


### PR DESCRIPTION
## Describe your changes
Set the ephemeral peer flag to false upon user logout to prevent it from being unnecessarily added to the deletion queue
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
