### PR TITLE
[management] Refactor job channel management to prevent panics

### DIFF
--- a/management/server/job/channel.go
+++ b/management/server/job/channel.go
@@ -1,0 +1,59 @@
+package job
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// todo consider the channel buffer size when we allow to run multiple jobs
+const jobChannelBuffer = 1
+
+var (
+	ErrJobChannelClosed = errors.New("job channel closed")
+)
+
+type Channel struct {
+	events chan *Event
+	once   sync.Once
+}
+
+func NewChannel() *Channel {
+	jc := &Channel{
+		events: make(chan *Event, jobChannelBuffer),
+	}
+
+	return jc
+}
+
+func (jc *Channel) AddEvent(ctx context.Context, responseWait time.Duration, event *Event) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+		// todo: timeout is handled in the wrong place. If the peer does not respond with the job response, the server does not clean it up from the pending jobs and cannot apply a new job
+	case <-time.After(responseWait):
+		return fmt.Errorf("failed to add the event to the channel")
+	case jc.events <- event:
+	}
+	return nil
+}
+
+func (jc *Channel) Close() {
+	jc.once.Do(func() {
+		close(jc.events)
+	})
+}
+
+func (jc *Channel) Event(ctx context.Context) (*Event, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case job, open := <-jc.events:
+		if !open {
+			return nil, ErrJobChannelClosed
+		}
+		return job, nil
+	}
+}

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -339,6 +339,9 @@ func (am *DefaultAccountManager) CreatePeerJob(ctx context.Context, accountID, p
 	}
 
 	// check if already has pending jobs
+	// todo: The job checks here are not protected. The user can run this function from multiple threads,
+	// and each thread can think there is no job yet. This means entries in the pending job map will be overwritten,
+	// and only one will be kept, but potentially another one will overwrite it in the queue.
 	if am.jobManager.IsPeerHasPendingJobs(peerID) {
 		return status.Errorf(status.BadRequest, "peer already has pending job")
 	}


### PR DESCRIPTION
Introduce a Channel abstraction to wrap job event channels with proper error handling. This
prevents panics when reading from or closing channels by using explicit error returns instead of
relying on channel close signals.

Key improvements:

- Add Channel struct with Event(), AddEvent(), and Close() methods
- Replace select-based channel reads with Channel.Event() that returns ErrJobChannelClosed
- Use sync.Once in Channel.Close() to prevent double-close panics
- Remove redundant CloseChannel() calls from error paths in sendJob()
- Simplify sendJobsLoop() and sendJob() function signatures

## Describe your changes

## Issue ticket number and link

## Stack

- `feature/remote-debug-release` - :warning: No PR associated with branch <!-- branch-stack -->
  - \#4592
    - \#4824 :point\_left:

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)

Paste the PR link from <https://github.com/netbirdio/docs> here:

<https://github.com/netbirdio/docs/pull/>\_\_
