### PR TITLE
[client] Fix nil pointer when run debug bundle

### DIFF
--- a/client/internal/debug/wgshow.go
+++ b/client/internal/debug/wgshow.go
@@ -14,6 +14,9 @@ type WGIface interface {
 }
 
 func (g *BundleGenerator) addWgShow() error {
+	if g.statusRecorder == nil {
+		return fmt.Errorf("no status recorder available for wg show")
+	}
 	result, err := g.statusRecorder.PeersStatus()
 	if err != nil {
 		return err


### PR DESCRIPTION
Handle the case when the service has already been down and the status recorder is not available

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
