### PR TITLE
[client] Fix macOS state-based dns cleanup

### DIFF
--- a/client/internal/dns/host_darwin_test.go
+++ b/client/internal/dns/host_darwin_test.go
@@ -1,0 +1,111 @@
+//go:build !ios
+
+package dns
+
+import (
+	"context"
+	"net/netip"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/internal/statemanager"
+)
+
+func TestDarwinDNSUncleanShutdownCleanup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping scutil integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	stateFile := filepath.Join(tmpDir, "state.json")
+
+	sm := statemanager.New(stateFile)
+	sm.RegisterState(&ShutdownState{})
+	sm.Start()
+	defer func() {
+		require.NoError(t, sm.Stop(context.Background()))
+	}()
+
+	configurator := &systemConfigurator{
+		createdKeys: make(map[string]struct{}),
+	}
+
+	config := HostDNSConfig{
+		ServerIP:   netip.MustParseAddr("100.64.0.1"),
+		ServerPort: 53,
+		RouteAll:   true,
+		Domains: []DomainConfig{
+			{Domain: "example.com", MatchOnly: true},
+		},
+	}
+
+	err := configurator.applyDNSConfig(config, sm)
+	require.NoError(t, err)
+
+	require.NoError(t, sm.PersistState(context.Background()))
+
+	searchKey := getKeyWithInput(netbirdDNSStateKeyFormat, searchSuffix)
+	matchKey := getKeyWithInput(netbirdDNSStateKeyFormat, matchSuffix)
+	localKey := getKeyWithInput(netbirdDNSStateKeyFormat, localSuffix)
+
+	defer func() {
+		for _, key := range []string{searchKey, matchKey, localKey} {
+			_ = removeTestDNSKey(key)
+		}
+	}()
+
+	for _, key := range []string{searchKey, matchKey, localKey} {
+		exists, err := checkDNSKeyExists(key)
+		require.NoError(t, err)
+		if exists {
+			t.Logf("Key %s exists before cleanup", key)
+		}
+	}
+
+	sm2 := statemanager.New(stateFile)
+	sm2.RegisterState(&ShutdownState{})
+	err = sm2.LoadState(&ShutdownState{})
+	require.NoError(t, err)
+
+	state := sm2.GetState(&ShutdownState{})
+	if state == nil {
+		t.Skip("State not saved, skipping cleanup test")
+	}
+
+	shutdownState, ok := state.(*ShutdownState)
+	require.True(t, ok)
+
+	err = shutdownState.Cleanup()
+	require.NoError(t, err)
+
+	for _, key := range []string{searchKey, matchKey, localKey} {
+		exists, err := checkDNSKeyExists(key)
+		require.NoError(t, err)
+		assert.False(t, exists, "Key %s should NOT exist after cleanup", key)
+	}
+}
+
+func checkDNSKeyExists(key string) (bool, error) {
+	cmd := exec.Command(scutilPath)
+	cmd.Stdin = strings.NewReader("show " + key + "\nquit\n")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(output), "No such key") {
+			return false, nil
+		}
+		return false, err
+	}
+	return !strings.Contains(string(output), "No such key"), nil
+}
+
+func removeTestDNSKey(key string) error {
+	cmd := exec.Command(scutilPath)
+	cmd.Stdin = strings.NewReader("remove " + key + "\nquit\n")
+	_, err := cmd.CombinedOutput()
+	return err
+}

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -179,13 +179,7 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig, stateManager
 		log.Infof("removed %s as main DNS forwarder for this peer", config.ServerIP)
 	}
 
-	if err := stateManager.UpdateState(&ShutdownState{
-		Guid:           r.guid,
-		GPO:            r.gpo,
-		NRPTEntryCount: r.nrptEntryCount,
-	}); err != nil {
-		log.Errorf("failed to update shutdown state: %s", err)
-	}
+	r.updateState(stateManager)
 
 	var searchDomains, matchDomains []string
 	for _, dConf := range config.Domains {
@@ -212,13 +206,7 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig, stateManager
 		r.nrptEntryCount = 0
 	}
 
-	if err := stateManager.UpdateState(&ShutdownState{
-		Guid:           r.guid,
-		GPO:            r.gpo,
-		NRPTEntryCount: r.nrptEntryCount,
-	}); err != nil {
-		log.Errorf("failed to update shutdown state: %s", err)
-	}
+	r.updateState(stateManager)
 
 	if err := r.updateSearchDomains(searchDomains); err != nil {
 		return fmt.Errorf("update search domains: %w", err)
@@ -227,6 +215,16 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig, stateManager
 	go r.flushDNSCache()
 
 	return nil
+}
+
+func (r *registryConfigurator) updateState(stateManager *statemanager.Manager) {
+	if err := stateManager.UpdateState(&ShutdownState{
+		Guid:           r.guid,
+		GPO:            r.gpo,
+		NRPTEntryCount: r.nrptEntryCount,
+	}); err != nil {
+		log.Errorf("failed to update shutdown state: %s", err)
+	}
 }
 
 func (r *registryConfigurator) addDNSSetupForAll(ip netip.Addr) error {

--- a/client/internal/dns/unclean_shutdown_darwin.go
+++ b/client/internal/dns/unclean_shutdown_darwin.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ShutdownState struct {
+	CreatedKeys []string
 }
 
 func (s *ShutdownState) Name() string {
@@ -17,6 +18,10 @@ func (s *ShutdownState) Cleanup() error {
 	manager, err := newHostManager()
 	if err != nil {
 		return fmt.Errorf("create host manager: %w", err)
+	}
+
+	for _, key := range s.CreatedKeys {
+		manager.createdKeys[key] = struct{}{}
 	}
 
 	if err := manager.restoreUncleanShutdownDNS(); err != nil {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

`CreatedKeys` wasn't saved in the state file so dns was also not cleaned up completely on crash

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
