### PR TITLE
[client] The status cmd will not be blocked by the ICE probe

### DIFF
--- a/client/status/status.go
+++ b/client/status/status.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/netbirdio/netbird/client/anonymize"
 	"github.com/netbirdio/netbird/client/internal/peer"
+	probeRelay "github.com/netbirdio/netbird/client/internal/relay"
 	"github.com/netbirdio/netbird/client/proto"
 	"github.com/netbirdio/netbird/shared/management/domain"
 	"github.com/netbirdio/netbird/version"
@@ -337,10 +338,16 @@ func ParseGeneralSummary(overview OutputOverview, showURL bool, showRelays bool,
 		for _, relay := range overview.Relays.Details {
 			available := "Available"
 			reason := ""
+
 			if !relay.Available {
-				available = "Unavailable"
-				reason = fmt.Sprintf(", reason: %s", relay.Error)
+				if relay.Error == probeRelay.ErrCheckInProgress.Error() {
+					available = "Checking..."
+				} else {
+					available = "Unavailable"
+					reason = fmt.Sprintf(", reason: %s", relay.Error)
+				}
 			}
+
 			relaysString += fmt.Sprintf("\n  [%s] is %s%s", relay.URI, available, reason)
 		}
 	} else {


### PR DESCRIPTION
 The status cmd will not be blocked by the ICE probe

Refactor the TURN and STUN probe, and cache the results. The NetBird status command will indicate a "checking…" state.

Relays: 
  [stun:192.168.0.10:3478] is Checking...
  [turn:192.168.0.10:3478?transport=udp] is Checking...
  [rel://192.168.6.1] is Available
  ```

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
