### PR TITLE
[misc] add extra proxy domain instructions

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -572,7 +572,7 @@ render_docker_compose_traefik_builtin() {
     extra_hosts:
       - \"$NETBIRD_DOMAIN:172.30.0.10\"
     ports:
-    - '51820:51820/udp'
+    - 51820:51820/udp
     restart: unless-stopped
     networks: [netbird]
     depends_on:


### PR DESCRIPTION
## Describe your changes

```shell
==========================================
  NETBIRD SETUP COMPLETE
==========================================

You can access the NetBird dashboard at:
  https://nb.test.com

Follow the onboarding steps to set up your NetBird instance.

Traefik is handling TLS certificates automatically via Let's Encrypt.
If you see certificate warnings, wait a moment for certificate issuance to complete.

Open ports:
  - 443/tcp   (HTTPS - all NetBird services)
  - 80/tcp    (HTTP - redirects to HTTPS)
  - 3478/udp   (STUN - required for NAT traversal)
  - 51820/udp (WIREGUARD - (optional) for P2P proxy connections)

NetBird Proxy:
  The proxy service is enabled and running.
  Any domain NOT matching nb.test.com will be passed through to the proxy.
  The proxy handles its own TLS certificates via ACME TLS-ALPN-01 challenge.
  Point your proxy domain to this server's domain address like in the example below:

  *.proxy.test.com    CNAME    nb.test.com
```

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Dashboard access formatted as a two-line label + URL; port listings reformatted (443/80) and STUN port shown.
  * Proxy DNS guidance updated to recommend a CNAME-based wildcard record with a clearer multi-line example and spacing.
* **Bug Fixes**
  * Improved proxy-domain validation: clearer WARNING and blank-line separation when domains conflict or are subdomains; validation now references a derived base domain.
* **Other**
  * Optional UDP port 51820 for WireGuard highlighted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->