### PR TITLE
[client] Add WireGuard interface lifecycle monitoring

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -479,9 +479,11 @@ func (e *Engine) Start() error {
 	go func() {
 		defer e.wgIfaceMonitorWg.Done()
 
-		if err := e.wgIfaceMonitor.Start(e.ctx, e.wgInterface.Name()); err != nil {
+		if shouldRestart, err := e.wgIfaceMonitor.Start(e.ctx, e.wgInterface.Name()); shouldRestart {
 			log.Infof("WireGuard interface monitor: %s, restarting engine", err)
 			e.restartEngine()
+		} else if err != nil {
+			log.Warnf("WireGuard interface monitor: %s", err)
 		}
 	}()
 


### PR DESCRIPTION
Implement a background watcher that restarts the engine when the WireGuard interface is created or deleted. This addition enhances the engines resilience to external changes in the interface state.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why):
Internal change

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
