### PR TITLE
[client] Make mss clamping optional for nftables

### DIFF
--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -754,8 +754,6 @@ func (r *router) addPostroutingRules() {
 		Chain: r.chains[chainNameRoutingNat],
 		Exprs: exprs2,
 	})
-
-	return
 }
 
 // addMSSClampingRules adds MSS clamping rules to prevent fragmentation for forwarded traffic.


### PR DESCRIPTION
## Describe your changes

- Flush critical setup first (chains, some rules)
- Then flush each optional step separately (within each method)

This avoids polluting the critical setup with optional rules that can fail.

## Issue ticket number and link
https://github.com/netbirdio/addon-netbird/issues/311
## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized firewall rule initialization to flush once after rule additions for more consistent startup.
  * Reordered rule insertion so certain return/post-routing rules are applied via the centralized post-routing path.
  * Simplified internal rule-addition flows and return handling.

* **Bug Fixes**
  * Improved error handling and tightened log messages when loading or listing firewall tables/rules to reduce spurious failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->