### PR TITLE
[client] Redirect dns forwarder port 5353 to new listening port 22054

### DIFF
--- a/client/firewall/iptables/manager_linux.go
+++ b/client/firewall/iptables/manager_linux.go
@@ -260,6 +260,22 @@ func (m *Manager) UpdateSet(set firewall.Set, prefixes []netip.Prefix) error {
 	return m.router.UpdateSet(set, prefixes)
 }
 
+// AddInboundDNAT adds an inbound DNAT rule redirecting traffic from NetBird peers to local services.
+func (m *Manager) AddInboundDNAT(localAddr netip.Addr, protocol firewall.Protocol, sourcePort, targetPort uint16) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.router.AddInboundDNAT(localAddr, protocol, sourcePort, targetPort)
+}
+
+// RemoveInboundDNAT removes an inbound DNAT rule.
+func (m *Manager) RemoveInboundDNAT(localAddr netip.Addr, protocol firewall.Protocol, sourcePort, targetPort uint16) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.router.RemoveInboundDNAT(localAddr, protocol, sourcePort, targetPort)
+}
+
 func getConntrackEstablished() []string {
 	return []string{"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
 }

--- a/client/firewall/manager/firewall.go
+++ b/client/firewall/manager/firewall.go
@@ -151,14 +151,20 @@ type Manager interface {
 
 	DisableRouting() error
 
-	// AddDNATRule adds a DNAT rule
+	// AddDNATRule adds outbound DNAT rule for forwarding external traffic to the NetBird network.
 	AddDNATRule(ForwardRule) (Rule, error)
 
-	// DeleteDNATRule deletes a DNAT rule
+	// DeleteDNATRule deletes the outbound DNAT rule.
 	DeleteDNATRule(Rule) error
 
 	// UpdateSet updates the set with the given prefixes
 	UpdateSet(hash Set, prefixes []netip.Prefix) error
+
+	// AddInboundDNAT adds an inbound DNAT rule redirecting traffic from NetBird peers to local services
+	AddInboundDNAT(localAddr netip.Addr, protocol Protocol, sourcePort, targetPort uint16) error
+
+	// RemoveInboundDNAT removes inbound DNAT rule
+	RemoveInboundDNAT(localAddr netip.Addr, protocol Protocol, sourcePort, targetPort uint16) error
 }
 
 func GenKey(format string, pair RouterPair) string {

--- a/client/firewall/nftables/manager_linux.go
+++ b/client/firewall/nftables/manager_linux.go
@@ -376,6 +376,22 @@ func (m *Manager) UpdateSet(set firewall.Set, prefixes []netip.Prefix) error {
 	return m.router.UpdateSet(set, prefixes)
 }
 
+// AddInboundDNAT adds an inbound DNAT rule redirecting traffic from NetBird peers to local services.
+func (m *Manager) AddInboundDNAT(localAddr netip.Addr, protocol firewall.Protocol, sourcePort, targetPort uint16) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.router.AddInboundDNAT(localAddr, protocol, sourcePort, targetPort)
+}
+
+// RemoveInboundDNAT removes an inbound DNAT rule.
+func (m *Manager) RemoveInboundDNAT(localAddr netip.Addr, protocol firewall.Protocol, sourcePort, targetPort uint16) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.router.RemoveInboundDNAT(localAddr, protocol, sourcePort, targetPort)
+}
+
 func (m *Manager) createWorkTable() (*nftables.Table, error) {
 	tables, err := m.rConn.ListTablesOfFamily(nftables.TableFamilyIPv4)
 	if err != nil {

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -1350,6 +1350,103 @@ func (r *router) UpdateSet(set firewall.Set, prefixes []netip.Prefix) error {
 	return nil
 }
 
+// AddInboundDNAT adds an inbound DNAT rule redirecting traffic from NetBird peers to local services.
+func (r *router) AddInboundDNAT(localAddr netip.Addr, protocol firewall.Protocol, sourcePort, targetPort uint16) error {
+	ruleID := fmt.Sprintf("inbound-dnat-%s-%s-%d-%d", localAddr.String(), protocol, sourcePort, targetPort)
+
+	if _, exists := r.rules[ruleID]; exists {
+		return nil
+	}
+
+	protoNum, err := protoToInt(protocol)
+	if err != nil {
+		return fmt.Errorf("convert protocol to number: %w", err)
+	}
+
+	exprs := []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyIIFNAME, Register: 1},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     ifname(r.wgIface.Name()),
+		},
+		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 2},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 2,
+			Data:     []byte{protoNum},
+		},
+		&expr.Payload{
+			DestRegister: 3,
+			Base:         expr.PayloadBaseTransportHeader,
+			Offset:       2,
+			Len:          2,
+		},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 3,
+			Data:     binaryutil.BigEndian.PutUint16(sourcePort),
+		},
+	}
+
+	exprs = append(exprs, applyPrefix(netip.PrefixFrom(localAddr, 32), false)...)
+
+	exprs = append(exprs,
+		&expr.Immediate{
+			Register: 1,
+			Data:     localAddr.AsSlice(),
+		},
+		&expr.Immediate{
+			Register: 2,
+			Data:     binaryutil.BigEndian.PutUint16(targetPort),
+		},
+		&expr.NAT{
+			Type:        expr.NATTypeDestNAT,
+			Family:      uint32(nftables.TableFamilyIPv4),
+			RegAddrMin:  1,
+			RegProtoMin: 2,
+			RegProtoMax: 0,
+		},
+	)
+
+	dnatRule := &nftables.Rule{
+		Table:    r.workTable,
+		Chain:    r.chains[chainNameRoutingRdr],
+		Exprs:    exprs,
+		UserData: []byte(ruleID),
+	}
+	r.conn.AddRule(dnatRule)
+
+	if err := r.conn.Flush(); err != nil {
+		return fmt.Errorf("add inbound DNAT rule: %w", err)
+	}
+
+	r.rules[ruleID] = dnatRule
+
+	return nil
+}
+
+// RemoveInboundDNAT removes an inbound DNAT rule.
+func (r *router) RemoveInboundDNAT(localAddr netip.Addr, protocol firewall.Protocol, sourcePort, targetPort uint16) error {
+	if err := r.refreshRulesMap(); err != nil {
+		return fmt.Errorf(refreshRulesMapError, err)
+	}
+
+	ruleID := fmt.Sprintf("inbound-dnat-%s-%s-%d-%d", localAddr.String(), protocol, sourcePort, targetPort)
+
+	if rule, exists := r.rules[ruleID]; exists {
+		if err := r.conn.DelRule(rule); err != nil {
+			return fmt.Errorf("delete inbound DNAT rule %s: %w", ruleID, err)
+		}
+		if err := r.conn.Flush(); err != nil {
+			return fmt.Errorf("flush delete inbound DNAT rule: %w", err)
+		}
+		delete(r.rules, ruleID)
+	}
+
+	return nil
+}
+
 // applyNetwork generates nftables expressions for networks (CIDR) or sets
 func (r *router) applyNetwork(
 	network firewall.Network,

--- a/client/firewall/uspfilter/conntrack/common.go
+++ b/client/firewall/uspfilter/conntrack/common.go
@@ -22,6 +22,8 @@ type BaseConnTrack struct {
 	PacketsRx atomic.Uint64
 	BytesTx   atomic.Uint64
 	BytesRx   atomic.Uint64
+
+	DNATOrigPort atomic.Uint32
 }
 
 // these small methods will be inlined by the compiler

--- a/client/firewall/uspfilter/conntrack/tcp_test.go
+++ b/client/firewall/uspfilter/conntrack/tcp_test.go
@@ -603,7 +603,7 @@ func TestTCPInboundInitiatedConnection(t *testing.T) {
 	serverPort := uint16(80)
 
 	// 1. Client sends SYN (we receive it as inbound)
-	tracker.TrackInbound(clientIP, serverIP, clientPort, serverPort, TCPSyn, nil, 100)
+	tracker.TrackInbound(clientIP, serverIP, clientPort, serverPort, TCPSyn, nil, 100, 0)
 
 	key := ConnKey{
 		SrcIP:   clientIP,
@@ -623,12 +623,12 @@ func TestTCPInboundInitiatedConnection(t *testing.T) {
 	tracker.TrackOutbound(serverIP, clientIP, serverPort, clientPort, TCPSyn|TCPAck, 100)
 
 	// 3. Client sends ACK to complete handshake
-	tracker.TrackInbound(clientIP, serverIP, clientPort, serverPort, TCPAck, nil, 100)
+	tracker.TrackInbound(clientIP, serverIP, clientPort, serverPort, TCPAck, nil, 100, 0)
 	require.Equal(t, TCPStateEstablished, conn.GetState(), "Connection should be ESTABLISHED after handshake completion")
 
 	// 4. Test data transfer
 	// Client sends data
-	tracker.TrackInbound(clientIP, serverIP, clientPort, serverPort, TCPPush|TCPAck, nil, 1000)
+	tracker.TrackInbound(clientIP, serverIP, clientPort, serverPort, TCPPush|TCPAck, nil, 1000, 0)
 
 	// Server sends ACK for data
 	tracker.TrackOutbound(serverIP, clientIP, serverPort, clientPort, TCPAck, 100)
@@ -637,7 +637,7 @@ func TestTCPInboundInitiatedConnection(t *testing.T) {
 	tracker.TrackOutbound(serverIP, clientIP, serverPort, clientPort, TCPPush|TCPAck, 1500)
 
 	// Client sends ACK for data
-	tracker.TrackInbound(clientIP, serverIP, clientPort, serverPort, TCPAck, nil, 100)
+	tracker.TrackInbound(clientIP, serverIP, clientPort, serverPort, TCPAck, nil, 100, 0)
 
 	// Verify state and counters
 	require.Equal(t, TCPStateEstablished, conn.GetState())

--- a/client/firewall/uspfilter/nat_bench_test.go
+++ b/client/firewall/uspfilter/nat_bench_test.go
@@ -414,3 +414,127 @@ func BenchmarkChecksumOptimizations(b *testing.B) {
 		}
 	})
 }
+
+// BenchmarkPortDNAT measures the performance of port DNAT operations
+func BenchmarkPortDNAT(b *testing.B) {
+	scenarios := []struct {
+		name         string
+		proto        layers.IPProtocol
+		setupDNAT    bool
+		useMatchPort bool
+		description  string
+	}{
+		{
+			name:         "tcp_inbound_dnat_match",
+			proto:        layers.IPProtocolTCP,
+			setupDNAT:    true,
+			useMatchPort: true,
+			description:  "TCP inbound port DNAT translation (22 → 22022)",
+		},
+		{
+			name:         "tcp_inbound_dnat_nomatch",
+			proto:        layers.IPProtocolTCP,
+			setupDNAT:    true,
+			useMatchPort: false,
+			description:  "TCP inbound with DNAT configured but no port match",
+		},
+		{
+			name:         "tcp_inbound_no_dnat",
+			proto:        layers.IPProtocolTCP,
+			setupDNAT:    false,
+			useMatchPort: false,
+			description:  "TCP inbound without DNAT (baseline)",
+		},
+		{
+			name:         "udp_inbound_dnat_match",
+			proto:        layers.IPProtocolUDP,
+			setupDNAT:    true,
+			useMatchPort: true,
+			description:  "UDP inbound port DNAT translation (5353 → 22054)",
+		},
+		{
+			name:         "udp_inbound_dnat_nomatch",
+			proto:        layers.IPProtocolUDP,
+			setupDNAT:    true,
+			useMatchPort: false,
+			description:  "UDP inbound with DNAT configured but no port match",
+		},
+		{
+			name:         "udp_inbound_no_dnat",
+			proto:        layers.IPProtocolUDP,
+			setupDNAT:    false,
+			useMatchPort: false,
+			description:  "UDP inbound without DNAT (baseline)",
+		},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			manager, err := Create(&IFaceMock{
+				SetFilterFunc: func(device.PacketFilter) error { return nil },
+			}, false, flowLogger)
+			require.NoError(b, err)
+			defer func() {
+				require.NoError(b, manager.Close(nil))
+			}()
+
+			// Set logger to error level to reduce noise during benchmarking
+			manager.SetLogLevel(log.ErrorLevel)
+			defer func() {
+				// Restore to info level after benchmark
+				manager.SetLogLevel(log.InfoLevel)
+			}()
+
+			localAddr := netip.MustParseAddr("100.0.2.175")
+			clientIP := netip.MustParseAddr("100.0.169.249")
+
+			var origPort, targetPort, testPort uint16
+			if sc.proto == layers.IPProtocolTCP {
+				origPort, targetPort = 22, 22022
+			} else {
+				origPort, targetPort = 5353, 22054
+			}
+
+			if sc.useMatchPort {
+				testPort = origPort
+			} else {
+				testPort = 443 // Different port
+			}
+
+			// Setup port DNAT mapping if needed
+			if sc.setupDNAT {
+				err := manager.AddInboundDNAT(localAddr, protocolToFirewall(sc.proto), origPort, targetPort)
+				require.NoError(b, err)
+			}
+
+			// Pre-establish inbound connection for outbound reverse test
+			if sc.setupDNAT && sc.useMatchPort {
+				inboundPacket := generateDNATTestPacket(b, clientIP, localAddr, sc.proto, 54321, origPort)
+				manager.filterInbound(inboundPacket, 0)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			// Benchmark inbound DNAT translation
+			b.Run("inbound", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					// Create fresh packet each time
+					packet := generateDNATTestPacket(b, clientIP, localAddr, sc.proto, 54321, testPort)
+					manager.filterInbound(packet, 0)
+				}
+			})
+
+			// Benchmark outbound reverse DNAT translation (only if DNAT is set up and port matches)
+			if sc.setupDNAT && sc.useMatchPort {
+				b.Run("outbound_reverse", func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						// Create fresh return packet (from target port)
+						packet := generateDNATTestPacket(b, localAddr, clientIP, sc.proto, targetPort, 54321)
+						manager.filterOutbound(packet, 0)
+					}
+				})
+			}
+		})
+	}
+}

--- a/client/firewall/uspfilter/nat_test.go
+++ b/client/firewall/uspfilter/nat_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/require"
 
+	firewall "github.com/netbirdio/netbird/client/firewall/manager"
 	"github.com/netbirdio/netbird/client/iface/device"
 )
 
@@ -142,4 +143,112 @@ func TestDNATMappingManagement(t *testing.T) {
 
 	err = manager.RemoveInternalDNATMapping(originalIP)
 	require.Error(t, err, "Should error when removing non-existent mapping")
+}
+
+func TestInboundPortDNAT(t *testing.T) {
+	manager, err := Create(&IFaceMock{
+		SetFilterFunc: func(device.PacketFilter) error { return nil },
+	}, false, flowLogger)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, manager.Close(nil))
+	}()
+
+	localAddr := netip.MustParseAddr("100.0.2.175")
+	clientIP := netip.MustParseAddr("100.0.169.249")
+
+	testCases := []struct {
+		name       string
+		protocol   layers.IPProtocol
+		sourcePort uint16
+		targetPort uint16
+	}{
+		{"TCP SSH", layers.IPProtocolTCP, 22, 22022},
+		{"UDP DNS", layers.IPProtocolUDP, 5353, 22054},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := manager.AddInboundDNAT(localAddr, protocolToFirewall(tc.protocol), tc.sourcePort, tc.targetPort)
+			require.NoError(t, err)
+
+			inboundPacket := generateDNATTestPacket(t, clientIP, localAddr, tc.protocol, 54321, tc.sourcePort)
+			d := parsePacket(t, inboundPacket)
+
+			translated := manager.translateInboundPortDNAT(inboundPacket, d, clientIP, localAddr)
+			require.True(t, translated, "Inbound packet should be translated")
+
+			d = parsePacket(t, inboundPacket)
+			var dstPort uint16
+			switch tc.protocol {
+			case layers.IPProtocolTCP:
+				dstPort = uint16(d.tcp.DstPort)
+			case layers.IPProtocolUDP:
+				dstPort = uint16(d.udp.DstPort)
+			}
+
+			require.Equal(t, tc.targetPort, dstPort, "Destination port should be rewritten to target port")
+
+			err = manager.RemoveInboundDNAT(localAddr, protocolToFirewall(tc.protocol), tc.sourcePort, tc.targetPort)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestInboundPortDNATNegative(t *testing.T) {
+	manager, err := Create(&IFaceMock{
+		SetFilterFunc: func(device.PacketFilter) error { return nil },
+	}, false, flowLogger)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, manager.Close(nil))
+	}()
+
+	localAddr := netip.MustParseAddr("100.0.2.175")
+	clientIP := netip.MustParseAddr("100.0.169.249")
+
+	err = manager.AddInboundDNAT(localAddr, firewall.ProtocolTCP, 22, 22022)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name     string
+		protocol layers.IPProtocol
+		srcIP    netip.Addr
+		dstIP    netip.Addr
+		srcPort  uint16
+		dstPort  uint16
+	}{
+		{"Wrong port", layers.IPProtocolTCP, clientIP, localAddr, 54321, 80},
+		{"Wrong IP", layers.IPProtocolTCP, clientIP, netip.MustParseAddr("100.64.0.99"), 54321, 22},
+		{"Wrong protocol", layers.IPProtocolUDP, clientIP, localAddr, 54321, 22},
+		{"ICMP", layers.IPProtocolICMPv4, clientIP, localAddr, 0, 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			packet := generateDNATTestPacket(t, tc.srcIP, tc.dstIP, tc.protocol, tc.srcPort, tc.dstPort)
+			d := parsePacket(t, packet)
+
+			translated := manager.translateInboundPortDNAT(packet, d, tc.srcIP, tc.dstIP)
+			require.False(t, translated, "Packet should NOT be translated for %s", tc.name)
+
+			d = parsePacket(t, packet)
+			if tc.protocol == layers.IPProtocolTCP {
+				require.Equal(t, tc.dstPort, uint16(d.tcp.DstPort), "Port should remain unchanged")
+			} else if tc.protocol == layers.IPProtocolUDP {
+				require.Equal(t, tc.dstPort, uint16(d.udp.DstPort), "Port should remain unchanged")
+			}
+		})
+	}
+}
+
+func protocolToFirewall(proto layers.IPProtocol) firewall.Protocol {
+	switch proto {
+	case layers.IPProtocolTCP:
+		return firewall.ProtocolTCP
+	case layers.IPProtocolUDP:
+		return firewall.ProtocolUDP
+	default:
+		return firewall.ProtocolALL
+	}
 }

--- a/client/firewall/uspfilter/tracer_test.go
+++ b/client/firewall/uspfilter/tracer_test.go
@@ -104,6 +104,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StagePeerACL,
@@ -126,6 +128,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StagePeerACL,
@@ -153,6 +157,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StagePeerACL,
@@ -179,6 +185,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StagePeerACL,
@@ -204,6 +212,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StageRouteACL,
@@ -228,6 +238,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StageRouteACL,
@@ -246,6 +258,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StageRouteACL,
@@ -264,6 +278,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StageCompleted,
@@ -287,6 +303,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageCompleted,
 			},
@@ -301,6 +319,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageOutbound1to1NAT,
+				StageOutboundPortReverse,
 				StageCompleted,
 			},
 			expectedAllow: true,
@@ -319,6 +339,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StagePeerACL,
@@ -340,6 +362,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StagePeerACL,
@@ -362,6 +386,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StagePeerACL,
@@ -382,6 +408,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageConntrack,
 				StageRouting,
 				StagePeerACL,
@@ -406,6 +434,8 @@ func TestTracePacket(t *testing.T) {
 			},
 			expectedStages: []PacketStage{
 				StageReceived,
+				StageInboundPortDNAT,
+				StageInbound1to1NAT,
 				StageRouting,
 				StagePeerACL,
 				StageCompleted,

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -202,9 +202,6 @@ type Engine struct {
 	// WireGuard interface monitor
 	wgIfaceMonitor   *WGIfaceMonitor
 	wgIfaceMonitorWg sync.WaitGroup
-
-	// dns forwarder port
-	dnsFwdPort uint16
 }
 
 // Peer is an instance of the Connection Peer
@@ -247,7 +244,6 @@ func NewEngine(
 		statusRecorder: statusRecorder,
 		checks:         checks,
 		connSemaphore:  semaphoregroup.NewSemaphoreGroup(connInitLimit),
-		dnsFwdPort:     dnsfwd.ListenPort(),
 	}
 
 	sm := profilemanager.NewServiceManager("")
@@ -1084,7 +1080,7 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 	}
 
 	fwdEntries := toRouteDomains(e.config.WgPrivateKey.PublicKey().String(), routes)
-	e.updateDNSForwarder(dnsRouteFeatureFlag, fwdEntries, uint16(protoDNSConfig.ForwarderPort))
+	e.updateDNSForwarder(dnsRouteFeatureFlag, fwdEntries)
 
 	// Ingress forward rules
 	forwardingRules, err := e.updateForwardRules(networkMap.GetForwardingRules())
@@ -1843,14 +1839,9 @@ func (e *Engine) GetWgAddr() netip.Addr {
 func (e *Engine) updateDNSForwarder(
 	enabled bool,
 	fwdEntries []*dnsfwd.ForwarderEntry,
-	forwarderPort uint16,
 ) {
 	if e.config.DisableServerRoutes {
 		return
-	}
-
-	if forwarderPort > 0 {
-		dnsfwd.SetListenPort(forwarderPort)
 	}
 
 	if !enabled {
@@ -1864,20 +1855,17 @@ func (e *Engine) updateDNSForwarder(
 	}
 
 	if len(fwdEntries) > 0 {
-		switch {
-		case e.dnsForwardMgr == nil:
-			e.dnsForwardMgr = dnsfwd.NewManager(e.firewall, e.statusRecorder)
+		if e.dnsForwardMgr == nil {
+			localAddr := e.wgInterface.Address().IP
+			e.dnsForwardMgr = dnsfwd.NewManager(e.firewall, e.statusRecorder, localAddr)
+
 			if err := e.dnsForwardMgr.Start(fwdEntries); err != nil {
 				log.Errorf("failed to start DNS forward: %v", err)
 				e.dnsForwardMgr = nil
 			}
-			log.Infof("started domain router service with %d entries", len(fwdEntries))
-		case e.dnsFwdPort != forwarderPort:
-			log.Infof("updating domain router service port from %d to %d", e.dnsFwdPort, forwarderPort)
-			e.restartDnsFwd(fwdEntries, forwarderPort)
-			e.dnsFwdPort = forwarderPort
 
-		default:
+			log.Infof("started domain router service with %d entries", len(fwdEntries))
+		} else {
 			e.dnsForwardMgr.UpdateDomains(fwdEntries)
 		}
 	} else if e.dnsForwardMgr != nil {
@@ -1885,20 +1873,6 @@ func (e *Engine) updateDNSForwarder(
 		if err := e.dnsForwardMgr.Stop(context.Background()); err != nil {
 			log.Errorf("failed to stop DNS forward: %v", err)
 		}
-		e.dnsForwardMgr = nil
-	}
-
-}
-
-func (e *Engine) restartDnsFwd(fwdEntries []*dnsfwd.ForwarderEntry, forwarderPort uint16) {
-	log.Infof("updating domain router service port from %d to %d", e.dnsFwdPort, forwarderPort)
-	// stop and start the forwarder to apply the new port
-	if err := e.dnsForwardMgr.Stop(context.Background()); err != nil {
-		log.Errorf("failed to stop DNS forward: %v", err)
-	}
-	e.dnsForwardMgr = dnsfwd.NewManager(e.firewall, e.statusRecorder)
-	if err := e.dnsForwardMgr.Start(fwdEntries); err != nil {
-		log.Errorf("failed to start DNS forward: %v", err)
 		e.dnsForwardMgr = nil
 	}
 }

--- a/client/internal/netflow/logger/logger.go
+++ b/client/internal/netflow/logger/logger.go
@@ -10,10 +10,10 @@ import (
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/netbirdio/netbird/client/internal/dnsfwd"
 	"github.com/netbirdio/netbird/client/internal/netflow/store"
 	"github.com/netbirdio/netbird/client/internal/netflow/types"
 	"github.com/netbirdio/netbird/client/internal/peer"
+	"github.com/netbirdio/netbird/dns"
 )
 
 type rcvChan chan *types.EventFields
@@ -138,7 +138,8 @@ func (l *Logger) UpdateConfig(dnsCollection, exitNodeCollection bool) {
 
 func (l *Logger) shouldStore(event *types.EventFields, isExitNode bool) bool {
 	// check dns collection
-	if !l.dnsCollection.Load() && event.Protocol == types.UDP && (event.DestPort == 53 || event.DestPort == uint16(dnsfwd.ListenPort())) {
+	if !l.dnsCollection.Load() && event.Protocol == types.UDP &&
+		(event.DestPort == 53 || event.DestPort == dns.ForwarderClientPort || event.DestPort == dns.ForwarderServerPort) {
 		return false
 	}
 

--- a/client/internal/routemanager/dnsinterceptor/handler.go
+++ b/client/internal/routemanager/dnsinterceptor/handler.go
@@ -18,9 +18,9 @@ import (
 	firewall "github.com/netbirdio/netbird/client/firewall/manager"
 	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	nbdns "github.com/netbirdio/netbird/client/internal/dns"
-	"github.com/netbirdio/netbird/client/internal/dnsfwd"
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/peerstore"
+	pkgdns "github.com/netbirdio/netbird/dns"
 	"github.com/netbirdio/netbird/client/internal/routemanager/common"
 	"github.com/netbirdio/netbird/client/internal/routemanager/fakeip"
 	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
@@ -257,7 +257,7 @@ func (d *DnsInterceptor) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		r.MsgHdr.AuthenticatedData = true
 	}
 
-	upstream := fmt.Sprintf("%s:%d", upstreamIP.String(), dnsfwd.ListenPort())
+	upstream := fmt.Sprintf("%s:%d", upstreamIP.String(), pkgdns.ForwarderClientPort)
 	ctx, cancel := context.WithTimeout(context.Background(), dnsTimeout)
 	defer cancel()
 

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -19,6 +19,10 @@ const (
 	RootZone = "."
 	// DefaultClass is the class supported by the system
 	DefaultClass = "IN"
+	// ForwarderClientPort is the port clients connect to. DNAT rewrites packets from ForwarderClientPort to ForwarderServerPort.
+	ForwarderClientPort uint16 = 5353
+	// ForwarderServerPort is the port the DNS forwarder actually listens on. Packets to ForwarderClientPort are DNATed here.
+	ForwarderServerPort uint16 = 22054
 )
 
 const invalidHostLabel = "[^a-zA-Z0-9-]+"

--- a/management/server/dns.go
+++ b/management/server/dns.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	dnsForwarderPort = 22054
-	oldForwarderPort = 5353
+	dnsForwarderPort = nbdns.ForwarderServerPort
+	oldForwarderPort = nbdns.ForwarderClientPort
 )
 
 const dnsForwarderPortMinVersion = "v0.59.0"
@@ -196,7 +196,7 @@ func validateDNSSettings(ctx context.Context, transaction store.Store, accountID
 // If all peers have the required version, it returns the new well-known port (22054), otherwise returns 0.
 func computeForwarderPort(peers []*nbpeer.Peer, requiredVersion string) int64 {
 	if len(peers) == 0 {
-		return oldForwarderPort
+		return int64(oldForwarderPort)
 	}
 
 	reqVer := semver.Canonical(requiredVersion)
@@ -211,17 +211,17 @@ func computeForwarderPort(peers []*nbpeer.Peer, requiredVersion string) int64 {
 		peerVersion := semver.Canonical("v" + peer.Meta.WtVersion)
 		if peerVersion == "" {
 			// If any peer doesn't have version info, return 0
-			return oldForwarderPort
+			return int64(oldForwarderPort)
 		}
 
 		// Compare versions
 		if semver.Compare(peerVersion, reqVer) < 0 {
-			return oldForwarderPort
+			return int64(oldForwarderPort)
 		}
 	}
 
 	// All peers have the required version or newer
-	return dnsForwarderPort
+	return int64(dnsForwarderPort)
 }
 
 // toProtocolDNSConfig converts nbdns.Config to proto.DNSConfig using the cache

--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -394,7 +394,7 @@ func BenchmarkToProtocolDNSConfig(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				toProtocolDNSConfig(testData, cache, dnsForwarderPort)
+				toProtocolDNSConfig(testData, cache, int64(dnsForwarderPort))
 			}
 		})
 
@@ -402,7 +402,7 @@ func BenchmarkToProtocolDNSConfig(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				cache := &DNSConfigCache{}
-				toProtocolDNSConfig(testData, cache, dnsForwarderPort)
+				toProtocolDNSConfig(testData, cache, int64(dnsForwarderPort))
 			}
 		})
 	}
@@ -455,13 +455,13 @@ func TestToProtocolDNSConfigWithCache(t *testing.T) {
 	}
 
 	// First run with config1
-	result1 := toProtocolDNSConfig(config1, &cache, dnsForwarderPort)
+	result1 := toProtocolDNSConfig(config1, &cache, int64(dnsForwarderPort))
 
 	// Second run with config2
-	result2 := toProtocolDNSConfig(config2, &cache, dnsForwarderPort)
+	result2 := toProtocolDNSConfig(config2, &cache, int64(dnsForwarderPort))
 
 	// Third run with config1 again
-	result3 := toProtocolDNSConfig(config1, &cache, dnsForwarderPort)
+	result3 := toProtocolDNSConfig(config1, &cache, int64(dnsForwarderPort))
 
 	// Verify that result1 and result3 are identical
 	if !reflect.DeepEqual(result1, result3) {
@@ -486,7 +486,7 @@ func TestComputeForwarderPort(t *testing.T) {
 	// Test with empty peers list
 	peers := []*nbpeer.Peer{}
 	result := computeForwarderPort(peers, "v0.59.0")
-	if result != oldForwarderPort {
+	if result != int64(oldForwarderPort) {
 		t.Errorf("Expected %d for empty peers list, got %d", oldForwarderPort, result)
 	}
 
@@ -504,7 +504,7 @@ func TestComputeForwarderPort(t *testing.T) {
 		},
 	}
 	result = computeForwarderPort(peers, "v0.59.0")
-	if result != oldForwarderPort {
+	if result != int64(oldForwarderPort) {
 		t.Errorf("Expected %d for peers with old versions, got %d", oldForwarderPort, result)
 	}
 
@@ -522,7 +522,7 @@ func TestComputeForwarderPort(t *testing.T) {
 		},
 	}
 	result = computeForwarderPort(peers, "v0.59.0")
-	if result != dnsForwarderPort {
+	if result != int64(dnsForwarderPort) {
 		t.Errorf("Expected %d for peers with new versions, got %d", dnsForwarderPort, result)
 	}
 
@@ -540,7 +540,7 @@ func TestComputeForwarderPort(t *testing.T) {
 		},
 	}
 	result = computeForwarderPort(peers, "v0.59.0")
-	if result != oldForwarderPort {
+	if result != int64(oldForwarderPort) {
 		t.Errorf("Expected %d for peers with mixed versions, got %d", oldForwarderPort, result)
 	}
 
@@ -553,7 +553,7 @@ func TestComputeForwarderPort(t *testing.T) {
 		},
 	}
 	result = computeForwarderPort(peers, "v0.59.0")
-	if result != oldForwarderPort {
+	if result != int64(oldForwarderPort) {
 		t.Errorf("Expected %d for peers with empty version, got %d", oldForwarderPort, result)
 	}
 
@@ -565,7 +565,7 @@ func TestComputeForwarderPort(t *testing.T) {
 		},
 	}
 	result = computeForwarderPort(peers, "v0.59.0")
-	if result == oldForwarderPort {
+	if result == int64(oldForwarderPort) {
 		t.Errorf("Expected %d for peers with dev version, got %d", dnsForwarderPort, result)
 	}
 
@@ -578,7 +578,7 @@ func TestComputeForwarderPort(t *testing.T) {
 		},
 	}
 	result = computeForwarderPort(peers, "v0.59.0")
-	if result != oldForwarderPort {
+	if result != int64(oldForwarderPort) {
 		t.Errorf("Expected %d for peers with unknown version, got %d", oldForwarderPort, result)
 	}
 }

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -1161,7 +1161,7 @@ func TestToSyncResponse(t *testing.T) {
 	}
 	dnsCache := &DNSConfigCache{}
 	accountSettings := &types.Settings{RoutingPeerDNSResolutionEnabled: true}
-	response := toSyncResponse(context.Background(), config, peer, turnRelayToken, turnRelayToken, networkMap, dnsName, checks, dnsCache, accountSettings, nil, []string{}, dnsForwarderPort)
+	response := toSyncResponse(context.Background(), config, peer, turnRelayToken, turnRelayToken, networkMap, dnsName, checks, dnsCache, accountSettings, nil, []string{}, int64(dnsForwarderPort))
 
 	assert.NotNil(t, response)
 	// assert peer config

--- a/shared/management/proto/management.proto
+++ b/shared/management/proto/management.proto
@@ -410,7 +410,7 @@ message DNSConfig {
   bool ServiceEnable = 1;
   repeated NameServerGroup NameServerGroups = 2;
   repeated CustomZone CustomZones = 3;
-  int64 ForwarderPort = 4;
+  int64 ForwarderPort = 4 [deprecated = true];
 }
 
 // CustomZone represents a dns.CustomZone


### PR DESCRIPTION
## Describe your changes

- Port dnat changes from https://github.com/netbirdio/netbird/pull/4015 (nftables/iptables/userspace)
  - For userspace: rewrite the original port to the target port
  - Remember original destination port in conntrack
  - Rewrite the source port back to the original port for replies
- Redirect incoming port 5353 to 22054 (tcp/udp)
- Revert port changes based on the network map received from management
- Adjust tracer to show NAT stages

Example tracer output

```
$ netbird debug trace in 100.0.169.249 self -p tcp --dport 5353
Packet trace 100.0.169.249:49561 → self:5353 (TCP)

Received: Received TCP packet: 100.0.169.249:49561 -> 100.0.2.175:5353
Inbound Port DNAT: TCP port DNAT applied: 100.0.2.175:5353 -> 100.0.2.175:22054
Inbound 1:1 NAT: 1:1 NAT not enabled
Connection Tracking: No existing connection found
Routing: Packet destined for local delivery
Peer ACL: Allowed by peer ACL rules (<no id>)
Completed: Processing completed

Final disposition: ALLOWED
```

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
