### PR TITLE
Include default groups claim in CLI audience

### DIFF
--- a/management/server/idp/embedded.go
+++ b/management/server/idp/embedded.go
@@ -20,7 +20,7 @@ const (
 	staticClientCLI        = "netbird-cli"
 	defaultCLIRedirectURL1 = "http://localhost:53000/"
 	defaultCLIRedirectURL2 = "http://localhost:54000/"
-	defaultScopes          = "openid profile email"
+	defaultScopes          = "openid profile email groups"
 	defaultUserIDClaim     = "sub"
 )
 


### PR DESCRIPTION
## Describe your changes

Adds groups scope to the device login flow to ensure jwt claim groups is filled.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default OAuth2 scopes now include group membership information in authentication flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->