### PR TITLE
[client] Fall back to individual IP rules when ipset is unavailable

### DIFF
--- a/client/firewall/iptables/acl_linux.go
+++ b/client/firewall/iptables/acl_linux.go
@@ -41,6 +41,7 @@ type aclManager struct {
 	optionalEntries map[string][]entry
 	ipsetStore      *ipsetStore
 	v6              bool
+	ipsetSupported  bool
 
 	stateManager *statemanager.Manager
 }
@@ -53,6 +54,7 @@ func newAclManager(iptablesClient *iptables.IPTables, wgIface iFaceMapper) (*acl
 		optionalEntries: make(map[string][]entry),
 		ipsetStore:      newIpsetStore(),
 		v6:              iptablesClient.Proto() == iptables.ProtocolIPv6,
+		ipsetSupported:  true,
 	}, nil
 }
 
@@ -85,6 +87,12 @@ func (m *aclManager) AddPeerFiltering(
 	ipsetName string,
 ) ([]firewall.Rule, error) {
 	chain := chainNameInputRules
+
+	// If ipset is not supported on this system (e.g. missing ip_set kernel module),
+	// clear the ipset name so rules fall back to individual IP matching (-s ip).
+	if !m.ipsetSupported {
+		ipsetName = ""
+	}
 
 	ipsetName = transformIPsetName(ipsetName, sPort, dPort, action)
 	if m.v6 && ipsetName != "" {
@@ -127,14 +135,27 @@ func (m *aclManager) AddPeerFiltering(
 			}
 		}
 		if err := m.createIPSet(ipsetName); err != nil {
-			return nil, fmt.Errorf("create ipset: %w", err)
-		}
-		if err := m.addToIPSet(ipsetName, ip); err != nil {
-			return nil, fmt.Errorf("add IP to ipset: %w", err)
-		}
+			log.Warnf("ipset not supported, falling back to individual IP rules: %v", err)
+			m.ipsetSupported = false
+			ipsetName = ""
 
-		ipList := newIpList(ip.String())
-		m.ipsetStore.addIpList(ipsetName, ipList)
+			// Regenerate specs without ipset
+			specs = filterRuleSpecs(ip, proto, sPort, dPort, action, "")
+			mangleSpecs = slices.Clone(specs)
+			mangleSpecs = append(mangleSpecs,
+				"-i", m.wgIface.Name(),
+				"-m", "addrtype", "--dst-type", "LOCAL",
+				"-j", "MARK", "--set-xmark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkRedirected),
+			)
+			specs = append(specs, "-j", actionToStr(action))
+		} else {
+			if err := m.addToIPSet(ipsetName, ip); err != nil {
+				return nil, fmt.Errorf("add IP to ipset: %w", err)
+			}
+
+			ipList := newIpList(ip.String())
+			m.ipsetStore.addIpList(ipsetName, ipList)
+		}
 	}
 
 	ok, err := m.iptablesClient.Exists(tableFilter, chain, specs...)


### PR DESCRIPTION
## Describe your changes

On systems where the `ip_set` kernel module is not available (e.g. Nvidia Jetson with Tegra kernels), ipset creation fails which causes `AddPeerFiltering` to return an error. The ACL manager's `applyPeerACLs` then calls `rollBack()`, deleting all rules from `NETBIRD-ACL-INPUT` and leaving it empty. Since the INPUT chain has a DROP catch-all for the WireGuard interface, **all tunnel traffic is blocked**.

### Root cause

1. `ip_set` kernel module missing → `createIPSet()` fails via netlink
2. `AddPeerFiltering` returns error → `applyPeerACLs` calls `rollBack()`
3. `rollBack()` deletes all newly added rules → `NETBIRD-ACL-INPUT` left empty
4. INPUT chain: `ESTABLISHED/RELATED → ACCEPT`, `jump NETBIRD-ACL-INPUT` (empty), `DROP -i wt0`
5. All new WireGuard connections dropped

### Changes

| File | Change |
|------|--------|
| `client/firewall/iptables/acl_linux.go` | Add `ipsetSupported` field; on first `createIPSet` failure, fall back to individual `-s ip` rules |

> Note: this PR originally also made `initNoTrackChain`/`initNoTrackChains` failures non-fatal. That part was superseded by #5621, which landed an equivalent fix upstream using `rawSupported`. After rebasing onto current `main`, only the ipset fallback remains — and it is still needed on Jetson Tegra kernels (confirmed 2026-04).

## Issue ticket number and link

No existing issue — discovered on Nvidia Jetson Orin AGX devices (Tegra kernel 5.15.148) where `ip_set` and `iptable_raw` kernel modules are absent.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This is an internal resilience fix — graceful fallback when the `ip_set` kernel module is unavailable. No user-facing configuration or behavior changes that require documentation.

## Test plan
- [x] Verify on system with `ip_set` module: ipset behavior unchanged, rules use `-m set --set` as before
- [x] Verify on system without `ip_set` module (e.g. Nvidia Jetson Tegra kernel): `NETBIRD-ACL-INPUT` populated with individual `-s <ip>` ACCEPT rules instead of empty chain, and inbound tunnel traffic is no longer dropped
- [x] Verify log contains \`"ipset not supported, falling back to individual IP rules"\` warning on affected systems

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Firewall ACL now detects whether optimized IP-set support is available and automatically falls back to per-IP matching when not, ensuring rules are applied even if optimizations fail.
  * Streamlined error handling and logging for firewall rule operations; failures during set operations are logged consistently and trigger safe fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/5401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->