### PR TITLE
[client] Add missing bsd flags in debug bundle

### DIFF
--- a/client/internal/routemanager/systemops/routeflags_bsd.go
+++ b/client/internal/routemanager/systemops/routeflags_bsd.go
@@ -4,16 +4,17 @@ package systemops
 
 import (
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // filterRoutesByFlags returns true if the route message should be ignored based on its flags.
 func filterRoutesByFlags(routeMessageFlags int) bool {
-	if routeMessageFlags&syscall.RTF_UP == 0 {
+	if routeMessageFlags&unix.RTF_UP == 0 {
 		return true
 	}
 
-	if routeMessageFlags&(syscall.RTF_REJECT|syscall.RTF_BLACKHOLE|syscall.RTF_WASCLONED) != 0 {
+	if routeMessageFlags&(unix.RTF_REJECT|unix.RTF_BLACKHOLE|unix.RTF_WASCLONED) != 0 {
 		return true
 	}
 
@@ -24,41 +25,50 @@ func filterRoutesByFlags(routeMessageFlags int) bool {
 func formatBSDFlags(flags int) string {
 	var flagStrs []string
 
-	if flags&syscall.RTF_UP != 0 {
+	if flags&unix.RTF_UP != 0 {
 		flagStrs = append(flagStrs, "U")
 	}
-	if flags&syscall.RTF_GATEWAY != 0 {
+	if flags&unix.RTF_GATEWAY != 0 {
 		flagStrs = append(flagStrs, "G")
 	}
-	if flags&syscall.RTF_HOST != 0 {
+	if flags&unix.RTF_HOST != 0 {
 		flagStrs = append(flagStrs, "H")
 	}
-	if flags&syscall.RTF_REJECT != 0 {
+	if flags&unix.RTF_REJECT != 0 {
 		flagStrs = append(flagStrs, "R")
 	}
-	if flags&syscall.RTF_DYNAMIC != 0 {
+	if flags&unix.RTF_DYNAMIC != 0 {
 		flagStrs = append(flagStrs, "D")
 	}
-	if flags&syscall.RTF_MODIFIED != 0 {
+	if flags&unix.RTF_MODIFIED != 0 {
 		flagStrs = append(flagStrs, "M")
 	}
-	if flags&syscall.RTF_STATIC != 0 {
+	if flags&unix.RTF_STATIC != 0 {
 		flagStrs = append(flagStrs, "S")
 	}
-	if flags&syscall.RTF_LLINFO != 0 {
+	if flags&unix.RTF_LLINFO != 0 {
 		flagStrs = append(flagStrs, "L")
 	}
-	if flags&syscall.RTF_LOCAL != 0 {
+	if flags&unix.RTF_LOCAL != 0 {
 		flagStrs = append(flagStrs, "l")
 	}
-	if flags&syscall.RTF_BLACKHOLE != 0 {
+	if flags&unix.RTF_BLACKHOLE != 0 {
 		flagStrs = append(flagStrs, "B")
 	}
-	if flags&syscall.RTF_CLONING != 0 {
+	if flags&unix.RTF_CLONING != 0 {
 		flagStrs = append(flagStrs, "C")
 	}
-	if flags&syscall.RTF_WASCLONED != 0 {
+	if flags&unix.RTF_WASCLONED != 0 {
 		flagStrs = append(flagStrs, "W")
+	}
+	if flags&unix.RTF_PROTO1 != 0 {
+		flagStrs = append(flagStrs, "1")
+	}
+	if flags&unix.RTF_PROTO2 != 0 {
+		flagStrs = append(flagStrs, "2")
+	}
+	if flags&unix.RTF_PROTO3 != 0 {
+		flagStrs = append(flagStrs, "3")
 	}
 
 	if len(flagStrs) == 0 {

--- a/client/internal/routemanager/systemops/routeflags_freebsd.go
+++ b/client/internal/routemanager/systemops/routeflags_freebsd.go
@@ -4,17 +4,18 @@ package systemops
 
 import (
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // filterRoutesByFlags returns true if the route message should be ignored based on its flags.
 func filterRoutesByFlags(routeMessageFlags int) bool {
-	if routeMessageFlags&syscall.RTF_UP == 0 {
+	if routeMessageFlags&unix.RTF_UP == 0 {
 		return true
 	}
 
-	// NOTE: syscall.RTF_WASCLONED deprecated in FreeBSD 8.0
-	if routeMessageFlags&(syscall.RTF_REJECT|syscall.RTF_BLACKHOLE) != 0 {
+	// NOTE: RTF_WASCLONED deprecated in FreeBSD 8.0
+	if routeMessageFlags&(unix.RTF_REJECT|unix.RTF_BLACKHOLE) != 0 {
 		return true
 	}
 
@@ -25,37 +26,46 @@ func filterRoutesByFlags(routeMessageFlags int) bool {
 func formatBSDFlags(flags int) string {
 	var flagStrs []string
 
-	if flags&syscall.RTF_UP != 0 {
+	if flags&unix.RTF_UP != 0 {
 		flagStrs = append(flagStrs, "U")
 	}
-	if flags&syscall.RTF_GATEWAY != 0 {
+	if flags&unix.RTF_GATEWAY != 0 {
 		flagStrs = append(flagStrs, "G")
 	}
-	if flags&syscall.RTF_HOST != 0 {
+	if flags&unix.RTF_HOST != 0 {
 		flagStrs = append(flagStrs, "H")
 	}
-	if flags&syscall.RTF_REJECT != 0 {
+	if flags&unix.RTF_REJECT != 0 {
 		flagStrs = append(flagStrs, "R")
 	}
-	if flags&syscall.RTF_DYNAMIC != 0 {
+	if flags&unix.RTF_DYNAMIC != 0 {
 		flagStrs = append(flagStrs, "D")
 	}
-	if flags&syscall.RTF_MODIFIED != 0 {
+	if flags&unix.RTF_MODIFIED != 0 {
 		flagStrs = append(flagStrs, "M")
 	}
-	if flags&syscall.RTF_STATIC != 0 {
+	if flags&unix.RTF_STATIC != 0 {
 		flagStrs = append(flagStrs, "S")
 	}
-	if flags&syscall.RTF_LLINFO != 0 {
+	if flags&unix.RTF_LLINFO != 0 {
 		flagStrs = append(flagStrs, "L")
 	}
-	if flags&syscall.RTF_LOCAL != 0 {
+	if flags&unix.RTF_LOCAL != 0 {
 		flagStrs = append(flagStrs, "l")
 	}
-	if flags&syscall.RTF_BLACKHOLE != 0 {
+	if flags&unix.RTF_BLACKHOLE != 0 {
 		flagStrs = append(flagStrs, "B")
 	}
 	// Note: RTF_CLONING and RTF_WASCLONED deprecated in FreeBSD 8.0
+	if flags&unix.RTF_PROTO1 != 0 {
+		flagStrs = append(flagStrs, "1")
+	}
+	if flags&unix.RTF_PROTO2 != 0 {
+		flagStrs = append(flagStrs, "2")
+	}
+	if flags&unix.RTF_PROTO3 != 0 {
+		flagStrs = append(flagStrs, "3")
+	}
 
 	if len(flagStrs) == 0 {
 		return "-"


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new routing protocol flags on BSD systems.

* **Chores**
  * Refactored BSD and FreeBSD route flag handling to use updated system libraries, improving long-term maintainability and platform compatibility.
  * Removed deprecated code paths to enhance reliability on FreeBSD systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->