### PR TITLE
[client] stop upstream retry loop immediately on context cancellation

### DIFF
--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -303,7 +303,7 @@ func (u *upstreamResolverBase) ProbeAvailability() {
 
 	// didn't find a working upstream server, let's disable and try later
 	if !success {
-		u.disableLocked(errors.ErrorOrNil())
+		u.disable(errors.ErrorOrNil())
 
 		if u.statusRecorder == nil {
 			return
@@ -379,12 +379,6 @@ func isTimeout(err error) bool {
 }
 
 func (u *upstreamResolverBase) disable(err error) {
-	u.mutex.Lock()
-	defer u.mutex.Unlock()
-	u.disableLocked(err)
-}
-
-func (u *upstreamResolverBase) disableLocked(err error) {
 	if u.disabled {
 		return
 	}


### PR DESCRIPTION
stop upstream retry loop immediately on context cancellation


## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bound upstream retry logic to request context so retries stop when operations are cancelled.
  * Improved cancellation handling to avoid treating cancelled retries as errors.
  * Clarified logging to distinguish cancellation events from genuine upstream errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->