### PR TITLE
[management] fix nil handling for extra settings

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -334,10 +334,9 @@ func (am *DefaultAccountManager) UpdateAccountSettings(ctx context.Context, acco
 		}
 
 		if newSettings.Extra == nil {
-			newSettings.Extra = &types.ExtraSettings{}
+			newSettings.Extra = oldSettings.Extra
 		}
-		newSettings.Extra.IntegratedValidatorGroups = oldSettings.Extra.IntegratedValidatorGroups
-		newSettings.Extra.IntegratedValidator = oldSettings.Extra.IntegratedValidator
+
 		if err = transaction.SaveAccountSettings(ctx, accountID, newSettings); err != nil {
 			return err
 		}

--- a/management/server/http/handlers/accounts/accounts_handler.go
+++ b/management/server/http/handlers/accounts/accounts_handler.go
@@ -175,7 +175,6 @@ func (h *handler) updateAccountRequestSettings(req api.PutApiAccountsAccountIdJS
 
 		PeerInactivityExpirationEnabled: req.Settings.PeerInactivityExpirationEnabled,
 		PeerInactivityExpiration:        time.Duration(float64(time.Second.Nanoseconds()) * float64(req.Settings.PeerInactivityExpiration)),
-		Extra:                           &types.ExtraSettings{},
 	}
 
 	if req.Settings.Extra != nil {


### PR DESCRIPTION
## Describe your changes
The server was throwing panic if the ExtraSettings are not set on the API call.

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/5045

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in account settings updates that could cause errors when certain settings fields are empty, improving stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->