### PR TITLE
[self-hosted] Better port mapping when using docker network

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -938,7 +938,9 @@ render_docker_compose_exposed_ports() {
   $EXTERNAL_PROXY_NETWORK:
     external: true"
     dashboard_port_bindings="expose: [80]"
-    server_port_bindings="expose: [80, $NETBIRD_STUN_PORT/udp]"
+    server_port_bindings="expose: [80]
+    ports:
+      - '$NETBIRD_STUN_PORT:$NETBIRD_STUN_PORT/udp'"
   fi
 
 


### PR DESCRIPTION
# Changes
1. Removed the port binding, when using a docker network, and replaced it with the "expose" key. This makes it so the port is only exposed inside the docker network and not mapped to a host port (stun is still mapped to the host).
2. Removed the "localhost only binding" prompt, if the user specified a docker network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved port configuration for external proxy deployments: prompts for host port binding only when needed, and automatically switches to internal port exposure when an external Docker network is used.
  * Dashboard, server and STUN ports handled consistently based on network choice, reducing manual configuration and simplifying generated deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->