### PR TITLE
Fix ui-post-install.sh to use the full username

### DIFF
--- a/release_files/ui-post-install.sh
+++ b/release_files/ui-post-install.sh
@@ -11,5 +11,5 @@ then
   username="$(id -nu "${uid}")"
   # Only re-run if it was already running
   pkill -x -f /usr/bin/netbird-ui >/dev/null 2>&1
-  su -l - "${username}" -c 'nohup /usr/bin/netbird-ui > /dev/null 2>&1 &'
+  su - "${username}" -c 'nohup /usr/bin/netbird-ui > /dev/null 2>&1 &'
 fi


### PR DESCRIPTION
## Describe your changes

Fixes https://github.com/netbirdio/netbird/issues/4808 by extracting the full username by:
1. Get PID using `pgrep`
2. Get UID from PID using `/proc/${PID}/loginuid`
3. Get user name from UID using `id`

Also replaces "complex" pipe from `ps` to `sed` with a (hopefully) "simpler" (as in requiring less knowledge about the arguments of `ps` and regexps) invocation of `cat` and `id`.

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/4808

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This fixes a post-install script used in Linux packages, which should be invisible to regular users.

### Docs PR URL (required if "docs added" is checked)

N/A

----

Closes: https://github.com/netbirdio/netbird/issues/4808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the UI post-install behavior: installation now reliably detects running UI processes and only attempts a restart when appropriate.
  * Strengthened error handling and execution safeguards during installation to prevent unexpected failures and ensure the UI is relaunched under the correct user context when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->