### PR TITLE
[client] Clean up match domain reg entries between config changes

### DIFF
--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -17,6 +17,7 @@ import (
 
 	nberrors "github.com/netbirdio/netbird/client/errors"
 	"github.com/netbirdio/netbird/client/internal/statemanager"
+	"github.com/netbirdio/netbird/client/internal/winregistry"
 )
 
 var (
@@ -274,9 +275,9 @@ func (r *registryConfigurator) configureDNSPolicy(policyPath string, domains []s
 		return fmt.Errorf("remove existing dns policy: %w", err)
 	}
 
-	regKey, _, err := registry.CreateKey(registry.LOCAL_MACHINE, policyPath, registry.SET_VALUE)
+	regKey, _, err := winregistry.CreateVolatileKey(registry.LOCAL_MACHINE, policyPath, registry.SET_VALUE)
 	if err != nil {
-		return fmt.Errorf("create registry key HKEY_LOCAL_MACHINE\\%s: %w", policyPath, err)
+		return fmt.Errorf("create volatile registry key HKEY_LOCAL_MACHINE\\%s: %w", policyPath, err)
 	}
 	defer closer(regKey)
 

--- a/client/internal/dns/host_windows_test.go
+++ b/client/internal/dns/host_windows_test.go
@@ -96,7 +96,7 @@ func registryKeyExists(path string) (bool, error) {
 	return true, nil
 }
 
-func cleanupRegistryKeys(t *testing.T) {
+func cleanupRegistryKeys(*testing.T) {
 	cfg := &registryConfigurator{nrptEntryCount: 10}
 	_ = cfg.removeDNSMatchPolicies()
 }

--- a/client/internal/winregistry/volatile_windows.go
+++ b/client/internal/winregistry/volatile_windows.go
@@ -1,0 +1,59 @@
+package winregistry
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+var (
+	advapi          = syscall.NewLazyDLL("advapi32.dll")
+	regCreateKeyExW = advapi.NewProc("RegCreateKeyExW")
+)
+
+const (
+	// Registry key options
+	regOptionNonVolatile = 0x0 // Key is preserved when system is rebooted
+	regOptionVolatile    = 0x1 // Key is not preserved when system is rebooted
+
+	// Registry disposition values
+	regCreatedNewKey     = 0x1
+	regOpenedExistingKey = 0x2
+)
+
+// CreateVolatileKey creates a volatile registry key named path under open key root.
+// CreateVolatileKey returns the new key and a boolean flag that reports whether the key already existed.
+// The access parameter specifies the access rights for the key to be created.
+//
+// Volatile keys are stored in memory and are automatically deleted when the system is shut down.
+// This provides automatic cleanup without requiring manual registry maintenance.
+func CreateVolatileKey(root registry.Key, path string, access uint32) (registry.Key, bool, error) {
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, false, err
+	}
+
+	var (
+		handle      syscall.Handle
+		disposition uint32
+	)
+
+	ret, _, _ := regCreateKeyExW.Call(
+		uintptr(root),
+		uintptr(unsafe.Pointer(pathPtr)),
+		0,                          // reserved
+		0,                          // class
+		uintptr(regOptionVolatile), // options - volatile key
+		uintptr(access),            // desired access
+		0,                          // security attributes
+		uintptr(unsafe.Pointer(&handle)),
+		uintptr(unsafe.Pointer(&disposition)),
+	)
+
+	if ret != 0 {
+		return 0, false, syscall.Errno(ret)
+	}
+
+	return registry.Key(handle), disposition == regOpenedExistingKey, nil
+}


### PR DESCRIPTION
## Describe your changes

- Clean up reg entries to avoid stale entries when the amount of match domains decreases between config updates
- Use temporary reg entries so they are cleaned up on crash/reboot automatically


## Issue ticket number and link
#3356 
## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
