### PR TITLE
feat(doc): Fix confusing comment

### DIFF
--- a/infrastructure_files/nginx.tmpl.conf
+++ b/infrastructure_files/nginx.tmpl.conf
@@ -17,7 +17,7 @@ upstream signal {
     server 127.0.0.1:10000;
 }
 upstream management {
-    # insert the grpc+http port of your signal container here
+    # insert the grpc+http port of your management container here
     server 127.0.0.1:8012;
 }
 


### PR DESCRIPTION
## Describe your changes
Simple typo fix, the management container nginx upstream comment is confusing and tells you to set it to the signal container instead.

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).
