### PR TITLE
Fix: Signal container backend port set to right value

### DIFF
--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -46,7 +46,7 @@ services:
       - $SIGNAL_VOLUMENAME:/var/lib/netbird
       - $LETSENCRYPT_VOLUMENAME:/etc/letsencrypt:ro
     ports:
-      - $NETBIRD_SIGNAL_PORT:80
+      - $NETBIRD_SIGNAL_PORT:$NETBIRD_SIGNAL_PORT
   #      # port and command for Let's Encrypt validation
   #      - 443:443
   #    command: ["--letsencrypt-domain", "$NETBIRD_LETSENCRYPT_DOMAIN", "--log-file", "console"]
@@ -95,7 +95,7 @@ services:
     environment:
       - NETBIRD_STORE_ENGINE_POSTGRES_DSN=$NETBIRD_STORE_ENGINE_POSTGRES_DSN
       - NETBIRD_STORE_ENGINE_MYSQL_DSN=$NETBIRD_STORE_ENGINE_MYSQL_DSN
-      
+
   # Coturn
   coturn:
     <<: *default


### PR DESCRIPTION
## Describe your changes
The backend port for the signal container was wrongly set to port 80 where the listenting port of the container is 10000 by default.


## Stack

<!-- branch-stack -->

### Checklist
- [x ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [ x] Documentation is **not needed** for this change (explain why)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated signal service port configuration to use environment variables for greater deployment flexibility, replacing the previously fixed port mapping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->