### PR TITLE
[client, management] Add OAuth select_account prompt support to PKCE flow

### DIFF
--- a/client/internal/auth/pkce_flow.go
+++ b/client/internal/auth/pkce_flow.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/netbirdio/netbird/client/internal"
 	"github.com/netbirdio/netbird/client/internal/templates"
+	"github.com/netbirdio/netbird/shared/management/client/common"
 )
 
 var _ OAuthFlow = &PKCEAuthorizationFlow{}
@@ -104,20 +105,12 @@ func (p *PKCEAuthorizationFlow) RequestAuthInfo(ctx context.Context) (AuthFlowIn
 		oauth2.SetAuthURLParam("audience", p.providerConfig.Audience),
 	}
 	if !p.providerConfig.DisablePromptLogin {
-		hasPromptLogin := p.providerConfig.LoginFlag.HasPromptLogin()
-		hasSelectAccount := p.providerConfig.LoginFlag.HasSelectAccount()
-
-		switch {
-		case hasPromptLogin && hasSelectAccount:
+		switch p.providerConfig.LoginFlag {
+		case common.LoginFlagPromptLogin:
 			params = append(params, oauth2.SetAuthURLParam("prompt", "login select_account"))
-		case hasPromptLogin:
-			params = append(params, oauth2.SetAuthURLParam("prompt", "login"))
-		case hasSelectAccount:
-			params = append(params, oauth2.SetAuthURLParam("prompt", "select_account"))
-		}
-
-		if p.providerConfig.LoginFlag.HasMaxAge0() {
+		case common.LoginFlagMaxAge0:
 			params = append(params, oauth2.SetAuthURLParam("max_age", "0"))
+			params = append(params, oauth2.SetAuthURLParam("prompt", "select_account"))
 		}
 	}
 	if p.providerConfig.LoginHint != "" {

--- a/client/internal/auth/pkce_flow_test.go
+++ b/client/internal/auth/pkce_flow_test.go
@@ -15,9 +15,8 @@ import (
 
 func TestPromptLogin(t *testing.T) {
 	const (
-		promptLogin              = "prompt=login"
+		promptSelectAccountLogin = "prompt=login+select_account"
 		promptSelectAccount      = "prompt=select_account"
-		promptLoginSelectAccount = "prompt=login+select_account"
 		maxAge0                  = "max_age=0"
 	)
 
@@ -25,32 +24,28 @@ func TestPromptLogin(t *testing.T) {
 		name               string
 		loginFlag          mgm.LoginFlag
 		disablePromptLogin bool
-		expect             string
+		expectContains     []string
 	}{
 		{
-			name:      "Prompt login",
-			loginFlag: mgm.LoginFlagPromptLogin,
-			expect:    promptLogin,
+			name:           "Prompt login with select account",
+			loginFlag:      mgm.LoginFlagPromptLogin,
+			expectContains: []string{promptSelectAccountLogin},
 		},
 		{
-			name:      "Max age 0 login",
-			loginFlag: mgm.LoginFlagMaxAge0,
-			expect:    maxAge0,
-		},
-		{
-			name:      "Prompt select account",
-			loginFlag: mgm.LoginFlagSelectAccount,
-			expect:    promptSelectAccount,
-		},
-		{
-			name:      "Prompt login and select account",
-			loginFlag: mgm.LoginFlagLoginSelectAccount,
-			expect:    promptLoginSelectAccount,
+			name:           "Max age 0 with select account",
+			loginFlag:      mgm.LoginFlagMaxAge0,
+			expectContains: []string{maxAge0, promptSelectAccount},
 		},
 		{
 			name:               "Disable prompt login",
 			loginFlag:          mgm.LoginFlagPromptLogin,
 			disablePromptLogin: true,
+			expectContains:     []string{},
+		},
+		{
+			name:           "None flag should not add parameters",
+			loginFlag:      mgm.LoginFlagNone,
+			expectContains: []string{},
 		},
 	}
 
@@ -65,6 +60,7 @@ func TestPromptLogin(t *testing.T) {
 				RedirectURLs:          []string{"http://127.0.0.1:33992/"},
 				UseIDToken:            true,
 				LoginFlag:             tc.loginFlag,
+				DisablePromptLogin:    tc.disablePromptLogin,
 			}
 			pkce, err := NewPKCEAuthorizationFlow(config)
 			if err != nil {
@@ -75,11 +71,8 @@ func TestPromptLogin(t *testing.T) {
 				t.Fatalf("Failed to request auth info: %v", err)
 			}
 
-			if !tc.disablePromptLogin {
-				require.Contains(t, authInfo.VerificationURIComplete, tc.expect)
-			} else {
-				require.Contains(t, authInfo.VerificationURIComplete, promptLogin)
-				require.NotContains(t, authInfo.VerificationURIComplete, maxAge0)
+			for _, expected := range tc.expectContains {
+				require.Contains(t, authInfo.VerificationURIComplete, expected)
 			}
 		})
 	}

--- a/shared/management/client/common/types.go
+++ b/shared/management/client/common/types.go
@@ -4,61 +4,17 @@ package common
 //
 // # Config Values
 //
-//	| Value | Flag                          | OAuth Parameters                  |
-//	|-------|-------------------------------|-----------------------------------|
-//	| 0     | LoginFlagPromptLogin          | prompt=login                      |
-//	| 1     | LoginFlagMaxAge0              | max_age=0                         |
-//	| 2     | LoginFlagSelectAccount        | prompt=select_account             |
-//	| 3     | LoginFlagSelectAccountMaxAge0 | prompt=select_account & max_age=0 |
-//	| 4     | LoginFlagLoginSelectAccount   | prompt=login select_account       |
-//	| 5     | LoginFlagNone                 | (none)                            |
-//
-// # Behavior
-//
-//	| Scenario                   | None          | PromptLogin       | MaxAge0           | SelectAccount     | SelectAccountMaxAge0            |
-//	|----------------------------|---------------|-------------------|-------------------|-------------------|---------------------------------|
-//	| 1 account, active session  | Auto login    | Password required | Password required | Auto login*       | Account selector + pwd required |
-//	| 2 accounts, both active    | Auto login    | Password required | Password required | Account selector  | Account selector + pwd required |
-//	| No session                 | Login form    | Login form        | Login form        | Login form        | Login form                      |
-//
-// * Some IDPs show account selector even with single account, others auto-login.
-//
-// # Use Cases
-//
-//	| Use Case                       | Recommended Flag          |
-//	|--------------------------------|---------------------------|
-//	| Default SSO behavior           | LoginFlagNone (5)         |
-//	| Multi-account environment      | LoginFlagSelectAccount (2)|
-//	| Security-sensitive operations  | LoginFlagPromptLogin (0)  |
-//	| Multi-account + force reauth   | LoginFlagSelectAccountMaxAge0 (3) |
+//	| Value | Flag                 | OAuth Parameters                        |
+//	|-------|----------------------|-----------------------------------------|
+//	| 0     | LoginFlagPromptLogin | prompt=select_account login             |
+//	| 1     | LoginFlagMaxAge0     | max_age=0 & prompt=select_account       |
 type LoginFlag uint8
 
 const (
-	// LoginFlagPromptLogin adds prompt=login to the authorization request
+	// LoginFlagPromptLogin adds prompt=select_account login to the authorization request
 	LoginFlagPromptLogin LoginFlag = iota
-	// LoginFlagMaxAge0 adds max_age=0 to the authorization request
+	// LoginFlagMaxAge0 adds max_age=0 and prompt=select_account to the authorization request
 	LoginFlagMaxAge0
-	// LoginFlagSelectAccount adds prompt=select_account to the authorization request
-	LoginFlagSelectAccount
-	// LoginFlagSelectAccountMaxAge0 adds prompt=select_account and max_age=0
-	LoginFlagSelectAccountMaxAge0
-	// LoginFlagLoginSelectAccount adds prompt=login select_account to the authorization request
-	LoginFlagLoginSelectAccount
 	// LoginFlagNone disables all login flags
 	LoginFlagNone
 )
-
-// HasPromptLogin returns true if prompt=login should be added
-func (f LoginFlag) HasPromptLogin() bool {
-	return f == LoginFlagPromptLogin || f == LoginFlagLoginSelectAccount
-}
-
-// HasMaxAge0 returns true if max_age=0 should be added
-func (f LoginFlag) HasMaxAge0() bool {
-	return f == LoginFlagMaxAge0 || f == LoginFlagSelectAccountMaxAge0
-}
-
-// HasSelectAccount returns true if prompt=select_account should be added
-func (f LoginFlag) HasSelectAccount() bool {
-	return f == LoginFlagSelectAccount || f == LoginFlagSelectAccountMaxAge0 || f == LoginFlagLoginSelectAccount
-}


### PR DESCRIPTION
Extends LoginFlag enum with select_account options to enable multi-account selection during authentication. This allows users to choose which account to use when multiple accounts have active sessions with the identity provider.

The new flags are backward compatible - existing LoginFlag values (0=prompt login, 1=max_age=0) retain their original behavior.

Example Management config:
```
"DisablePromptLogin": false,
"LoginFlag": 2
```

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account-selection prompt behavior, including a combined "login select_account" option and max_age=0 with select_account.

* **Tests**
  * Updated auth flow tests to validate select_account, login, combined prompts, and a new "none" flag case.

* **Chores**
  * Refined login-flag surface (renames and a new none option) and removed old predicate helpers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->