### PR TITLE
[client] Do not run up cmd if not needed

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,7 +18,7 @@ ENV \
     NB_LOG_FILE="console,/var/log/netbird/client.log" \
     NB_DAEMON_ADDR="unix:///var/run/netbird.sock" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="5" \
-    NB_ENTRYPOINT_LOGIN_TIMEOUT="1"
+    NB_ENTRYPOINT_LOGIN_TIMEOUT="5"
 
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -2,7 +2,7 @@
 set -eEuo pipefail
 
 : ${NB_ENTRYPOINT_SERVICE_TIMEOUT:="5"}
-: ${NB_ENTRYPOINT_LOGIN_TIMEOUT:="1"}
+: ${NB_ENTRYPOINT_LOGIN_TIMEOUT:="5"}
 NETBIRD_BIN="${NETBIRD_BIN:-"netbird"}"
 export NB_LOG_FILE="${NB_LOG_FILE:-"console,/var/log/netbird/client.log"}"
 service_pids=()
@@ -39,7 +39,7 @@ wait_for_message() {
     info "not waiting for log line ${message@Q} due to zero timeout."
   elif test -n "${log_file_path}"; then
     info "waiting for log line ${message@Q} for ${timeout} seconds..."
-    grep -q "${message}" <(timeout "${timeout}" tail -F "${log_file_path}" 2>/dev/null)
+    grep -E -q "${message}" <(timeout "${timeout}" tail -F "${log_file_path}" 2>/dev/null)
   else
     info "log file unsupported, sleeping for ${timeout} seconds..."
     sleep "${timeout}"
@@ -81,7 +81,7 @@ wait_for_daemon_startup() {
 login_if_needed() {
   local timeout="${1}"
 
-  if test -n "${log_file_path}" && wait_for_message "${timeout}" 'peer has been successfully registered'; then
+  if test -n "${log_file_path}" && wait_for_message "${timeout}" 'peer has been successfully registered|management connection state READY'; then
     info "already logged in, skipping 'netbird up'..."
   else
     info "logging in..."


### PR DESCRIPTION
## Describe your changes

- If the peer is already logged in according to the logs, do not run the up command.
- Increase the default timeout.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
