### PR TITLE
Fix ui-post-install.sh remove use of loginuid (#5082)

### DIFF
--- a/release_files/ui-post-install.sh
+++ b/release_files/ui-post-install.sh
@@ -7,9 +7,9 @@ set -u
 pid="$(pgrep -x -f /usr/bin/netbird-ui || true)"
 if [ -n "${pid}" ]
 then
-  uid="$(cat /proc/"${pid}"/loginuid)"
-  username="$(id -nu "${uid}")"
+  username="$(ps -o 'user:256=' -p "${pid}")"
   # Only re-run if it was already running
   pkill -x -f /usr/bin/netbird-ui >/dev/null 2>&1
-  su - "${username}" -c 'nohup /usr/bin/netbird-ui > /dev/null 2>&1 &'
+  # shellcheck disable=SC2086 # Use word-splitting to trim whitespace
+  su - ${username} -c 'nohup /usr/bin/netbird-ui > /dev/null 2>&1 &'
 fi


### PR DESCRIPTION
## Describe your changes

Edit: sorry for the spam; I took a second pass at this for a cleaner implementation.

Fixes #5082 by using non-truncated user field output from ps instead of getting uid and converting with id.

- Using `-o 'user:256='` instead of `--no-headers -o '%U'` prevents truncation up to at least 256 chars (the username length limit)
- Keeps simplified/refactored code from 9bd578d, avoiding the use of `sed` by using word-splitting on a known-format value.
- Tested script and ps invocations against multiple current and history distributions, including Alma, Fedora, Debian, Ubuntu
- Validated against shellcheck

## Issue ticket number and link

#5082

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This fixes a post-install script used in Linux packages, which should be invisible to regular users.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the post-installation process to more reliably retrieve user information during setup. All existing functionality is preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->