### PR TITLE
ES256 JWT validation fails when JWKS key contains x5c field

### DIFF
--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -236,33 +236,66 @@ func getPemKeys(keysLocation string) (*Jwks, error) {
 }
 
 func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
+	// todo as we load the jkws when the server is starting, we should build a JKS map with the pem cert at the boot time
 	for k := range jwks.Keys {
 		if token.Header["kid"] != jwks.Keys[k].Kid {
 			continue
 		}
-
+ 
+		// Key with matching kid found - check type
 		switch jwks.Keys[k].Kty {
 		case "RSA":
+			// For RSA, prefer x5c certificate if available
 			if len(jwks.Keys[k].X5c) != 0 {
 				cert := "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
 				return jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
 			}
 			return getPublicKeyFromRSA(jwks.Keys[k])
-
+ 
 		case "EC":
+			// For EC, prefer x, y, crv fields if present
 			if jwks.Keys[k].X != "" && jwks.Keys[k].Y != "" && jwks.Keys[k].Crv != "" {
 				return getPublicKeyFromECDSA(jwks.Keys[k])
 			}
+ 
+			// Fallback to x5c if x/y/crv are missing
 			if len(jwks.Keys[k].X5c) != 0 {
-				return parseECKeyFromCertificate(jwks.Keys[k]) // <- estratta
+				return parseECKeyFromCertificate(jwks.Keys[k])
 			}
-			return nil, fmt.Errorf("EC key incomplete (kid: %s)", jwks.Keys[k].Kid)
-
+ 
+			// Neither x/y/crv nor x5c available
+			return nil, fmt.Errorf("EC key incomplete: missing both x/y/crv fields and x5c certificate (kid: %s)", jwks.Keys[k].Kid)
+ 
 		default:
+			// Key type not supported
 			return nil, fmt.Errorf("%w: %s (kid: %s)", errUnsupportedKeyType, jwks.Keys[k].Kty, jwks.Keys[k].Kid)
 		}
 	}
+ 
+	// No key with matching kid found
 	return nil, errKeyNotFound
+}
+
+// parseECKeyFromCertificate extracts EC public key from x5c certificate
+func parseECKeyFromCertificate(jwk JSONWebKey) (*ecdsa.PublicKey, error) {
+	cert := "-----BEGIN CERTIFICATE-----\n" + jwk.X5c[0] + "\n-----END CERTIFICATE-----"
+ 
+	block, _ := pem.Decode([]byte(cert))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM certificate for EC key (kid: %s)", jwk.Kid)
+	}
+ 
+	certificate, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse x5c certificate for EC key (kid: %s): %w", jwk.Kid, err)
+	}
+ 
+	ecKey, ok := certificate.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("x5c certificate does not contain EC public key (kid: %s)", jwk.Kid)
+	}
+ 
+	return ecKey, nil
 }
 
 func getPublicKeyFromECDSA(jwk JSONWebKey) (publicKey *ecdsa.PublicKey, err error) {

--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -235,6 +235,16 @@ func getPemKeys(keysLocation string) (*Jwks, error) {
 	return jwks, nil
 }
 
+func isSupportedECCurve(crv string) bool {
+	switch crv {
+	case "P-256", "P-384", "P-521":
+		return true
+	default:
+		return false
+	}
+}
+ 
+// Sostituisci la funzione getPublicKey con questa versione aggiornata
 func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
 	// todo as we load the jkws when the server is starting, we should build a JKS map with the pem cert at the boot time
 	for k := range jwks.Keys {
@@ -253,8 +263,12 @@ func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
 			return getPublicKeyFromRSA(jwks.Keys[k])
  
 		case "EC":
-			// For EC, prefer x, y, crv fields if present
+			// For EC, prefer x, y, crv fields if present and curve is supported
 			if jwks.Keys[k].X != "" && jwks.Keys[k].Y != "" && jwks.Keys[k].Crv != "" {
+				// Validate curve is supported before calling getPublicKeyFromECDSA
+				if !isSupportedECCurve(jwks.Keys[k].Crv) {
+					return nil, fmt.Errorf("unsupported EC curve: %s (kid: %s)", jwks.Keys[k].Crv, jwks.Keys[k].Kid)
+				}
 				return getPublicKeyFromECDSA(jwks.Keys[k])
 			}
  

--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -308,6 +308,15 @@ func parseECKeyFromCertificate(jwk JSONWebKey) (*ecdsa.PublicKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("x5c certificate does not contain EC public key (kid: %s)", jwk.Kid)
 	}
+	
+	curveName := ""
+	if ecKey.Curve != nil && ecKey.Curve.Params() != nil {
+		curveName = ecKey.Curve.Params().Name
+	}
+	
+	if !isSupportedECCurve(curveName) {
+		return nil, fmt.Errorf("unsupported EC curve in x5c certificate: %s (kid: %s)", curveName, jwk.Kid)
+	}
  
 	return ecKey, nil
 }

--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -243,8 +243,26 @@ func isSupportedECCurve(crv string) bool {
 		return false
 	}
 }
+
+ func getPublicKeyForEC(jwk JSONWebKey) (interface{}, error) {
+	// For EC, prefer x, y, crv fields if present and curve is supported
+	if jwk.X != "" && jwk.Y != "" && jwk.Crv != "" {
+		// Validate curve is supported before calling getPublicKeyFromECDSA
+		if !isSupportedECCurve(jwk.Crv) {
+			return nil, fmt.Errorf("unsupported EC curve: %s (kid: %s)", jwk.Crv, jwk.Kid)
+		}
+		return getPublicKeyFromECDSA(jwk)
+	}
  
-// Sostituisci la funzione getPublicKey con questa versione aggiornata
+	// Fallback to x5c if x/y/crv are missing
+	if len(jwk.X5c) != 0 {
+		return parseECKeyFromCertificate(jwk)
+	}
+ 
+	// Neither x/y/crv nor x5c available
+	return nil, fmt.Errorf("EC key incomplete: missing both x/y/crv fields and x5c certificate (kid: %s)", jwk.Kid)
+}
+
 func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
 	// todo as we load the jkws when the server is starting, we should build a JKS map with the pem cert at the boot time
 	for k := range jwks.Keys {
@@ -263,22 +281,7 @@ func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
 			return getPublicKeyFromRSA(jwks.Keys[k])
  
 		case "EC":
-			// For EC, prefer x, y, crv fields if present and curve is supported
-			if jwks.Keys[k].X != "" && jwks.Keys[k].Y != "" && jwks.Keys[k].Crv != "" {
-				// Validate curve is supported before calling getPublicKeyFromECDSA
-				if !isSupportedECCurve(jwks.Keys[k].Crv) {
-					return nil, fmt.Errorf("unsupported EC curve: %s (kid: %s)", jwks.Keys[k].Crv, jwks.Keys[k].Kid)
-				}
-				return getPublicKeyFromECDSA(jwks.Keys[k])
-			}
- 
-			// Fallback to x5c if x/y/crv are missing
-			if len(jwks.Keys[k].X5c) != 0 {
-				return parseECKeyFromCertificate(jwks.Keys[k])
-			}
- 
-			// Neither x/y/crv nor x5c available
-			return nil, fmt.Errorf("EC key incomplete: missing both x/y/crv fields and x5c certificate (kid: %s)", jwks.Keys[k].Kid)
+			return getPublicKeyForEC(jwks.Keys[k])
  
 		default:
 			// Key type not supported
@@ -289,6 +292,7 @@ func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
 	// No key with matching kid found
 	return nil, errKeyNotFound
 }
+
 
 // parseECKeyFromCertificate extracts EC public key from x5c certificate
 func parseECKeyFromCertificate(jwk JSONWebKey) (*ecdsa.PublicKey, error) {
@@ -307,15 +311,6 @@ func parseECKeyFromCertificate(jwk JSONWebKey) (*ecdsa.PublicKey, error) {
 	ecKey, ok := certificate.PublicKey.(*ecdsa.PublicKey)
 	if !ok {
 		return nil, fmt.Errorf("x5c certificate does not contain EC public key (kid: %s)", jwk.Kid)
-	}
-	
-	curveName := ""
-	if ecKey.Curve != nil && ecKey.Curve.Params() != nil {
-		curveName = ecKey.Curve.Params().Name
-	}
-	
-	if !isSupportedECCurve(curveName) {
-		return nil, fmt.Errorf("unsupported EC curve in x5c certificate: %s (kid: %s)", curveName, jwk.Kid)
 	}
  
 	return ecKey, nil

--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -5,7 +5,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -68,6 +70,7 @@ var (
 	errTokenEmpty   = errors.New("required authorization token not found")
 	errTokenInvalid = errors.New("token is invalid")
 	errTokenParsing = errors.New("token could not be parsed")
+	errUnsupportedKeyType = errors.New("unsupported key type")
 )
 
 func NewValidator(issuer string, audienceList []string, keysLocation string, idpSignkeyRefreshEnabled bool) *Validator {
@@ -238,23 +241,55 @@ func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
 		if token.Header["kid"] != jwks.Keys[k].Kid {
 			continue
 		}
-
-		// Check key type first
-		if jwks.Keys[k].Kty == "RSA" {
+ 
+		// Key with matching kid found - now check type
+		switch jwks.Keys[k].Kty {
+		case "RSA":
 			// For RSA, prefer x5c certificate if available
 			if len(jwks.Keys[k].X5c) != 0 {
 				cert := "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
 				return jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
 			}
 			return getPublicKeyFromRSA(jwks.Keys[k])
-		}
-		
-		if jwks.Keys[k].Kty == "EC" {
-			// For EC, always use x, y, crv fields (ignore x5c)
-			return getPublicKeyFromECDSA(jwks.Keys[k])
+ 
+		case "EC":
+			// For EC, prefer x, y, crv fields if present
+			if jwks.Keys[k].X != "" && jwks.Keys[k].Y != "" && jwks.Keys[k].Crv != "" {
+				return getPublicKeyFromECDSA(jwks.Keys[k])
+			}
+ 
+			// Fallback to x5c if x/y/crv are missing
+			if len(jwks.Keys[k].X5c) != 0 {
+				cert := "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
+				
+				block, _ := pem.Decode([]byte(cert))
+				if block == nil {
+					return nil, fmt.Errorf("failed to decode PEM certificate for EC key (kid: %s)", jwks.Keys[k].Kid)
+				}
+ 
+				certificate, err := x509.ParseCertificate(block.Bytes)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse x5c certificate for EC key (kid: %s): %w", jwks.Keys[k].Kid, err)
+				}
+ 
+				ecKey, ok := certificate.PublicKey.(*ecdsa.PublicKey)
+				if !ok {
+					return nil, fmt.Errorf("x5c certificate does not contain EC public key (kid: %s)", jwks.Keys[k].Kid)
+				}
+ 
+				return ecKey, nil
+			}
+ 
+			// Neither x/y/crv nor x5c available
+			return nil, fmt.Errorf("EC key incomplete: missing both x/y/crv fields and x5c certificate (kid: %s)", jwks.Keys[k].Kid)
+ 
+		default:
+			// Key type not supported
+			return nil, fmt.Errorf("%w: %s (kid: %s)", errUnsupportedKeyType, jwks.Keys[k].Kty, jwks.Keys[k].Kid)
 		}
 	}
-
+ 
+	// No key with matching kid found
 	return nil, errKeyNotFound
 }
 

--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -236,60 +236,32 @@ func getPemKeys(keysLocation string) (*Jwks, error) {
 }
 
 func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
-	// todo as we load the jkws when the server is starting, we should build a JKS map with the pem cert at the boot time
 	for k := range jwks.Keys {
 		if token.Header["kid"] != jwks.Keys[k].Kid {
 			continue
 		}
- 
-		// Key with matching kid found - now check type
+
 		switch jwks.Keys[k].Kty {
 		case "RSA":
-			// For RSA, prefer x5c certificate if available
 			if len(jwks.Keys[k].X5c) != 0 {
 				cert := "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
 				return jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
 			}
 			return getPublicKeyFromRSA(jwks.Keys[k])
- 
+
 		case "EC":
-			// For EC, prefer x, y, crv fields if present
 			if jwks.Keys[k].X != "" && jwks.Keys[k].Y != "" && jwks.Keys[k].Crv != "" {
 				return getPublicKeyFromECDSA(jwks.Keys[k])
 			}
- 
-			// Fallback to x5c if x/y/crv are missing
 			if len(jwks.Keys[k].X5c) != 0 {
-				cert := "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
-				
-				block, _ := pem.Decode([]byte(cert))
-				if block == nil {
-					return nil, fmt.Errorf("failed to decode PEM certificate for EC key (kid: %s)", jwks.Keys[k].Kid)
-				}
- 
-				certificate, err := x509.ParseCertificate(block.Bytes)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse x5c certificate for EC key (kid: %s): %w", jwks.Keys[k].Kid, err)
-				}
- 
-				ecKey, ok := certificate.PublicKey.(*ecdsa.PublicKey)
-				if !ok {
-					return nil, fmt.Errorf("x5c certificate does not contain EC public key (kid: %s)", jwks.Keys[k].Kid)
-				}
- 
-				return ecKey, nil
+				return parseECKeyFromCertificate(jwks.Keys[k]) // <- estratta
 			}
- 
-			// Neither x/y/crv nor x5c available
-			return nil, fmt.Errorf("EC key incomplete: missing both x/y/crv fields and x5c certificate (kid: %s)", jwks.Keys[k].Kid)
- 
+			return nil, fmt.Errorf("EC key incomplete (kid: %s)", jwks.Keys[k].Kid)
+
 		default:
-			// Key type not supported
 			return nil, fmt.Errorf("%w: %s (kid: %s)", errUnsupportedKeyType, jwks.Keys[k].Kty, jwks.Keys[k].Kid)
 		}
 	}
- 
-	// No key with matching kid found
 	return nil, errKeyNotFound
 }
 


### PR DESCRIPTION
## Describe your changes

Fixed JWT validation failure when using EC/ES256 keys with x5c certificates in JWKS.
The bug occurred in shared/auth/jwt/validator.go where getPublicKey() checked for the presence of x5c before checking kty (key type). When an OIDC provider (like Authentik) returned an EC key with x5c field populated, NetBird attempted to parse it as RSA, causing authentication to fail with "key is not a valid RSA public key" error.
The fix reorders the checks to verify kty first, ensuring EC keys are handled correctly regardless of whether x5c is present.

## Issue ticket number and link

Closes #[5302](https://github.com/netbirdio/netbird/issues/5302)

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)


Explanation: This is an internal bug fix that corrects existing behavior without changing the public API or configuration format. Users don't need to change any settings - ES256/EC keys will simply work as documented after this fix.

### Docs PR URL (required if "docs added" is checked)

N/A

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JWT verification now chooses the verification method by key type first, improving correctness for RSA and EC tokens.
  * RSA verification prefers certificate-sourced keys when available; EC verification prefers explicit curve coordinates and validates supported curves, with safer fallbacks.
  * Error messages now clearly indicate incomplete EC keys, unsupported key types, and certificate/parsing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->