### PR TITLE
[client] Filter out own peer from remote peers list during peer updates.

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1121,6 +1121,15 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 
 	e.updateOfflinePeers(networkMap.GetOfflinePeers())
 
+	// Filter out own peer from the remote peers list
+	localPubKey := e.config.WgPrivateKey.PublicKey().String()
+	remotePeers := make([]*mgmProto.RemotePeerConfig, 0, len(networkMap.GetRemotePeers()))
+	for _, p := range networkMap.GetRemotePeers() {
+		if p.GetWgPubKey() != localPubKey {
+			remotePeers = append(remotePeers, p)
+		}
+	}
+
 	// cleanup request, most likely our peer has been deleted
 	if networkMap.GetRemotePeersIsEmpty() {
 		err := e.removeAllPeers()
@@ -1129,32 +1138,32 @@ func (e *Engine) updateNetworkMap(networkMap *mgmProto.NetworkMap) error {
 			return err
 		}
 	} else {
-		err := e.removePeers(networkMap.GetRemotePeers())
+		err := e.removePeers(remotePeers)
 		if err != nil {
 			return err
 		}
 
-		err = e.modifyPeers(networkMap.GetRemotePeers())
+		err = e.modifyPeers(remotePeers)
 		if err != nil {
 			return err
 		}
 
-		err = e.addNewPeers(networkMap.GetRemotePeers())
+		err = e.addNewPeers(remotePeers)
 		if err != nil {
 			return err
 		}
 
 		e.statusRecorder.FinishPeerListModifications()
 
-		e.updatePeerSSHHostKeys(networkMap.GetRemotePeers())
+		e.updatePeerSSHHostKeys(remotePeers)
 
-		if err := e.updateSSHClientConfig(networkMap.GetRemotePeers()); err != nil {
+		if err := e.updateSSHClientConfig(remotePeers); err != nil {
 			log.Warnf("failed to update SSH client config: %v", err)
 		}
 	}
 
 	// must set the exclude list after the peers are added. Without it the manager can not figure out the peers parameters from the store
-	excludedLazyPeers := e.toExcludedLazyPeers(forwardingRules, networkMap.GetRemotePeers())
+	excludedLazyPeers := e.toExcludedLazyPeers(forwardingRules, remotePeers)
 	e.connMgr.SetExcludeList(e.ctx, excludedLazyPeers)
 
 	e.networkSerial = serial


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected local peer handling in peer synchronization to ensure proper exclusion from remote peer operations.
  * Improved consistency in peer list modification and synchronization flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->