### PR TITLE
Fixed management.json Path in configure.sh when recreating artifacts files

### DIFF
--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -234,11 +234,10 @@ if [ "$NETBIRD_DASH_AUTH_USE_AUDIENCE" = "false" ]; then
 fi
 
 # Read the encryption key
-if test -f 'management.json'; then
-    encKey=$(jq -r  ".DataStoreEncryptionKey" management.json)
+if test -f "${artifacts_path}/management.json"; then
+    encKey=$(jq -r  ".DataStoreEncryptionKey" ${artifacts_path}/management.json)
     if [[ "$encKey" != "null" ]]; then
         export NETBIRD_DATASTORE_ENC_KEY=$encKey
-
     fi
 fi
 


### PR DESCRIPTION
## Describe your changes
When recreating the infrastructure artifacts files using the configure.sh script, it searches for the `DataStoreEncryptionKey` in the management.json file. 

The problem is, that it searches for the file in the folder `infrastructure_files` and not in the correct `$artifacts_path` folder. 

Thats why the `DataStoreEncryptionKey` gets cleared and newly generated every time the configure.sh script is executed.

This PR fixes the problem by using the correct path for the reading of the `DataStoreEncryptionKey` from `$artifacts_path/management.json`

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs not needed explanation
It's a bugfix in the infrastructure configure.sh script which doesn't change the way it's used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file path resolution to use artifact directory structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->