### PR TITLE
[client] Add macOS default resolvers as fallback

### DIFF
--- a/client/internal/dns/host_darwin_test.go
+++ b/client/internal/dns/host_darwin_test.go
@@ -109,3 +109,169 @@ func removeTestDNSKey(key string) error {
 	_, err := cmd.CombinedOutput()
 	return err
 }
+
+func TestGetOriginalNameservers(t *testing.T) {
+	configurator := &systemConfigurator{
+		createdKeys: make(map[string]struct{}),
+		origNameservers: []netip.Addr{
+			netip.MustParseAddr("8.8.8.8"),
+			netip.MustParseAddr("1.1.1.1"),
+		},
+	}
+
+	servers := configurator.getOriginalNameservers()
+	assert.Len(t, servers, 2)
+	assert.Equal(t, netip.MustParseAddr("8.8.8.8"), servers[0])
+	assert.Equal(t, netip.MustParseAddr("1.1.1.1"), servers[1])
+}
+
+func TestGetOriginalNameserversFromSystem(t *testing.T) {
+	configurator := &systemConfigurator{
+		createdKeys: make(map[string]struct{}),
+	}
+
+	_, err := configurator.getSystemDNSSettings()
+	require.NoError(t, err)
+
+	servers := configurator.getOriginalNameservers()
+
+	require.NotEmpty(t, servers, "expected at least one DNS server from system configuration")
+
+	for _, server := range servers {
+		assert.True(t, server.IsValid(), "server address should be valid")
+		assert.False(t, server.IsUnspecified(), "server address should not be unspecified")
+	}
+
+	t.Logf("found %d original nameservers: %v", len(servers), servers)
+}
+
+func setupTestConfigurator(t *testing.T) (*systemConfigurator, *statemanager.Manager, func()) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	stateFile := filepath.Join(tmpDir, "state.json")
+	sm := statemanager.New(stateFile)
+	sm.RegisterState(&ShutdownState{})
+	sm.Start()
+
+	configurator := &systemConfigurator{
+		createdKeys: make(map[string]struct{}),
+	}
+
+	searchKey := getKeyWithInput(netbirdDNSStateKeyFormat, searchSuffix)
+	matchKey := getKeyWithInput(netbirdDNSStateKeyFormat, matchSuffix)
+	localKey := getKeyWithInput(netbirdDNSStateKeyFormat, localSuffix)
+
+	cleanup := func() {
+		_ = sm.Stop(context.Background())
+		for _, key := range []string{searchKey, matchKey, localKey} {
+			_ = removeTestDNSKey(key)
+		}
+	}
+
+	return configurator, sm, cleanup
+}
+
+func TestOriginalNameserversNoTransition(t *testing.T) {
+	netbirdIP := netip.MustParseAddr("100.64.0.1")
+
+	testCases := []struct {
+		name     string
+		routeAll bool
+	}{
+		{"routeall_false", false},
+		{"routeall_true", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configurator, sm, cleanup := setupTestConfigurator(t)
+			defer cleanup()
+
+			_, err := configurator.getSystemDNSSettings()
+			require.NoError(t, err)
+			initialServers := configurator.getOriginalNameservers()
+			t.Logf("Initial servers: %v", initialServers)
+			require.NotEmpty(t, initialServers)
+
+			for _, srv := range initialServers {
+				require.NotEqual(t, netbirdIP, srv, "initial servers should not contain NetBird IP")
+			}
+
+			config := HostDNSConfig{
+				ServerIP:   netbirdIP,
+				ServerPort: 53,
+				RouteAll:   tc.routeAll,
+				Domains:    []DomainConfig{{Domain: "example.com", MatchOnly: true}},
+			}
+
+			for i := 1; i <= 2; i++ {
+				err = configurator.applyDNSConfig(config, sm)
+				require.NoError(t, err)
+
+				servers := configurator.getOriginalNameservers()
+				t.Logf("After apply %d (RouteAll=%v): %v", i, tc.routeAll, servers)
+				assert.Equal(t, initialServers, servers)
+			}
+		})
+	}
+}
+
+func TestOriginalNameserversRouteAllTransition(t *testing.T) {
+	netbirdIP := netip.MustParseAddr("100.64.0.1")
+
+	testCases := []struct {
+		name         string
+		initialRoute bool
+	}{
+		{"start_with_routeall_false", false},
+		{"start_with_routeall_true", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configurator, sm, cleanup := setupTestConfigurator(t)
+			defer cleanup()
+
+			_, err := configurator.getSystemDNSSettings()
+			require.NoError(t, err)
+			initialServers := configurator.getOriginalNameservers()
+			t.Logf("Initial servers: %v", initialServers)
+			require.NotEmpty(t, initialServers)
+
+			config := HostDNSConfig{
+				ServerIP:   netbirdIP,
+				ServerPort: 53,
+				RouteAll:   tc.initialRoute,
+				Domains:    []DomainConfig{{Domain: "example.com", MatchOnly: true}},
+			}
+
+			// First apply
+			err = configurator.applyDNSConfig(config, sm)
+			require.NoError(t, err)
+			servers := configurator.getOriginalNameservers()
+			t.Logf("After first apply (RouteAll=%v): %v", tc.initialRoute, servers)
+			assert.Equal(t, initialServers, servers)
+
+			// Toggle RouteAll
+			config.RouteAll = !tc.initialRoute
+			err = configurator.applyDNSConfig(config, sm)
+			require.NoError(t, err)
+			servers = configurator.getOriginalNameservers()
+			t.Logf("After toggle (RouteAll=%v): %v", config.RouteAll, servers)
+			assert.Equal(t, initialServers, servers)
+
+			// Toggle back
+			config.RouteAll = tc.initialRoute
+			err = configurator.applyDNSConfig(config, sm)
+			require.NoError(t, err)
+			servers = configurator.getOriginalNameservers()
+			t.Logf("After toggle back (RouteAll=%v): %v", config.RouteAll, servers)
+			assert.Equal(t, initialServers, servers)
+
+			for _, srv := range servers {
+				assert.NotEqual(t, netbirdIP, srv, "servers should not contain NetBird IP")
+			}
+		})
+	}
+}

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -615,7 +615,7 @@ func (s *DefaultServer) applyHostConfig() {
 	s.registerFallback(config)
 }
 
-// registerFallback registers original nameservers as low-priority fallback handlers
+// registerFallback registers original nameservers as low-priority fallback handlers.
 func (s *DefaultServer) registerFallback(config HostDNSConfig) {
 	hostMgrWithNS, ok := s.hostManager.(hostManagerWithOriginalNS)
 	if !ok {
@@ -624,6 +624,7 @@ func (s *DefaultServer) registerFallback(config HostDNSConfig) {
 
 	originalNameservers := hostMgrWithNS.getOriginalNameservers()
 	if len(originalNameservers) == 0 {
+		s.deregisterHandler([]string{nbdns.RootZone}, PriorityFallback)
 		return
 	}
 

--- a/client/internal/dns/test/mock.go
+++ b/client/internal/dns/test/mock.go
@@ -8,13 +8,19 @@ import (
 
 type MockResponseWriter struct {
 	WriteMsgFunc func(m *dns.Msg) error
+	lastResponse *dns.Msg
 }
 
 func (rw *MockResponseWriter) WriteMsg(m *dns.Msg) error {
+	rw.lastResponse = m
 	if rw.WriteMsgFunc != nil {
 		return rw.WriteMsgFunc(m)
 	}
 	return nil
+}
+
+func (rw *MockResponseWriter) GetLastResponse() *dns.Msg {
+	return rw.lastResponse
 }
 
 func (rw *MockResponseWriter) LocalAddr() net.Addr       { return nil }


### PR DESCRIPTION
## Describe your changes

This PR adds the detected default upstream nameserves as fallback handlers in the handler chain (prio -100).

This is useful if there is a dns route like `test.example.org` that makes macOS use the whole zone as match domain.
Now if there is no other upstream nameserver configured, requests to `morespecific.test.example.org` would fail since they're not matched by said DNS route.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS nameserver tracking and retrieval on macOS systems with thread-safe access.
  * Enhanced fallback DNS handling when original nameservers are unavailable.

* **Tests**
  * Added comprehensive tests for DNS nameserver management and configuration transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->