### PR TITLE
[client] Add support for disabling eBPF WireGuard proxy via environment variable

### DIFF
--- a/client/iface/wgproxy/factory_kernel.go
+++ b/client/iface/wgproxy/factory_kernel.go
@@ -3,10 +3,17 @@
 package wgproxy
 
 import (
+	"os"
+	"strconv"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/netbirdio/netbird/client/iface/wgproxy/ebpf"
 	udpProxy "github.com/netbirdio/netbird/client/iface/wgproxy/udp"
+)
+
+const (
+	envDisableEBPFWGProxy = "NB_DISABLE_EBPF_WG_PROXY"
 )
 
 type KernelFactory struct {
@@ -20,6 +27,12 @@ func NewKernelFactory(wgPort int, mtu uint16) *KernelFactory {
 	f := &KernelFactory{
 		wgPort: wgPort,
 		mtu:    mtu,
+	}
+
+	if isEBPFDisabled() {
+		log.Infof("WireGuard Proxy Factory will produce UDP proxy")
+		log.Infof("eBPF WireGuard proxy is disabled via %s environment variable", envDisableEBPFWGProxy)
+		return f
 	}
 
 	ebpfProxy := ebpf.NewWGEBPFProxy(wgPort, mtu)
@@ -46,4 +59,17 @@ func (w *KernelFactory) Free() error {
 		return nil
 	}
 	return w.ebpfProxy.Free()
+}
+
+func isEBPFDisabled() bool {
+	val := os.Getenv(envDisableEBPFWGProxy)
+	if val == "" {
+		return false
+	}
+	disabled, err := strconv.ParseBool(val)
+	if err != nil {
+		log.Warnf("failed to parse %s: %v", envDisableEBPFWGProxy, err)
+		return false
+	}
+	return disabled
 }


### PR DESCRIPTION
## Describe your changes
Add support for disabling eBPF WireGuard proxy via environment variable

`NB_DISABLE_EBPF_WG_PROXY=false`


## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variable configuration option added for WireGuard proxy implementation selection

* **Bug Fixes**
  * WireGuard proxy initialization includes automatic fallback mechanism; if primary proxy type fails during startup, system switches to alternative implementation and logs all proxy selection events

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->