### PR TITLE
[client] Handle fallback for invalid `loginuid` in `ui-post-install.sh`.

### DIFF
--- a/release_files/ui-post-install.sh
+++ b/release_files/ui-post-install.sh
@@ -8,6 +8,10 @@ pid="$(pgrep -x -f /usr/bin/netbird-ui || true)"
 if [ -n "${pid}" ]
 then
   uid="$(cat /proc/"${pid}"/loginuid)"
+  # loginuid can be 4294967295 (-1) if not set, fall back to process uid
+  if [ "${uid}" = "4294967295" ] || [ "${uid}" = "-1" ]; then
+    uid="$(stat -c '%u' /proc/"${pid}")"
+  fi
   username="$(id -nu "${uid}")"
   # Only re-run if it was already running
   pkill -x -f /usr/bin/netbird-ui >/dev/null 2>&1


### PR DESCRIPTION
## Describe your changes

Add fallback for loginuid detection when it returns 4294967295 or -1 (unset).  In these cases, use the process uid from /proc/[pid] stat instead to ensure the UI can be properly restarted after package updates.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where invalid or missing login user ID values could cause the post-installation script to incorrectly determine user ownership. The system now includes a fallback mechanism to retrieve the actual user ID directly from system process information, ensuring proper ownership and origin attribution in all scenarios, including when standard login user ID detection fails or returns invalid values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->