### PR TITLE
[client] Fix deadlock in delayed WG update function

### DIFF
--- a/client/internal/peer/endpoint.go
+++ b/client/internal/peer/endpoint.go
@@ -20,7 +20,7 @@ type EndpointUpdater struct {
 	wgConfig  WgConfig
 	initiator bool
 
-	// mu protects updateWireGuardPeer and cancelFunc
+	// mu protects cancelFunc
 	mu         sync.Mutex
 	cancelFunc func()
 	updateWg   sync.WaitGroup
@@ -86,11 +86,9 @@ func (e *EndpointUpdater) scheduleDelayedUpdate(ctx context.Context, addr *net.U
 	case <-ctx.Done():
 		return
 	case <-t.C:
-		e.mu.Lock()
 		if err := e.updateWireGuardPeer(addr, presharedKey); err != nil {
 			e.log.Errorf("failed to update WireGuard peer, address: %s, error: %v", addr, err)
 		}
-		e.mu.Unlock()
 	}
 }
 


### PR DESCRIPTION
A deadlock occurs when the scheduled update timer expires while an exported function holds the `mu` lock and is waiting for the goroutine to exit.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal concurrency handling for peer endpoint management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->