### PR TITLE
Refactor/channel based status updates

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -892,20 +892,7 @@ func (s *serviceClient) updateStatus() error {
 
 		switch {
 		case status.Status == string(internal.StatusConnected):
-			s.connected = true
-			s.sendNotification = true
-			if s.isUpdateIconActive {
-				systray.SetTemplateIcon(iconUpdateConnectedMacOS, s.icUpdateConnected)
-			} else {
-				systray.SetTemplateIcon(iconConnectedMacOS, s.icConnected)
-			}
-			systray.SetTooltip("NetBird (Connected)")
-			s.mStatus.SetTitle("Connected")
-			s.mStatus.SetIcon(s.icConnectedDot)
-			s.mUp.Disable()
-			s.mDown.Enable()
-			s.mNetworks.Enable()
-			go s.updateExitNodes()
+			s.setConnectedStatus()
 			systrayIconState = true
 		case status.Status == string(internal.StatusConnecting):
 			s.setConnectingStatus()
@@ -966,6 +953,23 @@ func (s *serviceClient) setDisconnectedStatus() {
 	s.mUp.Enable()
 	s.mNetworks.Disable()
 	s.mExitNode.Disable()
+	go s.updateExitNodes()
+}
+
+func (s *serviceClient) setConnectedStatus() {
+	s.connected = true
+	s.sendNotification = true
+	if s.isUpdateIconActive {
+		systray.SetTemplateIcon(iconUpdateConnectedMacOS, s.icUpdateConnected)
+	} else {
+		systray.SetTemplateIcon(iconConnectedMacOS, s.icConnected)
+	}
+	systray.SetTooltip("NetBird (Connected)")
+	s.mStatus.SetTitle("Connected")
+	s.mStatus.SetIcon(s.icConnectedDot)
+	s.mUp.Disable()
+	s.mDown.Enable()
+	s.mNetworks.Enable()
 	go s.updateExitNodes()
 }
 

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -318,7 +318,8 @@ type serviceClient struct {
 	logFile              string
 	wLoginURL            fyne.Window
 
-	connectCancel context.CancelFunc
+	connectCancel    context.CancelFunc
+	updateStatusChan chan struct{}
 }
 
 type menuHandler struct {
@@ -354,6 +355,7 @@ func newServiceClient(args *newServiceClientArgs) *serviceClient {
 		showAdvancedSettings: args.showSettings,
 		showNetworks:         args.showNetworks,
 		update:               version.NewUpdate("nb/client-ui"),
+		updateStatusChan:     make(chan struct{}, 1),
 	}
 
 	s.eventHandler = newEventHandler(s)
@@ -984,6 +986,36 @@ func (s *serviceClient) setConnectingStatus() {
 	s.mExitNode.Disable()
 }
 
+func (s *serviceClient) statusUpdateLoop() {
+	s.getSrvConfig()
+	time.Sleep(100 * time.Millisecond)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-s.updateStatusChan:
+		case <-ticker.C:
+		}
+
+		err := s.updateStatus()
+		if err != nil {
+			log.Errorf("error while updating status: %v", err)
+		}
+
+		s.checkAndUpdateFeatures()
+	}
+}
+
+func (s *serviceClient) triggerStatusUpdate() {
+	select {
+	case s.updateStatusChan <- struct{}{}:
+	default:
+	}
+}
+
 func (s *serviceClient) onTrayReady() {
 	systray.SetTemplateIcon(iconDisconnectedMacOS, s.icDisconnected)
 	systray.SetTooltip("NetBird")
@@ -1076,21 +1108,7 @@ func (s *serviceClient) onTrayReady() {
 	go s.updateExitNodes()
 
 	s.update.SetOnUpdateListener(s.onUpdateAvailable)
-	go func() {
-		s.getSrvConfig()
-		time.Sleep(100 * time.Millisecond) // To prevent race condition caused by systray not being fully initialized and ignoring setIcon
-		for {
-			err := s.updateStatus()
-			if err != nil {
-				log.Errorf("error while updating status: %v", err)
-			}
-
-			// Check features periodically to handle daemon restarts
-			s.checkAndUpdateFeatures()
-
-			time.Sleep(2 * time.Second)
-		}
-	}()
+	go s.statusUpdateLoop()
 
 	s.eventManager = event.NewManager(s.app, s.addr)
 	s.eventManager.SetNotificationsEnabled(s.mNotifications.Checked())

--- a/client/ui/event_handler.go
+++ b/client/ui/event_handler.go
@@ -90,9 +90,7 @@ func (h *eventHandler) handleConnectClick() {
 			}
 		}
 
-		if err := h.client.updateStatus(); err != nil {
-			log.Debugf("failed to update status after connect: %v", err)
-		}
+		h.client.triggerStatusUpdate()
 	}()
 }
 
@@ -116,9 +114,7 @@ func (h *eventHandler) handleDisconnectClick() {
 			}
 		}
 
-		if err := h.client.updateStatus(); err != nil {
-			log.Debugf("failed to update status after disconnect: %v", err)
-		}
+		h.client.triggerStatusUpdate()
 	}()
 }
 


### PR DESCRIPTION
## Describe your changes

Refactors the UI client's status update mechanism from a polling-only approach to a hybrid channel-based system. Introduces a statusUpdateLoop() that responds to both periodic ticks (every 2 seconds) and on-demand triggers via a buffered channel. Event handlers now call triggerStatusUpdate() instead of directly invoking updateStatus(), enabling immediate non-blocking status updates after connect/disconnect operations. Also extracts the connected status logic into a dedicated setConnectedStatus() helper function for consistency with existing setDisconnectedStatus() and setConnectingStatus() patterns.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized status-update flow to coordinate periodic and on-demand refreshes and to consolidate connecting/connected state handling for more consistent UI behavior.
* **Bug Fixes**
  * UI now updates promptly on system events and after connection changes, reducing stale or inconsistent status displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->