### PR TITLE
Fix log line which shows empty tag name

### DIFF
--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -52,7 +52,7 @@ get_release() {
 
 download_release_binary() {
     VERSION=$(get_release "$NETBIRD_RELEASE")
-	echo "Using the following tag name for binary installation: ${TAG_NAME}"
+    echo "Using the following version for binary installation: ${VERSION}"
     BASE_URL="https://github.com/${OWNER}/${REPO}/releases/download"
     BINARY_BASE_NAME="${VERSION#v}_${OS_TYPE}_${ARCH}.tar.gz"
 


### PR DESCRIPTION
## Describe your changes

This changes the log output line used when downloading a release binary so that instead of showing a blank TAG_NAME it shows the VERSION.

This change also changes the leading whitespace on this line from a tab to 4 spaces to match it's neighboring lines.

## Issue ticket number and link

Fixes #5280

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This PR fixes a very small log display issue and so doesn't need documentation.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved binary installation messaging to display the resolved version instead of the tag name, providing clearer and more accurate setup feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->