### PR TITLE
Stop sleep monitor on user requested disconnect and restart on connect

### DIFF
--- a/client/ui/event_handler.go
+++ b/client/ui/event_handler.go
@@ -79,6 +79,7 @@ func (h *eventHandler) handleConnectClick() {
 
 	go func() {
 		defer connectCancel()
+		defer h.client.startSleepListener()
 
 		if err := h.client.menuUpClick(connectCtx); err != nil {
 			st, ok := status.FromError(err)
@@ -104,6 +105,8 @@ func (h *eventHandler) handleDisconnectClick() {
 		h.client.connectCancel()
 		h.client.connectCancel = nil
 	}
+
+	h.client.stopSleepListener()
 
 	go func() {
 		if err := h.client.menuDownClick(); err != nil {


### PR DESCRIPTION
## Describe your changes
Sleep monitor shouldn't be running if user manually clicks disconnect
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sleep-detection to service monitoring for improved observability and responsiveness.

* **Improvements**
  * Added lifecycle controls for the sleep listener with idempotent startup, centralized shutdown, and mutex-protected registration/deregistration to reduce race conditions and improve startup/shutdown reliability around connect/disconnect.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->