### PR TITLE
[docs] Fix broken image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ export NETBIRD_DOMAIN=netbird.example.com; curl -fsSL https://github.com/netbird
 [Coturn](https://github.com/coturn/coturn) is the one that has been successfully used for STUN and TURN in NetBird setups.
 
 <p float="left" align="middle">
-  <img src="https://docs.netbird.io/docs-static/img/architecture/high-level-dia.png" width="700"/>
+  <img src="https://docs.netbird.io/docs-static/img/about-netbird/high-level-dia.png" width="700"/>
 </p>
 
 See a complete [architecture overview](https://docs.netbird.io/about-netbird/how-netbird-works#architecture) for details.


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This is a simple fix to the repository readme. An image path (`https://docs.netbird.io/docs-static/img/architecture/high-level-dia.png`) currently 404s. 

I searched the filename in the docs repository, and found that the image had been moved from `architecture/` to the `about-netbird/` directory. The Wayback Machine [confirms](https://web.archive.org/web/20251006081810/https://docs.netbird.io/docs-static/img/architecture/high-level-dia.png) that this image is the same as the relocated one.

This PR simply updates the now-broken image path.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

[Quick link to updated readme preview](https://github.com/netbirdio/netbird/blob/5d0d2d97dc64730bccbc4292e84efe94e295aa3a/README.md#a-bit-on-netbird-internals)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated image asset references in the project README for consistency with current documentation structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->