### PR TITLE
[client] Fix race condition and ensure correct message ordering in Relay

### DIFF
--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -249,6 +249,17 @@ func (c *Client) OpenConn(ctx context.Context, dstPeerID string) (net.Conn, erro
 		return nil, err
 	}
 
+	c.mu.Lock()
+	if !c.serviceIsRunning {
+		if savedContainer, ok := c.conns[peerID]; ok && savedContainer == container {
+			delete(c.conns, peerID)
+		}
+		c.mu.Unlock()
+		container.close()
+		return nil, fmt.Errorf("relay connection is not established")
+	}
+	c.mu.Unlock()
+
 	c.log.Infof("remote peer is available: %s", peerID)
 	return conn, nil
 }


### PR DESCRIPTION
Fix race condition and ensure correct message ordering in connection establishment

Reorder operations in OpenConn to register the connection before waiting for peer availability. This ensures:

- Connection is ready to receive messages before peer subscription completes
- Transport messages and onconnected events maintain proper ordering
- No messages are lost during the connection establishment window
- Concurrent OpenConn calls cannot create duplicate connections

If peer availability check fails, the pre-registered connection is properly cleaned up.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection initialization to track connection containers earlier and ensure partial resources are cleaned up if a remote peer is unavailable.
  * Enhanced error handling and logging around connection setup to make failures and status transitions clearer and reduce resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->