### PR TITLE
[client] Remove redundant square bracket trimming in USP endpoint parsing

### DIFF
--- a/client/iface/configurer/usp.go
+++ b/client/iface/configurer/usp.go
@@ -558,7 +558,7 @@ func parseStatus(deviceName, ipcStr string) (*Stats, error) {
 				continue
 			}
 
-			host, portStr, err := net.SplitHostPort(strings.Trim(val, "[]"))
+			host, portStr, err := net.SplitHostPort(val)
 			if err != nil {
 				log.Errorf("failed to parse endpoint: %v", err)
 				continue


### PR DESCRIPTION
## Describe your changes

Fix IPv6 endpoint parsing in userspace WireGuard

IPv6 endpoints like `[2001:aaa:bbb::ccc]:51820` were being incorrectly parsed, causing them to appear malformed as `2001:aaa:bbb::ccc]:51820`.

This bug affects debug bundle generation, causing IPv6 endpoint information to be missing from `wgshow.txt`. The error is non-fatal (logged and skipped), so peer connections still work normally, but troubleshooting IPv6
  connectivity issues was more difficult without the endpoint data.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint parsing to correctly handle IPv6 addresses and various address formats by removing unnecessary character manipulation that was interfering with proper host/port extraction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->