### PR TITLE
[client] Passthrough all non-NetBird chains to prevent them from dropping NetBird traffic

### DIFF
--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -1068,6 +1068,11 @@ func (r *router) acceptExternalChainsRules() error {
 	intf := ifname(r.wgIface.Name())
 
 	for _, chain := range chains {
+		if chain.Hooknum == nil {
+			log.Debugf("skipping external chain %s/%s: hooknum is nil", chain.Table.Name, chain.Name)
+			continue
+		}
+
 		log.Debugf("adding accept rules to external %s chain: %s %s/%s",
 			hookName(chain.Hooknum), familyName(chain.Table.Family), chain.Table.Name, chain.Name)
 


### PR DESCRIPTION
## Describe your changes

Currently, some tools (firewalld, miniupnpd, docker, ...) might create extra ntables tables with chains that have a drop policy. This would prevent NetBird's accept rules from working; hence we need to insert a passthrough rule in all input and forward chains that we find, not just the `ip filter` table from `iptables-nft`.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic detection and handling of external firewall chains with targeted accept rules for forward and input traffic.
  * Per-chain and per-interface rule insertion with expanded table support for broader firewall coverage.
  * Enhanced operational logging for clearer visibility.

* **Bug Fixes**
  * More reliable, deterministic cleanup of rules across filter and external chains.
  * Improved error aggregation and handling during rule application and removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->