### PR TITLE
[client] Try next DNS upstream on SERVFAIL/REFUSED responses

### DIFF
--- a/client/internal/dns/local/local.go
+++ b/client/internal/dns/local/local.go
@@ -81,7 +81,10 @@ func (d *Resolver) ProbeAvailability() {}
 
 // ServeDNS handles a DNS request
 func (d *Resolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
-	logger := log.WithField("request_id", resutil.GetRequestID(w))
+	logger := log.WithFields(log.Fields{
+		"request_id": resutil.GetRequestID(w),
+		"dns_id":     fmt.Sprintf("%04x", r.Id),
+	})
 
 	if len(r.Question) == 0 {
 		logger.Debug("received local resolver request with no question")

--- a/client/internal/dns/upstream_test.go
+++ b/client/internal/dns/upstream_test.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/netip"
 	"strings"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.zx2c4.com/wireguard/tun/netstack"
 
 	"github.com/netbirdio/netbird/client/iface/device"
@@ -140,6 +143,23 @@ func (c mockUpstreamResolver) exchange(_ context.Context, _ string, _ *dns.Msg) 
 	return c.r, c.rtt, c.err
 }
 
+type mockUpstreamResponse struct {
+	msg *dns.Msg
+	err error
+}
+
+type mockUpstreamResolverPerServer struct {
+	responses map[string]mockUpstreamResponse
+	rtt       time.Duration
+}
+
+func (c mockUpstreamResolverPerServer) exchange(_ context.Context, upstream string, _ *dns.Msg) (*dns.Msg, time.Duration, error) {
+	if r, ok := c.responses[upstream]; ok {
+		return r.msg, c.rtt, r.err
+	}
+	return nil, c.rtt, fmt.Errorf("no mock response for %s", upstream)
+}
+
 func TestUpstreamResolver_DeactivationReactivation(t *testing.T) {
 	mockClient := &mockUpstreamResolver{
 		err: dns.ErrTime,
@@ -189,5 +209,269 @@ func TestUpstreamResolver_DeactivationReactivation(t *testing.T) {
 
 	if resolver.disabled {
 		t.Errorf("should be enabled")
+	}
+}
+
+func TestUpstreamResolver_Failover(t *testing.T) {
+	upstream1 := netip.MustParseAddrPort("192.0.2.1:53")
+	upstream2 := netip.MustParseAddrPort("192.0.2.2:53")
+
+	successAnswer := "192.0.2.100"
+	timeoutErr := &net.OpError{Op: "read", Err: fmt.Errorf("i/o timeout")}
+
+	testCases := []struct {
+		name            string
+		upstream1       mockUpstreamResponse
+		upstream2       mockUpstreamResponse
+		expectedRcode   int
+		expectAnswer    bool
+		expectTrySecond bool
+	}{
+		{
+			name:            "success on first upstream",
+			upstream1:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeSuccess, successAnswer)},
+			upstream2:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeSuccess, successAnswer)},
+			expectedRcode:   dns.RcodeSuccess,
+			expectAnswer:    true,
+			expectTrySecond: false,
+		},
+		{
+			name:            "SERVFAIL from first should try second",
+			upstream1:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeServerFailure, "")},
+			upstream2:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeSuccess, successAnswer)},
+			expectedRcode:   dns.RcodeSuccess,
+			expectAnswer:    true,
+			expectTrySecond: true,
+		},
+		{
+			name:            "REFUSED from first should try second",
+			upstream1:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeRefused, "")},
+			upstream2:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeSuccess, successAnswer)},
+			expectedRcode:   dns.RcodeSuccess,
+			expectAnswer:    true,
+			expectTrySecond: true,
+		},
+		{
+			name:            "NXDOMAIN from first should NOT try second",
+			upstream1:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeNameError, "")},
+			upstream2:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeSuccess, successAnswer)},
+			expectedRcode:   dns.RcodeNameError,
+			expectAnswer:    false,
+			expectTrySecond: false,
+		},
+		{
+			name:            "timeout from first should try second",
+			upstream1:       mockUpstreamResponse{err: timeoutErr},
+			upstream2:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeSuccess, successAnswer)},
+			expectedRcode:   dns.RcodeSuccess,
+			expectAnswer:    true,
+			expectTrySecond: true,
+		},
+		{
+			name:            "no response from first should try second",
+			upstream1:       mockUpstreamResponse{msg: nil},
+			upstream2:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeSuccess, successAnswer)},
+			expectedRcode:   dns.RcodeSuccess,
+			expectAnswer:    true,
+			expectTrySecond: true,
+		},
+		{
+			name:            "both upstreams return SERVFAIL",
+			upstream1:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeServerFailure, "")},
+			upstream2:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeServerFailure, "")},
+			expectedRcode:   dns.RcodeServerFailure,
+			expectAnswer:    false,
+			expectTrySecond: true,
+		},
+		{
+			name:            "both upstreams timeout",
+			upstream1:       mockUpstreamResponse{err: timeoutErr},
+			upstream2:       mockUpstreamResponse{err: timeoutErr},
+			expectedRcode:   dns.RcodeServerFailure,
+			expectAnswer:    false,
+			expectTrySecond: true,
+		},
+		{
+			name:            "first SERVFAIL then timeout",
+			upstream1:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeServerFailure, "")},
+			upstream2:       mockUpstreamResponse{err: timeoutErr},
+			expectedRcode:   dns.RcodeServerFailure,
+			expectAnswer:    false,
+			expectTrySecond: true,
+		},
+		{
+			name:            "first timeout then SERVFAIL",
+			upstream1:       mockUpstreamResponse{err: timeoutErr},
+			upstream2:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeServerFailure, "")},
+			expectedRcode:   dns.RcodeServerFailure,
+			expectAnswer:    false,
+			expectTrySecond: true,
+		},
+		{
+			name:            "first REFUSED then SERVFAIL",
+			upstream1:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeRefused, "")},
+			upstream2:       mockUpstreamResponse{msg: buildMockResponse(dns.RcodeServerFailure, "")},
+			expectedRcode:   dns.RcodeServerFailure,
+			expectAnswer:    false,
+			expectTrySecond: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var queriedUpstreams []string
+			mockClient := &mockUpstreamResolverPerServer{
+				responses: map[string]mockUpstreamResponse{
+					upstream1.String(): tc.upstream1,
+					upstream2.String(): tc.upstream2,
+				},
+				rtt: time.Millisecond,
+			}
+
+			trackingClient := &trackingMockClient{
+				inner:            mockClient,
+				queriedUpstreams: &queriedUpstreams,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			resolver := &upstreamResolverBase{
+				ctx:             ctx,
+				upstreamClient:  trackingClient,
+				upstreamServers: []netip.AddrPort{upstream1, upstream2},
+				upstreamTimeout: UpstreamTimeout,
+			}
+
+			var responseMSG *dns.Msg
+			responseWriter := &test.MockResponseWriter{
+				WriteMsgFunc: func(m *dns.Msg) error {
+					responseMSG = m
+					return nil
+				},
+			}
+
+			inputMSG := new(dns.Msg).SetQuestion("example.com.", dns.TypeA)
+			resolver.ServeDNS(responseWriter, inputMSG)
+
+			require.NotNil(t, responseMSG, "should write a response")
+			assert.Equal(t, tc.expectedRcode, responseMSG.Rcode, "unexpected rcode")
+
+			if tc.expectAnswer {
+				require.NotEmpty(t, responseMSG.Answer, "expected answer records")
+				assert.Contains(t, responseMSG.Answer[0].String(), successAnswer)
+			}
+
+			if tc.expectTrySecond {
+				assert.Len(t, queriedUpstreams, 2, "should have tried both upstreams")
+				assert.Equal(t, upstream1.String(), queriedUpstreams[0])
+				assert.Equal(t, upstream2.String(), queriedUpstreams[1])
+			} else {
+				assert.Len(t, queriedUpstreams, 1, "should have only tried first upstream")
+				assert.Equal(t, upstream1.String(), queriedUpstreams[0])
+			}
+		})
+	}
+}
+
+type trackingMockClient struct {
+	inner            *mockUpstreamResolverPerServer
+	queriedUpstreams *[]string
+}
+
+func (t *trackingMockClient) exchange(ctx context.Context, upstream string, r *dns.Msg) (*dns.Msg, time.Duration, error) {
+	*t.queriedUpstreams = append(*t.queriedUpstreams, upstream)
+	return t.inner.exchange(ctx, upstream, r)
+}
+
+func buildMockResponse(rcode int, answer string) *dns.Msg {
+	m := new(dns.Msg)
+	m.Response = true
+	m.Rcode = rcode
+
+	if rcode == dns.RcodeSuccess && answer != "" {
+		m.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{
+					Name:   "example.com.",
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    300,
+				},
+				A: net.ParseIP(answer),
+			},
+		}
+	}
+	return m
+}
+
+func TestUpstreamResolver_SingleUpstreamFailure(t *testing.T) {
+	upstream := netip.MustParseAddrPort("192.0.2.1:53")
+
+	mockClient := &mockUpstreamResolverPerServer{
+		responses: map[string]mockUpstreamResponse{
+			upstream.String(): {msg: buildMockResponse(dns.RcodeServerFailure, "")},
+		},
+		rtt: time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resolver := &upstreamResolverBase{
+		ctx:             ctx,
+		upstreamClient:  mockClient,
+		upstreamServers: []netip.AddrPort{upstream},
+		upstreamTimeout: UpstreamTimeout,
+	}
+
+	var responseMSG *dns.Msg
+	responseWriter := &test.MockResponseWriter{
+		WriteMsgFunc: func(m *dns.Msg) error {
+			responseMSG = m
+			return nil
+		},
+	}
+
+	inputMSG := new(dns.Msg).SetQuestion("example.com.", dns.TypeA)
+	resolver.ServeDNS(responseWriter, inputMSG)
+
+	require.NotNil(t, responseMSG, "should write a response")
+	assert.Equal(t, dns.RcodeServerFailure, responseMSG.Rcode, "single upstream SERVFAIL should return SERVFAIL")
+}
+
+func TestFormatFailures(t *testing.T) {
+	testCases := []struct {
+		name     string
+		failures []upstreamFailure
+		expected string
+	}{
+		{
+			name:     "empty slice",
+			failures: []upstreamFailure{},
+			expected: "",
+		},
+		{
+			name: "single failure",
+			failures: []upstreamFailure{
+				{upstream: netip.MustParseAddrPort("8.8.8.8:53"), reason: "SERVFAIL"},
+			},
+			expected: "8.8.8.8:53=SERVFAIL",
+		},
+		{
+			name: "multiple failures",
+			failures: []upstreamFailure{
+				{upstream: netip.MustParseAddrPort("8.8.8.8:53"), reason: "SERVFAIL"},
+				{upstream: netip.MustParseAddrPort("8.8.4.4:53"), reason: "timeout after 2s"},
+			},
+			expected: "8.8.8.8:53=SERVFAIL, 8.8.4.4:53=timeout after 2s",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := formatFailures(tc.failures)
+			assert.Equal(t, tc.expected, result)
+		})
 	}
 }


### PR DESCRIPTION
## Describe your changes

Previously, we would only try the next upstream server if there was no response/timeout or any other query error.
Instead, we should also try the next upstream if the queried server reported issues.
This PR also improves logging for upstream failures.

Example when one fails (end result = success):

```

2026-01-23T10:25:34Z WARN [request_id: 06c63d15, dns_id: 8af7] client/internal/dns/upstream.go:239: 1/2 upstreams failed for domain=test.servfail.: 127.0.0.1:5353=SERVFAIL
2026-01-23T10:25:34Z TRAC [request_id: 06c63d15, dns_id: 8af7] client/internal/dns/handler_chain.go:264: response: domain=test.servfail. rcode=NOERROR answers=[192.0.2.200] upstream=127.0.0.1:5354 took=1.393757ms
```

Example when all fail:

```

2026-01-23T10:28:29Z ERRO [request_id: 3d5d0b4f, dns_id: 6468] client/internal/dns/upstream.go:241: 2/2 upstreams failed for domain=test.servfail.: 127.0.0.1:5353=SERVFAIL, 127.0.0.1:5354=SERVFAIL
2026-01-23T10:28:29Z TRAC [request_id: 3d5d0b4f, dns_id: 6468] client/internal/dns/handler_chain.go:264: response: domain=test.servfail. rcode=SERVFAIL answers=[] took=1.267542ms
█
```

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced DNS request logging with additional contextual information for improved debugging.
  * Improved upstream server failover logic with per-server failure tracking and detailed failure summaries.

* **Bug Fixes**
  * DNS error responses now only returned when all upstream servers fail, preventing premature error responses.

* **Tests**
  * Added comprehensive test coverage for DNS failover scenarios and failure handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->