### PR TITLE
[infra] Preset signal port on templates

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -53,7 +53,8 @@ services:
     command: [
       "--cert-file", "$NETBIRD_MGMT_API_CERT_FILE",
       "--cert-key", "$NETBIRD_MGMT_API_CERT_KEY_FILE",
-      "--log-file", "console"
+      "--log-file", "console",
+      "--port", "80"
     ]
 
   # Relay


### PR DESCRIPTION

## Describe your changes
When passing certificates to signal, it will select port 443 when no port is supplied. This changes forces port 80.

## Issue ticket number and link
closes #4918 #4941 #4763
## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated management API configuration to explicitly run on port 80.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->