### PR TITLE
[client] Skip dns upstream servers pointing to our dns server IP to prevent loops

### DIFF
--- a/client/internal/dns/file_parser_unix_test.go
+++ b/client/internal/dns/file_parser_unix_test.go
@@ -176,4 +176,3 @@ nameserver 192.168.0.1
 		t.Errorf("unexpected resolv.conf content: %v", cfg)
 	}
 }
-

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -695,6 +695,12 @@ func (s *DefaultServer) createHandlersForDomainGroup(domainGroup nsGroupsByDomai
 					ns.IP.String(), ns.NSType.String(), nbdns.UDPNameServerType.String())
 				continue
 			}
+
+			if ns.IP == s.service.RuntimeIP() {
+				log.Warnf("skipping nameserver %s as it matches our DNS server IP, preventing potential loop", ns.IP)
+				continue
+			}
+
 			handler.upstreamServers = append(handler.upstreamServers, ns.AddrPort())
 		}
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal change

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
