### PR TITLE
update client code ios build tags to add tvos target

### DIFF
--- a/client/iface/iface_new_ios.go
+++ b/client/iface/iface_new_ios.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package iface
 

--- a/client/iface/udpmux/mux_ios.go
+++ b/client/iface/udpmux/mux_ios.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package udpmux
 

--- a/client/internal/debug/debug_mobile.go
+++ b/client/internal/debug/debug_mobile.go
@@ -1,4 +1,4 @@
-//go:build ios || android
+//go:build ios || tvos || android
 
 package debug
 

--- a/client/internal/dns/unclean_shutdown_mobile.go
+++ b/client/internal/dns/unclean_shutdown_mobile.go
@@ -1,4 +1,4 @@
-//go:build ios || android
+//go:build ios || tvos || android
 
 package dns
 

--- a/client/internal/dns/upstream_ios.go
+++ b/client/internal/dns/upstream_ios.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package dns
 

--- a/client/internal/networkmonitor/monitor_mobile.go
+++ b/client/internal/networkmonitor/monitor_mobile.go
@@ -1,4 +1,4 @@
-//go:build ios || android
+//go:build ios || tvos || android
 
 package networkmonitor
 

--- a/client/internal/routemanager/dynamic/route_ios.go
+++ b/client/internal/routemanager/dynamic/route_ios.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package dynamic
 

--- a/client/internal/routemanager/notifier/notifier_ios.go
+++ b/client/internal/routemanager/notifier/notifier_ios.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package notifier
 

--- a/client/internal/routemanager/systemops/systemops_ios.go
+++ b/client/internal/routemanager/systemops/systemops_ios.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package systemops
 

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package NetBirdSDK
 

--- a/client/ios/NetBirdSDK/env_list.go
+++ b/client/ios/NetBirdSDK/env_list.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package NetBirdSDK
 

--- a/client/ios/NetBirdSDK/gomobile.go
+++ b/client/ios/NetBirdSDK/gomobile.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package NetBirdSDK
 

--- a/client/ios/NetBirdSDK/logger.go
+++ b/client/ios/NetBirdSDK/logger.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package NetBirdSDK
 

--- a/client/ios/NetBirdSDK/login.go
+++ b/client/ios/NetBirdSDK/login.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package NetBirdSDK
 

--- a/client/ios/NetBirdSDK/peer_notifier.go
+++ b/client/ios/NetBirdSDK/peer_notifier.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package NetBirdSDK
 

--- a/client/ios/NetBirdSDK/preferences.go
+++ b/client/ios/NetBirdSDK/preferences.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package NetBirdSDK
 

--- a/client/ios/NetBirdSDK/preferences_test.go
+++ b/client/ios/NetBirdSDK/preferences_test.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package NetBirdSDK
 

--- a/client/ios/NetBirdSDK/routes.go
+++ b/client/ios/NetBirdSDK/routes.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package NetBirdSDK
 

--- a/client/net/listen_ios.go
+++ b/client/net/listen_ios.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package net
 

--- a/management/server/testutil/store_ios.go
+++ b/management/server/testutil/store_ios.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios || tvos
 
 package testutil
 


### PR DESCRIPTION
## Describe your changes

build tags were added to the ios client code: `go:build ios`. these should also reference the tvos target: `go:build ios || tvos`

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tvOS support to the NetBird client, enabling compatibility with Apple TV devices alongside existing iOS and Android platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->