### PR TITLE
[client] Add block inbound option to the embed client

### DIFF
--- a/client/embed/embed.go
+++ b/client/embed/embed.go
@@ -69,6 +69,8 @@ type Options struct {
 	StatePath string
 	// DisableClientRoutes disables the client routes
 	DisableClientRoutes bool
+	// BlockInbound blocks all inbound connections from peers
+	BlockInbound bool
 }
 
 // validateCredentials checks that exactly one credential type is provided
@@ -137,6 +139,7 @@ func New(opts Options) (*Client, error) {
 		PreSharedKey:        &opts.PreSharedKey,
 		DisableServerRoutes: &t,
 		DisableClientRoutes: &opts.DisableClientRoutes,
+		BlockInbound:        &opts.BlockInbound,
 	}
 	if opts.ConfigPath != "" {
 		config, err = profilemanager.UpdateOrCreateConfig(input)

--- a/client/internal/networkmonitor/monitor.go
+++ b/client/internal/networkmonitor/monitor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/netbirdio/netbird/client/iface/netstack"
 	"github.com/netbirdio/netbird/client/internal/routemanager/systemops"
 )
 
@@ -37,6 +38,11 @@ func New() *NetworkMonitor {
 
 // Listen begins monitoring network changes. When a change is detected, this function will return without error.
 func (nw *NetworkMonitor) Listen(ctx context.Context) (err error) {
+	if netstack.IsEnabled() {
+		log.Debugf("Network monitor: skipping in netstack mode")
+		return nil
+	}
+
 	nw.mu.Lock()
 	if nw.cancel != nil {
 		nw.mu.Unlock()

--- a/client/internal/wg_iface_monitor.go
+++ b/client/internal/wg_iface_monitor.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/client/iface/netstack"
 )
 
 // WGIfaceMonitor monitors the WireGuard interface lifecycle and restarts the engine
@@ -33,6 +35,11 @@ func (m *WGIfaceMonitor) Start(ctx context.Context, ifaceName string) (shouldRes
 	if runtime.GOOS == "android" || runtime.GOOS == "ios" {
 		log.Debugf("Interface monitor: skipped on %s platform", runtime.GOOS)
 		return false, errors.New("not supported on mobile platforms")
+	}
+
+	if netstack.IsEnabled() {
+		log.Debugf("Interface monitor: skipped in netstack mode")
+		return false, nil
 	}
 
 	if ifaceName == "" {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new configuration option to block all inbound peer connections

* **Bug Fixes**
  * Improved network performance by skipping monitoring setup when netstack mode is enabled

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->