### PR TITLE
Refactor port forward manager cleanup lifecycle

### DIFF
--- a/client/internal/dns/local/local_test.go
+++ b/client/internal/dns/local/local_test.go
@@ -1263,9 +1263,9 @@ func TestLocalResolver_AuthoritativeFlag(t *testing.T) {
 	})
 }
 
-// TestLocalResolver_Stop tests cleanup on Stop
+// TestLocalResolver_Stop tests cleanup on GracefullyStop
 func TestLocalResolver_Stop(t *testing.T) {
-	t.Run("Stop clears all state", func(t *testing.T) {
+	t.Run("GracefullyStop clears all state", func(t *testing.T) {
 		resolver := NewResolver()
 		resolver.Update([]nbdns.CustomZone{{
 			Domain: "example.com.",
@@ -1285,7 +1285,7 @@ func TestLocalResolver_Stop(t *testing.T) {
 		assert.False(t, resolver.isInManagedZone("host.example.com."))
 	})
 
-	t.Run("Stop is safe to call multiple times", func(t *testing.T) {
+	t.Run("GracefullyStop is safe to call multiple times", func(t *testing.T) {
 		resolver := NewResolver()
 		resolver.Update([]nbdns.CustomZone{{
 			Domain: "example.com.",
@@ -1299,7 +1299,7 @@ func TestLocalResolver_Stop(t *testing.T) {
 		resolver.Stop()
 	})
 
-	t.Run("Stop cancels in-flight external resolution", func(t *testing.T) {
+	t.Run("GracefullyStop cancels in-flight external resolution", func(t *testing.T) {
 		resolver := NewResolver()
 
 		lookupStarted := make(chan struct{})

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -385,7 +385,7 @@ func (w *WorkerICE) injectPortForwardedCandidate(srflxCandidate ice.Candidate) {
 	w.muxAgent.Unlock()
 
 	pfManager := w.conn.portForwardManager
-	if pfManager == nil || !pfManager.IsAvailable() {
+	if pfManager == nil {
 		return
 	}
 

--- a/client/internal/portforward/env.go
+++ b/client/internal/portforward/env.go
@@ -1,0 +1,26 @@
+package portforward
+
+import (
+	"os"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	envDisableNATMapper = "NB_DISABLE_NAT_MAPPER"
+)
+
+func isDisabledByEnv() bool {
+	val := os.Getenv(envDisableNATMapper)
+	if val == "" {
+		return false
+	}
+
+	disabled, err := strconv.ParseBool(val)
+	if err != nil {
+		log.Warnf("failed to parse %s: %v", envDisableNATMapper, err)
+		return false
+	}
+	return disabled
+}

--- a/client/internal/portforward/manager_js.go
+++ b/client/internal/portforward/manager_js.go
@@ -3,8 +3,6 @@ package portforward
 import (
 	"context"
 	"net"
-
-	"github.com/netbirdio/netbird/client/internal/statemanager"
 )
 
 // Mapping represents port mapping information.
@@ -20,22 +18,17 @@ type Mapping struct {
 type Manager struct{}
 
 // NewManager returns a stub manager for js/wasm builds.
-func NewManager(_ *statemanager.Manager) *Manager {
+func NewManager() *Manager {
 	return &Manager{}
 }
 
 // Start is a no-op on js/wasm.
 func (m *Manager) Start(context.Context, uint16) {}
 
-// Stop is a no-op on js/wasm.
-func (m *Manager) Stop() {}
+// GracefullyStop is a no-op on js/wasm.
+func (m *Manager) GracefullyStop(context.Context) error { return nil }
 
 // GetMapping always returns nil on js/wasm.
 func (m *Manager) GetMapping() *Mapping {
 	return nil
-}
-
-// IsAvailable always returns false on js/wasm.
-func (m *Manager) IsAvailable() bool {
-	return false
 }

--- a/client/internal/portforward/manager_test.go
+++ b/client/internal/portforward/manager_test.go
@@ -96,7 +96,7 @@ func TestManager_CreateMapping(t *testing.T) {
 	m, cancel := setupTestManager(t)
 	defer cancel()
 
-	err := m.createMapping()
+	err := m.createMapping(nil)
 	require.NoError(t, err)
 
 	mapping := m.GetMapping()


### PR DESCRIPTION
Replace async goroutine-based cleanup with a synchronous flow where Start runs cleanup inline after renewLoop exits. Use a stopCtx channel so GracefullyStop can pass its deadline-bounded context to Start's cleanup path. When no graceful stop occurs, Start fires cleanup in a background goroutine with a 10s timeout.

Also fix GetMapping double Lock, renewMapping referencing undefined m.mu, cleanup referencing undefined variables, remove statemanager dependency

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
