### PR TITLE
[client] Fix panics in device and engine code

### DIFF
--- a/client/iface/device/device_netstack.go
+++ b/client/iface/device/device_netstack.go
@@ -82,7 +82,9 @@ func (t *TunNetstackDevice) create() (WGConfigurer, error) {
 	t.configurer = configurer.NewUSPConfigurer(t.device, t.name, t.bind.ActivityRecorder())
 	err = t.configurer.ConfigureInterface(t.key, t.port)
 	if err != nil {
-		_ = tunIface.Close()
+		if cErr := tunIface.Close(); cErr != nil {
+			log.Debugf("failed to close tun device: %v", cErr)
+		}
 		return nil, fmt.Errorf("error configuring interface: %s", err)
 	}
 

--- a/client/iface/netstack/tun.go
+++ b/client/iface/netstack/tun.go
@@ -66,7 +66,7 @@ func (t *NetStackTun) Create() (tun.Device, *netstack.Net, error) {
 		}
 	}()
 
-	return nsTunDev, tunNet, nil
+	return t.tundev, tunNet, nil
 }
 
 func (t *NetStackTun) Close() error {

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -543,11 +543,12 @@ func (e *Engine) Start(netbirdConfig *mgmProto.NetbirdConfig, mgmtURL *url.URL) 
 	// monitor WireGuard interface lifecycle and restart engine on changes
 	e.wgIfaceMonitor = NewWGIfaceMonitor()
 	e.shutdownWg.Add(1)
+	wgIfaceName := e.wgInterface.Name()
 
 	go func() {
 		defer e.shutdownWg.Done()
 
-		if shouldRestart, err := e.wgIfaceMonitor.Start(e.ctx, e.wgInterface.Name()); shouldRestart {
+		if shouldRestart, err := e.wgIfaceMonitor.Start(e.ctx, wgIfaceName); shouldRestart {
 			log.Infof("WireGuard interface monitor: %s, restarting engine", err)
 			e.triggerClientRestart()
 		} else if err != nil {


### PR DESCRIPTION
## Describe your changes

Capture `wgInterface.Name()` before launching the monitor goroutine to  avoid a race with `Engine.close()` setting wgInterface to nil. The goroutine previously read `e.wgInterface` by reference, which could be `nil`ed by a concurrent `Stop()`/`close()` call before the goroutine started.

Also fix a double close on the device

Exhibit A:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x90 pc=0x1015c3f84]

goroutine 11257 [running]:
github.com/netbirdio/netbird/client/internal.(*Engine).Start.func1()
	netbird/client/internal/engine.go:550 +0x54
created by github.com/netbirdio/netbird/client/internal.(*Engine).Start in goroutine 103
	netbird/client/internal/engine.go:547 +0xef4
exit status 2
```

Exhibit B:
```
panic: close of closed channel

goroutine 17585 [running]:
golang.zx2c4.com/wireguard/tun/netstack.(*netTun).Close(0x14002ef6be0)
	go/pkg/mod/github.com/netbirdio/wireguard-go@v0.0.0-20260107100953-33b7c9d03db0/tun/netstack/tun.go:176 +0x64
golang.zx2c4.com/wireguard/device.(*Device).Close(0x14002058f08)
	go/pkg/mod/github.com/netbirdio/wireguard-go@v0.0.0-20260107100953-33b7c9d03db0/device/device.go:384 +0x16c
created by golang.zx2c4.com/wireguard/device.(*Device).RoutineReadFromTUN in goroutine 18211
	go/pkg/mod/github.com/netbirdio/wireguard-go@v0.0.0-20260107100953-33b7c9d03db0/device/send.go:311 +0x760
exit status 2
```



## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
