### PR TITLE
Fixes for #4352

### DIFF
--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -61,7 +61,11 @@ func (p *program) Start(svc service.Service) error {
 			}
 		}
 
-		serverInstance := server.New(p.ctx, util.FindFirstLogPath(logFiles), configPath, profilesDisabled, updateSettingsDisabled)
+		key, err := getSetupKey()
+	if err != nil {
+		log.Errorf("Error getting setup key: %v", err)
+	}
+		serverInstance := server.New(p.ctx, util.FindFirstLogPath(logFiles), configPath, profilesDisabled, updateSettingsDisabled, key)
 		if err := serverInstance.Start(); err != nil {
 			log.Fatalf("failed to start daemon: %v", err)
 		}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -196,7 +196,7 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *pr
 	r := peer.NewRecorder(config.ManagementURL.String())
 	r.GetFullStatus()
 
-	connectClient := internal.NewConnectClient(ctx, config, r)
+	connectClient := internal.NewConnectClient(ctx, config, r, providedSetupKey)
 	SetupDebugHandler(ctx, config, r, connectClient, "")
 
 	return connectClient.Run(nil)

--- a/client/embed/embed.go
+++ b/client/embed/embed.go
@@ -131,7 +131,7 @@ func (c *Client) Start(startCtx context.Context) error {
 	}
 
 	recorder := peer.NewRecorder(c.config.ManagementURL.String())
-	client := internal.NewConnectClient(ctx, c.config, recorder)
+	client := internal.NewConnectClient(ctx, c.config, recorder, c.setupKey)
 
 	// either startup error (permanent backoff err) or nil err (successful engine up)
 	// TODO: make after-startup backoff err available


### PR DESCRIPTION
 feat(client): Pass setup key to service run command

No idea if this correctly solves or addresses #4352 but it did work when I tested it. 

 The `netbird service run` command did not correctly handle the `--setup-key` or
 `--setup-key-file` flags. This was because the setup key was not being passed to the service
 when it was started.

 This commit fixes the issue by:
 - Passing the setup key from the `service run` command to the server instance.
 - Ensuring the `getSetupKey` function is called to read the key from a file if provided.
 - Passing the setup key through the connection client to the login function.
 - Updating all calls to `NewConnectClient` to include the setup key.

With this change, the `netbird service run` command now correctly uses the setup key to register
  the peer.

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Fixes expected behavior