### PR TITLE
feat(client): auto-reconfigure WireGuard interface on peer IP change

### DIFF
--- a/client/internal/engine_ssh.go
+++ b/client/internal/engine_ssh.go
@@ -19,6 +19,7 @@ import (
 type sshServer interface {
 	Start(ctx context.Context, addr netip.AddrPort) error
 	Stop() error
+	Restart(ctx context.Context, newAddr netip.AddrPort) error
 	GetStatus() (bool, []sshserver.SessionInfo)
 }
 

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/netbirdio/netbird/management/server/groups"
 	"github.com/netbirdio/netbird/management/server/peers/ephemeral/manager"
 
+	firewallManager "github.com/netbirdio/netbird/client/firewall/manager"
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	"github.com/netbirdio/netbird/client/iface/device"
@@ -48,7 +49,9 @@ import (
 	icemaker "github.com/netbirdio/netbird/client/internal/peer/ice"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/internal/routemanager"
+	"github.com/netbirdio/netbird/client/internal/statemanager"
 	nbssh "github.com/netbirdio/netbird/client/ssh"
+	sshserver "github.com/netbirdio/netbird/client/ssh/server"
 	"github.com/netbirdio/netbird/client/system"
 	nbdns "github.com/netbirdio/netbird/dns"
 	"github.com/netbirdio/netbird/management/server"
@@ -417,10 +420,18 @@ func TestEngine_UpdateSelfPeerIP(t *testing.T) {
 
 	t.Run("updates address successfully", func(t *testing.T) {
 		updateAddrCalled := false
+		oldAddr, _ := wgaddr.ParseWGAddress("100.64.0.1/24")
+		newAddr, _ := wgaddr.ParseWGAddress("100.64.0.2/24")
+		currentAddr := oldAddr
+
 		wgIface := &MockWGIface{
-			UpdateAddrFunc: func(newAddr string) error {
+			AddressFunc: func() wgaddr.Address {
+				return currentAddr
+			},
+			UpdateAddrFunc: func(addr string) error {
 				updateAddrCalled = true
-				assert.Equal(t, "100.64.0.2/24", newAddr)
+				assert.Equal(t, "100.64.0.2/24", addr)
+				currentAddr = newAddr
 				return nil
 			},
 		}
@@ -439,7 +450,12 @@ func TestEngine_UpdateSelfPeerIP(t *testing.T) {
 	})
 
 	t.Run("returns error on interface update failure", func(t *testing.T) {
+		oldAddr, _ := wgaddr.ParseWGAddress("100.64.0.1/24")
+
 		wgIface := &MockWGIface{
+			AddressFunc: func() wgaddr.Address {
+				return oldAddr
+			},
 			UpdateAddrFunc: func(newAddr string) error {
 				return fmt.Errorf("mock update error")
 			},
@@ -458,6 +474,232 @@ func TestEngine_UpdateSelfPeerIP(t *testing.T) {
 		// Config should not be updated on failure
 		assert.Equal(t, "100.64.0.1/24", engine.config.WgAddr)
 	})
+
+	t.Run("restarts SSH server on address change", func(t *testing.T) {
+		oldAddr, _ := wgaddr.ParseWGAddress("100.64.0.1/24")
+		newAddr, _ := wgaddr.ParseWGAddress("100.64.0.2/24")
+		currentAddr := oldAddr
+
+		wgIface := &MockWGIface{
+			AddressFunc: func() wgaddr.Address {
+				return currentAddr
+			},
+			UpdateAddrFunc: func(addr string) error {
+				currentAddr = newAddr
+				return nil
+			},
+		}
+
+		sshRestartCalled := false
+		var restartAddr netip.AddrPort
+		mockSSH := &mockSSHServer{
+			restartFunc: func(ctx context.Context, addr netip.AddrPort) error {
+				sshRestartCalled = true
+				restartAddr = addr
+				return nil
+			},
+		}
+
+		removeDNATCalled := false
+		addDNATCalled := false
+		mockFirewall := &mockFirewallManager{
+			removeInboundDNATFunc: func(ip netip.Addr, protocol firewallManager.Protocol, port uint16, targetPort uint16) error {
+				removeDNATCalled = true
+				assert.Equal(t, oldAddr.IP, ip)
+				assert.Equal(t, uint16(22), port)
+				assert.Equal(t, uint16(22022), targetPort)
+				return nil
+			},
+			addInboundDNATFunc: func(ip netip.Addr, protocol firewallManager.Protocol, port uint16, targetPort uint16) error {
+				addDNATCalled = true
+				assert.Equal(t, newAddr.IP, ip)
+				assert.Equal(t, uint16(22), port)
+				assert.Equal(t, uint16(22022), targetPort)
+				return nil
+			},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		engine := &Engine{
+			ctx: ctx,
+			config: &EngineConfig{
+				WgAddr: "100.64.0.1/24",
+			},
+			wgInterface: wgIface,
+			sshServer:   mockSSH,
+			firewall:    mockFirewall,
+		}
+
+		err := engine.updateSelfPeerIP("100.64.0.1/24", "100.64.0.2/24")
+		assert.NoError(t, err)
+		assert.True(t, removeDNATCalled, "RemoveInboundDNAT should be called")
+		assert.True(t, sshRestartCalled, "SSH server Restart should be called")
+		assert.True(t, addDNATCalled, "AddInboundDNAT should be called")
+		assert.Equal(t, newAddr.IP, restartAddr.Addr(), "SSH should restart on new IP")
+		assert.Equal(t, uint16(22022), restartAddr.Port(), "SSH should restart on port 22022")
+	})
+
+	t.Run("skips SSH restart when SSH server is nil", func(t *testing.T) {
+		oldAddr, _ := wgaddr.ParseWGAddress("100.64.0.1/24")
+		newAddr, _ := wgaddr.ParseWGAddress("100.64.0.2/24")
+		currentAddr := oldAddr
+
+		wgIface := &MockWGIface{
+			AddressFunc: func() wgaddr.Address {
+				return currentAddr
+			},
+			UpdateAddrFunc: func(addr string) error {
+				currentAddr = newAddr
+				return nil
+			},
+		}
+
+		engine := &Engine{
+			config: &EngineConfig{
+				WgAddr: "100.64.0.1/24",
+			},
+			wgInterface: wgIface,
+			sshServer:   nil,
+			firewall:    nil,
+		}
+
+		err := engine.updateSelfPeerIP("100.64.0.1/24", "100.64.0.2/24")
+		assert.NoError(t, err)
+		assert.Equal(t, "100.64.0.2/24", engine.config.WgAddr)
+	})
+}
+
+// mockSSHServer implements the sshServer interface for testing
+type mockSSHServer struct {
+	startFunc     func(ctx context.Context, addr netip.AddrPort) error
+	stopFunc      func() error
+	restartFunc   func(ctx context.Context, newAddr netip.AddrPort) error
+	getStatusFunc func() (bool, []sshserver.SessionInfo)
+}
+
+func (m *mockSSHServer) Start(ctx context.Context, addr netip.AddrPort) error {
+	if m.startFunc != nil {
+		return m.startFunc(ctx, addr)
+	}
+	return nil
+}
+
+func (m *mockSSHServer) Stop() error {
+	if m.stopFunc != nil {
+		return m.stopFunc()
+	}
+	return nil
+}
+
+func (m *mockSSHServer) Restart(ctx context.Context, newAddr netip.AddrPort) error {
+	if m.restartFunc != nil {
+		return m.restartFunc(ctx, newAddr)
+	}
+	return nil
+}
+
+func (m *mockSSHServer) GetStatus() (bool, []sshserver.SessionInfo) {
+	if m.getStatusFunc != nil {
+		return m.getStatusFunc()
+	}
+	return false, nil
+}
+
+// mockFirewallManager implements a minimal firewall manager for testing
+type mockFirewallManager struct {
+	addInboundDNATFunc    func(ip netip.Addr, protocol firewallManager.Protocol, port uint16, targetPort uint16) error
+	removeInboundDNATFunc func(ip netip.Addr, protocol firewallManager.Protocol, port uint16, targetPort uint16) error
+}
+
+func (m *mockFirewallManager) Init(*statemanager.Manager) error {
+	return nil
+}
+
+func (m *mockFirewallManager) AllowNetbird() error {
+	return nil
+}
+
+func (m *mockFirewallManager) AddPeerFiltering(id []byte, ip net.IP, proto firewallManager.Protocol, sPort, dPort *firewallManager.Port, action firewallManager.Action, ipsetName string) ([]firewallManager.Rule, error) {
+	return nil, nil
+}
+
+func (m *mockFirewallManager) DeletePeerRule(rule firewallManager.Rule) error {
+	return nil
+}
+
+func (m *mockFirewallManager) IsServerRouteSupported() bool {
+	return true
+}
+
+func (m *mockFirewallManager) IsStateful() bool {
+	return false
+}
+
+func (m *mockFirewallManager) AddRouteFiltering(id []byte, sources []netip.Prefix, dest firewallManager.Network, proto firewallManager.Protocol, sPort, dPort *firewallManager.Port, action firewallManager.Action) (firewallManager.Rule, error) {
+	return nil, nil
+}
+
+func (m *mockFirewallManager) DeleteRouteRule(rule firewallManager.Rule) error {
+	return nil
+}
+
+func (m *mockFirewallManager) AddNatRule(pair firewallManager.RouterPair) error {
+	return nil
+}
+
+func (m *mockFirewallManager) RemoveNatRule(pair firewallManager.RouterPair) error {
+	return nil
+}
+
+func (m *mockFirewallManager) SetLegacyManagement(legacy bool) error {
+	return nil
+}
+
+func (m *mockFirewallManager) Close(stateManager *statemanager.Manager) error {
+	return nil
+}
+
+func (m *mockFirewallManager) Flush() error {
+	return nil
+}
+
+func (m *mockFirewallManager) SetLogLevel(level log.Level) {
+}
+
+func (m *mockFirewallManager) EnableRouting() error {
+	return nil
+}
+
+func (m *mockFirewallManager) DisableRouting() error {
+	return nil
+}
+
+func (m *mockFirewallManager) AddDNATRule(rule firewallManager.ForwardRule) (firewallManager.Rule, error) {
+	return nil, nil
+}
+
+func (m *mockFirewallManager) DeleteDNATRule(rule firewallManager.Rule) error {
+	return nil
+}
+
+func (m *mockFirewallManager) UpdateSet(hash firewallManager.Set, prefixes []netip.Prefix) error {
+	return nil
+}
+
+func (m *mockFirewallManager) AddInboundDNAT(ip netip.Addr, proto firewallManager.Protocol, port uint16, targetPort uint16) error {
+	if m.addInboundDNATFunc != nil {
+		return m.addInboundDNATFunc(ip, proto, port, targetPort)
+	}
+	return nil
+}
+
+func (m *mockFirewallManager) RemoveInboundDNAT(ip netip.Addr, proto firewallManager.Protocol, port uint16, targetPort uint16) error {
+	if m.removeInboundDNATFunc != nil {
+		return m.removeInboundDNATFunc(ip, proto, port, targetPort)
+	}
+	return nil
 }
 
 func TestEngine_UpdateNetworkMap(t *testing.T) {

--- a/client/ssh/server/server.go
+++ b/client/ssh/server/server.go
@@ -278,6 +278,18 @@ func (s *Server) Stop() error {
 	return nil
 }
 
+// Restart stops the SSH server and starts it again on a new address.
+// This is used when the WireGuard IP changes and the server needs to rebind.
+func (s *Server) Restart(ctx context.Context, newAddr netip.AddrPort) error {
+	if err := s.Stop(); err != nil {
+		return fmt.Errorf("stop server for restart: %w", err)
+	}
+
+	log.Infof("restarting SSH server on new address %s", newAddr)
+
+	return s.Start(ctx, newAddr)
+}
+
 // GetStatus returns the current status of the SSH server and active sessions
 func (s *Server) GetStatus() (enabled bool, sessions []SessionInfo) {
 	s.mu.RLock()


### PR DESCRIPTION
### Added

- Automatic WireGuard interface reconfiguration when peer IP changes
- The NetBird client now detects changes to the self peer’s IP address delivered by the Management Service and applies them live without requiring netbird down / netbird up. This is a more scalable approach for someone who has many peers and impossible to restart 1 by 1.

### Improved

- Enhanced client engine logic to watch for self-IP updates from network map diffs.
- Added logic to update interface address, routes, and internal state when the IP changes.
- Reduced downtime during CIDR migrations and tenant-level IP reassignment.
- Improved consistency between Management-assigned IPs and the active local WireGuard configuration.

### Fixed

- Fixed issue where the client received new IP configuration from Management but did not reconfigure the local interface until a manual reconnect.
- Fixed mismatch between API IP and active wtX/utunX interface, resulting in routing inconsistencies.

### Notes
- Implementation tested on macOS and Linux client builds.
- WG interface name handling remains platform-specific:
- macOS uses utun*
- Linux uses wg0 / kernel interface path

**This enhancement significantly improves NetBird’s dynamic IP behavior and avoids downtime during network CIDR changes.**

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hot-update of the local WireGuard IP during config changes.
  * Automatic SSH rebind and firewall DNAT refresh when the node IP changes.
  * Local IP state is refreshed to reflect address changes.

* **Bug Fixes**
  * Config updates now continue if an IP update fails; failures are logged rather than aborting.

* **Tests**
  * Added tests for IP-update scenarios, SSH restart lifecycle, and firewall/DNAT interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->