### PR TITLE
client/ui: more understandable connection lost messages

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -280,6 +280,7 @@ type serviceClient struct {
 	blockLANAccess      bool
 
 	connected            bool
+	connectivityLost     bool
 	update               *version.Update
 	daemonVersion        string
 	updateIndicationLock sync.Mutex
@@ -703,21 +704,41 @@ func (s *serviceClient) menuDownClick() error {
 	return nil
 }
 
+func (s *serviceClient) onStatusFailed(err error) {
+	log.Errorf("get client daemon service status: %v", err)
+	if s.connected {
+		s.connectivityLost = true
+		s.app.SendNotification(fyne.NewNotification(
+			"Warning",
+			"NetBird client service controls were interrupted.\n"+
+				"They should restore automatically.",
+		))
+	}
+	s.setDisconnectedStatus()
+}
+func (s *serviceClient) onStatusSucceeded() {
+	if s.connectivityLost {
+		s.connectivityLost = false
+		s.app.SendNotification(fyne.NewNotification(
+			"Info",
+			"NetBird client service controls were restored.",
+		))
+	}
+}
+
 func (s *serviceClient) updateStatus() error {
 	conn, err := s.getSrvClient(defaultFailTimeout)
 	if err != nil {
+		s.onStatusFailed(err)
 		return err
 	}
 	err = backoff.Retry(func() error {
 		status, err := conn.Status(s.ctx, &proto.StatusRequest{})
 		if err != nil {
-			log.Errorf("get service status: %v", err)
-			if s.connected {
-				s.app.SendNotification(fyne.NewNotification("Error", "Connection to service lost"))
-			}
-			s.setDisconnectedStatus()
+			s.onStatusFailed(err)
 			return err
 		}
+		s.onStatusSucceeded()
 
 		s.updateIndicationLock.Lock()
 		defer s.updateIndicationLock.Unlock()


### PR DESCRIPTION
## Describe your changes

The existing message is misleading and alarming for customers, even though the "error" is supposed to recover on the next run.

WARNING: I don't know how to cause this type of failure to test it in NetBird. I have generated the same message in https://github.com/fyne-io/demo to confirm `fyne` support multi-line notificatinos.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
