### PR TITLE
[relay-server] Add health-check agent recognition to avoid error logs

### DIFF
--- a/relay/healthcheck/peerid/peerid.go
+++ b/relay/healthcheck/peerid/peerid.go
@@ -1,0 +1,31 @@
+package peerid
+
+import (
+	"crypto/sha256"
+
+	v2 "github.com/netbirdio/netbird/shared/relay/auth/hmac/v2"
+	"github.com/netbirdio/netbird/shared/relay/messages"
+)
+
+var (
+	// HealthCheckPeerID is the hashed peer ID for health check connections
+	HealthCheckPeerID = messages.HashID("healthcheck-agent")
+
+	// DummyAuthToken is a structurally valid auth token for health check.
+	// The signature is not valid but the format is correct (1 byte algo + 32 bytes signature + payload).
+	DummyAuthToken = createDummyToken()
+)
+
+func createDummyToken() []byte {
+	token := v2.Token{
+		AuthAlgo:  v2.AuthAlgoHMACSHA256,
+		Signature: make([]byte, sha256.Size),
+		Payload:   []byte("healthcheck"),
+	}
+	return token.Marshal()
+}
+
+// IsHealthCheck checks if the given peer ID is the health check agent
+func IsHealthCheck(peerID *messages.PeerID) bool {
+	return peerID != nil && *peerID == HealthCheckPeerID
+}

--- a/relay/server/handshake.go
+++ b/relay/server/handshake.go
@@ -97,7 +97,7 @@ func (h *handshake) handshakeReceive() (*messages.PeerID, error) {
 		return nil, fmt.Errorf("invalid message type %d from %s", msgType, h.conn.RemoteAddr())
 	}
 	if err != nil {
-		return nil, err
+		return peerID, err
 	}
 	h.peerID = peerID
 	return peerID, nil
@@ -147,7 +147,7 @@ func (h *handshake) handleAuthMsg(buf []byte) (*messages.PeerID, error) {
 	}
 
 	if err := h.validator.Validate(authPayload); err != nil {
-		return nil, fmt.Errorf("validate %s (%s): %w", rawPeerID.String(), h.conn.RemoteAddr(), err)
+		return rawPeerID, fmt.Errorf("validate %s (%s): %w", rawPeerID.String(), h.conn.RemoteAddr(), err)
 	}
 
 	return rawPeerID, nil

--- a/relay/server/relay.go
+++ b/relay/server/relay.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/netbirdio/netbird/relay/healthcheck/peerid"
 	//nolint:staticcheck
 	"github.com/netbirdio/netbird/relay/metrics"
 	"github.com/netbirdio/netbird/relay/server/store"
@@ -123,7 +124,11 @@ func (r *Relay) Accept(conn net.Conn) {
 	}
 	peerID, err := h.handshakeReceive()
 	if err != nil {
-		log.Errorf("failed to handshake: %s", err)
+		if peerid.IsHealthCheck(peerID) {
+			log.Debugf("health check connection from %s", conn.RemoteAddr())
+		} else {
+			log.Errorf("failed to handshake: %s", err)
+		}
 		if cErr := conn.Close(); cErr != nil {
 			log.Errorf("failed to close connection, %s: %s", conn.RemoteAddr(), cErr)
 		}


### PR DESCRIPTION
Health-check connections now send a properly formatted auth message with a well-known peer ID instead of immediately closing. The server recognizes this peer ID and handles the connection gracefully with a debug log instead of error logs.

Changes:
- Add relay/healthcheck/peerid package with health-check peer ID and dummy auth token
- Update health-check client to send auth message before closing
- Return peer ID from handshake even on validation failure
- Check for health-check agent in relay Accept() to avoid error logs

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented specialized health check functionality for relay connections with dedicated identification and authentication mechanisms.
  * Enhanced WebSocket connection initialization with improved authentication message handling.

* **Bug Fixes**
  * Improved relay connection handshake error handling to preserve and return more accurate peer identification diagnostics during failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->