### PR TITLE
[client] reuse logic in both up and login - login now respects env + persist config

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/user"

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/term"
 	"google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/netbirdio/netbird/client/internal"
 	"github.com/netbirdio/netbird/client/internal/auth"
@@ -69,7 +70,7 @@ var loginCmd = &cobra.Command{
 			return nil
 		}
 
-		if err := loginInDaemonMode(ctx, cmd, activeProf, pm, profileSwitched); err != nil {
+		if _, err := doDaemonLogin(ctx, cmd, activeProf, pm, profileSwitched, &profilemanager.ConfigInput{}); err != nil {
 			return fmt.Errorf("daemon login failed: %v", err)
 		}
 
@@ -79,35 +80,34 @@ var loginCmd = &cobra.Command{
 	},
 }
 
-func loginInDaemonMode(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, profileSwitched bool) error {
+func doDaemonLogin(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, profileSwitched bool, ic *profilemanager.ConfigInput) (proto.DaemonServiceClient, error) {
 	// setup grpc connection
 	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {
-		return fmt.Errorf("connect to service CLI interface: %w", err)
+		return nil, fmt.Errorf("connect to service CLI interface: %w", err)
 	}
 	defer conn.Close()
 	client := proto.NewDaemonServiceClient(conn)
 
 	// setup daemon
-	alreadyConnected, err := doDaemonSetup(ctx, cmd, client, profileSwitched, &proto.SetConfigRequest{})
+	alreadyConnected, err := daemonSetup(ctx, cmd, client, profileSwitched, ic)
 	if err != nil {
-		return fmt.Errorf("daemon setup failed: %v", err)
+		return nil, fmt.Errorf("daemon setup failed: %v", err)
 	}
 
 	if alreadyConnected {
-		return nil
+		return client, nil
 	}
 
 	// login
-	if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, &proto.LoginRequest{}); err != nil {
-		return fmt.Errorf("daemon login failed: %v", err)
+	if err := daemonLogin(ctx, cmd, client, activeProf, pm, ic); err != nil {
+		return nil, fmt.Errorf("daemon login failed: %v", err)
 	}
 
-	return nil
+	return client, nil
 }
 
-func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, profileSwitched bool, setConfigReq *proto.SetConfigRequest) error {
-func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, profileSwitched bool, setConfigReq *proto.SetConfigRequest) (bool, error) {
+func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, profileSwitched bool, ic *profilemanager.ConfigInput) (bool, error) {
 	// Check if deprecated config flag is set and show warning
 	if cmd.Flag("config").Changed && configPath != "" {
 		cmd.PrintErrf("Warning: Config flag is deprecated on up command, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
@@ -139,6 +139,7 @@ func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonS
 	}
 
 	// set default values for setconfigreq
+	setConfigReq := configInputToSetConfigRequest(ic)
 	setConfigReq.ProfileName = profileName
 	setConfigReq.Username = username.Username
 	setConfigReq.ManagementUrl = managementURL
@@ -159,7 +160,7 @@ func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonS
 	return true, nil
 }
 
-func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, loginReq *proto.LoginRequest) error {
+func daemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, ic *profilemanager.ConfigInput) error {
 	providedSetupKey, err := getSetupKey()
 	if err != nil {
 		return err
@@ -171,6 +172,7 @@ func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonS
 	}
 
 	// set standard variables for login request
+	loginReq := configInputToLoginRequest(ic)
 	loginReq.SetupKey = providedSetupKey
 	loginReq.ManagementUrl = managementURL
 	loginReq.IsUnixDesktopClient = isUnixRunningDesktop()
@@ -474,4 +476,110 @@ func setEnvAndFlags(cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+func configInputToSetConfigRequest(ic *profilemanager.ConfigInput) *proto.SetConfigRequest {
+	req := &proto.SetConfigRequest{
+		ManagementUrl:                 ic.ManagementURL,
+		AdminURL:                      ic.AdminURL,
+		NatExternalIPs:                ic.NATExternalIPs,
+		ExtraIFaceBlacklist:           ic.ExtraIFaceBlackList,
+		CustomDNSAddress:              ic.CustomDNSAddress,
+		DnsLabels:                     ic.DNSLabels.ToPunycodeList(),
+		CleanDNSLabels:                ic.DNSLabels != nil && len(ic.DNSLabels) == 0,
+		CleanNATExternalIPs:           ic.NATExternalIPs != nil && len(ic.NATExternalIPs) == 0,
+		RosenpassEnabled:              ic.RosenpassEnabled,
+		RosenpassPermissive:           ic.RosenpassPermissive,
+		ServerSSHAllowed:              ic.ServerSSHAllowed,
+		EnableSSHRoot:                 ic.EnableSSHRoot,
+		EnableSSHSFTP:                 ic.EnableSSHSFTP,
+		EnableSSHLocalPortForwarding:  ic.EnableSSHLocalPortForwarding,
+		EnableSSHRemotePortForwarding: ic.EnableSSHRemotePortForwarding,
+		DisableSSHAuth:                ic.DisableSSHAuth,
+		InterfaceName:                 ic.InterfaceName,
+		NetworkMonitor:                ic.NetworkMonitor,
+		DisableAutoConnect:            ic.DisableAutoConnect,
+		DisableClientRoutes:           ic.DisableClientRoutes,
+		DisableServerRoutes:           ic.DisableServerRoutes,
+		DisableDns:                    ic.DisableDNS,
+		DisableFirewall:               ic.DisableFirewall,
+		BlockLanAccess:                ic.BlockLANAccess,
+		BlockInbound:                  ic.BlockInbound,
+		DisableNotifications:          ic.DisableNotifications,
+		LazyConnectionEnabled:         ic.LazyConnectionEnabled,
+		OptionalPreSharedKey:          ic.PreSharedKey,
+	}
+
+	// Type conversions needed
+	if ic.WireguardPort != nil {
+		p := int64(*ic.WireguardPort)
+		req.WireguardPort = &p
+	}
+	if ic.MTU != nil {
+		m := int64(*ic.MTU)
+		req.Mtu = &m
+	}
+	if ic.SSHJWTCacheTTL != nil {
+		ttl := int32(*ic.SSHJWTCacheTTL)
+		req.SshJWTCacheTTL = &ttl
+	}
+	if ic.DNSRouteInterval != nil {
+		req.DnsRouteInterval = durationpb.New(*ic.DNSRouteInterval)
+	}
+
+	return req
+}
+
+func configInputToLoginRequest(ic *profilemanager.ConfigInput) *proto.LoginRequest {
+	req := &proto.LoginRequest{
+		ManagementUrl:                 ic.ManagementURL,
+		AdminURL:                      ic.AdminURL,
+		NatExternalIPs:                ic.NATExternalIPs,
+		CleanNATExternalIPs:           ic.NATExternalIPs != nil && len(ic.NATExternalIPs) == 0,
+		ExtraIFaceBlacklist:           ic.ExtraIFaceBlackList,
+		CustomDNSAddress:              ic.CustomDNSAddress,
+		DnsLabels:                     ic.DNSLabels.ToPunycodeList(),
+		CleanDNSLabels:                ic.DNSLabels != nil && len(ic.DNSLabels) == 0,
+		RosenpassEnabled:              ic.RosenpassEnabled,
+		RosenpassPermissive:           ic.RosenpassPermissive,
+		ServerSSHAllowed:              ic.ServerSSHAllowed,
+		EnableSSHRoot:                 ic.EnableSSHRoot,
+		EnableSSHSFTP:                 ic.EnableSSHSFTP,
+		EnableSSHLocalPortForwarding:  ic.EnableSSHLocalPortForwarding,
+		EnableSSHRemotePortForwarding: ic.EnableSSHRemotePortForwarding,
+		DisableSSHAuth:                ic.DisableSSHAuth,
+		InterfaceName:                 ic.InterfaceName,
+		NetworkMonitor:                ic.NetworkMonitor,
+		DisableAutoConnect:            ic.DisableAutoConnect,
+		DisableClientRoutes:           ic.DisableClientRoutes,
+		DisableServerRoutes:           ic.DisableServerRoutes,
+		DisableDns:                    ic.DisableDNS,
+		DisableFirewall:               ic.DisableFirewall,
+		BlockLanAccess:                ic.BlockLANAccess,
+		BlockInbound:                  ic.BlockInbound,
+		DisableNotifications:          ic.DisableNotifications,
+		LazyConnectionEnabled:         ic.LazyConnectionEnabled,
+	}
+
+	// Type conversions needed
+	if ic.WireguardPort != nil {
+		p := int64(*ic.WireguardPort)
+		req.WireguardPort = &p
+	}
+	if ic.MTU != nil {
+		m := int64(*ic.MTU)
+		req.Mtu = &m
+	}
+	if ic.SSHJWTCacheTTL != nil {
+		ttl := int32(*ic.SSHJWTCacheTTL)
+		req.SshJWTCacheTTL = &ttl
+	}
+	if ic.DNSRouteInterval != nil {
+		req.DnsRouteInterval = durationpb.New(*ic.DNSRouteInterval)
+	}
+	if ic.PreSharedKey != nil {
+		req.OptionalPreSharedKey = ic.PreSharedKey
+	}
+
+	return req
 }

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -47,7 +47,6 @@ var loginCmd = &cobra.Command{
 		}
 
 		pm := profilemanager.NewProfileManager()
-
 		username, err := user.Current()
 		if err != nil {
 			return fmt.Errorf("get current user: %v", err)
@@ -59,49 +58,49 @@ var loginCmd = &cobra.Command{
 			return fmt.Errorf("get active profile: %v", err)
 		}
 
-		// workaround to run without service
+		// foreground mode
 		if util.FindFirstLogPath(logFiles) == "" {
 			if _, err := doForegroundLogin(ctx, cmd, activeProf, &profilemanager.ConfigInput{}); err != nil {
 				return fmt.Errorf("foreground login failed: %v", err)
 			}
-			return nil
+		} else { // daemon mode
+			// setup grpc connection + defer close
+			conn, err := DialClientGRPCServer(ctx, daemonAddr)
+			if err != nil {
+				return fmt.Errorf("connect to service CLI interface: %w", err)
+			}
+			defer conn.Close()
+			client := proto.NewDaemonServiceClient(conn)
+
+			// daemon login
+			if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, &profilemanager.ConfigInput{}); err != nil {
+				return fmt.Errorf("daemon login failed: %v", err)
+			}
 		}
 
-		if _, err := doDaemonLogin(ctx, cmd, activeProf, pm, &profilemanager.ConfigInput{}); err != nil {
-			return fmt.Errorf("daemon login failed: %v", err)
-		}
-
-		cmd.Println("Logging successfully")
+		cmd.Println("Logged in successfully")
 
 		return nil
 	},
 }
 
-func doDaemonLogin(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, ic *profilemanager.ConfigInput) (proto.DaemonServiceClient, error) {
-	// setup grpc connection
-	conn, err := DialClientGRPCServer(ctx, daemonAddr)
-	if err != nil {
-		return nil, fmt.Errorf("connect to service CLI interface: %w", err)
-	}
-	defer conn.Close()
-	client := proto.NewDaemonServiceClient(conn)
-
+func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, ic *profilemanager.ConfigInput) error {
 	// setup daemon
 	alreadyConnected, err := daemonSetup(ctx, cmd, client, ic)
 	if err != nil {
-		return nil, fmt.Errorf("daemon setup failed: %v", err)
+		return fmt.Errorf("daemon setup failed: %v", err)
 	}
 
 	if alreadyConnected {
-		return client, nil
+		return nil
 	}
 
 	// login
 	if err := daemonLogin(ctx, cmd, client, activeProf, pm, ic); err != nil {
-		return nil, fmt.Errorf("daemon login failed: %v", err)
+		return fmt.Errorf("daemon login failed: %v", err)
 	}
 
-	return client, nil
+	return nil
 }
 
 func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, ic *profilemanager.ConfigInput) (bool, error) {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -334,7 +334,7 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, activeProf *prof
 	if err != nil {
 		return nil, fmt.Errorf("foreground login failed: %v", err)
 	}
-	cmd.Println("Logging successfully")
+	cmd.Println("Logged in successfully")
 
 	return config, nil
 }

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -119,7 +119,8 @@ func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonSer
 
 	if status.Status == string(internal.StatusConnected) {
 		// if non-empty profileName, this means that we switched profile
-		if profileName != "" {
+		profileSwitched := profileName != ""
+		if !profileSwitched {
 			return true, nil
 		}
 

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -555,6 +555,7 @@ func configInputToLoginRequest(ic *profilemanager.ConfigInput) *proto.LoginReque
 		BlockInbound:                  ic.BlockInbound,
 		DisableNotifications:          ic.DisableNotifications,
 		LazyConnectionEnabled:         ic.LazyConnectionEnabled,
+		OptionalPreSharedKey:          ic.PreSharedKey,
 	}
 
 	// Type conversions needed
@@ -572,9 +573,6 @@ func configInputToLoginRequest(ic *profilemanager.ConfigInput) *proto.LoginReque
 	}
 	if ic.DNSRouteInterval != nil {
 		req.DnsRouteInterval = durationpb.New(*ic.DNSRouteInterval)
-	}
-	if ic.PreSharedKey != nil {
-		req.OptionalPreSharedKey = ic.PreSharedKey
 	}
 
 	return req

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -340,7 +340,6 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, activeProf *prof
 	if err != nil {
 		return nil, fmt.Errorf("foreground login failed: %v", err)
 	}
-	cmd.Println("Logged in successfully")
 
 	return config, nil
 }

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -106,7 +106,7 @@ func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonS
 func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, ic *profilemanager.ConfigInput) (bool, error) {
 	// Check if deprecated config flag is set and show warning
 	if cmd.Flag("config").Changed && configPath != "" {
-		cmd.PrintErrf("Warning: Config flag is deprecated on up command, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
+		cmd.PrintErrf("Warning: Config flag is deprecated, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
 	}
 
 	status, err := client.Status(ctx, &proto.StatusRequest{

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -48,6 +48,9 @@ var loginCmd = &cobra.Command{
 
 		pm := profilemanager.NewProfileManager()
 
+		// if non-empty profileName, this means that we switched profile
+		profileSwitched := profileName != ""
+
 		username, err := user.Current()
 		if err != nil {
 			return fmt.Errorf("get current user: %v", err)
@@ -58,9 +61,6 @@ var loginCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("get active profile: %v", err)
 		}
-
-		// if non-empty profileName, this means that we switched profile
-		profileSwitched := profileName != ""
 
 		// workaround to run without service
 		if util.FindFirstLogPath(logFiles) == "" {
@@ -90,8 +90,13 @@ func loginInDaemonMode(ctx context.Context, cmd *cobra.Command, activeProf *prof
 	client := proto.NewDaemonServiceClient(conn)
 
 	// setup daemon
-	if err := doDaemonSetup(ctx, cmd, client, profileSwitched, &proto.SetConfigRequest{}); err != nil {
+	alreadyConnected, err := doDaemonSetup(ctx, cmd, client, profileSwitched, &proto.SetConfigRequest{})
+	if err != nil {
 		return fmt.Errorf("daemon setup failed: %v", err)
+	}
+
+	if alreadyConnected {
+		return nil
 	}
 
 	// login
@@ -103,6 +108,7 @@ func loginInDaemonMode(ctx context.Context, cmd *cobra.Command, activeProf *prof
 }
 
 func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, profileSwitched bool, setConfigReq *proto.SetConfigRequest) error {
+func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, profileSwitched bool, setConfigReq *proto.SetConfigRequest) (bool, error) {
 	// Check if deprecated config flag is set and show warning
 	if cmd.Flag("config").Changed && configPath != "" {
 		cmd.PrintErrf("Warning: Config flag is deprecated on up command, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
@@ -112,23 +118,25 @@ func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonS
 		WaitForReady: func() *bool { b := true; return &b }(),
 	})
 	if err != nil {
-		return fmt.Errorf("unable to get daemon status: %v", err)
+		return false, fmt.Errorf("unable to get daemon status: %v", err)
 	}
 
 	if status.Status == string(internal.StatusConnected) {
 		if !profileSwitched {
-			return errors.New("Already connected")
+			return true, nil
 		}
 
+		// we are already conneted, but we want to switch profiles
+		// so we need to disconnect first
 		if _, err := client.Down(ctx, &proto.DownRequest{}); err != nil {
 			log.Errorf("call service down method: %v", err)
-			return err
+			return false, err
 		}
 	}
 
 	username, err := user.Current()
 	if err != nil {
-		return fmt.Errorf("get current user: %v", err)
+		return false, fmt.Errorf("get current user: %v", err)
 	}
 
 	// set default values for setconfigreq
@@ -145,11 +153,11 @@ func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonS
 		if st, ok := gstatus.FromError(err); ok && st.Code() == codes.Unavailable {
 			log.Warnf("setConfig method is not available in the daemon")
 		} else {
-			return fmt.Errorf("call service setConfig method: %v", err)
+			return false, fmt.Errorf("call service setConfig method: %v", err)
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, loginReq *proto.LoginRequest) error {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -56,20 +56,15 @@ var loginCmd = &cobra.Command{
 			return fmt.Errorf("get active profile: %v", err)
 		}
 
-		providedSetupKey, err := getSetupKey()
-		if err != nil {
-			return err
-		}
-
 		// workaround to run without service
 		if util.FindFirstLogPath(logFiles) == "" {
-			if err := doForegroundLogin(ctx, cmd, providedSetupKey, activeProf); err != nil {
+			if _, err := doForegroundLogin(ctx, cmd, activeProf, &profilemanager.ConfigInput{}); err != nil {
 				return fmt.Errorf("foreground login failed: %v", err)
 			}
 			return nil
 		}
 
-		if err := doDaemonLogin(ctx, cmd, providedSetupKey, activeProf, username.Username, pm); err != nil {
+		if err := doDaemonLogin(ctx, cmd, activeProf, username.Username, pm); err != nil {
 			return fmt.Errorf("daemon login failed: %v", err)
 		}
 
@@ -79,7 +74,12 @@ var loginCmd = &cobra.Command{
 	},
 }
 
-func doDaemonLogin(ctx context.Context, cmd *cobra.Command, providedSetupKey string, activeProf *profilemanager.Profile, username string, pm *profilemanager.ProfileManager) error {
+func doDaemonLogin(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, username string, pm *profilemanager.ProfileManager) error {
+	providedSetupKey, err := getSetupKey()
+	if err != nil {
+		return err
+	}
+
 	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {
 		//nolint
@@ -228,11 +228,15 @@ func switchProfile(ctx context.Context, profileName string, username string) err
 	return nil
 }
 
-func doForegroundLogin(ctx context.Context, cmd *cobra.Command, setupKey string, activeProf *profilemanager.Profile) error {
+func doForegroundLogin(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, ic *profilemanager.ConfigInput) (*profilemanager.Config, error) {
+	// override the default profile filepath if provided
+	if configPath != "" {
+		_ = profilemanager.NewServiceManager(configPath)
+	}
 
 	err := handleRebrand(cmd)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// update host's static platform and system information
@@ -240,21 +244,35 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, setupKey string,
 
 	configFilePath, err := activeProf.FilePath()
 	if err != nil {
-		return fmt.Errorf("get active profile file path: %v", err)
+		return nil, fmt.Errorf("get active profile file path: %v", err)
 
 	}
 
-	config, err := profilemanager.ReadConfig(configFilePath)
+	// update config with root flags
+	ic.ManagementURL = managementURL
+	ic.ConfigPath = configFilePath
+	ic.NATExternalIPs = natExternalIPs
+	ic.ExtraIFaceBlackList = extraIFaceBlackList
+	ic.DNSLabels = dnsLabelsValidated
+
+	config, err := profilemanager.UpdateOrCreateConfig(*ic)
 	if err != nil {
-		return fmt.Errorf("read config file %s: %v", configFilePath, err)
+		return nil, fmt.Errorf("get config file: %v", err)
 	}
 
-	err = foregroundLogin(ctx, cmd, config, setupKey, activeProf.Name)
+	_, _ = profilemanager.UpdateOldManagementURL(ctx, config, configFilePath)
+
+	providedSetupKey, err := getSetupKey()
 	if err != nil {
-		return fmt.Errorf("foreground login failed: %v", err)
+		return nil, err
+	}
+
+	err = foregroundLogin(ctx, cmd, config, providedSetupKey, activeProf.Name)
+	if err != nil {
+		return nil, fmt.Errorf("foreground login failed: %v", err)
 	}
 	cmd.Println("Logging successfully")
-	return nil
+	return nil, nil
 }
 
 func handleSSOLogin(ctx context.Context, cmd *cobra.Command, loginResp *proto.LoginResponse, client proto.DaemonServiceClient, pm *profilemanager.ProfileManager) error {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -124,7 +124,7 @@ func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonSer
 			return true, nil
 		}
 
-		// we are already conneted, but we want to switch profiles
+		// we are already connected, but we want to switch profiles
 		// so we need to disconnect first
 		if _, err := client.Down(ctx, &proto.DownRequest{}); err != nil {
 			log.Errorf("call service down method: %v", err)

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -48,9 +48,6 @@ var loginCmd = &cobra.Command{
 
 		pm := profilemanager.NewProfileManager()
 
-		// if non-empty profileName, this means that we switched profile
-		profileSwitched := profileName != ""
-
 		username, err := user.Current()
 		if err != nil {
 			return fmt.Errorf("get current user: %v", err)
@@ -70,7 +67,7 @@ var loginCmd = &cobra.Command{
 			return nil
 		}
 
-		if _, err := doDaemonLogin(ctx, cmd, activeProf, pm, profileSwitched, &profilemanager.ConfigInput{}); err != nil {
+		if _, err := doDaemonLogin(ctx, cmd, activeProf, pm, &profilemanager.ConfigInput{}); err != nil {
 			return fmt.Errorf("daemon login failed: %v", err)
 		}
 
@@ -80,7 +77,7 @@ var loginCmd = &cobra.Command{
 	},
 }
 
-func doDaemonLogin(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, profileSwitched bool, ic *profilemanager.ConfigInput) (proto.DaemonServiceClient, error) {
+func doDaemonLogin(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, ic *profilemanager.ConfigInput) (proto.DaemonServiceClient, error) {
 	// setup grpc connection
 	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {
@@ -90,7 +87,7 @@ func doDaemonLogin(ctx context.Context, cmd *cobra.Command, activeProf *profilem
 	client := proto.NewDaemonServiceClient(conn)
 
 	// setup daemon
-	alreadyConnected, err := daemonSetup(ctx, cmd, client, profileSwitched, ic)
+	alreadyConnected, err := daemonSetup(ctx, cmd, client, ic)
 	if err != nil {
 		return nil, fmt.Errorf("daemon setup failed: %v", err)
 	}
@@ -107,7 +104,7 @@ func doDaemonLogin(ctx context.Context, cmd *cobra.Command, activeProf *profilem
 	return client, nil
 }
 
-func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, profileSwitched bool, ic *profilemanager.ConfigInput) (bool, error) {
+func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, ic *profilemanager.ConfigInput) (bool, error) {
 	// Check if deprecated config flag is set and show warning
 	if cmd.Flag("config").Changed && configPath != "" {
 		cmd.PrintErrf("Warning: Config flag is deprecated on up command, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
@@ -121,7 +118,8 @@ func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonSer
 	}
 
 	if status.Status == string(internal.StatusConnected) {
-		if !profileSwitched {
+		// if non-empty profileName, this means that we switched profile
+		if profileName != "" {
 			return true, nil
 		}
 
@@ -224,7 +222,6 @@ func daemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonSer
 
 func getActiveProfile(ctx context.Context, pm *profilemanager.ProfileManager, profileName string, username string) (*profilemanager.Profile, error) {
 	// switch profile if provided
-
 	if profileName != "" {
 		if err := switchProfileOnDaemon(ctx, pm, profileName, username); err != nil {
 			return nil, fmt.Errorf("switch profile: %v", err)

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -86,7 +86,7 @@ var loginCmd = &cobra.Command{
 
 func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, ic *profilemanager.ConfigInput) error {
 	// setup daemon
-	alreadyConnected, err := daemonSetup(ctx, cmd, client, ic)
+	alreadyConnected, err := daemonSetup(ctx, cmd, client, activeProf, ic)
 	if err != nil {
 		return fmt.Errorf("daemon setup failed: %v", err)
 	}
@@ -103,7 +103,7 @@ func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonS
 	return nil
 }
 
-func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, ic *profilemanager.ConfigInput) (bool, error) {
+func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, ic *profilemanager.ConfigInput) (bool, error) {
 	// Check if deprecated config flag is set and show warning
 	if cmd.Flag("config").Changed && configPath != "" {
 		cmd.PrintErrf("Warning: Config flag is deprecated, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
@@ -138,7 +138,7 @@ func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonSer
 
 	// set default values for setconfigreq
 	setConfigReq := configInputToSetConfigRequest(ic)
-	setConfigReq.ProfileName = profileName
+	setConfigReq.ProfileName = activeProf.Name
 	setConfigReq.Username = username.Username
 	setConfigReq.ManagementUrl = managementURL
 	setConfigReq.AdminURL = adminURL

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -314,7 +314,6 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, activeProf *prof
 	configFilePath, err := activeProf.FilePath()
 	if err != nil {
 		return nil, fmt.Errorf("get active profile file path: %v", err)
-
 	}
 
 	// update config with root flags

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -53,7 +53,7 @@ var loginCmd = &cobra.Command{
 		}
 
 		// getActiveProfile will also switch the profile if needed
-		activeProf, err := getActiveProfile(cmd.Context(), pm, profileName, username.Username)
+		activeProf, err := getActiveProfile(ctx, pm, profileName, username.Username)
 		if err != nil {
 			return fmt.Errorf("get active profile: %v", err)
 		}

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -92,9 +92,16 @@ var loginCmd = &cobra.Command{
 }
 
 func loginInDaemonMode(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, profileSwitched bool) error {
-	// setup daemon
-	client, err := doDaemonSetup(ctx, cmd, activeProf, pm, profileSwitched, &proto.SetConfigRequest{})
+	// setup grpc connection
+	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {
+		return fmt.Errorf("connect to service CLI interface: %w", err)
+	}
+	defer conn.Close()
+	client := proto.NewDaemonServiceClient(conn)
+
+	// setup daemon
+	if err := doDaemonSetup(ctx, cmd, client, profileSwitched, &proto.SetConfigRequest{}); err != nil {
 		return fmt.Errorf("daemon setup failed: %v", err)
 	}
 
@@ -106,51 +113,34 @@ func loginInDaemonMode(ctx context.Context, cmd *cobra.Command, activeProf *prof
 	return nil
 }
 
-func doDaemonSetup(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, profileSwitched bool, setConfigReq *proto.SetConfigRequest) (proto.DaemonServiceClient, error) {
+func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, profileSwitched bool, setConfigReq *proto.SetConfigRequest) error {
 	// Check if deprecated config flag is set and show warning
 	if cmd.Flag("config").Changed && configPath != "" {
 		cmd.PrintErrf("Warning: Config flag is deprecated on up command, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
 	}
 
-	conn, err := DialClientGRPCServer(ctx, daemonAddr)
-	if err != nil {
-		//nolint
-		return nil, fmt.Errorf("failed to connect to daemon error: %v\n"+
-			"If the daemon is not running please run: "+
-			"\nnetbird service install \nnetbird service start\n", err)
-	}
-	defer func() {
-		err := conn.Close()
-		if err != nil {
-			log.Warnf("failed closing daemon gRPC client connection %v", err)
-			return
-		}
-	}()
-
-	client := proto.NewDaemonServiceClient(conn)
-
 	status, err := client.Status(ctx, &proto.StatusRequest{
 		WaitForReady: func() *bool { b := true; return &b }(),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get daemon status: %v", err)
+		return fmt.Errorf("unable to get daemon status: %v", err)
 	}
 
 	if status.Status == string(internal.StatusConnected) {
 		if !profileSwitched {
 			cmd.Println("Already connected")
-			return nil, nil
+			return nil
 		}
 
 		if _, err := client.Down(ctx, &proto.DownRequest{}); err != nil {
 			log.Errorf("call service down method: %v", err)
-			return nil, err
+			return err
 		}
 	}
 
 	username, err := user.Current()
 	if err != nil {
-		return nil, fmt.Errorf("get current user: %v", err)
+		return fmt.Errorf("get current user: %v", err)
 	}
 
 	// set default values for setconfigreq
@@ -167,11 +157,11 @@ func doDaemonSetup(ctx context.Context, cmd *cobra.Command, activeProf *profilem
 		if st, ok := gstatus.FromError(err); ok && st.Code() == codes.Unavailable {
 			log.Warnf("setConfig method is not available in the daemon")
 		} else {
-			return nil, fmt.Errorf("call service setConfig method: %v", err)
+			return fmt.Errorf("call service setConfig method: %v", err)
 		}
 	}
 
-	return client, nil
+	return nil
 }
 
 func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, loginReq *proto.LoginRequest) error {
@@ -357,7 +347,8 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, activeProf *prof
 		return nil, fmt.Errorf("foreground login failed: %v", err)
 	}
 	cmd.Println("Logging successfully")
-	return nil, nil
+
+	return config, nil
 }
 
 func handleSSOLogin(ctx context.Context, cmd *cobra.Command, loginResp *proto.LoginResponse, client proto.DaemonServiceClient, pm *profilemanager.ProfileManager) error {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -52,26 +53,14 @@ var loginCmd = &cobra.Command{
 			return fmt.Errorf("get current user: %v", err)
 		}
 
-		var profileSwitched bool
-		// switch profile if provided
-		if profileName != "" {
-			err = switchProfile(cmd.Context(), profileName, username.Username)
-			if err != nil {
-				return fmt.Errorf("switch profile: %v", err)
-			}
-
-			err = pm.SwitchProfile(profileName)
-			if err != nil {
-				return fmt.Errorf("switch profile: %v", err)
-			}
-
-			profileSwitched = true
-		}
-
+		// getActiveProfile will also switch the profile if needed
 		activeProf, err := getActiveProfile(cmd.Context(), pm, profileName, username.Username)
 		if err != nil {
 			return fmt.Errorf("get active profile: %v", err)
 		}
+
+		// if non-empty profileName, this means that we switched profile
+		profileSwitched := profileName != ""
 
 		// workaround to run without service
 		if util.FindFirstLogPath(logFiles) == "" {
@@ -128,8 +117,7 @@ func doDaemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonS
 
 	if status.Status == string(internal.StatusConnected) {
 		if !profileSwitched {
-			cmd.Println("Already connected")
-			return nil
+			return errors.New("Already connected")
 		}
 
 		if _, err := client.Down(ctx, &proto.DownRequest{}); err != nil {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -251,9 +251,6 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, activeProf *prof
 	// update config with root flags
 	ic.ManagementURL = managementURL
 	ic.ConfigPath = configFilePath
-	ic.NATExternalIPs = natExternalIPs
-	ic.ExtraIFaceBlackList = extraIFaceBlackList
-	ic.DNSLabels = dnsLabelsValidated
 
 	config, err := profilemanager.UpdateOrCreateConfig(*ic)
 	if err != nil {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -155,7 +155,7 @@ func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonSer
 		}
 	}
 
-	return true, nil
+	return false, nil
 }
 
 func daemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, ic *profilemanager.ConfigInput) error {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -39,7 +39,7 @@ var loginCmd = &cobra.Command{
 			return fmt.Errorf("set env and flags: %v", err)
 		}
 
-		ctx := internal.CtxInitState(context.Background())
+		ctx := internal.CtxInitState(cmd.Context())
 
 		if hostName != "" {
 			// nolint
@@ -85,8 +85,14 @@ var loginCmd = &cobra.Command{
 }
 
 func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, ic *profilemanager.ConfigInput) error {
+	// get user
+	user, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("get current user: %v", err)
+	}
+
 	// setup daemon
-	alreadyConnected, err := daemonSetup(ctx, cmd, client, activeProf, ic)
+	alreadyConnected, err := daemonSetup(ctx, cmd, client, activeProf, ic, user.Username)
 	if err != nil {
 		return fmt.Errorf("daemon setup failed: %v", err)
 	}
@@ -96,14 +102,14 @@ func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonS
 	}
 
 	// login
-	if err := daemonLogin(ctx, cmd, client, activeProf, pm, ic); err != nil {
+	if err := daemonLogin(ctx, cmd, client, activeProf, pm, ic, user.Username); err != nil {
 		return fmt.Errorf("daemon login failed: %v", err)
 	}
 
 	return nil
 }
 
-func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, ic *profilemanager.ConfigInput) (bool, error) {
+func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, ic *profilemanager.ConfigInput, username string) (bool, error) {
 	// Check if deprecated config flag is set and show warning
 	if cmd.Flag("config").Changed && configPath != "" {
 		cmd.PrintErrf("Warning: Config flag is deprecated, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
@@ -131,15 +137,10 @@ func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonSer
 		}
 	}
 
-	username, err := user.Current()
-	if err != nil {
-		return false, fmt.Errorf("get current user: %v", err)
-	}
-
 	// set default values for setconfigreq
 	setConfigReq := configInputToSetConfigRequest(ic)
 	setConfigReq.ProfileName = activeProf.Name
-	setConfigReq.Username = username.Username
+	setConfigReq.Username = username
 	setConfigReq.ManagementUrl = managementURL
 	setConfigReq.AdminURL = adminURL
 	if rootCmd.PersistentFlags().Changed(preSharedKeyFlag) {
@@ -158,15 +159,10 @@ func daemonSetup(ctx context.Context, cmd *cobra.Command, client proto.DaemonSer
 	return false, nil
 }
 
-func daemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, ic *profilemanager.ConfigInput) error {
+func daemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, ic *profilemanager.ConfigInput, username string) error {
 	providedSetupKey, err := getSetupKey()
 	if err != nil {
 		return err
-	}
-
-	username, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("get current user: %v", err)
 	}
 
 	// set standard variables for login request
@@ -176,7 +172,7 @@ func daemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonSer
 	loginReq.IsUnixDesktopClient = isUnixRunningDesktop()
 	loginReq.Hostname = hostName
 	loginReq.ProfileName = &activeProf.Name
-	loginReq.Username = &username.Username
+	loginReq.Username = &username
 
 	profileState, err := pm.GetProfileState(activeProf.Name)
 	if err != nil {
@@ -240,7 +236,7 @@ func getActiveProfile(ctx context.Context, pm *profilemanager.ProfileManager, pr
 }
 
 func switchProfileOnDaemon(ctx context.Context, pm *profilemanager.ProfileManager, profileName string, username string) error {
-	err := switchProfile(context.Background(), profileName, username)
+	err := switchProfile(ctx, profileName, username)
 	if err != nil {
 		return fmt.Errorf("switch profile on daemon: %v", err)
 	}

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -44,12 +44,29 @@ var loginCmd = &cobra.Command{
 			// nolint
 			ctx = context.WithValue(ctx, system.DeviceNameCtxKey, hostName)
 		}
+
+		pm := profilemanager.NewProfileManager()
+
 		username, err := user.Current()
 		if err != nil {
 			return fmt.Errorf("get current user: %v", err)
 		}
 
-		pm := profilemanager.NewProfileManager()
+		var profileSwitched bool
+		// switch profile if provided
+		if profileName != "" {
+			err = switchProfile(cmd.Context(), profileName, username.Username)
+			if err != nil {
+				return fmt.Errorf("switch profile: %v", err)
+			}
+
+			err = pm.SwitchProfile(profileName)
+			if err != nil {
+				return fmt.Errorf("switch profile: %v", err)
+			}
+
+			profileSwitched = true
+		}
 
 		activeProf, err := getActiveProfile(cmd.Context(), pm, profileName, username.Username)
 		if err != nil {
@@ -64,7 +81,7 @@ var loginCmd = &cobra.Command{
 			return nil
 		}
 
-		if err := doDaemonLogin(ctx, cmd, activeProf, username.Username, pm); err != nil {
+		if err := loginInDaemonMode(ctx, cmd, activeProf, pm, profileSwitched); err != nil {
 			return fmt.Errorf("daemon login failed: %v", err)
 		}
 
@@ -74,56 +91,124 @@ var loginCmd = &cobra.Command{
 	},
 }
 
-func doDaemonLogin(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, username string, pm *profilemanager.ProfileManager) error {
-	providedSetupKey, err := getSetupKey()
+func loginInDaemonMode(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, profileSwitched bool) error {
+	// setup daemon
+	client, err := doDaemonSetup(ctx, cmd, activeProf, pm, profileSwitched, &proto.SetConfigRequest{})
 	if err != nil {
-		return err
+		return fmt.Errorf("daemon setup failed: %v", err)
+	}
+
+	// login
+	if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, &proto.LoginRequest{}); err != nil {
+		return fmt.Errorf("daemon login failed: %v", err)
+	}
+
+	return nil
+}
+
+func doDaemonSetup(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, profileSwitched bool, setConfigReq *proto.SetConfigRequest) (proto.DaemonServiceClient, error) {
+	// Check if deprecated config flag is set and show warning
+	if cmd.Flag("config").Changed && configPath != "" {
+		cmd.PrintErrf("Warning: Config flag is deprecated on up command, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
 	}
 
 	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {
 		//nolint
-		return fmt.Errorf("failed to connect to daemon error: %v\n"+
+		return nil, fmt.Errorf("failed to connect to daemon error: %v\n"+
 			"If the daemon is not running please run: "+
 			"\nnetbird service install \nnetbird service start\n", err)
 	}
-	defer conn.Close()
+	defer func() {
+		err := conn.Close()
+		if err != nil {
+			log.Warnf("failed closing daemon gRPC client connection %v", err)
+			return
+		}
+	}()
 
 	client := proto.NewDaemonServiceClient(conn)
 
-	var dnsLabelsReq []string
-	if dnsLabelsValidated != nil {
-		dnsLabelsReq = dnsLabelsValidated.ToSafeStringList()
+	status, err := client.Status(ctx, &proto.StatusRequest{
+		WaitForReady: func() *bool { b := true; return &b }(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get daemon status: %v", err)
 	}
 
-	loginRequest := proto.LoginRequest{
-		SetupKey:            providedSetupKey,
-		ManagementUrl:       managementURL,
-		IsUnixDesktopClient: isUnixRunningDesktop(),
-		Hostname:            hostName,
-		DnsLabels:           dnsLabelsReq,
-		ProfileName:         &activeProf.Name,
-		Username:            &username,
+	if status.Status == string(internal.StatusConnected) {
+		if !profileSwitched {
+			cmd.Println("Already connected")
+			return nil, nil
+		}
+
+		if _, err := client.Down(ctx, &proto.DownRequest{}); err != nil {
+			log.Errorf("call service down method: %v", err)
+			return nil, err
+		}
 	}
+
+	username, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("get current user: %v", err)
+	}
+
+	// set default values for setconfigreq
+	setConfigReq.ProfileName = profileName
+	setConfigReq.Username = username.Username
+	setConfigReq.ManagementUrl = managementURL
+	setConfigReq.AdminURL = adminURL
+	if rootCmd.PersistentFlags().Changed(preSharedKeyFlag) {
+		setConfigReq.OptionalPreSharedKey = &preSharedKey
+	}
+
+	// set the new config
+	if _, err := client.SetConfig(ctx, setConfigReq); err != nil {
+		if st, ok := gstatus.FromError(err); ok && st.Code() == codes.Unavailable {
+			log.Warnf("setConfig method is not available in the daemon")
+		} else {
+			return nil, fmt.Errorf("call service setConfig method: %v", err)
+		}
+	}
+
+	return client, nil
+}
+
+func doDaemonLogin(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, activeProf *profilemanager.Profile, pm *profilemanager.ProfileManager, loginReq *proto.LoginRequest) error {
+	providedSetupKey, err := getSetupKey()
+	if err != nil {
+		return err
+	}
+
+	username, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("get current user: %v", err)
+	}
+
+	// set standard variables for login request
+	loginReq.SetupKey = providedSetupKey
+	loginReq.ManagementUrl = managementURL
+	loginReq.IsUnixDesktopClient = isUnixRunningDesktop()
+	loginReq.Hostname = hostName
+	loginReq.ProfileName = &activeProf.Name
+	loginReq.Username = &username.Username
 
 	profileState, err := pm.GetProfileState(activeProf.Name)
 	if err != nil {
 		log.Debugf("failed to get profile state for login hint: %v", err)
 	} else if profileState.Email != "" {
-		loginRequest.Hint = &profileState.Email
+		loginReq.Hint = &profileState.Email
 	}
 
 	if rootCmd.PersistentFlags().Changed(preSharedKeyFlag) {
-		loginRequest.OptionalPreSharedKey = &preSharedKey
+		loginReq.OptionalPreSharedKey = &preSharedKey
 	}
 
 	var loginErr error
-
 	var loginResp *proto.LoginResponse
-
 	err = WithBackOff(func() error {
 		var backOffErr error
-		loginResp, backOffErr = client.Login(ctx, &loginRequest)
+		loginResp, backOffErr = client.Login(ctx, loginReq)
 		if s, ok := gstatus.FromError(backOffErr); ok && (s.Code() == codes.InvalidArgument ||
 			s.Code() == codes.PermissionDenied ||
 			s.Code() == codes.NotFound ||
@@ -251,6 +336,9 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, activeProf *prof
 	// update config with root flags
 	ic.ManagementURL = managementURL
 	ic.ConfigPath = configFilePath
+	if rootCmd.PersistentFlags().Changed(preSharedKeyFlag) {
+		ic.PreSharedKey = &preSharedKey
+	}
 
 	config, err := profilemanager.UpdateOrCreateConfig(*ic)
 	if err != nil {

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -27,19 +27,12 @@ import (
 )
 
 const (
-	externalIPMapFlag        = "external-ip-map"
-	dnsResolverAddress       = "dns-resolver-address"
-	enableRosenpassFlag      = "enable-rosenpass"
-	rosenpassPermissiveFlag  = "rosenpass-permissive"
-	preSharedKeyFlag         = "preshared-key"
-	interfaceNameFlag        = "interface-name"
-	wireguardPortFlag        = "wireguard-port"
-	networkMonitorFlag       = "network-monitor"
-	disableAutoConnectFlag   = "disable-auto-connect"
-	extraIFaceBlackListFlag  = "extra-iface-blacklist"
-	dnsRouteIntervalFlag     = "dns-router-interval"
-	enableLazyConnectionFlag = "enable-lazy-connection"
-	mtuFlag                  = "mtu"
+	preSharedKeyFlag     = "preshared-key"
+	interfaceNameFlag    = "interface-name"
+	wireguardPortFlag    = "wireguard-port"
+	networkMonitorFlag   = "network-monitor"
+	dnsRouteIntervalFlag = "dns-router-interval"
+	mtuFlag              = "mtu"
 )
 
 var (
@@ -60,18 +53,11 @@ var (
 	setupKeyPath            string
 	hostName                string
 	preSharedKey            string
-	natExternalIPs          []string
-	customDNSAddress        string
-	rosenpassEnabled        bool
-	rosenpassPermissive     bool
 	interfaceName           string
 	wireguardPort           uint16
 	networkMonitor          bool
-	autoConnectDisabled     bool
-	extraIFaceBlackList     []string
 	anonymizeFlag           bool
 	dnsRouteInterval        time.Duration
-	lazyConnEnabled         bool
 	mtu                     uint16
 	profilesDisabled        bool
 	updateSettingsDisabled  bool
@@ -174,24 +160,6 @@ func init() {
 	profileCmd.AddCommand(profileAddCmd)
 	profileCmd.AddCommand(profileRemoveCmd)
 	profileCmd.AddCommand(profileSelectCmd)
-
-	upCmd.PersistentFlags().StringSliceVar(&natExternalIPs, externalIPMapFlag, nil,
-		`Sets external IPs maps between local addresses and interfaces.`+
-			`You can specify a comma-separated list with a single IP and IP/IP or IP/Interface Name. `+
-			`An empty string "" clears the previous configuration. `+
-			`E.g. --external-ip-map 12.34.56.78/10.0.0.1 or --external-ip-map 12.34.56.200,12.34.56.78/10.0.0.1,12.34.56.80/eth1 `+
-			`or --external-ip-map ""`,
-	)
-	upCmd.PersistentFlags().StringVar(&customDNSAddress, dnsResolverAddress, "",
-		`Sets a custom address for NetBird's local DNS resolver. `+
-			`If set, the agent won't attempt to discover the best ip and port to listen on. `+
-			`An empty string "" clears the previous configuration. `+
-			`E.g. --dns-resolver-address 127.0.0.1:5053 or --dns-resolver-address ""`,
-	)
-	upCmd.PersistentFlags().BoolVar(&rosenpassEnabled, enableRosenpassFlag, false, "[Experimental] Enable Rosenpass feature. If enabled, the connection will be post-quantum secured via Rosenpass.")
-	upCmd.PersistentFlags().BoolVar(&rosenpassPermissive, rosenpassPermissiveFlag, false, "[Experimental] Enable Rosenpass in permissive mode to allow this peer to accept WireGuard connections without requiring Rosenpass functionality from peers that do not have Rosenpass enabled.")
-	upCmd.PersistentFlags().BoolVar(&autoConnectDisabled, disableAutoConnectFlag, false, "Disables auto-connect feature. If enabled, then the client won't connect automatically when the service starts.")
-	upCmd.PersistentFlags().BoolVar(&lazyConnEnabled, enableLazyConnectionFlag, false, "[Experimental] Enable the lazy connection feature. If enabled, the client will establish connections on-demand. Note: this setting may be overridden by management configuration.")
 
 }
 

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -294,7 +294,7 @@ func setupSetConfigFromUpCmd(cmd *cobra.Command) (*proto.SetConfigRequest, error
 	if cmd.Flag(interfaceNameFlag).Changed {
 		if err := parseInterfaceName(interfaceName); err != nil {
 			log.Errorf("parse interface name: %v", err)
-			return nil, nil
+			return nil, err
 		}
 		req.InterfaceName = &interfaceName
 	}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"google.golang.org/protobuf/types/known/durationpb"
-
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/internal"
 	"github.com/netbirdio/netbird/client/internal/peer"
@@ -190,9 +188,9 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager
 		return fmt.Errorf("setup config: %v", err)
 	}
 
-	// setup grpc connection
-	conn, err := DialClientGRPCServer(ctx, daemonAddr)
+	client, err := doDaemonLogin(ctx, cmd, activeProf, pm, profileSwitched, ic)
 	if err != nil {
+<<<<<<< HEAD
 		return fmt.Errorf("connect to service CLI interface: %w", err)
 	}
 	defer conn.Close()
@@ -209,6 +207,9 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager
 		if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, setupLoginRequestFromConfigInput(cmd, ic)); err != nil {
 			return fmt.Errorf("daemon login failed: %v", err)
 		}
+=======
+		return err
+>>>>>>> 20f4fcd4d (use configinput in general and convert it around, much cleaner)
 	}
 
 	// up the service

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -155,26 +155,14 @@ func upFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get current user: %v", err)
 	}
 
-	var profileSwitched bool
-	// switch profile if provided
-	if profileName != "" {
-		err = switchProfile(cmd.Context(), profileName, username.Username)
-		if err != nil {
-			return fmt.Errorf("switch profile: %v", err)
-		}
-
-		err = pm.SwitchProfile(profileName)
-		if err != nil {
-			return fmt.Errorf("switch profile: %v", err)
-		}
-
-		profileSwitched = true
-	}
-
-	activeProf, err := pm.GetActiveProfile()
+	// getActiveProfile will also switch the profile if needed
+	activeProf, err := getActiveProfile(cmd.Context(), pm, profileName, username.Username)
 	if err != nil {
 		return fmt.Errorf("get active profile: %v", err)
 	}
+
+	// if non-empty profileName, this means that we switched profile
+	profileSwitched := profileName != ""
 
 	if foregroundMode {
 		return runInForegroundMode(ctx, cmd, activeProf)
@@ -304,6 +292,9 @@ func setupSetConfigFromUpCmd(cmd *cobra.Command) (*proto.SetConfigRequest, error
 	}
 
 	if cmd.Flag(mtuFlag).Changed {
+		if err := iface.ValidateMTU(mtu); err != nil {
+			return nil, err
+		}
 		m := int64(mtu)
 		req.Mtu = &m
 	}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -150,7 +150,7 @@ func upFunc(cmd *cobra.Command, args []string) error {
 		return runInForegroundMode(ctx, cmd, activeProf)
 	}
 
-	return runInDaemonMode(ctx, cmd, pm, activeProf)
+	return runInDaemonMode(ctx, cmd, pm, activeProf, username.Username)
 }
 
 func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile) error {
@@ -177,7 +177,7 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *pr
 	return connectClient.Run(nil, util.FindFirstLogPath(logFiles))
 }
 
-func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager.ProfileManager, activeProf *profilemanager.Profile) error {
+func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager.ProfileManager, activeProf *profilemanager.Profile, username string) error {
 	// get our config input, so we can generate
 	// proto.SetConfig and proto.LoginRequest
 	ic, err := setupConfigInputFromUpCmd(cmd)

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -293,35 +293,27 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 	if cmd.Flag(enableRosenpassFlag).Changed {
 		ic.RosenpassEnabled = &rosenpassEnabled
 	}
-
 	if cmd.Flag(rosenpassPermissiveFlag).Changed {
 		ic.RosenpassPermissive = &rosenpassPermissive
 	}
-
 	if cmd.Flag(serverSSHAllowedFlag).Changed {
 		ic.ServerSSHAllowed = &serverSSHAllowed
 	}
-
 	if cmd.Flag(enableSSHRootFlag).Changed {
 		ic.EnableSSHRoot = &enableSSHRoot
 	}
-
 	if cmd.Flag(enableSSHSFTPFlag).Changed {
 		ic.EnableSSHSFTP = &enableSSHSFTP
 	}
-
 	if cmd.Flag(enableSSHLocalPortForwardFlag).Changed {
 		ic.EnableSSHLocalPortForwarding = &enableSSHLocalPortForward
 	}
-
 	if cmd.Flag(enableSSHRemotePortForwardFlag).Changed {
 		ic.EnableSSHRemotePortForwarding = &enableSSHRemotePortForward
 	}
-
 	if cmd.Flag(disableSSHAuthFlag).Changed {
 		ic.DisableSSHAuth = &disableSSHAuth
 	}
-
 	if cmd.Flag(sshJWTCacheTTLFlag).Changed {
 		ic.SSHJWTCacheTTL = &sshJWTCacheTTL
 	}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -195,6 +194,13 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *pr
 }
 
 func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager.ProfileManager, activeProf *profilemanager.Profile, profileSwitched bool) error {
+	// get our config input, so we can generate
+	// proto.SetConfig and proto.LoginRequest
+	ic, err := setupConfigInputFromUpCmd(cmd)
+	if err != nil {
+		return fmt.Errorf("setup config: %v", err)
+	}
+
 	// setup grpc connection
 	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {
@@ -204,24 +210,14 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager
 	client := proto.NewDaemonServiceClient(conn)
 
 	// setup daemon
-	setConfigReq, err := setupSetConfigFromUpCmd(cmd)
-	if err != nil {
-		return err
-	}
-
-	alreadyConnected, err := doDaemonSetup(ctx, cmd, client, profileSwitched, setConfigReq)
+	alreadyConnected, err := doDaemonSetup(ctx, cmd, client, profileSwitched, setupSetConfigFromConfigInput(cmd, ic))
 	if err != nil {
 		return fmt.Errorf("daemon setup failed: %v", err)
 	}
 
 	// login if not already connected
 	if !alreadyConnected {
-		loginReq, err := setupLoginRequestFromUpCmd(cmd)
-		if err != nil {
-			return err
-		}
-
-		if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, loginReq); err != nil {
+		if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, setupLoginRequestFromConfigInput(cmd, ic)); err != nil {
 			return fmt.Errorf("daemon login failed: %v", err)
 		}
 	}
@@ -238,116 +234,59 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager
 	return nil
 }
 
-func setupSetConfigFromUpCmd(cmd *cobra.Command) (*proto.SetConfigRequest, error) {
-	req := proto.SetConfigRequest{
-		NatExternalIPs:      natExternalIPs,
-		ExtraIFaceBlacklist: extraIFaceBlackList,
-		DnsLabels:           dnsLabelsValidated.ToPunycodeList(),
-		CleanDNSLabels:      dnsLabels != nil && len(dnsLabels) == 0,
-		CleanNATExternalIPs: natExternalIPs != nil && len(natExternalIPs) == 0,
+func setupSetConfigFromConfigInput(cmd *cobra.Command, ic *profilemanager.ConfigInput) *proto.SetConfigRequest {
+	req := &proto.SetConfigRequest{
+		ManagementUrl:                 ic.ManagementURL,
+		AdminURL:                      ic.AdminURL,
+		NatExternalIPs:                ic.NATExternalIPs,
+		ExtraIFaceBlacklist:           ic.ExtraIFaceBlackList,
+		CustomDNSAddress:              ic.CustomDNSAddress,
+		DnsLabels:                     ic.DNSLabels.ToPunycodeList(),
+		CleanDNSLabels:                ic.DNSLabels != nil && len(ic.DNSLabels) == 0,
+		CleanNATExternalIPs:           ic.NATExternalIPs != nil && len(ic.NATExternalIPs) == 0,
+		RosenpassEnabled:              ic.RosenpassEnabled,
+		RosenpassPermissive:           ic.RosenpassPermissive,
+		ServerSSHAllowed:              ic.ServerSSHAllowed,
+		EnableSSHRoot:                 ic.EnableSSHRoot,
+		EnableSSHSFTP:                 ic.EnableSSHSFTP,
+		EnableSSHLocalPortForwarding:  ic.EnableSSHLocalPortForwarding,
+		EnableSSHRemotePortForwarding: ic.EnableSSHRemotePortForwarding,
+		DisableSSHAuth:                ic.DisableSSHAuth,
+		InterfaceName:                 ic.InterfaceName,
+		NetworkMonitor:                ic.NetworkMonitor,
+		DisableAutoConnect:            ic.DisableAutoConnect,
+		DisableClientRoutes:           ic.DisableClientRoutes,
+		DisableServerRoutes:           ic.DisableServerRoutes,
+		DisableDns:                    ic.DisableDNS,
+		DisableFirewall:               ic.DisableFirewall,
+		BlockLanAccess:                ic.BlockLANAccess,
+		BlockInbound:                  ic.BlockInbound,
+		DisableNotifications:          ic.DisableNotifications,
+		LazyConnectionEnabled:         ic.LazyConnectionEnabled,
+		OptionalPreSharedKey:          ic.PreSharedKey,
 	}
 
-	if cmd.Flag(dnsResolverAddress).Changed {
-		var err error
-		req.CustomDNSAddress, err = parseDNSAddress(customDNSAddress)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if cmd.Flag(enableRosenpassFlag).Changed {
-		req.RosenpassEnabled = &rosenpassEnabled
-	}
-	if cmd.Flag(rosenpassPermissiveFlag).Changed {
-		req.RosenpassPermissive = &rosenpassPermissive
-	}
-	if cmd.Flag(serverSSHAllowedFlag).Changed {
-		req.ServerSSHAllowed = &serverSSHAllowed
-	}
-	if cmd.Flag(enableSSHRootFlag).Changed {
-		req.EnableSSHRoot = &enableSSHRoot
-	}
-	if cmd.Flag(enableSSHSFTPFlag).Changed {
-		req.EnableSSHSFTP = &enableSSHSFTP
-	}
-	if cmd.Flag(enableSSHLocalPortForwardFlag).Changed {
-		req.EnableSSHLocalPortForwarding = &enableSSHLocalPortForward
-	}
-	if cmd.Flag(enableSSHRemotePortForwardFlag).Changed {
-		req.EnableSSHRemotePortForwarding = &enableSSHRemotePortForward
-	}
-	if cmd.Flag(disableSSHAuthFlag).Changed {
-		req.DisableSSHAuth = &disableSSHAuth
-	}
-	if cmd.Flag(sshJWTCacheTTLFlag).Changed {
-		sshJWTCacheTTL32 := int32(sshJWTCacheTTL)
-		req.SshJWTCacheTTL = &sshJWTCacheTTL32
-	}
-	if cmd.Flag(interfaceNameFlag).Changed {
-		if err := parseInterfaceName(interfaceName); err != nil {
-			log.Errorf("parse interface name: %v", err)
-			return nil, err
-		}
-		req.InterfaceName = &interfaceName
-	}
-	if cmd.Flag(wireguardPortFlag).Changed {
-		p := int64(wireguardPort)
+	// Type conversions needed
+	if ic.WireguardPort != nil {
+		p := int64(*ic.WireguardPort)
 		req.WireguardPort = &p
 	}
-
-	if cmd.Flag(mtuFlag).Changed {
-		if err := iface.ValidateMTU(mtu); err != nil {
-			return nil, err
-		}
-		m := int64(mtu)
+	if ic.MTU != nil {
+		m := int64(*ic.MTU)
 		req.Mtu = &m
 	}
-
-	if cmd.Flag(networkMonitorFlag).Changed {
-		req.NetworkMonitor = &networkMonitor
+	if ic.SSHJWTCacheTTL != nil {
+		ttl := int32(*ic.SSHJWTCacheTTL)
+		req.SshJWTCacheTTL = &ttl
 	}
-
-	if cmd.Flag(disableAutoConnectFlag).Changed {
-		req.DisableAutoConnect = &autoConnectDisabled
+	if ic.DNSRouteInterval != nil {
+		req.DnsRouteInterval = durationpb.New(*ic.DNSRouteInterval)
 	}
-
-	if cmd.Flag(dnsRouteIntervalFlag).Changed {
-		req.DnsRouteInterval = durationpb.New(dnsRouteInterval)
-	}
-
-	if cmd.Flag(disableClientRoutesFlag).Changed {
-		req.DisableClientRoutes = &disableClientRoutes
-	}
-
-	if cmd.Flag(disableServerRoutesFlag).Changed {
-		req.DisableServerRoutes = &disableServerRoutes
-	}
-
-	if cmd.Flag(disableDNSFlag).Changed {
-		req.DisableDns = &disableDNS
-	}
-
-	if cmd.Flag(disableFirewallFlag).Changed {
-		req.DisableFirewall = &disableFirewall
-	}
-
-	if cmd.Flag(blockLANAccessFlag).Changed {
-		req.BlockLanAccess = &blockLANAccess
-	}
-
-	if cmd.Flag(blockInboundFlag).Changed {
-		req.BlockInbound = &blockInbound
-	}
-
 	if cmd.Flag(disableIPv6Flag).Changed {
 		req.DisableIpv6 = &disableIPv6
 	}
 
-	if cmd.Flag(enableLazyConnectionFlag).Changed {
-		req.LazyConnectionEnabled = &lazyConnEnabled
-	}
-
-	return &req, nil
+	return &req
 }
 
 func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput, error) {
@@ -471,121 +410,61 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 	return &ic, nil
 }
 
-func setupLoginRequestFromUpCmd(cmd *cobra.Command) (*proto.LoginRequest, error) {
-	loginRequest := proto.LoginRequest{
-		NatExternalIPs:      natExternalIPs,
-		CleanNATExternalIPs: natExternalIPs != nil && len(natExternalIPs) == 0,
-		ExtraIFaceBlacklist: extraIFaceBlackList,
-		DnsLabels:           dnsLabelsValidated.ToPunycodeList(),
-		CleanDNSLabels:      dnsLabels != nil && len(dnsLabels) == 0,
+func setupLoginRequestFromConfigInput(cmd *cobra.Command, ic *profilemanager.ConfigInput) *proto.LoginRequest {
+	req := &proto.LoginRequest{
+		ManagementUrl:                 ic.ManagementURL,
+		AdminURL:                      ic.AdminURL,
+		NatExternalIPs:                ic.NATExternalIPs,
+		CleanNATExternalIPs:           ic.NATExternalIPs != nil && len(ic.NATExternalIPs) == 0,
+		ExtraIFaceBlacklist:           ic.ExtraIFaceBlackList,
+		CustomDNSAddress:              ic.CustomDNSAddress,
+		DnsLabels:                     ic.DNSLabels.ToPunycodeList(),
+		CleanDNSLabels:                ic.DNSLabels != nil && len(ic.DNSLabels) == 0,
+		RosenpassEnabled:              ic.RosenpassEnabled,
+		RosenpassPermissive:           ic.RosenpassPermissive,
+		ServerSSHAllowed:              ic.ServerSSHAllowed,
+		EnableSSHRoot:                 ic.EnableSSHRoot,
+		EnableSSHSFTP:                 ic.EnableSSHSFTP,
+		EnableSSHLocalPortForwarding:  ic.EnableSSHLocalPortForwarding,
+		EnableSSHRemotePortForwarding: ic.EnableSSHRemotePortForwarding,
+		DisableSSHAuth:                ic.DisableSSHAuth,
+		InterfaceName:                 ic.InterfaceName,
+		NetworkMonitor:                ic.NetworkMonitor,
+		DisableAutoConnect:            ic.DisableAutoConnect,
+		DisableClientRoutes:           ic.DisableClientRoutes,
+		DisableServerRoutes:           ic.DisableServerRoutes,
+		DisableDns:                    ic.DisableDNS,
+		DisableFirewall:               ic.DisableFirewall,
+		BlockLanAccess:                ic.BlockLANAccess,
+		BlockInbound:                  ic.BlockInbound,
+		DisableNotifications:          ic.DisableNotifications,
+		LazyConnectionEnabled:         ic.LazyConnectionEnabled,
 	}
 
-	if cmd.Flag(dnsResolverAddress).Changed {
-		var err error
-		loginRequest.CustomDNSAddress, err = parseDNSAddress(customDNSAddress)
-		if err != nil {
-			return nil, err
-		}
+	// Type conversions needed
+	if ic.WireguardPort != nil {
+		p := int64(*ic.WireguardPort)
+		req.WireguardPort = &p
 	}
-
-	if cmd.Flag(enableRosenpassFlag).Changed {
-		loginRequest.RosenpassEnabled = &rosenpassEnabled
+	if ic.MTU != nil {
+		m := int64(*ic.MTU)
+		req.Mtu = &m
 	}
-
-	if cmd.Flag(rosenpassPermissiveFlag).Changed {
-		loginRequest.RosenpassPermissive = &rosenpassPermissive
+	if ic.SSHJWTCacheTTL != nil {
+		ttl := int32(*ic.SSHJWTCacheTTL)
+		req.SshJWTCacheTTL = &ttl
 	}
-
-	if cmd.Flag(serverSSHAllowedFlag).Changed {
-		loginRequest.ServerSSHAllowed = &serverSSHAllowed
+	if ic.DNSRouteInterval != nil {
+		req.DnsRouteInterval = durationpb.New(*ic.DNSRouteInterval)
 	}
-
-	if cmd.Flag(enableSSHRootFlag).Changed {
-		loginRequest.EnableSSHRoot = &enableSSHRoot
+	if ic.PreSharedKey != nil {
+		req.OptionalPreSharedKey = ic.PreSharedKey
 	}
-
-	if cmd.Flag(enableSSHSFTPFlag).Changed {
-		loginRequest.EnableSSHSFTP = &enableSSHSFTP
-	}
-
-	if cmd.Flag(enableSSHLocalPortForwardFlag).Changed {
-		loginRequest.EnableSSHLocalPortForwarding = &enableSSHLocalPortForward
-	}
-
-	if cmd.Flag(enableSSHRemotePortForwardFlag).Changed {
-		loginRequest.EnableSSHRemotePortForwarding = &enableSSHRemotePortForward
-	}
-
-	if cmd.Flag(disableSSHAuthFlag).Changed {
-		loginRequest.DisableSSHAuth = &disableSSHAuth
-	}
-
-	if cmd.Flag(sshJWTCacheTTLFlag).Changed {
-		sshJWTCacheTTL32 := int32(sshJWTCacheTTL)
-		loginRequest.SshJWTCacheTTL = &sshJWTCacheTTL32
-	}
-
-	if cmd.Flag(disableAutoConnectFlag).Changed {
-		loginRequest.DisableAutoConnect = &autoConnectDisabled
-	}
-
-	if cmd.Flag(interfaceNameFlag).Changed {
-		if err := parseInterfaceName(interfaceName); err != nil {
-			return nil, err
-		}
-		loginRequest.InterfaceName = &interfaceName
-	}
-
-	if cmd.Flag(wireguardPortFlag).Changed {
-		wp := int64(wireguardPort)
-		loginRequest.WireguardPort = &wp
-	}
-
-	if cmd.Flag(mtuFlag).Changed {
-		if err := iface.ValidateMTU(mtu); err != nil {
-			return nil, err
-		}
-		m := int64(mtu)
-		loginRequest.Mtu = &m
-	}
-
-	if cmd.Flag(networkMonitorFlag).Changed {
-		loginRequest.NetworkMonitor = &networkMonitor
-	}
-
-	if cmd.Flag(dnsRouteIntervalFlag).Changed {
-		loginRequest.DnsRouteInterval = durationpb.New(dnsRouteInterval)
-	}
-
-	if cmd.Flag(disableClientRoutesFlag).Changed {
-		loginRequest.DisableClientRoutes = &disableClientRoutes
-	}
-	if cmd.Flag(disableServerRoutesFlag).Changed {
-		loginRequest.DisableServerRoutes = &disableServerRoutes
-	}
-	if cmd.Flag(disableDNSFlag).Changed {
-		loginRequest.DisableDns = &disableDNS
-	}
-	if cmd.Flag(disableFirewallFlag).Changed {
-		loginRequest.DisableFirewall = &disableFirewall
-	}
-
-	if cmd.Flag(blockLANAccessFlag).Changed {
-		loginRequest.BlockLanAccess = &blockLANAccess
-	}
-
-	if cmd.Flag(blockInboundFlag).Changed {
-		loginRequest.BlockInbound = &blockInbound
-	}
-
 	if cmd.Flag(disableIPv6Flag).Changed {
 		loginRequest.DisableIpv6 = &disableIPv6
 	}
 
-	if cmd.Flag(enableLazyConnectionFlag).Changed {
-		loginRequest.LazyConnectionEnabled = &lazyConnEnabled
-	}
-	return &loginRequest, nil
+	return req
 }
 
 func validateNATExternalIPs(list []string) error {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -141,7 +141,7 @@ func upFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	// getActiveProfile will also switch the profile if needed
-	activeProf, err := getActiveProfile(cmd.Context(), pm, profileName, username.Username)
+	activeProf, err := getActiveProfile(ctx, pm, profileName, username.Username)
 	if err != nil {
 		return fmt.Errorf("get active profile: %v", err)
 	}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -53,7 +53,6 @@ const (
 var (
 	foregroundMode      bool
 	dnsLabels           []string
-	dnsLabelsValidated  domain.List
 	extraIFaceBlackList []string
 	natExternalIPs      []string
 	customDNSAddress    string
@@ -128,16 +127,6 @@ func upFunc(cmd *cobra.Command, args []string) error {
 	err := util.InitLog(logLevel, util.LogConsole)
 	if err != nil {
 		return fmt.Errorf("failed initializing log %v", err)
-	}
-
-	err = validateNATExternalIPs(natExternalIPs)
-	if err != nil {
-		return err
-	}
-
-	dnsLabelsValidated, err = validateDnsLabels(dnsLabels)
-	if err != nil {
-		return err
 	}
 
 	ctx := internal.CtxInitState(cmd.Context())
@@ -293,7 +282,18 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 	ic := profilemanager.ConfigInput{
 		NATExternalIPs:      natExternalIPs,
 		ExtraIFaceBlackList: extraIFaceBlackList,
-		DNSLabels:           dnsLabelsValidated,
+	}
+
+	if err := validateNATExternalIPs(natExternalIPs); err != nil {
+		return nil, err
+	}
+
+	if dnsLabels != nil {
+		var err error
+		ic.DNSLabels, err = validateDnsLabels(dnsLabels)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if cmd.Flag(dnsResolverAddress).Changed {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -293,27 +293,35 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 	if cmd.Flag(enableRosenpassFlag).Changed {
 		ic.RosenpassEnabled = &rosenpassEnabled
 	}
+
 	if cmd.Flag(rosenpassPermissiveFlag).Changed {
 		ic.RosenpassPermissive = &rosenpassPermissive
 	}
+
 	if cmd.Flag(serverSSHAllowedFlag).Changed {
 		ic.ServerSSHAllowed = &serverSSHAllowed
 	}
+
 	if cmd.Flag(enableSSHRootFlag).Changed {
 		ic.EnableSSHRoot = &enableSSHRoot
 	}
+
 	if cmd.Flag(enableSSHSFTPFlag).Changed {
 		ic.EnableSSHSFTP = &enableSSHSFTP
 	}
+
 	if cmd.Flag(enableSSHLocalPortForwardFlag).Changed {
 		ic.EnableSSHLocalPortForwarding = &enableSSHLocalPortForward
 	}
+
 	if cmd.Flag(enableSSHRemotePortForwardFlag).Changed {
 		ic.EnableSSHRemotePortForwarding = &enableSSHRemotePortForward
 	}
+
 	if cmd.Flag(disableSSHAuthFlag).Changed {
 		ic.DisableSSHAuth = &disableSSHAuth
 	}
+
 	if cmd.Flag(sshJWTCacheTTLFlag).Changed {
 		ic.SSHJWTCacheTTL = &sshJWTCacheTTL
 	}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -153,46 +153,21 @@ func upFunc(cmd *cobra.Command, args []string) error {
 }
 
 func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile) error {
-	// override the default profile filepath if provided
-	if configPath != "" {
-		_ = profilemanager.NewServiceManager(configPath)
-	}
-
-	err := handleRebrand(cmd)
-	if err != nil {
-		return err
-	}
-
 	customDNSAddressConverted, err := parseCustomDNSAddress(cmd.Flag(dnsResolverAddress).Changed)
 	if err != nil {
 		return err
 	}
 
-	configFilePath, err := activeProf.FilePath()
-	if err != nil {
-		return fmt.Errorf("get active profile file path: %v", err)
-	}
-
-	ic, err := setupConfig(customDNSAddressConverted, cmd, configFilePath)
+	ic, err := setupConfigInputFromUpCmd(cmd)
 	if err != nil {
 		return fmt.Errorf("setup config: %v", err)
 	}
 
-	providedSetupKey, err := getSetupKey()
+	ic.CustomDNSAddress = customDNSAddressConverted
+
+	config, err := doForegroundLogin(ctx, cmd, activeProf, ic)
 	if err != nil {
 		return err
-	}
-
-	config, err := profilemanager.UpdateOrCreateConfig(*ic)
-	if err != nil {
-		return fmt.Errorf("get config file: %v", err)
-	}
-
-	_, _ = profilemanager.UpdateOldManagementURL(ctx, config, configFilePath)
-
-	err = foregroundLogin(ctx, cmd, config, providedSetupKey, activeProf.Name)
-	if err != nil {
-		return fmt.Errorf("foreground login failed: %v", err)
 	}
 
 	var cancel context.CancelFunc
@@ -446,15 +421,8 @@ func setupSetConfigReq(customDNSAddressConverted []byte, cmd *cobra.Command, pro
 	return &req
 }
 
-func setupConfig(customDNSAddressConverted []byte, cmd *cobra.Command, configFilePath string) (*profilemanager.ConfigInput, error) {
-	ic := profilemanager.ConfigInput{
-		ManagementURL:       managementURL,
-		ConfigPath:          configFilePath,
-		NATExternalIPs:      natExternalIPs,
-		CustomDNSAddress:    customDNSAddressConverted,
-		ExtraIFaceBlackList: extraIFaceBlackList,
-		DNSLabels:           dnsLabelsValidated,
-	}
+func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput, error) {
+	var ic profilemanager.ConfigInput
 
 	if cmd.Flag(enableRosenpassFlag).Changed {
 		ic.RosenpassEnabled = &rosenpassEnabled

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -277,16 +277,14 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 
 	if dnsLabels != nil {
 		var err error
-		ic.DNSLabels, err = validateDnsLabels(dnsLabels)
-		if err != nil {
+		if ic.DNSLabels, err = validateDnsLabels(dnsLabels); err != nil {
 			return nil, err
 		}
 	}
 
 	if cmd.Flag(dnsResolverAddress).Changed {
 		var err error
-		ic.CustomDNSAddress, err = parseDNSAddress(customDNSAddress)
-		if err != nil {
+		if ic.CustomDNSAddress, err = parseDNSAddress(customDNSAddress); err != nil {
 			return nil, err
 		}
 	}
@@ -352,12 +350,9 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 
 	if cmd.Flag(disableAutoConnectFlag).Changed {
 		ic.DisableAutoConnect = &autoConnectDisabled
-
 		if autoConnectDisabled {
 			cmd.Println("Autoconnect has been disabled. The client won't connect automatically when the service starts.")
-		}
-
-		if !autoConnectDisabled {
+		} else {
 			cmd.Println("Autoconnect has been enabled. The client will connect automatically when the service starts.")
 		}
 	}
@@ -369,12 +364,15 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 	if cmd.Flag(disableClientRoutesFlag).Changed {
 		ic.DisableClientRoutes = &disableClientRoutes
 	}
+
 	if cmd.Flag(disableServerRoutesFlag).Changed {
 		ic.DisableServerRoutes = &disableServerRoutes
 	}
+
 	if cmd.Flag(disableDNSFlag).Changed {
 		ic.DisableDNS = &disableDNS
 	}
+
 	if cmd.Flag(disableFirewallFlag).Changed {
 		ic.DisableFirewall = &disableFirewall
 	}

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -209,20 +209,24 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager
 		return err
 	}
 
-	if err := doDaemonSetup(ctx, cmd, client, profileSwitched, setConfigReq); err != nil {
+	alreadyConnected, err := doDaemonSetup(ctx, cmd, client, profileSwitched, setConfigReq)
+	if err != nil {
 		return fmt.Errorf("daemon setup failed: %v", err)
 	}
 
-	// login
-	loginReq, err := setupLoginRequestFromUpCmd(cmd)
-	if err != nil {
-		return err
+	// login if not already connected
+	if !alreadyConnected {
+		loginReq, err := setupLoginRequestFromUpCmd(cmd)
+		if err != nil {
+			return err
+		}
+
+		if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, loginReq); err != nil {
+			return fmt.Errorf("daemon login failed: %v", err)
+		}
 	}
 
-	if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, loginReq); err != nil {
-		return fmt.Errorf("daemon login failed: %v", err)
-	}
-
+	// up the service
 	if _, err := client.Up(ctx, &proto.UpRequest{
 		ProfileName: &activeProf.Name,
 		Username:    &username,

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -135,7 +135,6 @@ func upFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	pm := profilemanager.NewProfileManager()
-
 	username, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("get current user: %v", err)
@@ -147,13 +146,11 @@ func upFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get active profile: %v", err)
 	}
 
-	// if non-empty profileName, this means that we switched profile
-	profileSwitched := profileName != ""
-
 	if foregroundMode {
 		return runInForegroundMode(ctx, cmd, activeProf)
 	}
-	return runInDaemonMode(ctx, cmd, pm, activeProf, profileSwitched)
+
+	return runInDaemonMode(ctx, cmd, pm, activeProf)
 }
 
 func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile) error {
@@ -180,7 +177,7 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *pr
 	return connectClient.Run(nil, util.FindFirstLogPath(logFiles))
 }
 
-func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager.ProfileManager, activeProf *profilemanager.Profile, profileSwitched bool) error {
+func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager.ProfileManager, activeProf *profilemanager.Profile) error {
 	// get our config input, so we can generate
 	// proto.SetConfig and proto.LoginRequest
 	ic, err := setupConfigInputFromUpCmd(cmd)
@@ -188,28 +185,17 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager
 		return fmt.Errorf("setup config: %v", err)
 	}
 
-	client, err := doDaemonLogin(ctx, cmd, activeProf, pm, profileSwitched, ic)
+	// setup client
+	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {
-<<<<<<< HEAD
 		return fmt.Errorf("connect to service CLI interface: %w", err)
 	}
 	defer conn.Close()
 	client := proto.NewDaemonServiceClient(conn)
 
-	// setup daemon
-	alreadyConnected, err := doDaemonSetup(ctx, cmd, client, profileSwitched, setupSetConfigFromConfigInput(cmd, ic))
-	if err != nil {
-		return fmt.Errorf("daemon setup failed: %v", err)
-	}
-
-	// login if not already connected
-	if !alreadyConnected {
-		if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, setupLoginRequestFromConfigInput(cmd, ic)); err != nil {
-			return fmt.Errorf("daemon login failed: %v", err)
-		}
-=======
+	// do login
+	if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, ic); err != nil {
 		return err
->>>>>>> 20f4fcd4d (use configinput in general and convert it around, much cleaner)
 	}
 
 	// up the service

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -207,14 +207,21 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *pr
 }
 
 func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager.ProfileManager, activeProf *profilemanager.Profile, profileSwitched bool) error {
+	// setup grpc connection
+	conn, err := DialClientGRPCServer(ctx, daemonAddr)
+	if err != nil {
+		return fmt.Errorf("connect to service CLI interface: %w", err)
+	}
+	defer conn.Close()
+	client := proto.NewDaemonServiceClient(conn)
+
 	// setup daemon
 	setConfigReq, err := setupSetConfigFromUpCmd(cmd)
 	if err != nil {
 		return err
 	}
 
-	client, err := doDaemonSetup(ctx, cmd, activeProf, pm, profileSwitched, setConfigReq)
-	if err != nil {
+	if err := doDaemonSetup(ctx, cmd, client, profileSwitched, setConfigReq); err != nil {
 		return fmt.Errorf("daemon setup failed: %v", err)
 	}
 

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -12,9 +12,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc/codes"
 
-	gstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/netbirdio/netbird/client/iface"
@@ -185,17 +183,10 @@ func upFunc(cmd *cobra.Command, args []string) error {
 }
 
 func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile) error {
-	customDNSAddressConverted, err := parseCustomDNSAddress(cmd.Flag(dnsResolverAddress).Changed)
-	if err != nil {
-		return err
-	}
-
 	ic, err := setupConfigInputFromUpCmd(cmd)
 	if err != nil {
 		return fmt.Errorf("setup config: %v", err)
 	}
-
-	ic.CustomDNSAddress = customDNSAddressConverted
 
 	config, err := doForegroundLogin(ctx, cmd, activeProf, ic)
 	if err != nil {
@@ -216,123 +207,25 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *pr
 }
 
 func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager.ProfileManager, activeProf *profilemanager.Profile, profileSwitched bool) error {
-	// Check if deprecated config flag is set and show warning
-	if cmd.Flag("config").Changed && configPath != "" {
-		cmd.PrintErrf("Warning: Config flag is deprecated on up command, it should be set as a service argument with $NB_CONFIG environment or with \"-config\" flag; netbird service reconfigure --service-env=\"NB_CONFIG=<file_path>\" or netbird service run --config=<file_path>\n")
-	}
-
-	customDNSAddressConverted, err := parseCustomDNSAddress(cmd.Flag(dnsResolverAddress).Changed)
+	// setup daemon
+	setConfigReq, err := setupSetConfigFromUpCmd(cmd)
 	if err != nil {
-		return fmt.Errorf("parse custom DNS address: %v", err)
+		return err
 	}
 
-	conn, err := DialClientGRPCServer(ctx, daemonAddr)
+	client, err := doDaemonSetup(ctx, cmd, activeProf, pm, profileSwitched, setConfigReq)
 	if err != nil {
-		//nolint
-		return fmt.Errorf("failed to connect to daemon error: %v\n"+
-			"If the daemon is not running please run: "+
-			"\nnetbird service install \nnetbird service start\n", err)
+		return fmt.Errorf("daemon setup failed: %v", err)
 	}
-	defer func() {
-		err := conn.Close()
-		if err != nil {
-			log.Warnf("failed closing daemon gRPC client connection %v", err)
-			return
-		}
-	}()
 
-	client := proto.NewDaemonServiceClient(conn)
-
-	status, err := client.Status(ctx, &proto.StatusRequest{
-		WaitForReady: func() *bool { b := true; return &b }(),
-	})
+	// login
+	loginReq, err := setupLoginRequestFromUpCmd(cmd)
 	if err != nil {
-		return fmt.Errorf("unable to get daemon status: %v", err)
+		return err
 	}
 
-	if status.Status == string(internal.StatusConnected) {
-		if !profileSwitched {
-			cmd.Println("Already connected")
-			return nil
-		}
-
-		if _, err := client.Down(ctx, &proto.DownRequest{}); err != nil {
-			log.Errorf("call service down method: %v", err)
-			return err
-		}
-	}
-
-	username, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("get current user: %v", err)
-	}
-
-	// set the new config
-	req := setupSetConfigReq(customDNSAddressConverted, cmd, activeProf.Name, username.Username)
-	if _, err := client.SetConfig(ctx, req); err != nil {
-		if st, ok := gstatus.FromError(err); ok && st.Code() == codes.Unavailable {
-			log.Warnf("setConfig method is not available in the daemon")
-		} else {
-			return fmt.Errorf("call service setConfig method: %v", err)
-		}
-	}
-
-	if err := doDaemonUp(ctx, cmd, client, pm, activeProf, customDNSAddressConverted, username.Username); err != nil {
-		return fmt.Errorf("daemon up failed: %v", err)
-	}
-	cmd.Println("Connected")
-	return nil
-}
-
-func doDaemonUp(ctx context.Context, cmd *cobra.Command, client proto.DaemonServiceClient, pm *profilemanager.ProfileManager, activeProf *profilemanager.Profile, customDNSAddressConverted []byte, username string) error {
-
-	providedSetupKey, err := getSetupKey()
-	if err != nil {
-		return fmt.Errorf("get setup key: %v", err)
-	}
-
-	loginRequest, err := setupLoginRequest(providedSetupKey, customDNSAddressConverted, cmd)
-	if err != nil {
-		return fmt.Errorf("setup login request: %v", err)
-	}
-
-	loginRequest.ProfileName = &activeProf.Name
-	loginRequest.Username = &username
-
-	profileState, err := pm.GetProfileState(activeProf.Name)
-	if err != nil {
-		log.Debugf("failed to get profile state for login hint: %v", err)
-	} else if profileState.Email != "" {
-		loginRequest.Hint = &profileState.Email
-	}
-
-	var loginErr error
-	var loginResp *proto.LoginResponse
-
-	err = WithBackOff(func() error {
-		var backOffErr error
-		loginResp, backOffErr = client.Login(ctx, loginRequest)
-		if s, ok := gstatus.FromError(backOffErr); ok && (s.Code() == codes.InvalidArgument ||
-			s.Code() == codes.PermissionDenied ||
-			s.Code() == codes.NotFound ||
-			s.Code() == codes.Unimplemented) {
-			loginErr = backOffErr
-			return nil
-		}
-		return backOffErr
-	})
-	if err != nil {
-		return fmt.Errorf("login backoff cycle failed: %v", err)
-	}
-
-	if loginErr != nil {
-		return fmt.Errorf("login failed: %v", loginErr)
-	}
-
-	if loginResp.NeedsSSOLogin {
-		if err := handleSSOLogin(ctx, cmd, loginResp, client, pm); err != nil {
-			return fmt.Errorf("sso login failed: %v", err)
-		}
+	if err := doDaemonLogin(ctx, cmd, client, activeProf, pm, loginReq); err != nil {
+		return fmt.Errorf("daemon login failed: %v", err)
 	}
 
 	if _, err := client.Up(ctx, &proto.UpRequest{
@@ -342,22 +235,26 @@ func doDaemonUp(ctx context.Context, cmd *cobra.Command, client proto.DaemonServ
 		return fmt.Errorf("call service up method: %v", err)
 	}
 
+	cmd.Println("Connected")
 	return nil
 }
 
-func setupSetConfigReq(customDNSAddressConverted []byte, cmd *cobra.Command, profileName, username string) *proto.SetConfigRequest {
+func setupSetConfigFromUpCmd(cmd *cobra.Command) (*proto.SetConfigRequest, error) {
 	var req proto.SetConfigRequest
-	req.ProfileName = profileName
-	req.Username = username
 
-	req.ManagementUrl = managementURL
-	req.AdminURL = adminURL
 	req.NatExternalIPs = natExternalIPs
-	req.CustomDNSAddress = customDNSAddressConverted
 	req.ExtraIFaceBlacklist = extraIFaceBlackList
 	req.DnsLabels = dnsLabelsValidated.ToPunycodeList()
 	req.CleanDNSLabels = dnsLabels != nil && len(dnsLabels) == 0
 	req.CleanNATExternalIPs = natExternalIPs != nil && len(natExternalIPs) == 0
+
+	if cmd.Flag(dnsResolverAddress).Changed {
+		var err error
+		req.CustomDNSAddress, err = parseDNSAddress(customDNSAddress)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if cmd.Flag(enableRosenpassFlag).Changed {
 		req.RosenpassEnabled = &rosenpassEnabled
@@ -390,7 +287,7 @@ func setupSetConfigReq(customDNSAddressConverted []byte, cmd *cobra.Command, pro
 	if cmd.Flag(interfaceNameFlag).Changed {
 		if err := parseInterfaceName(interfaceName); err != nil {
 			log.Errorf("parse interface name: %v", err)
-			return nil
+			return nil, nil
 		}
 		req.InterfaceName = &interfaceName
 	}
@@ -407,9 +304,7 @@ func setupSetConfigReq(customDNSAddressConverted []byte, cmd *cobra.Command, pro
 	if cmd.Flag(networkMonitorFlag).Changed {
 		req.NetworkMonitor = &networkMonitor
 	}
-	if rootCmd.PersistentFlags().Changed(preSharedKeyFlag) {
-		req.OptionalPreSharedKey = &preSharedKey
-	}
+
 	if cmd.Flag(disableAutoConnectFlag).Changed {
 		req.DisableAutoConnect = &autoConnectDisabled
 	}
@@ -450,7 +345,7 @@ func setupSetConfigReq(customDNSAddressConverted []byte, cmd *cobra.Command, pro
 		req.LazyConnectionEnabled = &lazyConnEnabled
 	}
 
-	return &req
+	return &req, nil
 }
 
 func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput, error) {
@@ -458,6 +353,14 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 		NATExternalIPs:      natExternalIPs,
 		ExtraIFaceBlackList: extraIFaceBlackList,
 		DNSLabels:           dnsLabelsValidated,
+	}
+
+	if cmd.Flag(dnsResolverAddress).Changed {
+		var err error
+		ic.CustomDNSAddress, err = parseDNSAddress(customDNSAddress)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if cmd.Flag(enableRosenpassFlag).Changed {
@@ -519,10 +422,6 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 		ic.NetworkMonitor = &networkMonitor
 	}
 
-	if rootCmd.PersistentFlags().Changed(preSharedKeyFlag) {
-		ic.PreSharedKey = &preSharedKey
-	}
-
 	if cmd.Flag(disableAutoConnectFlag).Changed {
 		ic.DisableAutoConnect = &autoConnectDisabled
 
@@ -570,22 +469,21 @@ func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput,
 	return &ic, nil
 }
 
-func setupLoginRequest(providedSetupKey string, customDNSAddressConverted []byte, cmd *cobra.Command) (*proto.LoginRequest, error) {
+func setupLoginRequestFromUpCmd(cmd *cobra.Command) (*proto.LoginRequest, error) {
 	loginRequest := proto.LoginRequest{
-		SetupKey:            providedSetupKey,
-		ManagementUrl:       managementURL,
 		NatExternalIPs:      natExternalIPs,
 		CleanNATExternalIPs: natExternalIPs != nil && len(natExternalIPs) == 0,
-		CustomDNSAddress:    customDNSAddressConverted,
-		IsUnixDesktopClient: isUnixRunningDesktop(),
-		Hostname:            hostName,
 		ExtraIFaceBlacklist: extraIFaceBlackList,
 		DnsLabels:           dnsLabels,
 		CleanDNSLabels:      dnsLabels != nil && len(dnsLabels) == 0,
 	}
 
-	if rootCmd.PersistentFlags().Changed(preSharedKeyFlag) {
-		loginRequest.OptionalPreSharedKey = &preSharedKey
+	if cmd.Flag(dnsResolverAddress).Changed {
+		var err error
+		loginRequest.CustomDNSAddress, err = parseDNSAddress(customDNSAddress)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if cmd.Flag(enableRosenpassFlag).Changed {
@@ -763,17 +661,15 @@ func isValidInterface(name string) (bool, error) {
 	return false, nil
 }
 
-func parseCustomDNSAddress(modified bool) ([]byte, error) {
+func parseDNSAddress(dnsAddress string) ([]byte, error) {
 	var parsed []byte
-	if modified {
-		if !isValidAddrPort(customDNSAddress) {
-			return nil, fmt.Errorf("%s is invalid, it should be formatted as IP:Port string or as an empty string like \"\"", customDNSAddress)
-		}
-		if customDNSAddress == "" && util.FindFirstLogPath(logFiles) != "" {
-			parsed = []byte("empty")
-		} else {
-			parsed = []byte(customDNSAddress)
-		}
+	if !isValidAddrPort(dnsAddress) {
+		return nil, fmt.Errorf("%s is invalid, it should be formatted as IP:Port string or as an empty string like \"\"", dnsAddress)
+	}
+	if dnsAddress == "" && util.FindFirstLogPath(logFiles) != "" {
+		parsed = []byte("empty")
+	} else {
+		parsed = []byte(dnsAddress)
 	}
 	return parsed, nil
 }

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -34,7 +34,14 @@ const (
 )
 
 const (
-	dnsLabelsFlag = "extra-dns-labels"
+	dnsLabelsFlag            = "extra-dns-labels"
+	extraIFaceBlackListFlag  = "extra-iface-blacklist"
+	externalIPMapFlag        = "external-ip-map"
+	dnsResolverAddress       = "dns-resolver-address"
+	enableRosenpassFlag      = "enable-rosenpass"
+	rosenpassPermissiveFlag  = "rosenpass-permissive"
+	disableAutoConnectFlag   = "disable-auto-connect"
+	enableLazyConnectionFlag = "enable-lazy-connection"
 
 	noBrowserFlag = "no-browser"
 	noBrowserDesc = "do not open the browser for SSO login"
@@ -47,13 +54,20 @@ const (
 )
 
 var (
-	foregroundMode     bool
-	dnsLabels          []string
-	dnsLabelsValidated domain.List
-	noBrowser          bool
-	showQR             bool
-	profileName        string
-	configPath         string
+	foregroundMode      bool
+	dnsLabels           []string
+	dnsLabelsValidated  domain.List
+	extraIFaceBlackList []string
+	natExternalIPs      []string
+	customDNSAddress    string
+	rosenpassEnabled    bool
+	rosenpassPermissive bool
+	autoConnectDisabled bool
+	lazyConnEnabled     bool
+	noBrowser           bool
+	showQR              bool
+	profileName         string
+	configPath          string
 
 	upCmd = &cobra.Command{
 		Use:   "up",
@@ -87,6 +101,24 @@ func init() {
 	upCmd.PersistentFlags().BoolVar(&showQR, showQRFlag, false, showQRDesc)
 	upCmd.PersistentFlags().StringVar(&profileName, profileNameFlag, "", profileNameDesc)
 	upCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "(DEPRECATED) NetBird config file location. ")
+
+	upCmd.PersistentFlags().StringSliceVar(&natExternalIPs, externalIPMapFlag, nil,
+		`Sets external IPs maps between local addresses and interfaces.`+
+			`You can specify a comma-separated list with a single IP and IP/IP or IP/Interface Name. `+
+			`An empty string "" clears the previous configuration. `+
+			`E.g. --external-ip-map 12.34.56.78/10.0.0.1 or --external-ip-map 12.34.56.200,12.34.56.78/10.0.0.1,12.34.56.80/eth1 `+
+			`or --external-ip-map ""`,
+	)
+	upCmd.PersistentFlags().StringVar(&customDNSAddress, dnsResolverAddress, "",
+		`Sets a custom address for NetBird's local DNS resolver. `+
+			`If set, the agent won't attempt to discover the best ip and port to listen on. `+
+			`An empty string "" clears the previous configuration. `+
+			`E.g. --dns-resolver-address 127.0.0.1:5053 or --dns-resolver-address ""`,
+	)
+	upCmd.PersistentFlags().BoolVar(&rosenpassEnabled, enableRosenpassFlag, false, "[Experimental] Enable Rosenpass feature. If enabled, the connection will be post-quantum secured via Rosenpass.")
+	upCmd.PersistentFlags().BoolVar(&rosenpassPermissive, rosenpassPermissiveFlag, false, "[Experimental] Enable Rosenpass in permissive mode to allow this peer to accept WireGuard connections without requiring Rosenpass functionality from peers that do not have Rosenpass enabled.")
+	upCmd.PersistentFlags().BoolVar(&autoConnectDisabled, disableAutoConnectFlag, false, "Disables auto-connect feature. If enabled, then the client won't connect automatically when the service starts.")
+	upCmd.PersistentFlags().BoolVar(&lazyConnEnabled, enableLazyConnectionFlag, false, "[Experimental] Enable the lazy connection feature. If enabled, the client will establish connections on-demand. Note: this setting may be overridden by management configuration.")
 
 }
 

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/internal"
@@ -262,7 +263,7 @@ func setupSetConfigFromConfigInput(cmd *cobra.Command, ic *profilemanager.Config
 		req.DisableIpv6 = &disableIPv6
 	}
 
-	return &req
+	return req
 }
 
 func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput, error) {
@@ -446,7 +447,7 @@ func setupLoginRequestFromConfigInput(cmd *cobra.Command, ic *profilemanager.Con
 		req.OptionalPreSharedKey = ic.PreSharedKey
 	}
 	if cmd.Flag(disableIPv6Flag).Changed {
-		loginRequest.DisableIpv6 = &disableIPv6
+		req.DisableIpv6 = &disableIPv6
 	}
 
 	return req

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -454,7 +454,11 @@ func setupSetConfigReq(customDNSAddressConverted []byte, cmd *cobra.Command, pro
 }
 
 func setupConfigInputFromUpCmd(cmd *cobra.Command) (*profilemanager.ConfigInput, error) {
-	var ic profilemanager.ConfigInput
+	ic := profilemanager.ConfigInput{
+		NATExternalIPs:      natExternalIPs,
+		ExtraIFaceBlackList: extraIFaceBlackList,
+		DNSLabels:           dnsLabelsValidated,
+	}
 
 	if cmd.Flag(enableRosenpassFlag).Changed {
 		ic.RosenpassEnabled = &rosenpassEnabled

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -235,13 +235,13 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager
 }
 
 func setupSetConfigFromUpCmd(cmd *cobra.Command) (*proto.SetConfigRequest, error) {
-	var req proto.SetConfigRequest
-
-	req.NatExternalIPs = natExternalIPs
-	req.ExtraIFaceBlacklist = extraIFaceBlackList
-	req.DnsLabels = dnsLabelsValidated.ToPunycodeList()
-	req.CleanDNSLabels = dnsLabels != nil && len(dnsLabels) == 0
-	req.CleanNATExternalIPs = natExternalIPs != nil && len(natExternalIPs) == 0
+	req := proto.SetConfigRequest{
+		NatExternalIPs:      natExternalIPs,
+		ExtraIFaceBlacklist: extraIFaceBlackList,
+		DnsLabels:           dnsLabelsValidated.ToPunycodeList(),
+		CleanDNSLabels:      dnsLabels != nil && len(dnsLabels) == 0,
+		CleanNATExternalIPs: natExternalIPs != nil && len(natExternalIPs) == 0,
+	}
 
 	if cmd.Flag(dnsResolverAddress).Changed {
 		var err error
@@ -472,7 +472,7 @@ func setupLoginRequestFromUpCmd(cmd *cobra.Command) (*proto.LoginRequest, error)
 		NatExternalIPs:      natExternalIPs,
 		CleanNATExternalIPs: natExternalIPs != nil && len(natExternalIPs) == 0,
 		ExtraIFaceBlacklist: extraIFaceBlackList,
-		DnsLabels:           dnsLabels,
+		DnsLabels:           dnsLabelsValidated.ToPunycodeList(),
 		CleanDNSLabels:      dnsLabels != nil && len(dnsLabels) == 0,
 	}
 


### PR DESCRIPTION
## Describe your changes
Reopening because my previous PR was closed, because a new PR was merged, which doesn't resolve the issue I initially had. These changes still apply cleanly on top of the other PR :)

I've moved a bunch of logic from up, into login, and then reused it for both commands.

- Moved logic from up.go into login.go (reason for using login.go, was that up.go seemed to rely heavily on it anyways)
-  Moved flags from root.go into up.go, unsure why they were placed there
- login will now respect env
- login will now save the configuration


## Issue ticket number and link
Discussed it on Slack https://netbirdio.slack.com/archives/C02KHAE8VLZ/p1770216154715019

Previous PR https://github.com/netbirdio/netbird/pull/5263

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon-aware login that auto-selects foreground vs. daemon mode.
  * New up command flags for interface blacklist, external IP mapping, DNS resolver, Rosenpass, auto-connect and lazy-connection behavior.

* **Changes**
  * Unified config input for login and up flows; simplified daemon interactions.
  * CLI flags reorganized (some flags removed from root and surfaced/changed on up).
  * Deprecation warning when using --config with the service.
  * Updated success message: "Logged in successfully".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/5412)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->