### PR TITLE
[management] Fix/nmap dns filter

### DIFF
--- a/management/server/dns.go
+++ b/management/server/dns.go
@@ -20,27 +20,7 @@ import (
 
 // DNSConfigCache is a thread-safe cache for DNS configuration components
 type DNSConfigCache struct {
-	CustomZones      sync.Map
 	NameServerGroups sync.Map
-}
-
-// GetCustomZone retrieves a cached custom zone
-func (c *DNSConfigCache) GetCustomZone(key string) (*proto.CustomZone, bool) {
-	if c == nil {
-		return nil, false
-	}
-	if value, ok := c.CustomZones.Load(key); ok {
-		return value.(*proto.CustomZone), true
-	}
-	return nil, false
-}
-
-// SetCustomZone stores a custom zone in the cache
-func (c *DNSConfigCache) SetCustomZone(key string, value *proto.CustomZone) {
-	if c == nil {
-		return
-	}
-	c.CustomZones.Store(key, value)
 }
 
 // GetNameServerGroup retrieves a cached name server group
@@ -212,14 +192,8 @@ func toProtocolDNSConfig(update nbdns.Config, cache *DNSConfigCache) *proto.DNSC
 	}
 
 	for _, zone := range update.CustomZones {
-		cacheKey := zone.Domain
-		if cachedZone, exists := cache.GetCustomZone(cacheKey); exists {
-			protoUpdate.CustomZones = append(protoUpdate.CustomZones, cachedZone)
-		} else {
-			protoZone := convertToProtoCustomZone(zone)
-			cache.SetCustomZone(cacheKey, protoZone)
-			protoUpdate.CustomZones = append(protoUpdate.CustomZones, protoZone)
-		}
+		protoZone := convertToProtoCustomZone(zone)
+		protoUpdate.CustomZones = append(protoUpdate.CustomZones, protoZone)
 	}
 
 	for _, nsGroup := range update.NameServerGroups {

--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -474,15 +474,6 @@ func TestToProtocolDNSConfigWithCache(t *testing.T) {
 		t.Errorf("Results should be different for different inputs")
 	}
 
-	// Verify that the cache contains elements from both configs
-	if _, exists := cache.GetCustomZone("example.com"); !exists {
-		t.Errorf("Cache should contain custom zone for example.com")
-	}
-
-	if _, exists := cache.GetCustomZone("example.org"); !exists {
-		t.Errorf("Cache should contain custom zone for example.org")
-	}
-
 	if _, exists := cache.GetNameServerGroup("group1"); !exists {
 		t.Errorf("Cache should contain name server group 'group1'")
 	}

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -298,10 +298,8 @@ func (a *Account) GetPeerNetworkMap(
 		ServiceEnable: dnsManagementStatus,
 	}
 
-	log.WithContext(ctx).Tracef("peer %s dns management status: %v", peerID, dnsManagementStatus)
 	if dnsManagementStatus {
 		var zones []nbdns.CustomZone
-		log.WithContext(ctx).Tracef("peer %s has dns management enabled with peersCustomZone: %v, and %d peers to connect, peer[0] %v", peerID, peersCustomZone, len(peersToConnect), peersToConnect[0])
 		if peersCustomZone.Domain != "" {
 			records := filterZoneRecordsForPeers(peer, peersCustomZone, peersToConnect)
 			zones = append(zones, nbdns.CustomZone{
@@ -309,7 +307,6 @@ func (a *Account) GetPeerNetworkMap(
 				Records: records,
 			})
 		}
-		log.WithContext(ctx).Tracef("peer %s custom zones are %v", peerID, zones)
 		dnsUpdate.CustomZones = zones
 		dnsUpdate.NameServerGroups = getPeerNSGroups(a, peerID)
 	}


### PR DESCRIPTION
## Describe your changes
This PR removes the caching mechanism for DNS custom zones in the gRPC proto message.

This caching has become redundant since we recently introduced a filtering mechanism that selects zones based on available peers. With this dynamic filtering in place, the cache is no longer necessary and could potentially serve stale data. 
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
