### PR TITLE
[management] filter own peer when having a group to peer policy to themself

### DIFF
--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -1152,7 +1152,11 @@ func (a *Account) getPeerFromResource(resource Resource, peerID string) ([]*nbpe
 		return []*nbpeer.Peer{}, false
 	}
 
-	return []*nbpeer.Peer{peer}, resource.ID == peerID
+	if peer.ID == peerID {
+		return []*nbpeer.Peer{}, true
+	}
+
+	return []*nbpeer.Peer{peer}, false
 }
 
 // validatePostureChecksOnPeer validates the posture checks on a peer


### PR DESCRIPTION
## Describe your changes

There was a bug where it was possible to use a group with a peer in the source to access that same peer as a direct peer in a policy. This resulted in the peer getting send self as part of the network map so peers would connect to themself.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with peer resource identification in the routing system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->