### PR TITLE
Fix GetConfig to load the mTLS certificate

### DIFF
--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -603,6 +603,16 @@ func GetConfig(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
 	}
 
+	if config.ClientCertPath != "" && config.ClientCertKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(config.ClientCertPath, config.ClientCertKeyPath)
+		if err != nil {
+			log.Errorf("Failed to load mTLS cert/key pair from %s and %s: %v", config.ClientCertPath, config.ClientCertKeyPath, err)
+		} else {
+			config.ClientCertKeyPair = &cert
+			log.Info("Loaded client mTLS cert/key pair")
+		}
+	}
+
 	return config, nil
 }
 


### PR DESCRIPTION
## Describe your changes

Add mTLS certificate loading into the new GetConfig()
maybe its worth considering JSON-ing the cert?
I leave those decisions to the devs :)



## Issue ticket number and link
Fixes #4278

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
