### PR TITLE
[management] Ensure configure.sh does not clear the DataStoreEncryptionKey value

### DIFF
--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -233,14 +233,16 @@ if [ "$NETBIRD_DASH_AUTH_USE_AUDIENCE" = "false" ]; then
     export NETBIRD_AUTH_PKCE_AUDIENCE=
 fi
 
-# Read the encryption key
-if test -f 'management.json'; then
-    encKey=$(jq -r  ".DataStoreEncryptionKey" management.json)
-    if [[ "$encKey" != "null" ]]; then
-        export NETBIRD_DATASTORE_ENC_KEY=$encKey
-
+# Read the encryption key from existing config (check artifacts/ first, then root)
+for mgmt_file in "${artifacts_path}/management.json" "management.json"; do
+    if test -f "$mgmt_file"; then
+        encKey=$(jq -r ".DataStoreEncryptionKey" "$mgmt_file")
+        if [[ "$encKey" != "null" && -n "$encKey" ]]; then
+            export NETBIRD_DATASTORE_ENC_KEY=$encKey
+            break
+        fi
     fi
-fi
+done
 
 env | grep NETBIRD
 


### PR DESCRIPTION
## Describe your changes

Ensure `configure.sh` script does not clear the `DataStoreEncryptionKey` value, even for the `artifacts/management.json` file.

The script currently already has this logic for the `management.json` file. This PR only extends it to the `artifacts/management.json` file.

## Issue ticket number and link

Hotfix for #5257

## Stack

<!-- branch-stack -->

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

This PR aligns actual behavior with expected behavior.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption key retrieval process to check multiple configuration locations and validate keys more robustly, ensuring reliable setup and deployment initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->