### PR TITLE
Change NETBIRD_SIGNAL_PORT mapping from 80 to 10000

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -46,7 +46,7 @@ services:
       - $SIGNAL_VOLUMENAME:/var/lib/netbird
       - $LETSENCRYPT_VOLUMENAME:/etc/letsencrypt:ro
     ports:
-      - $NETBIRD_SIGNAL_PORT:80
+      - $NETBIRD_SIGNAL_PORT:10000
   #      # port and command for Let's Encrypt validation
   #      - 443:443
   #    command: ["--letsencrypt-domain", "$NETBIRD_LETSENCRYPT_DOMAIN", "--log-file", "console"]


### PR DESCRIPTION
This update aligns the template with the actual behavior of the Signal service and the official NetBird documentation.

## Describe your changes

The advanced-setup docker-compose.yml template incorrectly mapped:

```yaml
# Signal
  signal:
    ....
    ports:
  - $NETBIRD_SIGNAL_PORT:80
```

However, the netbird-signal container listens on port 10000 internally.

This mismatch caused external Signal connections to fail unless users manually adjusted their NAT/firewall rules or remapped the port.
The update changes the port mapping to:

```yaml
# Signal
  signal:
    ....
    ports:
  - $NETBIRD_SIGNAL_PORT:10000
```

This ensures correct behavior out of the box and makes the template consistent with the actual service configuration and official documentation.

## Issue ticket number and link

N/A — Bug discovered during advanced setup deployment.
(If an issue is later opened, it can be added here.)

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (the fix corrects an incorrect port mapping in the docker template; no user-facing feature or behavior is changed, only the template is corrected to match the actual service port.)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Signal service port configuration in deployment setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->