### PR TITLE
[client] Fix IPv4-only in bind proxy

### DIFF
--- a/client/iface/wgproxy/ebpf/wrapper.go
+++ b/client/iface/wgproxy/ebpf/wrapper.go
@@ -94,7 +94,9 @@ func (p *ProxyWrapper) RedirectAs(endpoint *net.UDPAddr) {
 	p.pausedCond.L.Lock()
 	p.paused = false
 
-	p.wgEndpointCurrentUsedAddr = endpoint
+	if endpoint != nil && endpoint.IP != nil {
+		p.wgEndpointCurrentUsedAddr = endpoint
+	}
 
 	p.pausedCond.Signal()
 	p.pausedCond.L.Unlock()


### PR DESCRIPTION
## Describe your changes

Fixes:
```
2026-01-22T17:01:45+01:00 WARN client/iface/bind/activity.go:85: could not find record for address invalid AddrPort
panic: As4 called on IP zero value

goroutine 382 [running]:
net/netip.Addr.As4(...)
	/home/vma/dev/go/go/src/net/netip/netip.go:719
golang.zx2c4.com/wireguard/conn.(*StdNetBind).Send(0xc0000bc5a0, {0xc000ca27c8, 0x1, 0x1}, {0x121b03e0, 0xc000e96d00})
	/home/vma/dev/go/pkg/mod/github.com/netbirdio/wireguard-go@v0.0.0-20260107100953-33b7c9d03db0/conn/bind_std.go:389 +0xc05
github.com/netbirdio/netbird/client/iface/bind.(*ICEBind).Send(0xc0002089c0, {0xc000ca27c8, 0x1, 0x1}, {0x121b03e0, 0xc000e96d00})
	/home/vma/dev/netbird/client/iface/bind/ice_bind.go:159 +0x176
golang.zx2c4.com/wireguard/device.(*Peer).SendBuffers(0xc0006de308, {0xc000ca27c8, 0x1, 0x1})
	/home/vma/dev/go/pkg/mod/github.com/netbirdio/wireguard-go@v0.0.0-20260107100953-33b7c9d03db0/device/peer.go:136 +0x272
golang.zx2c4.com/wireguard/device.(*Peer).RoutineSequentialSender(0xc0006de308, 0x1)
	/home/vma/dev/go/pkg/mod/github.com/netbirdio/wireguard-go@v0.0.0-20260107100953-33b7c9d03db0/device/send.go:519 +0x686
created by golang.zx2c4.com/wireguard/device.(*Peer).Start in goroutine 269
	/home/vma/dev/go/pkg/mod/github.com/netbirdio/wireguard-go@v0.0.0-20260107100953-33b7c9d03db0/device/peer.go:208 +0x427
```

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened network address conversion with improved error handling to detect and properly handle conversion failures
  * Added defensive validation checks for endpoint assignments to prevent edge cases with nil or invalid values
  * Enhanced error propagation in endpoint operations to improve overall proxy stability and reliability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->