### PR TITLE
Update url_windows.go to offer arm64 executable download

### DIFF
--- a/version/url_windows.go
+++ b/version/url_windows.go
@@ -1,9 +1,13 @@
 package version
 
-import "golang.org/x/sys/windows/registry"
+import (
+	"golang.org/x/sys/windows/registry"
+	"runtime"
+)
 
 const (
 	urlWinExe = "https://pkgs.netbird.io/windows/x64"
+	urlWinExeArm = "https://pkgs.netbird.io/windows/arm64"
 )
 
 var regKeyAppPath = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\Netbird"
@@ -14,6 +18,16 @@ func DownloadUrl() string {
 	if err == nil {
 		return urlWinExe
 	} else {
+		return downloadURL
+	}
+
+PKGINSTALL:
+	switch runtime.GOARCH {
+	case "amd64":
+		return urlWinExe
+	case "arm64":
+		return urlWinExeArm
+	default:
 		return downloadURL
 	}
 }


### PR DESCRIPTION
## Describe your changes

When the Windows arm64 client detects an update, it offers the amd64 download URL instead of the arm64 one; so I borrowed the selection pattern from the [macOS client's url_darwin.go ](https://github.com/netbirdio/netbird/blob/e7b5537dcc280384470668f461bbb1f7d2f41218/version/url_darwin.go)

## Issue ticket number and link
Relates to #2317 

## Stack

<!-- branch-stack -->

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
