### PR TITLE
[client] Fix wrong URL being logged for DefaultAdminURL

### DIFF
--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -252,7 +252,7 @@ func (config *Config) apply(input ConfigInput) (updated bool, err error) {
 	}
 
 	if config.AdminURL == nil {
-		log.Infof("using default Admin URL %s", DefaultManagementURL)
+		log.Infof("using default Admin URL %s", DefaultAdminURL)
 		config.AdminURL, err = parseURL("Admin URL", DefaultAdminURL)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
## Describe your changes
Just a simple fix for `DefaultManagementURL` being logged instead of `DefaultAdminURL`.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Admin URL configuration initialization to use the appropriate default endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->