### PR TITLE
[client] skip UAPI listener in netstack mode

### DIFF
--- a/client/iface/configurer/uapi.go
+++ b/client/iface/configurer/uapi.go
@@ -5,20 +5,18 @@ package configurer
 import (
 	"net"
 
-	log "github.com/sirupsen/logrus"
 	"golang.zx2c4.com/wireguard/ipc"
 )
 
 func openUAPI(deviceName string) (net.Listener, error) {
 	uapiSock, err := ipc.UAPIOpen(deviceName)
 	if err != nil {
-		log.Errorf("failed to open uapi socket: %v", err)
 		return nil, err
 	}
 
 	listener, err := ipc.UAPIListen(deviceName, uapiSock)
 	if err != nil {
-		log.Errorf("failed to listen on uapi socket: %v", err)
+		_ = uapiSock.Close()
 		return nil, err
 	}
 

--- a/client/iface/configurer/usp.go
+++ b/client/iface/configurer/usp.go
@@ -54,6 +54,14 @@ func NewUSPConfigurer(device *device.Device, deviceName string, activityRecorder
 	return wgCfg
 }
 
+func NewUSPConfigurerNoUAPI(device *device.Device, deviceName string, activityRecorder *bind.ActivityRecorder) *WGUSPConfigurer {
+	return &WGUSPConfigurer{
+		device:           device,
+		deviceName:       deviceName,
+		activityRecorder: activityRecorder,
+	}
+}
+
 func (c *WGUSPConfigurer) ConfigureInterface(privateKey string, port int) error {
 	log.Debugf("adding Wireguard private key")
 	key, err := wgtypes.ParseKey(privateKey)

--- a/client/iface/device/device_netstack.go
+++ b/client/iface/device/device_netstack.go
@@ -79,7 +79,7 @@ func (t *TunNetstackDevice) create() (WGConfigurer, error) {
 		device.NewLogger(wgLogLevel(), "[netbird] "),
 	)
 
-	t.configurer = configurer.NewUSPConfigurer(t.device, t.name, t.bind.ActivityRecorder())
+	t.configurer = configurer.NewUSPConfigurerNoUAPI(t.device, t.name, t.bind.ActivityRecorder())
 	err = t.configurer.ConfigureInterface(t.key, t.port)
 	if err != nil {
 		if cErr := tunIface.Close(); cErr != nil {


### PR DESCRIPTION
## Describe your changes

In netstack (proxy) mode, the process lacks permission to create
/var/run/wireguard, making the UAPI listener unnecessary and causing
a misleading error log. Introduce NewUSPConfigurerNoUAPI and use it
for the netstack device to avoid attempting to open the UAPI socket
entirely. Also consolidate UAPI error logging to a single call site.
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in UAPI operations with proper resource cleanup on failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->