### PR TITLE
fix pg db deadlock after app panic

### DIFF
--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -2917,6 +2917,7 @@ func (s *SqlStore) ExecuteInTransaction(ctx context.Context, operation func(stor
 	defer func() {
 		if r := recover(); r != nil {
 			tx.Rollback()
+			panic(r)
 		}
 	}()
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction reliability by ensuring automatic rollback on unexpected panics or failures.
  * Added database-level timeout protections to guard against long-running statements and locks.
  * Maintained existing foreign-key handling and commit behavior while strengthening error handling and rollback paths.
  * Ensured timeout settings are applied transactionally and will roll back if they cannot be set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->