### PR TITLE
[client] Revert migrate deprecated grpc client code

### DIFF
--- a/client/grpc/dialer.go
+++ b/client/grpc/dialer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"runtime"
 	"time"
@@ -12,7 +11,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
@@ -20,35 +18,12 @@ import (
 	"github.com/netbirdio/netbird/util/embeddedroots"
 )
 
-// ErrConnectionShutdown indicates that the connection entered shutdown state before becoming ready
-var ErrConnectionShutdown = errors.New("connection shutdown before ready")
-
 // Backoff returns a backoff configuration for gRPC calls
 func Backoff(ctx context.Context) backoff.BackOff {
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = 10 * time.Second
 	b.Clock = backoff.SystemClock
 	return backoff.WithContext(b, ctx)
-}
-
-// waitForConnectionReady blocks until the connection becomes ready or fails.
-// Returns an error if the connection times out, is cancelled, or enters shutdown state.
-func waitForConnectionReady(ctx context.Context, conn *grpc.ClientConn) error {
-	conn.Connect()
-
-	state := conn.GetState()
-	for state != connectivity.Ready && state != connectivity.Shutdown {
-		if !conn.WaitForStateChange(ctx, state) {
-			return fmt.Errorf("wait state change from %s: %w", state, ctx.Err())
-		}
-		state = conn.GetState()
-	}
-
-	if state == connectivity.Shutdown {
-		return ErrConnectionShutdown
-	}
-
-	return nil
 }
 
 // CreateConnection creates a gRPC client connection with the appropriate transport options.
@@ -68,25 +43,22 @@ func CreateConnection(ctx context.Context, addr string, tlsEnabled bool, compone
 		}))
 	}
 
-	conn, err := grpc.NewClient(
+	connCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	conn, err := grpc.DialContext(
+		connCtx,
 		addr,
 		transportOption,
 		WithCustomDialer(tlsEnabled, component),
+		grpc.WithBlock(),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:    30 * time.Second,
 			Timeout: 10 * time.Second,
 		}),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("new client: %w", err)
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	if err := waitForConnectionReady(ctx, conn); err != nil {
-		_ = conn.Close()
-		return nil, err
+		return nil, fmt.Errorf("dial context: %w", err)
 	}
 
 	return conn, nil


### PR DESCRIPTION
This reverts commit 43c9a519131ef69c86c74a8d6a579e4f2c1d236d.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined gRPC connection initialization with an optimized dial timeout mechanism for improved connection reliability and handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->