### PR TITLE
feat: prefer CLI flags over environment variables

### DIFF
--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -201,6 +201,9 @@ func SetupCloseHandler(ctx context.Context, cancel context.CancelFunc) {
 func SetFlagsFromEnvVars(cmd *cobra.Command) {
 	flags := cmd.PersistentFlags()
 	flags.VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			return
+		}
 		oldEnvVar := FlagNameToEnvVar(f.Name, "WT_")
 
 		if value, present := os.LookupEnv(oldEnvVar); present {

--- a/relay/cmd/env.go
+++ b/relay/cmd/env.go
@@ -13,6 +13,9 @@ import (
 func setFlagsFromEnvVars(cmd *cobra.Command) {
 	flags := cmd.PersistentFlags()
 	flags.VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			return
+		}
 		newEnvVar := flagNameToEnvVar(f.Name, "NB_")
 		value, present := os.LookupEnv(newEnvVar)
 		if !present {

--- a/signal/cmd/env.go
+++ b/signal/cmd/env.go
@@ -13,6 +13,9 @@ import (
 func setFlagsFromEnvVars(cmd *cobra.Command) {
 	flags := cmd.PersistentFlags()
 	flags.VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			return
+		}
 		newEnvVar := flagNameToEnvVar(f.Name, "NB_")
 		value, present := os.LookupEnv(newEnvVar)
 		if !present {


### PR DESCRIPTION
DO-NOT-MERGE (see the description)

## Describe your changes

Makes NetBird CLI behave with the usual precedence of the command line tooling, where directly passed command line flags take precedence over environment variables.

The general consensus is that we should not change this behavior right now, because it was working like this since forever and we might have users & customers depending on this behavior.

There are at least 2 examples of flags where envvar taking precedence over CLI flag makes sense (centrally-managed devices that user should not be able to reconfigure):
1. `--disable-profiles` / `NB_DISABLE_PROFILES`
2. `--disable-update-settings` / `NB_DISABLE_UPDATE_SETTINGS`

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/4515

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Documentation update will be needed if/when we decide to merge this.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
