### PR TITLE
[client] add option to prevent remove peers and routes when management services are not available

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -433,8 +433,12 @@ func (conn *Conn) onICEStateDisconnected() {
 	} else {
 		conn.Log.Infof("ICE disconnected, do not switch to Relay. Reset priority to: %s", conntype.None.String())
 		conn.currentConnPriority = conntype.None
-		if err := conn.config.WgConfig.WgInterface.RemoveEndpointAddress(conn.config.WgConfig.RemoteKey); err != nil {
-			conn.Log.Errorf("failed to remove wg endpoint: %v", err)
+
+		// Prevent removing peer endpoint if management connection is down and NB_KEEP_CONNECTION_ON_MANAGEMENT_DOWN is set
+		if (conn.statusRecorder.GetManagementState().Connected && conn.statusRecorder.GetSignalState().Connected) || !IsKeepConnectionOnMgmtDown() {
+			if err := conn.config.WgConfig.WgInterface.RemoveEndpointAddress(conn.config.WgConfig.RemoteKey); err != nil {
+				conn.Log.Errorf("failed to remove wg endpoint: %v", err)
+			}
 		}
 	}
 
@@ -529,8 +533,12 @@ func (conn *Conn) onRelayDisconnected() {
 	if conn.currentConnPriority == conntype.Relay {
 		conn.Log.Debugf("clean up WireGuard config")
 		conn.currentConnPriority = conntype.None
-		if err := conn.config.WgConfig.WgInterface.RemoveEndpointAddress(conn.config.WgConfig.RemoteKey); err != nil {
-			conn.Log.Errorf("failed to remove wg endpoint: %v", err)
+
+		// Prevent removing peer endpoint if management connection is down and NB_KEEP_CONNECTION_ON_MANAGEMENT_DOWN is set
+		if (conn.statusRecorder.GetManagementState().Connected && conn.statusRecorder.GetSignalState().Connected) || !IsKeepConnectionOnMgmtDown() {
+			if err := conn.config.WgConfig.WgInterface.RemoveEndpointAddress(conn.config.WgConfig.RemoteKey); err != nil {
+				conn.Log.Errorf("failed to remove wg endpoint: %v", err)
+			}
 		}
 	}
 

--- a/client/internal/peer/env.go
+++ b/client/internal/peer/env.go
@@ -4,10 +4,14 @@ import (
 	"os"
 	"runtime"
 	"strings"
+
+	"gvisor.dev/gvisor/pkg/log"
 )
 
 const (
 	EnvKeyNBForceRelay = "NB_FORCE_RELAY"
+	// EnvKeepConnectionOnMgmtDown controls whether peer and routes are kept even when ice peers are considered unavailable and the management connection is down.
+	EnvKeepConnectionOnMgmtDown = "NB_KEEP_CONNECTION_ON_MANAGEMENT_DOWN"
 )
 
 func isForceRelayed() bool {
@@ -15,4 +19,15 @@ func isForceRelayed() bool {
 		return true
 	}
 	return strings.EqualFold(os.Getenv(EnvKeyNBForceRelay), "true")
+}
+
+// isConnectionKeepOnMgmtDown checks if peers and routes should be kept when management connection is down
+func IsKeepConnectionOnMgmtDown() bool {
+	stickyOnManagementDownEnv := os.Getenv(EnvKeepConnectionOnMgmtDown)
+	if stickyOnManagementDownEnv == "" {
+		return false
+	}
+
+	log.Infof("peers will be kept on failure as %s is set to %s", EnvKeepConnectionOnMgmtDown, stickyOnManagementDownEnv)
+	return strings.ToLower(stickyOnManagementDownEnv) == "true"
 }

--- a/client/internal/routemanager/client/client.go
+++ b/client/internal/routemanager/client/client.go
@@ -336,6 +336,12 @@ func (w *Watcher) recalculateRoutes(rsn reason, routerPeerStatuses map[route.ID]
 			return nil
 		}
 
+		// Prevent removing routes if management connection is down and NB_KEEP_CONNECTION_ON_MANAGEMENT_DOWN is set
+		if !(w.statusRecorder.GetManagementState().Connected && w.statusRecorder.GetSignalState().Connected) && peer.IsKeepConnectionOnMgmtDown() {
+			log.Warnf("No available routes for network [%v], keep current route %s", w.handler, w.currentChosen.Peer)
+			return nil
+		}
+
 		if err := w.removeAllowedIPs(w.currentChosen, rsn); err != nil {
 			return fmt.Errorf("remove obsolete: %w", err)
 		}


### PR DESCRIPTION
## Describe your changes

NetBird clients rely on the **management service** and **signal service** to establish and maintain connections.
When the management service is temporary unavailable, a NetBird client is unable to re-establish existing connections after an ICE disconnect.

Introduce a new environment variable option: `NB_KEEP_CONNECTION_ON_MANAGEMENT_DOWN`.

When this flag is enabled and the management service is unavailable:

* The client will **not remove peers** after an ICE disconnect.
* If a network route cannot select a new peer, the client will **retain the existing peer** instead of removing it.


## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection stability during management server maintenance by preserving active endpoints and routes under specific conditions, preventing unnecessary disconnections when the management service is temporarily unavailable.

* **New Features**
  * Added configuration option to keep connections alive during management downtime scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->