### PR TITLE
[infrastructure] Change NETBIRD_SIGNAL_PORT mapping from 80 to 10000

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -46,7 +46,7 @@ services:
       - $SIGNAL_VOLUMENAME:/var/lib/netbird
       - $LETSENCRYPT_VOLUMENAME:/etc/letsencrypt:ro
     ports:
-      - $NETBIRD_SIGNAL_PORT:80
+      - $NETBIRD_SIGNAL_PORT:10000
   #      # port and command for Let's Encrypt validation
   #      - 443:443
   #    command: ["--letsencrypt-domain", "$NETBIRD_LETSENCRYPT_DOMAIN", "--log-file", "console"]


### PR DESCRIPTION
I found that the signal port is 10000 in the container logs. That's why this change is being made.

## Describe your changes
During my deployment I found that peers were not able to connect upon checking the logs, I saw that the service was running on the same port as the default signal port. As such, I made this change to fix the port 80 issue. 
## Issue ticket number and link
#4755 and probably a few others
## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

the default port specified is the same as this fix

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Signal service port mapping from 80 to 10000 for improved network port management in deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->