### PR TITLE
[client] Change default rosenpass log level

### DIFF
--- a/client/internal/rosenpass/manager.go
+++ b/client/internal/rosenpass/manager.go
@@ -146,7 +146,7 @@ func getLogLevel() slog.Level {
 	case "error":
 		return slog.LevelError
 	default:
-		log.Warnf("unknown log level: %s. Using default %s", level, defaultLog)
+		log.Warnf("unknown log level: %s. Using default %s", level, defaultLog.String())
 		return defaultLog
 	}
 }


### PR DESCRIPTION
## Describe your changes
- Add support to environment configuration
- Change default log level to info
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logging level is now configurable via the NB_ROSENPASS_LOG_LEVEL environment variable (supports debug, info, warn, error).
* **Improvements**
  * Key-generation emits finer trace-level logs for troubleshooting.
  * Unknown log level values now warn and fall back to a sensible default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->