### PR TITLE
[client] Chase CNAMEs in the local resolver to ensure musl compatibility

### DIFF
--- a/client/internal/dns/handler_chain.go
+++ b/client/internal/dns/handler_chain.go
@@ -3,11 +3,15 @@ package dns
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/client/internal/dns/resutil"
 )
 
 const (
@@ -43,7 +47,23 @@ type HandlerChain struct {
 type ResponseWriterChain struct {
 	dns.ResponseWriter
 	origPattern    string
+	requestID      string
 	shouldContinue bool
+	response       *dns.Msg
+	meta           map[string]string
+}
+
+// RequestID returns the request ID for tracing
+func (w *ResponseWriterChain) RequestID() string {
+	return w.requestID
+}
+
+// SetMeta sets a metadata key-value pair for logging
+func (w *ResponseWriterChain) SetMeta(key, value string) {
+	if w.meta == nil {
+		w.meta = make(map[string]string)
+	}
+	w.meta[key] = value
 }
 
 func (w *ResponseWriterChain) WriteMsg(m *dns.Msg) error {
@@ -52,6 +72,7 @@ func (w *ResponseWriterChain) WriteMsg(m *dns.Msg) error {
 		w.shouldContinue = true
 		return nil
 	}
+	w.response = m
 	return w.ResponseWriter.WriteMsg(m)
 }
 
@@ -101,6 +122,8 @@ func (c *HandlerChain) AddHandler(pattern string, handler dns.Handler, priority 
 
 	pos := c.findHandlerPosition(entry)
 	c.handlers = append(c.handlers[:pos], append([]HandlerEntry{entry}, c.handlers[pos:]...)...)
+
+	c.logHandlers()
 }
 
 // findHandlerPosition determines where to insert a new handler based on priority and specificity
@@ -140,10 +163,29 @@ func (c *HandlerChain) removeEntry(pattern string, priority int) {
 	for i := len(c.handlers) - 1; i >= 0; i-- {
 		entry := c.handlers[i]
 		if strings.EqualFold(entry.OrigPattern, pattern) && entry.Priority == priority {
+			log.Debugf("removing handler pattern: domain=%s priority=%d", entry.OrigPattern, priority)
 			c.handlers = append(c.handlers[:i], c.handlers[i+1:]...)
+			c.logHandlers()
 			break
 		}
 	}
+}
+
+// logHandlers logs the current handler chain state. Caller must hold the lock.
+func (c *HandlerChain) logHandlers() {
+	if !log.IsLevelEnabled(log.TraceLevel) {
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString("handler chain (" + strconv.Itoa(len(c.handlers)) + "):\n")
+	for _, h := range c.handlers {
+		b.WriteString("  - pattern: domain=" + h.Pattern + " original: domain=" + h.OrigPattern +
+			" wildcard=" + strconv.FormatBool(h.IsWildcard) +
+			" match_subdomain=" + strconv.FormatBool(h.MatchSubdomains) +
+			" priority=" + strconv.Itoa(h.Priority) + "\n")
+	}
+	log.Trace(strings.TrimSuffix(b.String(), "\n"))
 }
 
 func (c *HandlerChain) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
@@ -151,55 +193,77 @@ func (c *HandlerChain) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		return
 	}
 
-	qname := strings.ToLower(r.Question[0].Name)
+	startTime := time.Now()
+	requestID := resutil.GenerateRequestID()
+	logger := log.WithFields(log.Fields{
+		"request_id": requestID,
+		"dns_id":     fmt.Sprintf("%04x", r.Id),
+	})
+
+	question := r.Question[0]
+	qname := strings.ToLower(question.Name)
 
 	c.mu.RLock()
 	handlers := slices.Clone(c.handlers)
 	c.mu.RUnlock()
 
-	if log.IsLevelEnabled(log.TraceLevel) {
-		var b strings.Builder
-		b.WriteString(fmt.Sprintf("DNS request domain=%s, handlers (%d):\n", qname, len(handlers)))
-		for _, h := range handlers {
-			b.WriteString(fmt.Sprintf("  - pattern: domain=%s original: domain=%s wildcard=%v match_subdomain=%v priority=%d\n",
-				h.Pattern, h.OrigPattern, h.IsWildcard, h.MatchSubdomains, h.Priority))
-		}
-		log.Trace(strings.TrimSuffix(b.String(), "\n"))
-	}
-
 	// Try handlers in priority order
 	for _, entry := range handlers {
-		matched := c.isHandlerMatch(qname, entry)
-
-		if matched {
-			log.Tracef("handler matched: domain=%s -> pattern=%s wildcard=%v match_subdomain=%v priority=%d",
-				qname, entry.OrigPattern, entry.IsWildcard, entry.MatchSubdomains, entry.Priority)
-
-			chainWriter := &ResponseWriterChain{
-				ResponseWriter: w,
-				origPattern:    entry.OrigPattern,
-			}
-			entry.Handler.ServeDNS(chainWriter, r)
-
-			// If handler wants to continue, try next handler
-			if chainWriter.shouldContinue {
-				// Only log continue for non-management cache handlers to reduce noise
-				if entry.Priority != PriorityMgmtCache {
-					log.Tracef("handler requested continue to next handler for domain=%s", qname)
-				}
-				continue
-			}
-			return
+		if !c.isHandlerMatch(qname, entry) {
+			continue
 		}
+
+		handlerName := entry.OrigPattern
+		if s, ok := entry.Handler.(interface{ String() string }); ok {
+			handlerName = s.String()
+		}
+
+		logger.Tracef("question: domain=%s type=%s class=%s -> handler=%s pattern=%s wildcard=%v match_subdomain=%v priority=%d",
+			qname, dns.TypeToString[question.Qtype], dns.ClassToString[question.Qclass],
+			handlerName, entry.OrigPattern, entry.IsWildcard, entry.MatchSubdomains, entry.Priority)
+
+		chainWriter := &ResponseWriterChain{
+			ResponseWriter: w,
+			origPattern:    entry.OrigPattern,
+			requestID:      requestID,
+		}
+		entry.Handler.ServeDNS(chainWriter, r)
+
+		// If handler wants to continue, try next handler
+		if chainWriter.shouldContinue {
+			if entry.Priority != PriorityMgmtCache {
+				logger.Tracef("handler requested continue for domain=%s", qname)
+			}
+			continue
+		}
+
+		c.logResponse(logger, chainWriter, qname, startTime)
+		return
 	}
 
 	// No handler matched or all handlers passed
-	log.Tracef("no handler found for domain=%s", qname)
+	logger.Tracef("no handler found for domain=%s type=%s class=%s",
+		qname, dns.TypeToString[question.Qtype], dns.ClassToString[question.Qclass])
 	resp := &dns.Msg{}
 	resp.SetRcode(r, dns.RcodeRefused)
 	if err := w.WriteMsg(resp); err != nil {
-		log.Errorf("failed to write DNS response: %v", err)
+		logger.Errorf("failed to write DNS response: %v", err)
 	}
+}
+
+func (c *HandlerChain) logResponse(logger *log.Entry, cw *ResponseWriterChain, qname string, startTime time.Time) {
+	if cw.response == nil {
+		return
+	}
+
+	var meta string
+	for k, v := range cw.meta {
+		meta += " " + k + "=" + v
+	}
+
+	logger.Tracef("response: domain=%s rcode=%s answers=%s%s took=%s",
+		qname, dns.RcodeToString[cw.response.Rcode], resutil.FormatAnswers(cw.response.Answer),
+		meta, time.Since(startTime))
 }
 
 func (c *HandlerChain) isHandlerMatch(qname string, entry HandlerEntry) bool {

--- a/client/internal/dns/local/local.go
+++ b/client/internal/dns/local/local.go
@@ -1,30 +1,50 @@
 package local
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/netip"
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 
+	"github.com/netbirdio/netbird/client/internal/dns/resutil"
 	"github.com/netbirdio/netbird/client/internal/dns/types"
 	nbdns "github.com/netbirdio/netbird/dns"
 	"github.com/netbirdio/netbird/shared/management/domain"
 )
 
+const externalResolutionTimeout = 4 * time.Second
+
+type resolver interface {
+	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+
 type Resolver struct {
-	mu      sync.RWMutex
-	records map[dns.Question][]dns.RR
-	domains map[domain.Domain]struct{}
+	mu       sync.RWMutex
+	records  map[dns.Question][]dns.RR
+	domains  map[domain.Domain]struct{}
+	zones    []domain.Domain
+	resolver resolver
+
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func NewResolver() *Resolver {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Resolver{
 		records: make(map[dns.Question][]dns.RR),
 		domains: make(map[domain.Domain]struct{}),
+		ctx:     ctx,
+		cancel:  cancel,
 	}
 }
 
@@ -37,7 +57,18 @@ func (d *Resolver) String() string {
 	return fmt.Sprintf("LocalResolver [%d records]", len(d.records))
 }
 
-func (d *Resolver) Stop() {}
+func (d *Resolver) Stop() {
+	if d.cancel != nil {
+		d.cancel()
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	maps.Clear(d.records)
+	maps.Clear(d.domains)
+	d.zones = nil
+}
 
 // ID returns the unique handler ID
 func (d *Resolver) ID() types.HandlerID {
@@ -48,36 +79,45 @@ func (d *Resolver) ProbeAvailability() {}
 
 // ServeDNS handles a DNS request
 func (d *Resolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
+	logger := log.WithField("request_id", resutil.GetRequestID(w))
+
 	if len(r.Question) == 0 {
-		log.Debugf("received local resolver request with no question")
+		logger.Debug("received local resolver request with no question")
 		return
 	}
 	question := r.Question[0]
 	question.Name = strings.ToLower(dns.Fqdn(question.Name))
 
-	log.Tracef("received local question: domain=%s type=%v class=%v", r.Question[0].Name, question.Qtype, question.Qclass)
-
 	replyMessage := &dns.Msg{}
 	replyMessage.SetReply(r)
 	replyMessage.RecursionAvailable = true
 
-	// lookup all records matching the question
-	records := d.lookupRecords(question)
-	if len(records) > 0 {
-		replyMessage.Rcode = dns.RcodeSuccess
-		replyMessage.Answer = append(replyMessage.Answer, records...)
-	} else {
-		// Check if we have any records for this domain name with different types
-		if d.hasRecordsForDomain(domain.Domain(question.Name)) {
-			replyMessage.Rcode = dns.RcodeSuccess // NOERROR with 0 records
-		} else {
-			replyMessage.Rcode = dns.RcodeNameError // NXDOMAIN
-		}
-	}
+	result := d.lookupRecords(logger, question)
+	replyMessage.Authoritative = !result.hasExternalData
+	replyMessage.Answer = result.records
+	replyMessage.Rcode = d.determineRcode(question, result)
 
 	if err := w.WriteMsg(replyMessage); err != nil {
-		log.Warnf("failed to write the local resolver response: %v", err)
+		logger.Warnf("failed to write the local resolver response: %v", err)
 	}
+}
+
+// determineRcode returns the appropriate DNS response code.
+// Per RFC 6604, CNAME chains should return the rcode of the final target resolution,
+// even if CNAME records are included in the answer.
+func (d *Resolver) determineRcode(question dns.Question, result lookupResult) int {
+	// Use the rcode from lookup - this properly handles CNAME chains where
+	// the target may be NXDOMAIN or SERVFAIL even though we have CNAME records
+	if result.rcode != 0 {
+		return result.rcode
+	}
+
+	// No records found, but domain exists with different record types (NODATA)
+	if d.hasRecordsForDomain(domain.Domain(question.Name)) {
+		return dns.RcodeSuccess
+	}
+
+	return dns.RcodeNameError
 }
 
 // hasRecordsForDomain checks if any records exist for the given domain name regardless of type
@@ -89,8 +129,33 @@ func (d *Resolver) hasRecordsForDomain(domainName domain.Domain) bool {
 	return exists
 }
 
+// isInManagedZone checks if the given name falls within any of our managed zones.
+// This is used to avoid unnecessary external resolution for CNAME targets that
+// are within zones we manage - if we don't have a record for it, it doesn't exist.
+// Caller must NOT hold the lock.
+func (d *Resolver) isInManagedZone(name string) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	name = dns.Fqdn(name)
+	for _, zone := range d.zones {
+		zoneStr := dns.Fqdn(zone.PunycodeString())
+		if strings.EqualFold(name, zoneStr) || strings.HasSuffix(strings.ToLower(name), strings.ToLower("."+zoneStr)) {
+			return true
+		}
+	}
+	return false
+}
+
+// lookupResult contains the result of a DNS lookup operation.
+type lookupResult struct {
+	records         []dns.RR
+	rcode           int
+	hasExternalData bool
+}
+
 // lookupRecords fetches *all* DNS records matching the first question in r.
-func (d *Resolver) lookupRecords(question dns.Question) []dns.RR {
+func (d *Resolver) lookupRecords(logger *log.Entry, question dns.Question) lookupResult {
 	d.mu.RLock()
 	records, found := d.records[question]
 
@@ -98,10 +163,14 @@ func (d *Resolver) lookupRecords(question dns.Question) []dns.RR {
 		d.mu.RUnlock()
 		// alternatively check if we have a cname
 		if question.Qtype != dns.TypeCNAME {
-			question.Qtype = dns.TypeCNAME
-			return d.lookupRecords(question)
+			cnameQuestion := dns.Question{
+				Name:   question.Name,
+				Qtype:  dns.TypeCNAME,
+				Qclass: question.Qclass,
+			}
+			return d.lookupCNAMEChain(logger, cnameQuestion, question.Qtype)
 		}
-		return nil
+		return lookupResult{rcode: dns.RcodeNameError}
 	}
 
 	recordsCopy := slices.Clone(records)
@@ -119,15 +188,171 @@ func (d *Resolver) lookupRecords(question dns.Question) []dns.RR {
 		d.mu.Unlock()
 	}
 
-	return recordsCopy
+	return lookupResult{records: recordsCopy, rcode: dns.RcodeSuccess}
 }
 
-func (d *Resolver) Update(update []nbdns.SimpleRecord) {
+// lookupCNAMEChain follows a CNAME chain and returns the CNAME records along with
+// the final resolved record of the requested type. This is required for musl libc
+// compatibility, which expects the full answer chain rather than just the CNAME.
+func (d *Resolver) lookupCNAMEChain(logger *log.Entry, cnameQuestion dns.Question, targetType uint16) lookupResult {
+	const maxDepth = 8
+	var chain []dns.RR
+
+	for range maxDepth {
+		cnameRecords := d.getRecords(cnameQuestion)
+		if len(cnameRecords) == 0 {
+			break
+		}
+
+		chain = append(chain, cnameRecords...)
+
+		cname, ok := cnameRecords[0].(*dns.CNAME)
+		if !ok {
+			break
+		}
+
+		targetName := strings.ToLower(cname.Target)
+		targetResult := d.resolveCNAMETarget(logger, targetName, targetType, cnameQuestion.Qclass)
+
+		// keep following chain
+		if targetResult.rcode == -1 {
+			cnameQuestion = dns.Question{Name: targetName, Qtype: dns.TypeCNAME, Qclass: cnameQuestion.Qclass}
+			continue
+		}
+
+		return d.buildChainResult(chain, targetResult)
+	}
+
+	if len(chain) > 0 {
+		return lookupResult{records: chain, rcode: dns.RcodeSuccess}
+	}
+	return lookupResult{rcode: dns.RcodeSuccess}
+}
+
+// buildChainResult combines CNAME chain records with the target resolution result.
+// Per RFC 6604, the final rcode is propagated through the chain.
+func (d *Resolver) buildChainResult(chain []dns.RR, target lookupResult) lookupResult {
+	records := chain
+	if len(target.records) > 0 {
+		records = append(records, target.records...)
+	}
+
+	// preserve hasExternalData for SERVFAIL so caller knows the error came from upstream
+	if target.hasExternalData && target.rcode == dns.RcodeServerFailure {
+		return lookupResult{
+			records:         records,
+			rcode:           dns.RcodeServerFailure,
+			hasExternalData: true,
+		}
+	}
+
+	return lookupResult{
+		records:         records,
+		rcode:           target.rcode,
+		hasExternalData: target.hasExternalData,
+	}
+}
+
+// resolveCNAMETarget attempts to resolve a CNAME target name.
+// Returns rcode=-1 to signal "keep following the chain".
+func (d *Resolver) resolveCNAMETarget(logger *log.Entry, targetName string, targetType uint16, qclass uint16) lookupResult {
+	if records := d.getRecords(dns.Question{Name: targetName, Qtype: targetType, Qclass: qclass}); len(records) > 0 {
+		return lookupResult{records: records, rcode: dns.RcodeSuccess}
+	}
+
+	// another CNAME, keep following
+	if d.hasRecord(dns.Question{Name: targetName, Qtype: dns.TypeCNAME, Qclass: qclass}) {
+		return lookupResult{rcode: -1}
+	}
+
+	// domain exists locally but not this record type (NODATA)
+	if d.hasRecordsForDomain(domain.Domain(targetName)) {
+		return lookupResult{rcode: dns.RcodeSuccess}
+	}
+
+	// in our zone but doesn't exist (NXDOMAIN)
+	if d.isInManagedZone(targetName) {
+		return lookupResult{rcode: dns.RcodeNameError}
+	}
+
+	return d.resolveExternal(logger, targetName, targetType)
+}
+
+func (d *Resolver) getRecords(q dns.Question) []dns.RR {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.records[q]
+}
+
+func (d *Resolver) hasRecord(q dns.Question) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	_, ok := d.records[q]
+	return ok
+}
+
+// resolveExternal resolves a domain name using the system resolver.
+// This is used to resolve CNAME targets that point outside our local zone,
+// which is required for musl libc compatibility (musl expects complete answers).
+func (d *Resolver) resolveExternal(logger *log.Entry, name string, qtype uint16) lookupResult {
+	network := resutil.NetworkForQtype(qtype)
+	if network == "" {
+		return lookupResult{rcode: dns.RcodeNotImplemented}
+	}
+
+	resolver := d.resolver
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+
+	ctx, cancel := context.WithTimeout(d.ctx, externalResolutionTimeout)
+	defer cancel()
+
+	result := resutil.LookupIP(ctx, resolver, network, name, qtype)
+	if result.Err != nil {
+		d.logDNSError(logger, name, qtype, result.Err)
+		return lookupResult{rcode: result.Rcode, hasExternalData: true}
+	}
+
+	return lookupResult{
+		records:         resutil.IPsToRRs(name, result.IPs, 60),
+		rcode:           dns.RcodeSuccess,
+		hasExternalData: true,
+	}
+}
+
+// logDNSError logs DNS resolution errors for debugging.
+func (d *Resolver) logDNSError(logger *log.Entry, hostname string, qtype uint16, err error) {
+	qtypeName := dns.TypeToString[qtype]
+
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		logger.Debugf("DNS resolution failed for %s type %s: %v", hostname, qtypeName, err)
+		return
+	}
+
+	if dnsErr.IsNotFound {
+		logger.Tracef("DNS target not found: %s type %s", hostname, qtypeName)
+		return
+	}
+
+	if dnsErr.Server != "" {
+		logger.Debugf("DNS resolution failed for %s type %s server=%s: %v", hostname, qtypeName, dnsErr.Server, err)
+	} else {
+		logger.Debugf("DNS resolution failed for %s type %s: %v", hostname, qtypeName, err)
+	}
+}
+
+// Update updates the resolver with new records and zone information.
+// The zones parameter specifies which DNS zones this resolver manages.
+func (d *Resolver) Update(update []nbdns.SimpleRecord, zones []domain.Domain) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	maps.Clear(d.records)
 	maps.Clear(d.domains)
+
+	d.zones = zones
 
 	for _, rec := range update {
 		if err := d.registerRecord(rec); err != nil {

--- a/client/internal/dns/resutil/resolve.go
+++ b/client/internal/dns/resutil/resolve.go
@@ -1,0 +1,197 @@
+// Package resutil provides shared DNS resolution utilities
+package resutil
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"net"
+	"net/netip"
+	"strings"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+)
+
+// GenerateRequestID creates a random 8-character hex string for request tracing.
+func GenerateRequestID() string {
+	bytes := make([]byte, 4)
+	if _, err := rand.Read(bytes); err != nil {
+		log.Errorf("generate request ID: %v", err)
+		return ""
+	}
+	return hex.EncodeToString(bytes)
+}
+
+// IPsToRRs converts a slice of IP addresses to DNS resource records.
+// IPv4 addresses become A records, IPv6 addresses become AAAA records.
+func IPsToRRs(name string, ips []netip.Addr, ttl uint32) []dns.RR {
+	var result []dns.RR
+
+	for _, ip := range ips {
+		if ip.Is6() {
+			result = append(result, &dns.AAAA{
+				Hdr: dns.RR_Header{
+					Name:   name,
+					Rrtype: dns.TypeAAAA,
+					Class:  dns.ClassINET,
+					Ttl:    ttl,
+				},
+				AAAA: ip.AsSlice(),
+			})
+		} else {
+			result = append(result, &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   name,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    ttl,
+				},
+				A: ip.AsSlice(),
+			})
+		}
+	}
+
+	return result
+}
+
+// NetworkForQtype returns the network string ("ip4" or "ip6") for a DNS query type.
+// Returns empty string for unsupported types.
+func NetworkForQtype(qtype uint16) string {
+	switch qtype {
+	case dns.TypeA:
+		return "ip4"
+	case dns.TypeAAAA:
+		return "ip6"
+	default:
+		return ""
+	}
+}
+
+type resolver interface {
+	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+
+// chainedWriter is implemented by ResponseWriters that carry request metadata
+type chainedWriter interface {
+	RequestID() string
+	SetMeta(key, value string)
+}
+
+// GetRequestID extracts a request ID from the ResponseWriter if available,
+// otherwise generates a new one.
+func GetRequestID(w dns.ResponseWriter) string {
+	if cw, ok := w.(chainedWriter); ok {
+		if id := cw.RequestID(); id != "" {
+			return id
+		}
+	}
+	return GenerateRequestID()
+}
+
+// SetMeta sets metadata on the ResponseWriter if it supports it.
+func SetMeta(w dns.ResponseWriter, key, value string) {
+	if cw, ok := w.(chainedWriter); ok {
+		cw.SetMeta(key, value)
+	}
+}
+
+// LookupResult contains the result of an external DNS lookup
+type LookupResult struct {
+	IPs   []netip.Addr
+	Rcode int
+	Err   error // Original error for caller's logging needs
+}
+
+// LookupIP performs a DNS lookup and determines the appropriate rcode.
+func LookupIP(ctx context.Context, r resolver, network, host string, qtype uint16) LookupResult {
+	ips, err := r.LookupNetIP(ctx, network, host)
+	if err != nil {
+		return LookupResult{
+			Rcode: getRcodeForError(ctx, r, host, qtype, err),
+			Err:   err,
+		}
+	}
+
+	// Unmap IPv4-mapped IPv6 addresses that some resolvers may return
+	for i, ip := range ips {
+		ips[i] = ip.Unmap()
+	}
+
+	return LookupResult{
+		IPs:   ips,
+		Rcode: dns.RcodeSuccess,
+	}
+}
+
+func getRcodeForError(ctx context.Context, r resolver, host string, qtype uint16, err error) int {
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return dns.RcodeServerFailure
+	}
+
+	if dnsErr.IsNotFound {
+		return getRcodeForNotFound(ctx, r, host, qtype)
+	}
+
+	return dns.RcodeServerFailure
+}
+
+// getRcodeForNotFound distinguishes between NXDOMAIN (domain doesn't exist) and NODATA
+// (domain exists but no records of requested type) by checking the opposite record type.
+//
+// musl libc (the reason we need this distinction) only queries A/AAAA pairs in getaddrinfo,
+// so checking the opposite A/AAAA type is sufficient. Other record types (MX, TXT, etc.)
+// are not queried by musl and don't need this handling.
+func getRcodeForNotFound(ctx context.Context, r resolver, domain string, originalQtype uint16) int {
+	// Try querying for a different record type to see if the domain exists
+	// If the original query was for AAAA, try A. If it was for A, try AAAA.
+	// This helps distinguish between NXDOMAIN and NODATA.
+	var alternativeNetwork string
+	switch originalQtype {
+	case dns.TypeAAAA:
+		alternativeNetwork = "ip4"
+	case dns.TypeA:
+		alternativeNetwork = "ip6"
+	default:
+		return dns.RcodeNameError
+	}
+
+	if _, err := r.LookupNetIP(ctx, alternativeNetwork, domain); err != nil {
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+			// Alternative query also returned not found - domain truly doesn't exist
+			return dns.RcodeNameError
+		}
+		// Some other error (timeout, server failure, etc.) - can't determine, assume domain exists
+		return dns.RcodeSuccess
+	}
+
+	// Alternative query succeeded - domain exists but has no records of this type
+	return dns.RcodeSuccess
+}
+
+// FormatAnswers formats DNS resource records for logging.
+func FormatAnswers(answers []dns.RR) string {
+	if len(answers) == 0 {
+		return "[]"
+	}
+
+	parts := make([]string, 0, len(answers))
+	for _, rr := range answers {
+		switch r := rr.(type) {
+		case *dns.A:
+			parts = append(parts, r.A.String())
+		case *dns.AAAA:
+			parts = append(parts, r.AAAA.String())
+		case *dns.CNAME:
+			parts = append(parts, "CNAME:"+r.Target)
+		case *dns.PTR:
+			parts = append(parts, "PTR:"+r.Ptr)
+		default:
+			parts = append(parts, dns.TypeToString[rr.Header().Rrtype])
+		}
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -385,7 +385,7 @@ func TestUpdateDNSServer(t *testing.T) {
 			}()
 
 			dnsServer.dnsMuxMap = testCase.initUpstreamMap
-			dnsServer.localResolver.Update(testCase.initLocalRecords)
+			dnsServer.localResolver.Update(testCase.initLocalRecords, nil)
 			dnsServer.updateSerial = testCase.initSerial
 
 			err = dnsServer.UpdateDNSServer(testCase.inputSerial, testCase.inputUpdate)
@@ -511,7 +511,7 @@ func TestDNSFakeResolverHandleUpdates(t *testing.T) {
 		},
 	}
 	//dnsServer.localResolver.RegisteredMap = local.RegistrationMap{local.BuildRecordKey("netbird.cloud", dns.ClassINET, dns.TypeA): struct{}{}}
-	dnsServer.localResolver.Update([]nbdns.SimpleRecord{{Name: "netbird.cloud", Type: int(dns.TypeA), Class: nbdns.DefaultClass, TTL: 300, RData: "10.0.0.1"}})
+	dnsServer.localResolver.Update([]nbdns.SimpleRecord{{Name: "netbird.cloud", Type: int(dns.TypeA), Class: nbdns.DefaultClass, TTL: 300, RData: "10.0.0.1"}}, nil)
 	dnsServer.updateSerial = 0
 
 	nameServers := []nbdns.NameServer{
@@ -2013,7 +2013,7 @@ func TestLocalResolverPriorityInServer(t *testing.T) {
 		},
 	}
 
-	localMuxUpdates, _, err := server.buildLocalHandlerUpdate(config.CustomZones)
+	localMuxUpdates, _, _, err := server.buildLocalHandlerUpdate(config.CustomZones)
 	assert.NoError(t, err)
 
 	upstreamMuxUpdates, err := server.buildUpstreamHandlerUpdate(config.NameServerGroups)
@@ -2074,7 +2074,7 @@ func TestLocalResolverPriorityConstants(t *testing.T) {
 		},
 	}
 
-	localMuxUpdates, _, err := server.buildLocalHandlerUpdate(config.CustomZones)
+	localMuxUpdates, _, _, err := server.buildLocalHandlerUpdate(config.CustomZones)
 	assert.NoError(t, err)
 	assert.Len(t, localMuxUpdates, 1)
 	assert.Equal(t, PriorityLocal, localMuxUpdates[0].priority, "Local handler should use PriorityLocal")

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -21,6 +20,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/internal/dns/resutil"
 	"github.com/netbirdio/netbird/client/internal/dns/types"
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/proto"
@@ -113,10 +113,7 @@ func (u *upstreamResolverBase) Stop() {
 
 // ServeDNS handles a DNS request
 func (u *upstreamResolverBase) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
-	requestID := GenerateRequestID()
-	logger := log.WithField("request_id", requestID)
-
-	logger.Tracef("received upstream question: domain=%s type=%v class=%v", r.Question[0].Name, r.Question[0].Qtype, r.Question[0].Qclass)
+	logger := log.WithField("request_id", resutil.GetRequestID(w))
 
 	u.prepareRequest(r)
 
@@ -202,11 +199,14 @@ func (u *upstreamResolverBase) handleUpstreamError(err error, upstream netip.Add
 
 func (u *upstreamResolverBase) writeSuccessResponse(w dns.ResponseWriter, rm *dns.Msg, upstream netip.AddrPort, domain string, t time.Duration, logger *log.Entry) bool {
 	u.successCount.Add(1)
-	logger.Tracef("took %s to query the upstream %s for question domain=%s", t, upstream, domain)
+
+	resutil.SetMeta(w, "upstream", upstream.String())
 
 	if err := w.WriteMsg(rm); err != nil {
 		logger.Errorf("failed to write DNS response for question domain=%s: %s", domain, err)
+		return true
 	}
+
 	return true
 }
 
@@ -412,16 +412,6 @@ func ExchangeWithFallback(ctx context.Context, client *dns.Client, r *dns.Msg, u
 	// TODO: once TCP is implemented, rm.Truncate() if the request came in over UDP
 
 	return rm, t, nil
-}
-
-func GenerateRequestID() string {
-	bytes := make([]byte, 4)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		log.Errorf("failed to generate request ID: %v", err)
-		return ""
-	}
-	return hex.EncodeToString(bytes)
 }
 
 // FormatPeerStatus formats peer connection status information for debugging DNS timeouts

--- a/client/internal/dnsfwd/forwarder.go
+++ b/client/internal/dnsfwd/forwarder.go
@@ -18,6 +18,7 @@ import (
 
 	nberrors "github.com/netbirdio/netbird/client/errors"
 	firewall "github.com/netbirdio/netbird/client/firewall/manager"
+	"github.com/netbirdio/netbird/client/internal/dns/resutil"
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/route"
 )
@@ -189,29 +190,22 @@ func (f *DNSForwarder) Close(ctx context.Context) error {
 	return nberrors.FormatErrorOrNil(result)
 }
 
-func (f *DNSForwarder) handleDNSQuery(w dns.ResponseWriter, query *dns.Msg) *dns.Msg {
+func (f *DNSForwarder) handleDNSQuery(logger *log.Entry, w dns.ResponseWriter, query *dns.Msg) *dns.Msg {
 	if len(query.Question) == 0 {
 		return nil
 	}
 	question := query.Question[0]
-	log.Tracef("received DNS request for DNS forwarder: domain=%v type=%v class=%v",
-		question.Name, question.Qtype, question.Qclass)
+	logger.Tracef("received DNS request for DNS forwarder: domain=%s type=%s class=%s",
+		question.Name, dns.TypeToString[question.Qtype], dns.ClassToString[question.Qclass])
 
 	domain := strings.ToLower(question.Name)
 
 	resp := query.SetReply(query)
-	var network string
-	switch question.Qtype {
-	case dns.TypeA:
-		network = "ip4"
-	case dns.TypeAAAA:
-		network = "ip6"
-	default:
-		// TODO: Handle other types
-
+	network := resutil.NetworkForQtype(question.Qtype)
+	if network == "" {
 		resp.Rcode = dns.RcodeNotImplemented
 		if err := w.WriteMsg(resp); err != nil {
-			log.Errorf("failed to write DNS response: %v", err)
+			logger.Errorf("failed to write DNS response: %v", err)
 		}
 		return nil
 	}
@@ -221,33 +215,35 @@ func (f *DNSForwarder) handleDNSQuery(w dns.ResponseWriter, query *dns.Msg) *dns
 	if mostSpecificResId == "" {
 		resp.Rcode = dns.RcodeRefused
 		if err := w.WriteMsg(resp); err != nil {
-			log.Errorf("failed to write DNS response: %v", err)
+			logger.Errorf("failed to write DNS response: %v", err)
 		}
 		return nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), upstreamTimeout)
 	defer cancel()
-	ips, err := f.resolver.LookupNetIP(ctx, network, domain)
-	if err != nil {
-		f.handleDNSError(ctx, w, question, resp, domain, err)
+
+	result := resutil.LookupIP(ctx, f.resolver, network, domain, question.Qtype)
+	if result.Err != nil {
+		f.handleDNSError(ctx, logger, w, question, resp, domain, result)
 		return nil
 	}
 
-	// Unmap IPv4-mapped IPv6 addresses that some resolvers may return
-	for i, ip := range ips {
-		ips[i] = ip.Unmap()
-	}
-
-	f.updateInternalState(ips, mostSpecificResId, matchingEntries)
-	f.addIPsToResponse(resp, domain, ips)
-	f.cache.set(domain, question.Qtype, ips)
+	f.updateInternalState(result.IPs, mostSpecificResId, matchingEntries)
+	resp.Answer = append(resp.Answer, resutil.IPsToRRs(domain, result.IPs, f.ttl)...)
+	f.cache.set(domain, question.Qtype, result.IPs)
 
 	return resp
 }
 
 func (f *DNSForwarder) handleDNSQueryUDP(w dns.ResponseWriter, query *dns.Msg) {
-	resp := f.handleDNSQuery(w, query)
+	startTime := time.Now()
+	logger := log.WithFields(log.Fields{
+		"request_id": resutil.GenerateRequestID(),
+		"dns_id":     fmt.Sprintf("%04x", query.Id),
+	})
+
+	resp := f.handleDNSQuery(logger, w, query)
 	if resp == nil {
 		return
 	}
@@ -265,19 +261,33 @@ func (f *DNSForwarder) handleDNSQueryUDP(w dns.ResponseWriter, query *dns.Msg) {
 	}
 
 	if err := w.WriteMsg(resp); err != nil {
-		log.Errorf("failed to write DNS response: %v", err)
+		logger.Errorf("failed to write DNS response: %v", err)
+		return
 	}
+
+	logger.Tracef("response: domain=%s rcode=%s answers=%s took=%s",
+		query.Question[0].Name, dns.RcodeToString[resp.Rcode], resutil.FormatAnswers(resp.Answer), time.Since(startTime))
 }
 
 func (f *DNSForwarder) handleDNSQueryTCP(w dns.ResponseWriter, query *dns.Msg) {
-	resp := f.handleDNSQuery(w, query)
+	startTime := time.Now()
+	logger := log.WithFields(log.Fields{
+		"request_id": resutil.GenerateRequestID(),
+		"dns_id":     fmt.Sprintf("%04x", query.Id),
+	})
+
+	resp := f.handleDNSQuery(logger, w, query)
 	if resp == nil {
 		return
 	}
 
 	if err := w.WriteMsg(resp); err != nil {
-		log.Errorf("failed to write DNS response: %v", err)
+		logger.Errorf("failed to write DNS response: %v", err)
+		return
 	}
+
+	logger.Tracef("response: domain=%s rcode=%s answers=%s took=%s",
+		query.Question[0].Name, dns.RcodeToString[resp.Rcode], resutil.FormatAnswers(resp.Answer), time.Since(startTime))
 }
 
 func (f *DNSForwarder) updateInternalState(ips []netip.Addr, mostSpecificResId route.ResID, matchingEntries []*ForwarderEntry) {
@@ -315,140 +325,64 @@ func (f *DNSForwarder) updateFirewall(matchingEntries []*ForwarderEntry, prefixe
 	}
 }
 
-// setResponseCodeForNotFound determines and sets the appropriate response code when IsNotFound is true
-// It distinguishes between NXDOMAIN (domain doesn't exist) and NODATA (domain exists but no records of requested type)
-//
-// LIMITATION: This function only checks A and AAAA record types to determine domain existence.
-// If a domain has only other record types (MX, TXT, CNAME, etc.) but no A/AAAA records,
-// it may incorrectly return NXDOMAIN instead of NODATA. This is acceptable since the forwarder
-// only handles A/AAAA queries and returns NOTIMP for other types.
-func (f *DNSForwarder) setResponseCodeForNotFound(ctx context.Context, resp *dns.Msg, domain string, originalQtype uint16) {
-	// Try querying for a different record type to see if the domain exists
-	// If the original query was for AAAA, try A. If it was for A, try AAAA.
-	// This helps distinguish between NXDOMAIN and NODATA.
-	var alternativeNetwork string
-	switch originalQtype {
-	case dns.TypeAAAA:
-		alternativeNetwork = "ip4"
-	case dns.TypeA:
-		alternativeNetwork = "ip6"
-	default:
-		resp.Rcode = dns.RcodeNameError
-		return
-	}
-
-	if _, err := f.resolver.LookupNetIP(ctx, alternativeNetwork, domain); err != nil {
-		var dnsErr *net.DNSError
-		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
-			// Alternative query also returned not found - domain truly doesn't exist
-			resp.Rcode = dns.RcodeNameError
-			return
-		}
-		// Some other error (timeout, server failure, etc.) - can't determine, assume domain exists
-		resp.Rcode = dns.RcodeSuccess
-		return
-	}
-
-	// Alternative query succeeded - domain exists but has no records of this type
-	resp.Rcode = dns.RcodeSuccess
-}
-
 // handleDNSError processes DNS lookup errors and sends an appropriate error response.
 func (f *DNSForwarder) handleDNSError(
 	ctx context.Context,
+	logger *log.Entry,
 	w dns.ResponseWriter,
 	question dns.Question,
 	resp *dns.Msg,
 	domain string,
-	err error,
+	result resutil.LookupResult,
 ) {
-	// Default to SERVFAIL; override below when appropriate.
-	resp.Rcode = dns.RcodeServerFailure
-
 	qType := question.Qtype
 	qTypeName := dns.TypeToString[qType]
 
-	// Prefer typed DNS errors; fall back to generic logging otherwise.
-	var dnsErr *net.DNSError
-	if !errors.As(err, &dnsErr) {
-		log.Warnf(errResolveFailed, domain, err)
-		if writeErr := w.WriteMsg(resp); writeErr != nil {
-			log.Errorf("failed to write failure DNS response: %v", writeErr)
-		}
-		return
-	}
+	resp.Rcode = result.Rcode
 
-	// NotFound: set NXDOMAIN / appropriate code via helper.
-	if dnsErr.IsNotFound {
-		f.setResponseCodeForNotFound(ctx, resp, domain, qType)
-		if writeErr := w.WriteMsg(resp); writeErr != nil {
-			log.Errorf("failed to write failure DNS response: %v", writeErr)
-		}
+	// NotFound: cache negative result and respond
+	if result.Rcode == dns.RcodeNameError || result.Rcode == dns.RcodeSuccess {
 		f.cache.set(domain, question.Qtype, nil)
+		if writeErr := w.WriteMsg(resp); writeErr != nil {
+			logger.Errorf("failed to write failure DNS response: %v", writeErr)
+		}
 		return
 	}
 
 	// Upstream failed but we might have a cached answer—serve it if present.
 	if ips, ok := f.cache.get(domain, qType); ok {
 		if len(ips) > 0 {
-			log.Debugf("serving cached DNS response after upstream failure: domain=%s type=%s", domain, qTypeName)
-			f.addIPsToResponse(resp, domain, ips)
+			logger.Debugf("serving cached DNS response after upstream failure: domain=%s type=%s", domain, qTypeName)
+			resp.Answer = append(resp.Answer, resutil.IPsToRRs(domain, ips, f.ttl)...)
 			resp.Rcode = dns.RcodeSuccess
 			if writeErr := w.WriteMsg(resp); writeErr != nil {
-				log.Errorf("failed to write cached DNS response: %v", writeErr)
+				logger.Errorf("failed to write cached DNS response: %v", writeErr)
 			}
-		} else { // send NXDOMAIN / appropriate code if cache is empty
-			f.setResponseCodeForNotFound(ctx, resp, domain, qType)
-			if writeErr := w.WriteMsg(resp); writeErr != nil {
-				log.Errorf("failed to write failure DNS response: %v", writeErr)
-			}
+			return
 		}
-		return
+
+		// Cached negative result - re-verify NXDOMAIN vs NODATA
+		verifyResult := resutil.LookupIP(ctx, f.resolver, resutil.NetworkForQtype(qType), domain, qType)
+		if verifyResult.Rcode == dns.RcodeNameError || verifyResult.Rcode == dns.RcodeSuccess {
+			resp.Rcode = verifyResult.Rcode
+			if writeErr := w.WriteMsg(resp); writeErr != nil {
+				logger.Errorf("failed to write failure DNS response: %v", writeErr)
+			}
+			return
+		}
 	}
 
-	// No cache. Log with or without the server field for more context.
-	if dnsErr.Server != "" {
-		log.Warnf("failed to resolve: type=%s domain=%s server=%s: %v", qTypeName, domain, dnsErr.Server, err)
+	// No cache or verification failed. Log with or without the server field for more context.
+	var dnsErr *net.DNSError
+	if errors.As(result.Err, &dnsErr) && dnsErr.Server != "" {
+		logger.Warnf("failed to resolve: type=%s domain=%s server=%s: %v", qTypeName, domain, dnsErr.Server, result.Err)
 	} else {
-		log.Warnf(errResolveFailed, domain, err)
+		logger.Warnf(errResolveFailed, domain, result.Err)
 	}
 
 	// Write final failure response.
 	if writeErr := w.WriteMsg(resp); writeErr != nil {
-		log.Errorf("failed to write failure DNS response: %v", writeErr)
-	}
-}
-
-// addIPsToResponse adds IP addresses to the DNS response as appropriate A or AAAA records
-func (f *DNSForwarder) addIPsToResponse(resp *dns.Msg, domain string, ips []netip.Addr) {
-	for _, ip := range ips {
-		var respRecord dns.RR
-		if ip.Is6() {
-			log.Tracef("resolved domain=%s to IPv6=%s", domain, ip)
-			rr := dns.AAAA{
-				AAAA: ip.AsSlice(),
-				Hdr: dns.RR_Header{
-					Name:   domain,
-					Rrtype: dns.TypeAAAA,
-					Class:  dns.ClassINET,
-					Ttl:    f.ttl,
-				},
-			}
-			respRecord = &rr
-		} else {
-			log.Tracef("resolved domain=%s to IPv4=%s", domain, ip)
-			rr := dns.A{
-				A: ip.AsSlice(),
-				Hdr: dns.RR_Header{
-					Name:   domain,
-					Rrtype: dns.TypeA,
-					Class:  dns.ClassINET,
-					Ttl:    f.ttl,
-				},
-			}
-			respRecord = &rr
-		}
-		resp.Answer = append(resp.Answer, respRecord)
+		logger.Errorf("failed to write failure DNS response: %v", writeErr)
 	}
 }
 

--- a/client/internal/routemanager/dnsinterceptor/handler.go
+++ b/client/internal/routemanager/dnsinterceptor/handler.go
@@ -19,6 +19,7 @@ import (
 	firewall "github.com/netbirdio/netbird/client/firewall/manager"
 	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	nbdns "github.com/netbirdio/netbird/client/internal/dns"
+	"github.com/netbirdio/netbird/client/internal/dns/resutil"
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/peerstore"
 	"github.com/netbirdio/netbird/client/internal/routemanager/common"
@@ -219,14 +220,14 @@ func (d *DnsInterceptor) RemoveAllowedIPs() error {
 
 // ServeDNS implements the dns.Handler interface
 func (d *DnsInterceptor) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
-	requestID := nbdns.GenerateRequestID()
-	logger := log.WithField("request_id", requestID)
+	logger := log.WithFields(log.Fields{
+		"request_id": resutil.GetRequestID(w),
+		"dns_id":     fmt.Sprintf("%04x", r.Id),
+	})
 
 	if len(r.Question) == 0 {
 		return
 	}
-	logger.Tracef("received DNS request for domain=%s type=%v class=%v",
-		r.Question[0].Name, r.Question[0].Qtype, r.Question[0].Qclass)
 
 	// pass if non A/AAAA query
 	if r.Question[0].Qtype != dns.TypeA && r.Question[0].Qtype != dns.TypeAAAA {
@@ -280,15 +281,10 @@ func (d *DnsInterceptor) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		return
 	}
 
-	var answer []dns.RR
-	if reply != nil {
-		answer = reply.Answer
-	}
-
-	logger.Tracef("upstream %s (%s) DNS response for domain=%s answers=%v", upstreamIP.String(), peerKey, r.Question[0].Name, answer)
+	resutil.SetMeta(w, "peer", peerKey)
 
 	reply.Id = r.Id
-	if err := d.writeMsg(w, reply); err != nil {
+	if err := d.writeMsg(w, reply, logger); err != nil {
 		logger.Errorf("failed writing DNS response: %v", err)
 	}
 }
@@ -324,7 +320,7 @@ func (d *DnsInterceptor) getUpstreamIP(peerKey string) (netip.Addr, error) {
 	return peerAllowedIP, nil
 }
 
-func (d *DnsInterceptor) writeMsg(w dns.ResponseWriter, r *dns.Msg) error {
+func (d *DnsInterceptor) writeMsg(w dns.ResponseWriter, r *dns.Msg, logger *log.Entry) error {
 	if r == nil {
 		return fmt.Errorf("received nil DNS message")
 	}
@@ -350,14 +346,14 @@ func (d *DnsInterceptor) writeMsg(w dns.ResponseWriter, r *dns.Msg) error {
 			case *dns.A:
 				addr, ok := netip.AddrFromSlice(rr.A)
 				if !ok {
-					log.Tracef("failed to convert A record for domain=%s ip=%v", resolvedDomain, rr.A)
+					logger.Tracef("failed to convert A record for domain=%s ip=%v", resolvedDomain, rr.A)
 					continue
 				}
 				ip = addr
 			case *dns.AAAA:
 				addr, ok := netip.AddrFromSlice(rr.AAAA)
 				if !ok {
-					log.Tracef("failed to convert AAAA record for domain=%s ip=%v", resolvedDomain, rr.AAAA)
+					logger.Tracef("failed to convert AAAA record for domain=%s ip=%v", resolvedDomain, rr.AAAA)
 					continue
 				}
 				ip = addr
@@ -370,11 +366,11 @@ func (d *DnsInterceptor) writeMsg(w dns.ResponseWriter, r *dns.Msg) error {
 		}
 
 		if len(newPrefixes) > 0 {
-			if err := d.updateDomainPrefixes(resolvedDomain, originalDomain, newPrefixes); err != nil {
-				log.Errorf("failed to update domain prefixes: %v", err)
+			if err := d.updateDomainPrefixes(resolvedDomain, originalDomain, newPrefixes, logger); err != nil {
+				logger.Errorf("failed to update domain prefixes: %v", err)
 			}
 
-			d.replaceIPsInDNSResponse(r, newPrefixes)
+			d.replaceIPsInDNSResponse(r, newPrefixes, logger)
 		}
 	}
 
@@ -386,22 +382,22 @@ func (d *DnsInterceptor) writeMsg(w dns.ResponseWriter, r *dns.Msg) error {
 }
 
 // logPrefixChanges handles the logging for prefix changes
-func (d *DnsInterceptor) logPrefixChanges(resolvedDomain, originalDomain domain.Domain, toAdd, toRemove []netip.Prefix) {
+func (d *DnsInterceptor) logPrefixChanges(resolvedDomain, originalDomain domain.Domain, toAdd, toRemove []netip.Prefix, logger *log.Entry) {
 	if len(toAdd) > 0 {
-		log.Debugf("added dynamic route(s) for domain=%s (pattern: domain=%s): %s",
+		logger.Debugf("added dynamic route(s) for domain=%s (pattern: domain=%s): %s",
 			resolvedDomain.SafeString(),
 			originalDomain.SafeString(),
 			toAdd)
 	}
 	if len(toRemove) > 0 && !d.route.KeepRoute {
-		log.Debugf("removed dynamic route(s) for domain=%s (pattern: domain=%s): %s",
+		logger.Debugf("removed dynamic route(s) for domain=%s (pattern: domain=%s): %s",
 			resolvedDomain.SafeString(),
 			originalDomain.SafeString(),
 			toRemove)
 	}
 }
 
-func (d *DnsInterceptor) updateDomainPrefixes(resolvedDomain, originalDomain domain.Domain, newPrefixes []netip.Prefix) error {
+func (d *DnsInterceptor) updateDomainPrefixes(resolvedDomain, originalDomain domain.Domain, newPrefixes []netip.Prefix, logger *log.Entry) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -418,9 +414,9 @@ func (d *DnsInterceptor) updateDomainPrefixes(resolvedDomain, originalDomain dom
 			realIP := prefix.Addr()
 			if fakeIP, err := d.fakeIPManager.AllocateFakeIP(realIP); err == nil {
 				dnatMappings[fakeIP] = realIP
-				log.Tracef("allocated fake IP %s for real IP %s", fakeIP, realIP)
+				logger.Tracef("allocated fake IP %s for real IP %s", fakeIP, realIP)
 			} else {
-				log.Errorf("Failed to allocate fake IP for %s: %v", realIP, err)
+				logger.Errorf("failed to allocate fake IP for %s: %v", realIP, err)
 			}
 		}
 	}
@@ -432,7 +428,7 @@ func (d *DnsInterceptor) updateDomainPrefixes(resolvedDomain, originalDomain dom
 		}
 	}
 
-	d.addDNATMappings(dnatMappings)
+	d.addDNATMappings(dnatMappings, logger)
 
 	if !d.route.KeepRoute {
 		// Remove old prefixes
@@ -448,7 +444,7 @@ func (d *DnsInterceptor) updateDomainPrefixes(resolvedDomain, originalDomain dom
 			}
 		}
 
-		d.removeDNATMappings(toRemove)
+		d.removeDNATMappings(toRemove, logger)
 	}
 
 	// Update domain prefixes using resolved domain as key - store real IPs
@@ -463,14 +459,14 @@ func (d *DnsInterceptor) updateDomainPrefixes(resolvedDomain, originalDomain dom
 		// Store real IPs for status (user-facing), not fake IPs
 		d.statusRecorder.UpdateResolvedDomainsStates(originalDomain, resolvedDomain, newPrefixes, d.route.GetResourceID())
 
-		d.logPrefixChanges(resolvedDomain, originalDomain, toAdd, toRemove)
+		d.logPrefixChanges(resolvedDomain, originalDomain, toAdd, toRemove, logger)
 	}
 
 	return nberrors.FormatErrorOrNil(merr)
 }
 
 // removeDNATMappings removes DNAT mappings from the firewall for real IP prefixes
-func (d *DnsInterceptor) removeDNATMappings(realPrefixes []netip.Prefix) {
+func (d *DnsInterceptor) removeDNATMappings(realPrefixes []netip.Prefix, logger *log.Entry) {
 	if len(realPrefixes) == 0 {
 		return
 	}
@@ -484,9 +480,9 @@ func (d *DnsInterceptor) removeDNATMappings(realPrefixes []netip.Prefix) {
 		realIP := prefix.Addr()
 		if fakeIP, exists := d.fakeIPManager.GetFakeIP(realIP); exists {
 			if err := dnatFirewall.RemoveInternalDNATMapping(fakeIP); err != nil {
-				log.Errorf("Failed to remove DNAT mapping for %s: %v", fakeIP, err)
+				logger.Errorf("failed to remove DNAT mapping for %s: %v", fakeIP, err)
 			} else {
-				log.Debugf("Removed DNAT mapping for: %s -> %s", fakeIP, realIP)
+				logger.Debugf("removed DNAT mapping: %s -> %s", fakeIP, realIP)
 			}
 		}
 	}
@@ -502,7 +498,7 @@ func (d *DnsInterceptor) internalDnatFw() (internalDNATer, bool) {
 }
 
 // addDNATMappings adds DNAT mappings to the firewall
-func (d *DnsInterceptor) addDNATMappings(mappings map[netip.Addr]netip.Addr) {
+func (d *DnsInterceptor) addDNATMappings(mappings map[netip.Addr]netip.Addr, logger *log.Entry) {
 	if len(mappings) == 0 {
 		return
 	}
@@ -514,9 +510,9 @@ func (d *DnsInterceptor) addDNATMappings(mappings map[netip.Addr]netip.Addr) {
 
 	for fakeIP, realIP := range mappings {
 		if err := dnatFirewall.AddInternalDNATMapping(fakeIP, realIP); err != nil {
-			log.Errorf("Failed to add DNAT mapping %s -> %s: %v", fakeIP, realIP, err)
+			logger.Errorf("failed to add DNAT mapping %s -> %s: %v", fakeIP, realIP, err)
 		} else {
-			log.Debugf("Added DNAT mapping: %s -> %s", fakeIP, realIP)
+			logger.Debugf("added DNAT mapping: %s -> %s", fakeIP, realIP)
 		}
 	}
 }
@@ -528,12 +524,12 @@ func (d *DnsInterceptor) cleanupDNATMappings() {
 	}
 
 	for _, prefixes := range d.interceptedDomains {
-		d.removeDNATMappings(prefixes)
+		d.removeDNATMappings(prefixes, log.NewEntry(log.StandardLogger()))
 	}
 }
 
 // replaceIPsInDNSResponse replaces real IPs with fake IPs in the DNS response
-func (d *DnsInterceptor) replaceIPsInDNSResponse(reply *dns.Msg, realPrefixes []netip.Prefix) {
+func (d *DnsInterceptor) replaceIPsInDNSResponse(reply *dns.Msg, realPrefixes []netip.Prefix, logger *log.Entry) {
 	if _, ok := d.internalDnatFw(); !ok {
 		return
 	}
@@ -549,7 +545,7 @@ func (d *DnsInterceptor) replaceIPsInDNSResponse(reply *dns.Msg, realPrefixes []
 
 			if fakeIP, exists := d.fakeIPManager.GetFakeIP(realIP); exists {
 				rr.A = fakeIP.AsSlice()
-				log.Tracef("Replaced real IP %s with fake IP %s in DNS response", realIP, fakeIP)
+				logger.Tracef("replaced real IP %s with fake IP %s in DNS response", realIP, fakeIP)
 			}
 
 		case *dns.AAAA:
@@ -560,7 +556,7 @@ func (d *DnsInterceptor) replaceIPsInDNSResponse(reply *dns.Msg, realPrefixes []
 
 			if fakeIP, exists := d.fakeIPManager.GetFakeIP(realIP); exists {
 				rr.AAAA = fakeIP.AsSlice()
-				log.Tracef("Replaced real IP %s with fake IP %s in DNS response", realIP, fakeIP)
+				logger.Tracef("replaced real IP %s with fake IP %s in DNS response", realIP, fakeIP)
 			}
 		}
 	}


### PR DESCRIPTION
## Describe your changes

- Chase CNAMEs in the local resolver, either in our managed zones or external. This is required to satisfy musl libc, which won't follow up on CNAMEs by itself
- Refactor and extract some code from the DNS forwarder for use in the local resolver
- Improve DNS logging across the board:
  - Add request_id to local resolver and DNS forwarder
  - Move some logs to the handler chain and reduce some excessive logging there
  - Add dns_id from the DNS request. This can be tracked across routing client/peers and various tools like tcpdump


## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added request tracing with unique request IDs for improved diagnostics and logging
  * Enhanced CNAME chain resolution with proper handling of domain aliases
  * Implemented external DNS resolution fallback for domains not found locally
  * Added zone-aware DNS query handling
  * Introduced response metadata tracking for better observability

* **Bug Fixes**
  * Improved DNS error handling with better distinction between domain-not-found and server errors

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->