### PR TITLE
[client] Fix nil pointer panic in ICE agent during sleep/wake cycles

### DIFF
--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -107,8 +107,10 @@ func (w *WorkerICE) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 		}
 		w.log.Debugf("agent already exists, recreate the connection")
 		w.agentDialerCancel()
-		if err := w.agent.Close(); err != nil {
-			w.log.Warnf("failed to close ICE agent: %s", err)
+		if w.agent != nil {
+			if err := w.agent.Close(); err != nil {
+				w.log.Warnf("failed to close ICE agent: %s", err)
+			}
 		}
 
 		sessionID, err := NewICESessionID()


### PR DESCRIPTION
Add defensive nil checks in ThreadSafeAgent.Close() to prevent panic when agent field is nil. This can occur during Windows suspend/resume when network interfaces are disrupted or the pion/ice library returns nil without error.

Also capture agent pointer in local variable before goroutine execution to prevent race conditions.

Fixes service crashes on laptop wake-up.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ICE (Interactive Connectivity Establishment) agent initialization with better error detection and reporting
  * Improved ICE connection cleanup operations with enhanced error handling and logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->