### PR TITLE
goreleaser: add netbird-management package for debian

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -149,6 +149,24 @@ nfpms:
       preremove: "release_files/pre_remove.sh"
 
   - maintainer: Netbird <dev@netbird.io>
+    description: Netbird management plane.
+    homepage: https://netbird.io/
+    id: netbird-mgmt-deb
+    package_name: netbird-management
+    bindir: /usr/bin
+    builds:
+      - netbird-mgmt
+      - netbird-relay
+      - netbird-signal
+    formats:
+      - deb
+    contents:
+      - src: ./release_files/systemd/netbird-management.service
+        dst: /usr/lib/systemd/system/netbird-management.service
+      - src: ./release_files/systemd/netbird-signal.service
+        dst: /usr/lib/systemd/system/netbird-signal.service
+
+  - maintainer: Netbird <dev@netbird.io>
     description: Netbird client.
     homepage: https://netbird.io/
     id: netbird-rpm


### PR DESCRIPTION
## Describe your changes

For goreleaser, create an additional Debian package artifact which contains the `netbird-mgmt`, `netbird-relay` and `netbird-signal` binaries.

While I think it makes sense to have a single package with just all three binaries, I'm happy to change it such that each service has its own package, if that is preferred.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Simply adds a new debian package; goreleaser is pretty self-documenting and these things are not documented anywhere else w.r.t this.
