### PR TITLE
[management] implement separate method for getaccount without users

### DIFF
--- a/management/internals/controllers/network_map/controller/controller.go
+++ b/management/internals/controllers/network_map/controller/controller.go
@@ -144,7 +144,7 @@ func (c *Controller) sendUpdateAccountPeers(ctx context.Context, accountID strin
 	if c.experimentalNetworkMap(accountID) {
 		account = c.getAccountFromHolderOrInit(accountID)
 	} else {
-		account, err = c.requestBuffer.GetAccountWithBackpressure(ctx, accountID)
+		account, err = c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountID)
 		if err != nil {
 			return fmt.Errorf("failed to get account: %v", err)
 		}
@@ -300,7 +300,7 @@ func (c *Controller) UpdateAccountPeer(ctx context.Context, accountId string, pe
 		return fmt.Errorf("peer %s doesn't have a channel, skipping network map update", peerId)
 	}
 
-	account, err := c.requestBuffer.GetAccountWithBackpressure(ctx, accountId)
+	account, err := c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountId)
 	if err != nil {
 		return fmt.Errorf("failed to send out updates to peer %s: %v", peerId, err)
 	}
@@ -414,7 +414,7 @@ func (c *Controller) GetValidatedPeerWithMap(ctx context.Context, isRequiresAppr
 	if c.experimentalNetworkMap(accountID) {
 		account = c.getAccountFromHolderOrInit(accountID)
 	} else {
-		account, err = c.requestBuffer.GetAccountWithBackpressure(ctx, accountID)
+		account, err = c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountID)
 		if err != nil {
 			return nil, nil, nil, 0, err
 		}
@@ -506,7 +506,7 @@ func (c *Controller) recalculateNetworkMapCache(account *types.Account, validate
 
 func (c *Controller) RecalculateNetworkMapCache(ctx context.Context, accountId string) error {
 	if c.experimentalNetworkMap(accountId) {
-		account, err := c.requestBuffer.GetAccountWithBackpressure(ctx, accountId)
+		account, err := c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountId)
 		if err != nil {
 			return err
 		}
@@ -548,7 +548,7 @@ func (c *Controller) getAccountFromHolderOrInit(accountID string) *types.Account
 	if a != nil {
 		return a
 	}
-	account, err := c.holder.LoadOrStoreFunc(accountID, c.requestBuffer.GetAccountWithBackpressure)
+	account, err := c.holder.LoadOrStoreFunc(accountID, c.requestBuffer.GetAccountWithoutUsersWithBackpressure)
 	if err != nil {
 		return nil
 	}
@@ -715,7 +715,7 @@ func (c *Controller) OnPeersUpdated(ctx context.Context, accountID string, peerI
 func (c *Controller) OnPeersAdded(ctx context.Context, accountID string, peerIDs []string) error {
 	for _, peerID := range peerIDs {
 		if c.experimentalNetworkMap(accountID) {
-			account, err := c.requestBuffer.GetAccountWithBackpressure(ctx, accountID)
+			account, err := c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountID)
 			if err != nil {
 				return err
 			}
@@ -761,7 +761,7 @@ func (c *Controller) OnPeersDeleted(ctx context.Context, accountID string, peerI
 		c.peersUpdateManager.CloseChannel(ctx, peerID)
 
 		if c.experimentalNetworkMap(accountID) {
-			account, err := c.requestBuffer.GetAccountWithBackpressure(ctx, accountID)
+			account, err := c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountID)
 			if err != nil {
 				log.WithContext(ctx).Errorf("failed to get account %s: %v", accountID, err)
 				continue

--- a/management/internals/controllers/network_map/controller/controller.go
+++ b/management/internals/controllers/network_map/controller/controller.go
@@ -144,7 +144,7 @@ func (c *Controller) sendUpdateAccountPeers(ctx context.Context, accountID strin
 	if c.experimentalNetworkMap(accountID) {
 		account = c.getAccountFromHolderOrInit(accountID)
 	} else {
-		account, err = c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountID)
+		account, err = c.requestBuffer.GetAccountLightWithBackpressure(ctx, accountID)
 		if err != nil {
 			return fmt.Errorf("failed to get account: %v", err)
 		}
@@ -300,7 +300,7 @@ func (c *Controller) UpdateAccountPeer(ctx context.Context, accountId string, pe
 		return fmt.Errorf("peer %s doesn't have a channel, skipping network map update", peerId)
 	}
 
-	account, err := c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountId)
+	account, err := c.requestBuffer.GetAccountLightWithBackpressure(ctx, accountId)
 	if err != nil {
 		return fmt.Errorf("failed to send out updates to peer %s: %v", peerId, err)
 	}
@@ -414,7 +414,7 @@ func (c *Controller) GetValidatedPeerWithMap(ctx context.Context, isRequiresAppr
 	if c.experimentalNetworkMap(accountID) {
 		account = c.getAccountFromHolderOrInit(accountID)
 	} else {
-		account, err = c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountID)
+		account, err = c.requestBuffer.GetAccountLightWithBackpressure(ctx, accountID)
 		if err != nil {
 			return nil, nil, nil, 0, err
 		}
@@ -506,7 +506,7 @@ func (c *Controller) recalculateNetworkMapCache(account *types.Account, validate
 
 func (c *Controller) RecalculateNetworkMapCache(ctx context.Context, accountId string) error {
 	if c.experimentalNetworkMap(accountId) {
-		account, err := c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountId)
+		account, err := c.requestBuffer.GetAccountLightWithBackpressure(ctx, accountId)
 		if err != nil {
 			return err
 		}
@@ -548,7 +548,7 @@ func (c *Controller) getAccountFromHolderOrInit(accountID string) *types.Account
 	if a != nil {
 		return a
 	}
-	account, err := c.holder.LoadOrStoreFunc(accountID, c.requestBuffer.GetAccountWithoutUsersWithBackpressure)
+	account, err := c.holder.LoadOrStoreFunc(accountID, c.requestBuffer.GetAccountLightWithBackpressure)
 	if err != nil {
 		return nil
 	}
@@ -715,7 +715,7 @@ func (c *Controller) OnPeersUpdated(ctx context.Context, accountID string, peerI
 func (c *Controller) OnPeersAdded(ctx context.Context, accountID string, peerIDs []string) error {
 	for _, peerID := range peerIDs {
 		if c.experimentalNetworkMap(accountID) {
-			account, err := c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountID)
+			account, err := c.requestBuffer.GetAccountLightWithBackpressure(ctx, accountID)
 			if err != nil {
 				return err
 			}
@@ -761,7 +761,7 @@ func (c *Controller) OnPeersDeleted(ctx context.Context, accountID string, peerI
 		c.peersUpdateManager.CloseChannel(ctx, peerID)
 
 		if c.experimentalNetworkMap(accountID) {
-			account, err := c.requestBuffer.GetAccountWithoutUsersWithBackpressure(ctx, accountID)
+			account, err := c.requestBuffer.GetAccountLightWithBackpressure(ctx, accountID)
 			if err != nil {
 				log.WithContext(ctx).Errorf("failed to get account %s: %v", accountID, err)
 				continue

--- a/management/server/account/request_buffer.go
+++ b/management/server/account/request_buffer.go
@@ -7,5 +7,6 @@ import (
 )
 
 type RequestBuffer interface {
-	GetAccountWithoutUsersWithBackpressure(ctx context.Context, accountID string) (*types.Account, error)
+	// GetAccountLightWithBackpressure returns account without users, setup keys, and onboarding data with request buffering
+	GetAccountLightWithBackpressure(ctx context.Context, accountID string) (*types.Account, error)
 }

--- a/management/server/account/request_buffer.go
+++ b/management/server/account/request_buffer.go
@@ -7,5 +7,5 @@ import (
 )
 
 type RequestBuffer interface {
-	GetAccountWithBackpressure(ctx context.Context, accountID string) (*types.Account, error)
+	GetAccountWithoutUsersWithBackpressure(ctx context.Context, accountID string) (*types.Account, error)
 }

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -796,6 +796,13 @@ func (s *SqlStore) GetAccount(ctx context.Context, accountID string) (*types.Acc
 	return s.getAccountGorm(ctx, accountID)
 }
 
+func (s *SqlStore) GetAccountWithoutUsers(ctx context.Context, accountID string) (*types.Account, error) {
+	if s.pool != nil {
+		return s.getAccountWithoutUsersPgx(ctx, accountID)
+	}
+	return s.getAccountWithoutUsersGorm(ctx, accountID)
+}
+
 func (s *SqlStore) getAccountGorm(ctx context.Context, accountID string) (*types.Account, error) {
 	start := time.Now()
 	defer func() {
@@ -860,6 +867,94 @@ func (s *SqlStore) getAccountGorm(ctx context.Context, accountID string) (*types
 		user.PATsG = nil
 	}
 	account.UsersG = nil
+	account.Groups = make(map[string]*types.Group, len(account.GroupsG))
+	for _, group := range account.GroupsG {
+		group.Peers = make([]string, len(group.GroupPeers))
+		for i, gp := range group.GroupPeers {
+			group.Peers[i] = gp.PeerID
+		}
+		if group.Resources == nil {
+			group.Resources = []types.Resource{}
+		}
+		account.Groups[group.ID] = group
+	}
+	account.GroupsG = nil
+
+	account.Routes = make(map[route.ID]*route.Route, len(account.RoutesG))
+	for _, route := range account.RoutesG {
+		account.Routes[route.ID] = &route
+	}
+	account.RoutesG = nil
+	account.NameServerGroups = make(map[string]*nbdns.NameServerGroup, len(account.NameServerGroupsG))
+	for _, ns := range account.NameServerGroupsG {
+		ns.AccountID = ""
+		if ns.NameServers == nil {
+			ns.NameServers = []nbdns.NameServer{}
+		}
+		if ns.Groups == nil {
+			ns.Groups = []string{}
+		}
+		if ns.Domains == nil {
+			ns.Domains = []string{}
+		}
+		account.NameServerGroups[ns.ID] = &ns
+	}
+	account.NameServerGroupsG = nil
+	account.InitOnce()
+	return &account, nil
+}
+
+func (s *SqlStore) getAccountWithoutUsersGorm(ctx context.Context, accountID string) (*types.Account, error) {
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		if elapsed > 1*time.Second {
+			log.WithContext(ctx).Tracef("GetAccountWithoutUsers for account %s exceeded 1s, took: %v", accountID, elapsed)
+		}
+	}()
+
+	var account types.Account
+	result := s.db.Model(&account).
+		Preload("Policies.Rules").
+		Preload("SetupKeysG").
+		Preload("PeersG").
+		Preload("GroupsG.GroupPeers").
+		Preload("RoutesG").
+		Preload("NameServerGroupsG").
+		Preload("PostureChecks").
+		Preload("Networks").
+		Preload("NetworkRouters").
+		Preload("NetworkResources").
+		Preload("Onboarding").
+		Take(&account, idQueryCondition, accountID)
+	if result.Error != nil {
+		log.WithContext(ctx).Errorf("error when getting account %s from the store: %s", accountID, result.Error)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, status.NewAccountNotFoundError(accountID)
+		}
+		return nil, status.NewGetAccountFromStoreError(result.Error)
+	}
+
+	account.SetupKeys = make(map[string]*types.SetupKey, len(account.SetupKeysG))
+	for _, key := range account.SetupKeysG {
+		if key.UpdatedAt.IsZero() {
+			key.UpdatedAt = key.CreatedAt
+		}
+		if key.AutoGroups == nil {
+			key.AutoGroups = []string{}
+		}
+		account.SetupKeys[key.Key] = &key
+	}
+	account.SetupKeysG = nil
+
+	account.Peers = make(map[string]*nbpeer.Peer, len(account.PeersG))
+	for _, peer := range account.PeersG {
+		account.Peers[peer.ID] = &peer
+	}
+	account.PeersG = nil
+
+	account.Users = make(map[string]*types.User)
+
 	account.Groups = make(map[string]*types.Group, len(account.GroupsG))
 	for _, group := range account.GroupsG {
 		group.Peers = make([]string, len(group.GroupPeers))
@@ -1140,6 +1235,246 @@ func (s *SqlStore) getAccountPgx(ctx context.Context, accountID string) (*types.
 		}
 		account.Users[user.Id] = user
 	}
+
+	for i := range account.Policies {
+		policy := account.Policies[i]
+		if policyRules, ok := rulesByPolicyID[policy.ID]; ok {
+			policy.Rules = policyRules
+		}
+	}
+
+	account.Groups = make(map[string]*types.Group, len(account.GroupsG))
+	for i := range account.GroupsG {
+		group := account.GroupsG[i]
+		if peerIDs, ok := peersByGroupID[group.ID]; ok {
+			group.Peers = peerIDs
+		}
+		account.Groups[group.ID] = group
+	}
+
+	account.Routes = make(map[route.ID]*route.Route, len(account.RoutesG))
+	for i := range account.RoutesG {
+		route := &account.RoutesG[i]
+		account.Routes[route.ID] = route
+	}
+
+	account.NameServerGroups = make(map[string]*nbdns.NameServerGroup, len(account.NameServerGroupsG))
+	for i := range account.NameServerGroupsG {
+		nsg := &account.NameServerGroupsG[i]
+		nsg.AccountID = ""
+		account.NameServerGroups[nsg.ID] = nsg
+	}
+
+	account.SetupKeysG = nil
+	account.PeersG = nil
+	account.UsersG = nil
+	account.GroupsG = nil
+	account.RoutesG = nil
+	account.NameServerGroupsG = nil
+
+	return account, nil
+}
+
+func (s *SqlStore) getAccountWithoutUsersPgx(ctx context.Context, accountID string) (*types.Account, error) {
+	account, err := s.getAccount(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	var wg sync.WaitGroup
+	errChan := make(chan error, 11)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		keys, err := s.getSetupKeys(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.SetupKeysG = keys
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		peers, err := s.getPeers(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.PeersG = peers
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		groups, err := s.getGroups(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.GroupsG = groups
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		policies, err := s.getPolicies(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.Policies = policies
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		routes, err := s.getRoutes(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.RoutesG = routes
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		nsgs, err := s.getNameServerGroups(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.NameServerGroupsG = nsgs
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		checks, err := s.getPostureChecks(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.PostureChecks = checks
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		networks, err := s.getNetworks(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.Networks = networks
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		routers, err := s.getNetworkRouters(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.NetworkRouters = routers
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resources, err := s.getNetworkResources(ctx, accountID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		account.NetworkResources = resources
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := s.getAccountOnboarding(ctx, accountID, account)
+		if err != nil {
+			errChan <- err
+			return
+		}
+	}()
+
+	wg.Wait()
+	close(errChan)
+	for e := range errChan {
+		if e != nil {
+			return nil, e
+		}
+	}
+
+	var policyIDs []string
+	for _, p := range account.Policies {
+		policyIDs = append(policyIDs, p.ID)
+	}
+	var groupIDs []string
+	for _, g := range account.GroupsG {
+		groupIDs = append(groupIDs, g.ID)
+	}
+
+	wg.Add(2)
+	errChan = make(chan error, 2)
+
+	var rules []*types.PolicyRule
+	go func() {
+		defer wg.Done()
+		var err error
+		rules, err = s.getPolicyRules(ctx, policyIDs)
+		if err != nil {
+			errChan <- err
+		}
+	}()
+
+	var groupPeers []types.GroupPeer
+	go func() {
+		defer wg.Done()
+		var err error
+		groupPeers, err = s.getGroupPeers(ctx, groupIDs)
+		if err != nil {
+			errChan <- err
+		}
+	}()
+
+	wg.Wait()
+	close(errChan)
+	for e := range errChan {
+		if e != nil {
+			return nil, e
+		}
+	}
+
+	rulesByPolicyID := make(map[string][]*types.PolicyRule)
+	for _, rule := range rules {
+		rulesByPolicyID[rule.PolicyID] = append(rulesByPolicyID[rule.PolicyID], rule)
+	}
+
+	peersByGroupID := make(map[string][]string)
+	for _, gp := range groupPeers {
+		peersByGroupID[gp.GroupID] = append(peersByGroupID[gp.GroupID], gp.PeerID)
+	}
+
+	account.SetupKeys = make(map[string]*types.SetupKey, len(account.SetupKeysG))
+	for i := range account.SetupKeysG {
+		key := &account.SetupKeysG[i]
+		account.SetupKeys[key.Key] = key
+	}
+
+	account.Peers = make(map[string]*nbpeer.Peer, len(account.PeersG))
+	for i := range account.PeersG {
+		peer := &account.PeersG[i]
+		account.Peers[peer.ID] = peer
+	}
+
+	account.Users = make(map[string]*types.User)
 
 	for i := range account.Policies {
 		policy := account.Policies[i]

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	GetAccountsCounter(ctx context.Context) (int64, error)
 	GetAllAccounts(ctx context.Context) []*types.Account
 	GetAccount(ctx context.Context, accountID string) (*types.Account, error)
+	GetAccountWithoutUsers(ctx context.Context, accountID string) (*types.Account, error)
 	GetAccountMeta(ctx context.Context, lockStrength LockingStrength, accountID string) (*types.AccountMeta, error)
 	GetAccountOnboarding(ctx context.Context, accountID string) (*types.AccountOnboarding, error)
 	AccountExists(ctx context.Context, lockStrength LockingStrength, id string) (bool, error)

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -51,7 +51,8 @@ type Store interface {
 	GetAccountsCounter(ctx context.Context) (int64, error)
 	GetAllAccounts(ctx context.Context) []*types.Account
 	GetAccount(ctx context.Context, accountID string) (*types.Account, error)
-	GetAccountWithoutUsers(ctx context.Context, accountID string) (*types.Account, error)
+	// GetAccountLight returns account without users, setup keys, and onboarding data
+	GetAccountLight(ctx context.Context, accountID string) (*types.Account, error)
 	GetAccountMeta(ctx context.Context, lockStrength LockingStrength, accountID string) (*types.AccountMeta, error)
 	GetAccountOnboarding(ctx context.Context, accountID string) (*types.AccountOnboarding, error)
 	AccountExists(ctx context.Context, lockStrength LockingStrength, id string) (bool, error)


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

small performance improvement

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lighter account retrieval path that returns reduced account data (excludes users, setup keys, onboarding) for faster, privacy-friendly reads.
* **Refactor**
  * Split account request handling into parallel batched flows with backpressure for light vs. full account loads to improve responsiveness and reduce load.
* **Performance**
  * Parallelized and optimized account data loading for faster responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->