### PR TITLE
[shared] allow setting a user agent for the rest client

### DIFF
--- a/shared/management/client/rest/client.go
+++ b/shared/management/client/rest/client.go
@@ -16,6 +16,7 @@ type Client struct {
 	managementURL string
 	authHeader    string
 	httpClient    HttpClient
+	userAgent     string
 
 	// Accounts NetBird account APIs
 	// see more: https://docs.netbird.io/api/resources/accounts
@@ -127,6 +128,9 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body io.Re
 	req.Header.Add("Accept", "application/json")
 	if body != nil {
 		req.Header.Add("Content-Type", "application/json")
+	}
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
 	}
 
 	if len(query) != 0 {

--- a/shared/management/client/rest/client_test.go
+++ b/shared/management/client/rest/client_test.go
@@ -4,9 +4,13 @@
 package rest_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/netbirdio/netbird/management/server/http/testing/testing_tools/channel"
 	"github.com/netbirdio/netbird/shared/management/client/rest"
@@ -31,4 +35,51 @@ func withBlackBoxServer(t *testing.T, callback func(*rest.Client)) {
 	defer server.Close()
 	c := rest.New(server.URL, "nbp_apTmlmUXHSC4PKmHwtIZNaGr8eqcVI2gMURp")
 	callback(c)
+}
+
+func TestClient_UserAgent_Set(t *testing.T) {
+	expectedUserAgent := "TestApp/1.2.3"
+	mux := &http.ServeMux{}
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/api/accounts", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, expectedUserAgent, r.Header.Get("User-Agent"))
+		w.WriteHeader(200)
+		_, err := w.Write([]byte("[]"))
+		require.NoError(t, err)
+	})
+
+	c := rest.NewWithOptions(
+		rest.WithManagementURL(server.URL),
+		rest.WithPAT("test-token"),
+		rest.WithUserAgent(expectedUserAgent),
+	)
+
+	_, err := c.Accounts.List(context.Background())
+	require.NoError(t, err)
+}
+
+func TestClient_UserAgent_NotSet(t *testing.T) {
+	mux := &http.ServeMux{}
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/api/accounts", func(w http.ResponseWriter, r *http.Request) {
+		// When no custom user agent is set, Go's default HTTP client will set one
+		// We just verify that the header exists (it will be Go's default)
+		userAgent := r.Header.Get("User-Agent")
+		assert.NotEmpty(t, userAgent)
+		w.WriteHeader(200)
+		_, err := w.Write([]byte("[]"))
+		require.NoError(t, err)
+	})
+
+	c := rest.NewWithOptions(
+		rest.WithManagementURL(server.URL),
+		rest.WithPAT("test-token"),
+	)
+
+	_, err := c.Accounts.List(context.Background())
+	require.NoError(t, err)
 }

--- a/shared/management/client/rest/options.go
+++ b/shared/management/client/rest/options.go
@@ -42,3 +42,10 @@ func WithAuthHeader(value string) option {
 		c.authHeader = value
 	}
 }
+
+// WithUserAgent sets a custom User-Agent header for HTTP requests
+func WithUserAgent(userAgent string) option {
+	return func(c *Client) {
+		c.userAgent = userAgent
+	}
+}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the User-Agent header in REST client requests, allowing applications to identify themselves with a custom User-Agent string in all HTTP communications.

* **Tests**
  * Added unit tests to validate User-Agent header handling, ensuring correct behavior when user-agent values are configured and when system defaults are used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->