### PR TITLE
[management] during JSON migration filter duplicates on conflict

### DIFF
--- a/management/server/migration/migration.go
+++ b/management/server/migration/migration.go
@@ -15,6 +15,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func GetColumnName(db *gorm.DB, column string) string {
@@ -466,7 +467,7 @@ func MigrateJsonToTable[T any](ctx context.Context, db *gorm.DB, columnName stri
 			}
 
 			for _, value := range data {
-				if err := tx.Create(
+				if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(
 					mapperFunc(row["account_id"].(string), row["id"].(string), value),
 				).Error; err != nil {
 					return fmt.Errorf("failed to insert id %v: %w", row["id"], err)


### PR DESCRIPTION
## Describe your changes
In case of dublicated peer entries in the same group we filter those during migration to comply with the uniqueness constraint.

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/4299

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
