### PR TITLE
[client] Fix WASM peer connection to lazy peers

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -671,9 +671,7 @@ func (conn *Conn) isConnectedOnAllWay() (connected bool) {
 
 	// For JS platform: only relay connection is supported
 	if runtime.GOOS == "js" {
-		if conn.statusRelay.Get() == worker.StatusDisconnected {
-			return false
-		}
+		return conn.statusRelay.Get() == worker.StatusConnected
 	}
 
 	// For non-JS platforms: check ICE connection status


### PR DESCRIPTION
WASM peers now properly initiate relay connections instead of waiting for offers that lazy peers won't send.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer connection detection with clearer platform-specific behavior for web and non-web runtimes.
  * Enforced relay status checks when a relay path is available to prevent false-positive connections.
  * Ensured consistent connection validation across ICE and relay scenarios for more reliable session state reporting.
  * Reduced intermittent misreports of connected/disconnected state in mixed environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->