### PR TITLE
[client] Use management-provided dns forwarder port on the client side

### DIFF
--- a/client/internal/routemanager/common/params.go
+++ b/client/internal/routemanager/common/params.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/netbirdio/netbird/client/firewall/manager"
@@ -25,4 +26,5 @@ type HandlerParams struct {
 	UseNewDNSRoute       bool
 	Firewall             manager.Manager
 	FakeIPManager        *fakeip.Manager
+	ForwarderPort        *atomic.Uint32
 }

--- a/client/internal/routemanager/mock.go
+++ b/client/internal/routemanager/mock.go
@@ -90,6 +90,10 @@ func (m *MockManager) SetFirewall(firewall.Manager) error {
 	panic("implement me")
 }
 
+// SetDNSForwarderPort mock implementation of SetDNSForwarderPort from Manager interface
+func (m *MockManager) SetDNSForwarderPort(port uint16) {
+}
+
 // Stop mock implementation of Stop from Manager interface
 func (m *MockManager) Stop(stateManager *statemanager.Manager) {
 	if m.StopFunc != nil {

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -35,6 +35,8 @@ type Config struct {
 	NameServerGroups []*NameServerGroup
 	// CustomZones contains a list of custom zone
 	CustomZones []CustomZone
+	// ForwarderPort is the port clients should connect to on routing peers for DNS forwarding
+	ForwarderPort uint16
 }
 
 // CustomZone represents a custom zone to be resolved by the dns server


### PR DESCRIPTION
## Describe your changes

- Makes routing client respect management-provided dns forwarder port to keep compatibility with older routing peers

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
