### PR TITLE
[Client] cleanup leftover dns and nrpt policies on windows

### DIFF
--- a/client/installer.nsis
+++ b/client/installer.nsis
@@ -298,6 +298,7 @@ NRPT_Loop:
 
     DetailPrint "Deleting NRPT key: $1"
     DeleteRegKey HKLM "SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\DnsPolicyConfig\$1"
+    Goto NRPT_Loop
 
 NRPT_Next:
     IntOp $0 $0 + 1
@@ -307,6 +308,7 @@ NRPT_Done: ;
 DetailPrint "NRPT cleanup completed."
 DetailPrint "Restarting DNS Client service..."
 nsExec::ExecToLog "sc stop Dnscache"
+Sleep 2000
 nsExec::ExecToLog "sc start Dnscache"
 
 ; Handle data deletion based on checkbox


### PR DESCRIPTION
## Describe your changes
In some cases, the Windows client does not clean up DNS and NRPT policies in the registry.
This can break the user's DNS resolution when using split-horizon DNS.
If these entries are not properly removed, the user may lose access to domains configured under the split-horizon setup.

## Issue ticket number and link
N/A
## Stack
Windows
<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)
It happens in the uninstaller

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adds explicit DNS policy cleanup during uninstall to remove leftover DNS entries and improve network state
  * Restarts the DNS client service as part of uninstall to ensure changes take effect
  * Clarifies and preserves the user data deletion choice, adds a brief wait before final removal to avoid conflicts
  * Improves uninstall logging and step sequencing for more reliable diagnostics

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->