### PR TITLE
[client] Set up networkd to ignore ip rules

### DIFF
--- a/client/cmd/service_installer.go
+++ b/client/cmd/service_installer.go
@@ -279,6 +279,7 @@ func configureSystemdNetworkd() error {
 		return nil
 	}
 
+	// nolint:gosec // standard networkd permissions
 	if err := os.WriteFile(networkdConfFile, []byte(networkdConfContent), 0644); err != nil {
 		return fmt.Errorf("write networkd configuration: %w", err)
 	}


### PR DESCRIPTION
## Describe your changes

If networkd is in use, a restart would wipe all NetBird ip rules. This config prevents that.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
