### PR TITLE
[client] Fix netstack detection and add wireguard port option

### DIFF
--- a/client/embed/embed.go
+++ b/client/embed/embed.go
@@ -71,6 +71,8 @@ type Options struct {
 	DisableClientRoutes bool
 	// BlockInbound blocks all inbound connections from peers
 	BlockInbound bool
+	// WireguardPort is the port for the WireGuard interface. Use 0 for a random port.
+	WireguardPort *int
 }
 
 // validateCredentials checks that exactly one credential type is provided
@@ -140,6 +142,7 @@ func New(opts Options) (*Client, error) {
 		DisableServerRoutes: &t,
 		DisableClientRoutes: &opts.DisableClientRoutes,
 		BlockInbound:        &opts.BlockInbound,
+		WireguardPort:       opts.WireguardPort,
 	}
 	if opts.ConfigPath != "" {
 		config, err = profilemanager.UpdateOrCreateConfig(input)

--- a/client/iface/iface.go
+++ b/client/iface/iface.go
@@ -18,6 +18,7 @@ import (
 	"github.com/netbirdio/netbird/client/errors"
 	"github.com/netbirdio/netbird/client/iface/configurer"
 	"github.com/netbirdio/netbird/client/iface/device"
+	nbnetstack "github.com/netbirdio/netbird/client/iface/netstack"
 	"github.com/netbirdio/netbird/client/iface/udpmux"
 	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/iface/wgproxy"
@@ -226,6 +227,10 @@ func (w *WGIface) Close() error {
 
 	if err := w.tun.Close(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("failed to close wireguard interface %s: %w", w.Name(), err))
+	}
+
+	if nbnetstack.IsEnabled() {
+		return errors.FormatErrorOrNil(result)
 	}
 
 	if err := w.waitUntilRemoved(); err != nil {

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/netstack"
 	"github.com/netbirdio/netbird/client/internal/dns"
 	"github.com/netbirdio/netbird/client/internal/listener"
 	"github.com/netbirdio/netbird/client/internal/peer"
@@ -244,7 +245,7 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 		localPeerState := peer.LocalPeerState{
 			IP:              loginResp.GetPeerConfig().GetAddress(),
 			PubKey:          myPrivateKey.PublicKey().String(),
-			KernelInterface: device.WireGuardModuleIsLoaded(),
+			KernelInterface: device.WireGuardModuleIsLoaded() && !netstack.IsEnabled(),
 			FQDN:            loginResp.GetPeerConfig().GetFqdn(),
 		}
 		c.statusRecorder.UpdateLocalPeerState(localPeerState)

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1017,7 +1017,7 @@ func (e *Engine) updateConfig(conf *mgmProto.PeerConfig) error {
 	state := e.statusRecorder.GetLocalPeerState()
 	state.IP = e.wgInterface.Address().String()
 	state.PubKey = e.config.WgPrivateKey.PublicKey().String()
-	state.KernelInterface = device.WireGuardModuleIsLoaded()
+	state.KernelInterface = !e.wgInterface.IsUserspaceBind()
 	state.FQDN = conf.GetFqdn()
 
 	e.statusRecorder.UpdateLocalPeerState(state)

--- a/client/internal/engine_ssh.go
+++ b/client/internal/engine_ssh.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	firewallManager "github.com/netbirdio/netbird/client/firewall/manager"
+	"github.com/netbirdio/netbird/client/iface/netstack"
 	nftypes "github.com/netbirdio/netbird/client/internal/netflow/types"
 	sshauth "github.com/netbirdio/netbird/client/ssh/auth"
 	sshconfig "github.com/netbirdio/netbird/client/ssh/config"
@@ -94,6 +95,10 @@ func (e *Engine) updateSSH(sshConf *mgmProto.SSHConfig) error {
 
 // updateSSHClientConfig updates the SSH client configuration with peer information
 func (e *Engine) updateSSHClientConfig(remotePeers []*mgmProto.RemotePeerConfig) error {
+	if netstack.IsEnabled() {
+		return nil
+	}
+
 	peerInfo := e.extractPeerSSHInfo(remotePeers)
 	if len(peerInfo) == 0 {
 		log.Debug("no SSH-enabled peers found, skipping SSH config update")
@@ -216,6 +221,10 @@ func (e *Engine) GetPeerSSHKey(peerAddress string) ([]byte, bool) {
 
 // cleanupSSHConfig removes NetBird SSH client configuration on shutdown
 func (e *Engine) cleanupSSHConfig() {
+	if netstack.IsEnabled() {
+		return
+	}
+
 	configMgr := sshconfig.New()
 
 	if err := configMgr.RemoveSSHClientConfig(); err != nil {


### PR DESCRIPTION
- Add WireguardPort option to embed.Options for custom port configuration
- Fix KernelInterface detection to account for netstack mode
- Skip SSH config updates when running in netstack mode
- Skip interface removal wait when running in netstack mode
- Use BindListener for netstack to avoid port conflicts on same host

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable WireGuard port, allowing custom port selection

* **Improvements**
  * Enhanced netstack mode with optimized SSH client configuration handling
  * Improved network listener selection for better resource management in netstack-enabled environments
  * Refined kernel interface detection for more accurate state reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->