### PR TITLE
[management] Add CreatedAt field to Peer and model

### DIFF
--- a/management/server/http/handlers/peers/peers_handler.go
+++ b/management/server/http/handlers/peers/peers_handler.go
@@ -354,6 +354,7 @@ func toSinglePeerResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dnsD
 	}
 
 	return &api.Peer{
+		CreatedAt:                  peer.CreatedAt,
 		Id:                          peer.ID,
 		Name:                        peer.Name,
 		Ip:                          peer.IP.String(),
@@ -390,6 +391,7 @@ func toPeerListItemResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dn
 	}
 
 	return &api.PeerBatch{
+		CreatedAt:             peer.CreatedAt,
 		Id:                     peer.ID,
 		Name:                   peer.Name,
 		Ip:                     peer.IP.String(),

--- a/shared/management/http/api/openapi.yml
+++ b/shared/management/http/api/openapi.yml
@@ -369,6 +369,11 @@ components:
         - $ref: '#/components/schemas/PeerMinimum'
         - type: object
           properties:
+            created_at:
+              description: Peer creation date (UTC)
+              type: string
+              format: date-time
+              example: "2023-05-05T09:00:35.477782Z"
             ip:
               description: Peer's IP address
               type: string
@@ -471,6 +476,7 @@ components:
             - connected
             - connection_ip
             - country_code
+            - created_at
             - dns_label
             - geoname_id
             - groups
@@ -544,11 +550,17 @@ components:
         - $ref: '#/components/schemas/Peer'
         - type: object
           properties:
+            created_at:
+              description: Peer creation date (UTC)
+              type: string
+              format: date-time
+              example: "2023-05-05T09:00:35.477782Z"
             accessible_peers_count:
               description: Number of accessible peers
               type: integer
               example: 5
           required:
+            - created_at
             - accessible_peers_count
     SetupKeyBase:
       type: object

--- a/shared/management/http/api/types.gen.go
+++ b/shared/management/http/api/types.gen.go
@@ -1015,6 +1015,8 @@ type OSVersionCheck struct {
 
 // Peer defines model for Peer.
 type Peer struct {
+    // CreatedAt Peer creation date (UTC)
+    CreatedAt time.Time `json:"created_at"`
 	// ApprovalRequired (Cloud only) Indicates whether peer needs approval
 	ApprovalRequired bool `json:"approval_required"`
 
@@ -1096,6 +1098,8 @@ type Peer struct {
 
 // PeerBatch defines model for PeerBatch.
 type PeerBatch struct {
+    // CreatedAt Peer creation date (UTC)
+    CreatedAt time.Time `json:"created_at"`
 	// AccessiblePeersCount Number of accessible peers
 	AccessiblePeersCount int `json:"accessible_peers_count"`
 


### PR DESCRIPTION
This update introduces the CreatedAt field to the Peer and PeerBatch models, reflecting the peer's creation date in UTC. The OpenAPI specification has been updated accordingly to include this new field in the API responses.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)
.
### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
