### PR TITLE
fix: profilemanager panic when reading incomplete config

### DIFF
--- a/client/cmd/service.go
+++ b/client/cmd/service.go
@@ -47,7 +47,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&serviceName, "service", "s", defaultServiceName, "Netbird system service name")
 	serviceEnvDesc := `Sets extra environment variables for the service. ` +
 		`You can specify a comma-separated list of KEY=VALUE pairs. ` +
-		`E.g. --service-env LOG_LEVEL=debug,CUSTOM_VAR=value`
+		`E.g. --service-env NB_LOG_LEVEL=debug,CUSTOM_VAR=value`
 
 	installCmd.Flags().StringSliceVar(&serviceEnvVars, "service-env", nil, serviceEnvDesc)
 	reconfigureCmd.Flags().StringSliceVar(&serviceEnvVars, "service-env", nil, serviceEnvDesc)

--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -593,17 +593,9 @@ func update(input ConfigInput) (*Config, error) {
 	return config, nil
 }
 
+// GetConfig read config file and return with Config. Errors out if it does not exist
 func GetConfig(configPath string) (*Config, error) {
-	if !fileExists(configPath) {
-		return nil, fmt.Errorf("config file %s does not exist", configPath)
-	}
-
-	config := &Config{}
-	if _, err := util.ReadJson(configPath, config); err != nil {
-		return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
-	}
-
-	return config, nil
+	return readConfig(configPath, false)
 }
 
 // UpdateOldManagementURL checks whether client can switch to the new Management URL with port 443 and the management domain.
@@ -695,6 +687,11 @@ func CreateInMemoryConfig(input ConfigInput) (*Config, error) {
 
 // ReadConfig read config file and return with Config. If it is not exists create a new with default values
 func ReadConfig(configPath string) (*Config, error) {
+	return readConfig(configPath, true)
+}
+
+// ReadConfig read config file and return with Config. If it is not exists create a new with default values
+func readConfig(configPath string, createIfMissing bool) (*Config, error) {
 	if fileExists(configPath) {
 		err := util.EnforcePermission(configPath)
 		if err != nil {
@@ -715,6 +712,8 @@ func ReadConfig(configPath string) (*Config, error) {
 		}
 
 		return config, nil
+	} else if !createIfMissing {
+		return nil, fmt.Errorf("config file %s does not exist", configPath)
 	}
 
 	cfg, err := createNewConfig(ConfigInput{ConfigPath: configPath})


### PR DESCRIPTION
## Describe your changes

properly initializes config in profilemanager

## Issue ticket number and link

tests failure in nixpkgs https://github.com/NixOS/nixpkgs/pull/431976/checks?check_run_id=47683203864 / https://github.com/NixOS/nixpkgs/pull/431976

```
Aug 08 15:09:08 clients systemd[1]: Started A WireGuard-based mesh network that connects your devices into a single private network.
Aug 08 15:09:09 clients netbird[1599]: 2025-08-08T15:09:09Z INFO client/cmd/service_controller.go:27: starting Netbird service
Aug 08 15:09:09 clients netbird[1599]: panic: runtime error: invalid memory address or nil pointer dereference
Aug 08 15:09:09 clients netbird[1599]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x60f56c]
Aug 08 15:09:09 clients netbird[1599]: goroutine 13 [running]:
Aug 08 15:09:09 clients netbird[1599]: net/url.(*URL).String(0x2e117a0?)
Aug 08 15:09:09 clients netbird[1599]:         net/url/url.go:833 +0x2c
Aug 08 15:09:09 clients netbird[1599]: github.com/netbirdio/netbird/client/server.(*Server).Start(0xc00034ac00)
Aug 08 15:09:09 clients netbird[1599]:         github.com/netbirdio/netbird/client/server/server.go:159 +0x675
Aug 08 15:09:09 clients netbird[1599]: github.com/netbirdio/netbird/client/cmd.(*program).Start.func1()
Aug 08 15:09:09 clients netbird[1599]:         github.com/netbirdio/netbird/client/cmd/service_controller.go:65 +0x4e6
Aug 08 15:09:09 clients netbird[1599]: created by github.com/netbirdio/netbird/client/cmd.(*program).Start in goroutine 1
Aug 08 15:09:09 clients netbird[1599]:         github.com/netbirdio/netbird/client/cmd/service_controller.go:54 +0x2be
Aug 08 15:09:09 clients systemd[1]: netbird.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Aug 08 15:09:09 clients systemd[1]: netbird.service: Failed with result 'exit-code'.
```

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
