### PR TITLE
[internal] Add missing assignment of iFaceDiscover when netstack is disabled

### DIFF
--- a/client/internal/stdnet/stdnet.go
+++ b/client/internal/stdnet/stdnet.go
@@ -40,7 +40,7 @@ func NewNetWithDiscover(iFaceDiscover ExternalIFaceDiscover, disallowList []stri
 	if netstack.IsEnabled() {
 		n.iFaceDiscover = pionDiscover{}
 	} else {
-		newMobileIFaceDiscover(iFaceDiscover)
+		n.iFaceDiscover = newMobileIFaceDiscover(iFaceDiscover)
 	}
 	return n, n.UpdateInterfaces()
 }


### PR DESCRIPTION
The internal updateInterfaces() function expects Net's field iFaceDiscover to not be nil

## Describe your changes

Return usage of mobileIFaceDiscover as Net's iFaceDiscover implementation when netstack isn't enabled

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

mobileIFaceDiscover was already used as the default iFaceDiscover implementation prior to adding netstack.
Running the application on Android (tested on 14) from revision 9f841657 onwards crashes the app and doesn't retain peer connectivity.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
