### PR TITLE
[client] Fix Advanced Settings not opening on Windows with Japanese locale (#4455)

### DIFF
--- a/client/ui/font_windows.go
+++ b/client/ui/font_windows.go
@@ -31,7 +31,6 @@ func (s *serviceClient) getWindowsFontFilePath() string {
 			"chr-CHER-US": "Gadugi.ttf",
 			"zh-HK":       "Segoeui.ttf",
 			"zh-TW":       "Segoeui.ttf",
-			"ja-JP":       "Yugothm.ttc",
 			"km-KH":       "Leelawui.ttf",
 			"ko-KR":       "Malgun.ttf",
 			"th-TH":       "Leelawui.ttf",


### PR DESCRIPTION
The Fyne framework does not support TTC font files. Use the default system font (Segoe UI) instead, so Windows can automatically fall back to a Japanese font when needed.

## Describe your changes

Stop specifying `Yugothm.ttc` for Japanese locale. 

The same fix has been introduced to v0.39.1 for Chinese locale; https://github.com/A-Archives-and-Forks/netbird/commit/4508c6172840c127a1a5bd6c2ab08c922160bfd1


## Issue ticket number and link

- #4455 

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This is just a bug fix which does not change the current product spec.

---

This is a screenshot for verifying automatic Japanese font fall back is working. (this change is not committed)

<img width="350" alt="スクリーンショット 2025-10-14 193436" src="https://github.com/user-attachments/assets/6c2fd7ac-a752-475a-91d8-57be6b812900" />

---

Crash log:

```
2025/10/14 19:13:30 Fyne error:  font load error
2025/10/14 19:13:30   Cause: collections not allowed
2025/10/14 19:13:30   At: C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/internal/painter/font.go:197
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff73b389344]

goroutine 1 [running, locked to thread]:
fyne.io/fyne/v2/internal/painter.(*dynamicFontMap).ResolveFace(0xc003ce27e0, 0x20)
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/internal/painter/font.go:362 +0x64
fyne.io/fyne/v2/internal/painter.walkString({0x7ff73c761840, 0xc003ce27e0}, {0xc000202f04?, 0x0?}, 0x380, {0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...)
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/internal/painter/font.go:256 +0xb9
fyne.io/fyne/v2/internal/painter.MeasureString({0x7ff73c761840?, 0xc003ce27e0?}, {0xc000202f04?, 0x0?}, 0x0?, {0x0, 0x0, 0x0, 0x0, 0x0, ...})
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/internal/painter/font.go:207 +0x6e
fyne.io/fyne/v2/internal/painter.measureText({0xc000202f04, 0x0}, 0x41600000, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, {0x0, ...})
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/internal/painter/font.go:233 +0xa5
fyne.io/fyne/v2/internal/painter.RenderedTextSize({0xc000202f04, 0x0}, 0x41600000, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, {0x0, ...})
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/internal/painter/font.go:218 +0xf8
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).RenderedTextSize(0x0?, {0xc000202f04?, 0x7ff73b3b69ae?}, 0x3c58f162?, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, ...)
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/internal/driver/glfw/driver.go:72 +0x7f
fyne.io/fyne/v2.MeasureText({0xc000202f04, 0x0}, 0x41600000, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/text.go:72 +0x98
fyne.io/fyne/v2/widget.(*RichText).updateRowBounds.func1({0xc000205be0?, 0x7ff73c5a51e9?, 0x0?})
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/widget/richtext.go:481 +0x892
fyne.io/fyne/v2/widget.(*RichText).updateRowBounds(0xc00036ed38)
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/widget/richtext.go:495 +0x1f0
fyne.io/fyne/v2/widget.(*entryRenderer).Refresh(0xc000210640)
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/widget/entry.go:1811 +0xcf
fyne.io/fyne/v2/widget.(*BaseWidget).Refresh(0xc00036ec08)
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/widget/widget.go:137 +0x9d
fyne.io/fyne/v2/widget.(*Entry).Refresh(0xc00036ec08)
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/widget/entry.go:488 +0x52
fyne.io/fyne/v2/widget.(*DisableableWidget).Disable(0xc00036ec08?)
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/widget/widget.go:207 +0x4e
fyne.io/fyne/v2/widget.(*Entry).Disable(...)
        C:/Users/******/go/pkg/mod/fyne.io/fyne/v2@v2.5.3/widget/entry.go:225
main.(*serviceClient).showSettingsUI(0xc00045e708)
        C:/Users/******/git/netbird/client/ui/client_ui.go:414 +0x225
main.newServiceClient(0xc000237ee0)
        C:/Users/******/git/netbird/client/ui/client_ui.go:342 +0x23d
main.main()
        C:/Users/******/git/netbird/client/ui/client_ui.go:88 +0x250
2025-10-14T19:13:30+09:00 INFO client/ui/event_handler.go:228: command 'settings true' failed with exit code 2
```



