### PR TITLE
Fix MySQL 8 migration failure on indexed string columns

### DIFF
--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -19,7 +19,7 @@ type Peer struct {
 	// AccountID is a reference to Account that this object belongs
 	AccountID string `json:"-" gorm:"index"`
 	// WireGuard public key
-	Key string // uniqueness index (check migrations)
+	Key string `gorm:"size:255;uniqueIndex"`
 	// IP address of the Peer
 	IP net.IP `gorm:"serializer:json"` // uniqueness index per accountID (check migrations)
 	// Meta is a Peer system meta data


### PR DESCRIPTION
## Describe your changes
This PR fixes a MySQL 8 / Aurora migration failure that occurs when upgrading NetBird from v0.62 to v0.63+. Older versions defined indexed string columns (e.g. Peer.Key) without explicit size constraints. During upgrades, GORM AutoMigrate attempts to convert these indexed VARCHAR columns into LONGTEXT, which MySQL does not allow without a key length, resulting in Error 1170 and management service startup failure.
The fix explicitly defines a fixed VARCHAR size for indexed string fields to
prevent GORM from converting them to TEXT/LONGTEXT during migrations.

## Issue ticket number and link
Fixes #5171  
https://github.com/netbirdio/netbird/issues/5171

## Stack

<!-- branch-stack -->

### Checklist
- [X ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X ] Documentation is **not needed** for this change (explain why)
This change only affects internal database migrations and does not introduce any user-facing configuration or behavioral changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

Reproduced using MySQL 8.0 by upgrading schema created with v0.62 to v0.64.0.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data integrity by adding constraints to prevent duplicate entries and enforce field size limits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->