### PR TITLE
[client] Fix RFC 4592 wildcard matching for existing domain names

### DIFF
--- a/client/internal/dns/local/local_test.go
+++ b/client/internal/dns/local/local_test.go
@@ -2506,8 +2506,10 @@ func TestLocalResolver_MixedRecordTypes(t *testing.T) {
 		resolver.ServeDNS(&test.MockResponseWriter{WriteMsgFunc: func(m *dns.Msg) error { respAAAA = m; return nil }}, msgAAAA)
 
 		require.NotNil(t, respAAAA)
-		// host.example.com exists (has A), so AAAA query returns NODATA, not wildcard
+		// RFC 4592 section 2.2.1: wildcard should NOT match when the name EXISTS in zone.
+		// host.example.com exists (has A record), so AAAA query returns NODATA, not wildcard.
 		assert.Equal(t, dns.RcodeSuccess, respAAAA.Rcode, "Should return NODATA for existing host without AAAA")
+		assert.Len(t, respAAAA.Answer, 0, "RFC 4592: wildcard should not match when name exists")
 
 		// AAAA query for other host should return wildcard AAAA
 		msgAAAAOther := new(dns.Msg).SetQuestion("other.example.com.", dns.TypeAAAA)


### PR DESCRIPTION
## Describe your changes
Per RFC 4592 section 2.2.1, wildcards should only match when the queried name does not exist in the zone. Previously, if host.example.com had an A record and *.example.com had an AAAA record, querying AAAA for host.example.com would incorrectly return the wildcard AAAA instead of NODATA.

Now the resolver checks if the domain exists (with any record type) before falling back to wildcard matching, returning proper NODATA responses for existing names without the requested record type.
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DNS wildcard record matching behavior. Wildcard records will no longer match when a queried domain already exists in the local zone, aligning with RFC 4592 standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->