### PR TITLE
[client] Add client-side support for mTLS.

### DIFF
--- a/client/grpc/dialer.go
+++ b/client/grpc/dialer.go
@@ -28,7 +28,7 @@ func Backoff(ctx context.Context) backoff.BackOff {
 
 // CreateConnection creates a gRPC client connection with the appropriate transport options.
 // The component parameter specifies the WebSocket proxy component path (e.g., "/management", "/signal").
-func CreateConnection(ctx context.Context, addr string, tlsEnabled bool, component string, extraOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+func CreateConnection(ctx context.Context, addr string, tlsEnabled bool, component string, clientCert *tls.Certificate, extraOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	transportOption := grpc.WithTransportCredentials(insecure.NewCredentials())
 	// for js, the outer websocket layer takes care of tls
 	if tlsEnabled && runtime.GOOS != "js" {
@@ -38,9 +38,19 @@ func CreateConnection(ctx context.Context, addr string, tlsEnabled bool, compone
 			certPool = embeddedroots.Get()
 		}
 
-		transportOption = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		tlsConfig := &tls.Config{
 			RootCAs: certPool,
-		}))
+		}
+
+		// Only add client certificate if provided
+		if clientCert != nil {
+			log.Tracef("Using client certificate for communication to backend component %s. mTLS enabled.", component)
+			tlsConfig.Certificates = []tls.Certificate{*clientCert}
+		} else {
+			log.Tracef("Client certificate (mTLS) not configured for %s", component)
+		}
+
+		transportOption = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 
 	connCtx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/client/internal/auth/auth.go
+++ b/client/internal/auth/auth.go
@@ -46,7 +46,7 @@ func NewAuth(ctx context.Context, privateKey string, mgmURL *url.URL, config *pr
 	mgmTLSEnabled := mgmURL.Scheme == "https"
 
 	log.Debugf("connecting to Management Service %s", mgmURL.String())
-	mgmClient, err := mgm.NewClient(ctx, mgmURL.Host, myPrivateKey, mgmTLSEnabled)
+	mgmClient, err := mgm.NewClient(ctx, mgmURL.Host, myPrivateKey, mgmTLSEnabled, config.MgmtClientCertKeyPair)
 	if err != nil {
 		log.Errorf("failed connecting to Management Service %s: %v", mgmURL.String(), err)
 		return nil, err
@@ -346,7 +346,7 @@ func (a *Auth) reconnect(ctx context.Context, brokenClient *mgm.GrpcClient) erro
 	// Create new connection FIRST, before closing the old one
 	// This ensures a.client is never nil, preventing panics in other threads
 	log.Debugf("reconnecting to Management Service %s", a.mgmURL.String())
-	mgmClient, err := mgm.NewClient(ctx, a.mgmURL.Host, a.privateKey, a.mgmTLSEnabled)
+	mgmClient, err := mgm.NewClient(ctx, a.mgmURL.Host, a.privateKey, a.mgmTLSEnabled, a.config.MgmtClientCertKeyPair)
 	if err != nil {
 		log.Errorf("failed reconnecting to Management Service %s: %v", a.mgmURL.String(), err)
 		// Keep the old client if reconnection fails

--- a/client/internal/auth/auth.go
+++ b/client/internal/auth/auth.go
@@ -46,7 +46,7 @@ func NewAuth(ctx context.Context, privateKey string, mgmURL *url.URL, config *pr
 	mgmTLSEnabled := mgmURL.Scheme == "https"
 
 	log.Debugf("connecting to Management Service %s", mgmURL.String())
-	mgmClient, err := mgm.NewClient(ctx, mgmURL.Host, myPrivateKey, mgmTLSEnabled, config.MgmtClientCertKeyPair)
+	mgmClient, err := mgm.NewClient(ctx, mgmURL.Host, myPrivateKey, mgmTLSEnabled, config.MgmtClientCert.KeyPair)
 	if err != nil {
 		log.Errorf("failed connecting to Management Service %s: %v", mgmURL.String(), err)
 		return nil, err
@@ -221,7 +221,7 @@ func (a *Auth) getPKCEFlow(client *mgm.GrpcClient) (*PKCEAuthorizationFlow, erro
 		Scope:                 protoConfig.GetScope(),
 		RedirectURLs:          protoConfig.GetRedirectURLs(),
 		UseIDToken:            protoConfig.GetUseIDToken(),
-		ClientCertPair:        a.config.ClientCertKeyPair,
+		ClientCertPair:        a.config.IDPClientCert.KeyPair,
 		DisablePromptLogin:    protoConfig.GetDisablePromptLogin(),
 		LoginFlag:             common.LoginFlag(protoConfig.GetLoginFlag()),
 	}
@@ -346,7 +346,7 @@ func (a *Auth) reconnect(ctx context.Context, brokenClient *mgm.GrpcClient) erro
 	// Create new connection FIRST, before closing the old one
 	// This ensures a.client is never nil, preventing panics in other threads
 	log.Debugf("reconnecting to Management Service %s", a.mgmURL.String())
-	mgmClient, err := mgm.NewClient(ctx, a.mgmURL.Host, a.privateKey, a.mgmTLSEnabled, a.config.MgmtClientCertKeyPair)
+	mgmClient, err := mgm.NewClient(ctx, a.mgmURL.Host, a.privateKey, a.mgmTLSEnabled, a.config.MgmtClientCert.KeyPair)
 	if err != nil {
 		log.Errorf("failed reconnecting to Management Service %s: %v", a.mgmURL.String(), err)
 		// Keep the old client if reconnection fails

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -251,7 +252,7 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 		}()
 
 		log.Debugf("connecting to the Management service %s", c.config.ManagementURL.Host)
-		mgmClient, err := mgm.NewClient(engineCtx, c.config.ManagementURL.Host, myPrivateKey, mgmTlsEnabled)
+		mgmClient, err := mgm.NewClient(engineCtx, c.config.ManagementURL.Host, myPrivateKey, mgmTlsEnabled, c.config.MgmtClientCertKeyPair)
 		if err != nil {
 			return wrapErr(gstatus.Errorf(codes.FailedPrecondition, "failed connecting to Management Service : %s", err))
 		}
@@ -313,7 +314,7 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 		}()
 
 		// with the global Netbird config in hand connect (just a connection, no stream yet) Signal
-		signalClient, err := connectToSignal(engineCtx, loginResp.GetNetbirdConfig(), myPrivateKey)
+		signalClient, err := connectToSignal(engineCtx, loginResp.GetNetbirdConfig(), myPrivateKey, c.config.MgmtClientCertKeyPair)
 		if err != nil {
 			log.Error(err)
 			return wrapErr(err)
@@ -339,7 +340,7 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 			return wrapErr(err)
 		}
 
-		relayManager := relayClient.NewManager(engineCtx, relayURLs, myPrivateKey.PublicKey().String(), engineConfig.MTU)
+		relayManager := relayClient.NewManager(engineCtx, relayURLs, myPrivateKey.PublicKey().String(), engineConfig.MTU, c.config.MgmtClientCertKeyPair)
 		c.statusRecorder.SetRelayMgr(relayManager)
 		if len(relayURLs) > 0 {
 			if token != nil {
@@ -600,7 +601,7 @@ func selectMTU(localMTU uint16, peerMTU int32) uint16 {
 }
 
 // connectToSignal creates Signal Service client and established a connection
-func connectToSignal(ctx context.Context, wtConfig *mgmProto.NetbirdConfig, ourPrivateKey wgtypes.Key) (*signal.GrpcClient, error) {
+func connectToSignal(ctx context.Context, wtConfig *mgmProto.NetbirdConfig, ourPrivateKey wgtypes.Key, mgmtClientCert *tls.Certificate) (*signal.GrpcClient, error) {
 	var sigTLSEnabled bool
 	if wtConfig.Signal.Protocol == mgmProto.HostConfig_HTTPS {
 		sigTLSEnabled = true
@@ -608,7 +609,7 @@ func connectToSignal(ctx context.Context, wtConfig *mgmProto.NetbirdConfig, ourP
 		sigTLSEnabled = false
 	}
 
-	signalClient, err := signal.NewClient(ctx, wtConfig.Signal.Uri, ourPrivateKey, sigTLSEnabled)
+	signalClient, err := signal.NewClient(ctx, wtConfig.Signal.Uri, ourPrivateKey, sigTLSEnabled, mgmtClientCert)
 	if err != nil {
 		log.Errorf("error while connecting to the Signal Exchange Service %s: %s", wtConfig.Signal.Uri, err)
 		return nil, gstatus.Errorf(codes.FailedPrecondition, "failed connecting to Signal Service : %s", err)

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -252,7 +252,7 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 		}()
 
 		log.Debugf("connecting to the Management service %s", c.config.ManagementURL.Host)
-		mgmClient, err := mgm.NewClient(engineCtx, c.config.ManagementURL.Host, myPrivateKey, mgmTlsEnabled, c.config.MgmtClientCertKeyPair)
+		mgmClient, err := mgm.NewClient(engineCtx, c.config.ManagementURL.Host, myPrivateKey, mgmTlsEnabled, c.config.MgmtClientCert.KeyPair)
 		if err != nil {
 			return wrapErr(gstatus.Errorf(codes.FailedPrecondition, "failed connecting to Management Service : %s", err))
 		}
@@ -314,7 +314,7 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 		}()
 
 		// with the global Netbird config in hand connect (just a connection, no stream yet) Signal
-		signalClient, err := connectToSignal(engineCtx, loginResp.GetNetbirdConfig(), myPrivateKey, c.config.MgmtClientCertKeyPair)
+		signalClient, err := connectToSignal(engineCtx, loginResp.GetNetbirdConfig(), myPrivateKey, c.config.MgmtClientCert.KeyPair)
 		if err != nil {
 			log.Error(err)
 			return wrapErr(err)
@@ -340,7 +340,7 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 			return wrapErr(err)
 		}
 
-		relayManager := relayClient.NewManager(engineCtx, relayURLs, myPrivateKey.PublicKey().String(), engineConfig.MTU, c.config.MgmtClientCertKeyPair)
+		relayManager := relayClient.NewManager(engineCtx, relayURLs, myPrivateKey.PublicKey().String(), engineConfig.MTU, c.config.MgmtClientCert.KeyPair)
 		c.statusRecorder.SetRelayMgr(relayManager)
 		if len(relayURLs) > 0 {
 			if token != nil {

--- a/client/internal/debug/debug.go
+++ b/client/internal/debug/debug.go
@@ -623,11 +623,17 @@ func (g *BundleGenerator) addCommonConfigFields(configContent *strings.Builder) 
 
 	configContent.WriteString(fmt.Sprintf("DNSRouteInterval: %s\n", g.internalConfig.DNSRouteInterval))
 
-	if g.internalConfig.ClientCertPath != "" {
-		configContent.WriteString(fmt.Sprintf("ClientCertPath: %s\n", g.internalConfig.ClientCertPath))
+	if g.internalConfig.IDPClientCert.CertPath != "" {
+		configContent.WriteString(fmt.Sprintf("IDPClientCertPath: %s\n", g.internalConfig.IDPClientCert.CertPath))
 	}
-	if g.internalConfig.ClientCertKeyPath != "" {
-		configContent.WriteString(fmt.Sprintf("ClientCertKeyPath: %s\n", g.internalConfig.ClientCertKeyPath))
+	if g.internalConfig.IDPClientCert.KeyPath != "" {
+		configContent.WriteString(fmt.Sprintf("IDPClientCertKeyPath: %s\n", g.internalConfig.IDPClientCert.KeyPath))
+	}
+	if g.internalConfig.MgmtClientCert.CertPath != "" {
+		configContent.WriteString(fmt.Sprintf("MgmtClientCertPath: %s\n", g.internalConfig.MgmtClientCert.CertPath))
+	}
+	if g.internalConfig.MgmtClientCert.KeyPath != "" {
+		configContent.WriteString(fmt.Sprintf("MgmtClientCertKeyPath: %s\n", g.internalConfig.MgmtClientCert.KeyPath))
 	}
 
 	configContent.WriteString(fmt.Sprintf("LazyConnectionEnabled: %v\n", g.internalConfig.LazyConnectionEnabled))

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -249,7 +249,7 @@ func TestEngine_SSH(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU)
+	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU, nil)
 	engine := NewEngine(
 		ctx, cancel,
 		&EngineConfig{
@@ -428,7 +428,7 @@ func TestEngine_UpdateNetworkMap(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU)
+	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU, nil)
 	engine := NewEngine(ctx, cancel, &EngineConfig{
 		WgIfaceName:  "utun102",
 		WgAddr:       "100.64.0.1/24",
@@ -652,7 +652,7 @@ func TestEngine_Sync(t *testing.T) {
 		}
 		return nil
 	}
-	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU)
+	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU, nil)
 	engine := NewEngine(ctx, cancel, &EngineConfig{
 		WgIfaceName:  "utun103",
 		WgAddr:       "100.64.0.1/24",
@@ -822,7 +822,7 @@ func TestEngine_UpdateNetworkMapWithRoutes(t *testing.T) {
 			wgIfaceName := fmt.Sprintf("utun%d", 104+n)
 			wgAddr := fmt.Sprintf("100.66.%d.1/24", n)
 
-			relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU)
+			relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU, nil)
 			engine := NewEngine(ctx, cancel, &EngineConfig{
 				WgIfaceName:  wgIfaceName,
 				WgAddr:       wgAddr,
@@ -1029,7 +1029,7 @@ func TestEngine_UpdateNetworkMapWithDNSUpdate(t *testing.T) {
 			wgIfaceName := fmt.Sprintf("utun%d", 104+n)
 			wgAddr := fmt.Sprintf("100.66.%d.1/24", n)
 
-			relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU)
+			relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU, nil)
 			engine := NewEngine(ctx, cancel, &EngineConfig{
 				WgIfaceName:  wgIfaceName,
 				WgAddr:       wgAddr,
@@ -1530,11 +1530,11 @@ func createEngine(ctx context.Context, cancel context.CancelFunc, setupKey strin
 	if err != nil {
 		return nil, err
 	}
-	mgmtClient, err := mgmt.NewClient(ctx, mgmtAddr, key, false)
+	mgmtClient, err := mgmt.NewClient(ctx, mgmtAddr, key, false, nil)
 	if err != nil {
 		return nil, err
 	}
-	signalClient, err := signal.NewClient(ctx, signalAddr, key, false)
+	signalClient, err := signal.NewClient(ctx, signalAddr, key, false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1561,7 +1561,7 @@ func createEngine(ctx context.Context, cancel context.CancelFunc, setupKey strin
 		MTU:          iface.DefaultMTU,
 	}
 
-	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU)
+	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU, nil)
 	e, err := NewEngine(ctx, cancel, conf, EngineServices{
 		SignalClient:   signalClient,
 		MgmClient:      mgmtClient,

--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -80,12 +80,10 @@ type ConfigInput struct {
 	DisableAutoConnect            *bool
 	ExtraIFaceBlackList           []string
 	DNSRouteInterval              *time.Duration
-	// Path to client certificate used for mTLS authentication that is used for OAuth PKCE Authorization Flow with the identity provider (SSO)
-	ClientCertPath    string
-	ClientCertKeyPath string
-	// Path to client certificate used for mTLS authentication that is used to connect to management/signal/relay backend
-	MgmtClientCertPath string
-	MgmtClientKeyPath  string
+	// IDPClientCert holds the mTLS cert/key paths for OAuth PKCE Authorization Flow with the identity provider (SSO)
+	IDPClientCert MTLSConfig
+	// MgmtClientCert holds the mTLS cert/key paths for connecting to management/signal/relay backend
+	MgmtClientCert MTLSConfig
 
 	DisableClientRoutes *bool
 	DisableServerRoutes *bool
@@ -165,17 +163,16 @@ type Config struct {
 	// DNSRouteInterval is the interval in which the DNS routes are updated
 	DNSRouteInterval time.Duration
 
-	// Path to client certificate used for mTLS authentication that is used for OAuth PKCE Authorization Flow with the identity provider (SSO)
-	ClientCertPath string
+	// IDPClientCert holds the mTLS cert/key paths for OAuth PKCE Authorization Flow with the identity provider (SSO)
+	IDPClientCert MTLSConfig
 
-	// Path to corresponding private key of ClientCertPath
-	ClientCertKeyPath string
-	ClientCertKeyPair *tls.Certificate `json:"-"`
+	// MgmtClientCert holds the mTLS cert/key paths for connecting to management/signal/relay backend
+	MgmtClientCert MTLSConfig
 
-	// Path to client certificate used for mTLS authentication that is used to connect to management/signal/relay backend
-	MgmtClientCertPath    string
-	MgmtClientKeyPath     string
-	MgmtClientCertKeyPair *tls.Certificate `json:"-"`
+	// Deprecated: use IDPClientCert.CertPath instead. Kept for reading legacy config files.
+	ClientCertPath string `json:",omitempty"`
+	// Deprecated: use IDPClientCert.KeyPath instead. Kept for reading legacy config files.
+	ClientCertKeyPath string `json:",omitempty"`
 
 	LazyConnectionEnabled bool
 
@@ -254,6 +251,10 @@ func createNewConfig(input ConfigInput) (*Config, error) {
 }
 
 func (config *Config) apply(input ConfigInput) (updated bool, err error) {
+	if config.migrateLegacyClientCertFields() {
+		updated = true
+	}
+
 	if config.ManagementURL == nil {
 		log.Infof("using default Management URL %s", DefaultManagementURL)
 		config.ManagementURL, err = parseURL("Management URL", DefaultManagementURL)
@@ -568,49 +569,17 @@ func (config *Config) apply(input ConfigInput) (updated bool, err error) {
 		updated = true
 	}
 
-	if input.ClientCertKeyPath != "" {
-		config.ClientCertKeyPath = input.ClientCertKeyPath
-		updated = true
+	certUpdated, err := applyMTLSCertKeyPair(&config.IDPClientCert, input.IDPClientCert)
+	if err != nil {
+		return updated, err
 	}
+	updated = updated || certUpdated
 
-	if input.ClientCertPath != "" {
-		config.ClientCertPath = input.ClientCertPath
-		updated = true
+	mgmtUpdated, err := applyMTLSCertKeyPair(&config.MgmtClientCert, input.MgmtClientCert)
+	if err != nil {
+		return updated, err
 	}
-
-	if config.ClientCertPath != "" && config.ClientCertKeyPath != "" {
-		cert, err := tls.LoadX509KeyPair(config.ClientCertPath, config.ClientCertKeyPath)
-		if err != nil {
-			log.Error("Failed to load mTLS cert/key pair: ", err)
-		} else {
-			config.ClientCertKeyPair = &cert
-			log.Info("Loaded client mTLS cert/key pair")
-		}
-	}
-
-	if input.MgmtClientKeyPath != "" {
-		config.MgmtClientKeyPath = input.MgmtClientKeyPath
-		updated = true
-	}
-
-	if input.MgmtClientCertPath != "" {
-		config.MgmtClientCertPath = input.MgmtClientCertPath
-		updated = true
-	}
-
-	// reset cached pair before reloading
-	config.MgmtClientCertKeyPair = nil
-	if (config.MgmtClientCertPath == "") != (config.MgmtClientKeyPath == "") {
-		return updated, fmt.Errorf("both MgmtClientCertPath and MgmtClientKeyPath must be set together")
-	}
-	if config.MgmtClientCertPath != "" {
-		cert, err := tls.LoadX509KeyPair(config.MgmtClientCertPath, config.MgmtClientKeyPath)
-		if err != nil {
-			return updated, fmt.Errorf("failed to load management mTLS cert/key pair: %w", err)
-		}
-		config.MgmtClientCertKeyPair = &cert
-		log.Info("Loaded client mTLS cert/key pair for management.")
-	}
+	updated = updated || mgmtUpdated
 
 	if input.DNSLabels != nil && !slices.Equal(config.DNSLabels, input.DNSLabels) {
 		log.Infof("updating DNS labels [ %s ] (old value: [ %s ])",
@@ -798,7 +767,7 @@ func UpdateOldManagementURL(ctx context.Context, config *Config, configPath stri
 		return config, err
 	}
 
-	client, err := newMgmProber(ctx, newURL.Host, key, mgmTlsEnabled, config.MgmtClientCertKeyPair)
+	client, err := newMgmProber(ctx, newURL.Host, key, mgmTlsEnabled, config.MgmtClientCert.KeyPair)
 	if err != nil {
 		log.Infof("couldn't switch to the new Management %s", newURL.String())
 		return config, err

--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -47,8 +47,8 @@ type mgmProber interface {
 
 // newMgmProber creates a management client for probing URL reachability.
 // Overridden in tests to avoid real network calls.
-var newMgmProber = func(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled bool) (mgmProber, error) {
-	return mgm.NewClient(ctx, addr, key, tlsEnabled)
+var newMgmProber = func(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled bool, mgmtClientCert *tls.Certificate) (mgmProber, error) {
+	return mgm.NewClient(ctx, addr, key, tlsEnabled, mgmtClientCert)
 }
 
 var DefaultInterfaceBlacklist = []string{
@@ -80,8 +80,12 @@ type ConfigInput struct {
 	DisableAutoConnect            *bool
 	ExtraIFaceBlackList           []string
 	DNSRouteInterval              *time.Duration
-	ClientCertPath                string
-	ClientCertKeyPath             string
+	// Path to client certificate used for mTLS authentication that is used for OAuth PKCE Authorization Flow with the identity provider (SSO)
+	ClientCertPath    string
+	ClientCertKeyPath string
+	// Path to client certificate used for mTLS authentication that is used to connect to management/signal/relay backend
+	MgmtClientCertPath string
+	MgmtClientKeyPath  string
 
 	DisableClientRoutes *bool
 	DisableServerRoutes *bool
@@ -160,13 +164,18 @@ type Config struct {
 
 	// DNSRouteInterval is the interval in which the DNS routes are updated
 	DNSRouteInterval time.Duration
-	// Path to a certificate used for mTLS authentication
+
+	// Path to client certificate used for mTLS authentication that is used for OAuth PKCE Authorization Flow with the identity provider (SSO)
 	ClientCertPath string
 
 	// Path to corresponding private key of ClientCertPath
 	ClientCertKeyPath string
-
 	ClientCertKeyPair *tls.Certificate `json:"-"`
+
+	// Path to client certificate used for mTLS authentication that is used to connect to management/signal/relay backend
+	MgmtClientCertPath    string
+	MgmtClientKeyPath     string
+	MgmtClientCertKeyPair *tls.Certificate `json:"-"`
 
 	LazyConnectionEnabled bool
 
@@ -579,6 +588,30 @@ func (config *Config) apply(input ConfigInput) (updated bool, err error) {
 		}
 	}
 
+	if input.MgmtClientKeyPath != "" {
+		config.MgmtClientKeyPath = input.MgmtClientKeyPath
+		updated = true
+	}
+
+	if input.MgmtClientCertPath != "" {
+		config.MgmtClientCertPath = input.MgmtClientCertPath
+		updated = true
+	}
+
+	// reset cached pair before reloading
+	config.MgmtClientCertKeyPair = nil
+	if (config.MgmtClientCertPath == "") != (config.MgmtClientKeyPath == "") {
+		return updated, fmt.Errorf("both MgmtClientCertPath and MgmtClientKeyPath must be set together")
+	}
+	if config.MgmtClientCertPath != "" {
+		cert, err := tls.LoadX509KeyPair(config.MgmtClientCertPath, config.MgmtClientKeyPath)
+		if err != nil {
+			return updated, fmt.Errorf("failed to load management mTLS cert/key pair: %w", err)
+		}
+		config.MgmtClientCertKeyPair = &cert
+		log.Info("Loaded client mTLS cert/key pair for management.")
+	}
+
 	if input.DNSLabels != nil && !slices.Equal(config.DNSLabels, input.DNSLabels) {
 		log.Infof("updating DNS labels [ %s ] (old value: [ %s ])",
 			input.DNSLabels.SafeString(),
@@ -765,7 +798,7 @@ func UpdateOldManagementURL(ctx context.Context, config *Config, configPath stri
 		return config, err
 	}
 
-	client, err := newMgmProber(ctx, newURL.Host, key, mgmTlsEnabled)
+	client, err := newMgmProber(ctx, newURL.Host, key, mgmTlsEnabled, config.MgmtClientCertKeyPair)
 	if err != nil {
 		log.Infof("couldn't switch to the new Management %s", newURL.String())
 		return config, err

--- a/client/internal/profilemanager/config_mtls.go
+++ b/client/internal/profilemanager/config_mtls.go
@@ -1,0 +1,67 @@
+package profilemanager
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// MTLSConfig holds the paths to a client certificate/key pair and the loaded certificate.
+// The KeyPair field is populated at runtime from the paths and is never persisted.
+type MTLSConfig struct {
+	CertPath string           `json:",omitempty"`
+	KeyPath  string           `json:",omitempty"`
+	KeyPair  *tls.Certificate `json:"-"`
+}
+
+// migrateLegacyClientCertFields copies the old flat ClientCertPath / ClientCertKeyPath fields
+// into the IDPClientCert sub-struct, logs a warning, and clears the legacy fields so they are
+// not written back to disk on the next save. Returns true if a migration was performed.
+func (c *Config) migrateLegacyClientCertFields() bool {
+	if c.ClientCertPath == "" && c.ClientCertKeyPath == "" {
+		return false
+	}
+	log.Warn("config contains deprecated ClientCertPath/ClientCertKeyPath fields, migrating to IDPClientCert")
+	if c.IDPClientCert.CertPath == "" {
+		c.IDPClientCert.CertPath = c.ClientCertPath
+	}
+	if c.IDPClientCert.KeyPath == "" {
+		c.IDPClientCert.KeyPath = c.ClientCertKeyPath
+	}
+	c.ClientCertPath = ""
+	c.ClientCertKeyPath = ""
+	return true
+}
+
+// applyMTLSCertKeyPair updates the cert/key paths on config from the given input values,
+// resets and reloads the cached TLS certificate pair.
+// Both paths must either both be set or both be empty; a mismatch is returned as an error.
+// It returns whether any field was updated and any error encountered.
+func applyMTLSCertKeyPair(config *MTLSConfig, input MTLSConfig) (updated bool, err error) {
+	if input.KeyPath != "" {
+		config.KeyPath = input.KeyPath
+		updated = true
+	}
+
+	if input.CertPath != "" {
+		config.CertPath = input.CertPath
+		updated = true
+	}
+
+	// reset cached pair before reloading
+	config.KeyPair = nil
+	if (config.CertPath == "") != (config.KeyPath == "") {
+		return updated, fmt.Errorf("both CertPath and KeyPath must be set together")
+	}
+	if config.CertPath != "" {
+		cert, err := tls.LoadX509KeyPair(config.CertPath, config.KeyPath)
+		if err != nil {
+			return updated, fmt.Errorf("failed to load mTLS cert/key pair: %w", err)
+		}
+		config.KeyPair = &cert
+		log.Info("Loaded mTLS cert/key pair.")
+	}
+
+	return updated, nil
+}

--- a/client/internal/profilemanager/config_test.go
+++ b/client/internal/profilemanager/config_test.go
@@ -2,6 +2,7 @@ package profilemanager
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"os"
 	"path/filepath"
@@ -244,7 +245,7 @@ func TestWireguardPortDefaultVsExplicit(t *testing.T) {
 
 func TestUpdateOldManagementURL(t *testing.T) {
 	origProber := newMgmProber
-	newMgmProber = func(_ context.Context, _ string, _ wgtypes.Key, _ bool) (mgmProber, error) {
+	newMgmProber = func(_ context.Context, _ string, _ wgtypes.Key, _ bool, _ *tls.Certificate) (mgmProber, error) {
 		return &mockMgmProber{}, nil
 	}
 	t.Cleanup(func() { newMgmProber = origProber })

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -1042,7 +1042,7 @@ func (s *Server) sendLogoutRequestWithConfig(ctx context.Context, config *profil
 	}
 
 	mgmTlsEnabled := config.ManagementURL.Scheme == "https"
-	mgmClient, err := mgm.NewClient(ctx, config.ManagementURL.Host, key, mgmTlsEnabled, config.MgmtClientCertKeyPair)
+	mgmClient, err := mgm.NewClient(ctx, config.ManagementURL.Host, key, mgmTlsEnabled, config.MgmtClientCert.KeyPair)
 	if err != nil {
 		return fmt.Errorf("connect to management server: %w", err)
 	}

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -1042,7 +1042,7 @@ func (s *Server) sendLogoutRequestWithConfig(ctx context.Context, config *profil
 	}
 
 	mgmTlsEnabled := config.ManagementURL.Scheme == "https"
-	mgmClient, err := mgm.NewClient(ctx, config.ManagementURL.Host, key, mgmTlsEnabled)
+	mgmClient, err := mgm.NewClient(ctx, config.ManagementURL.Host, key, mgmTlsEnabled, config.MgmtClientCertKeyPair)
 	if err != nil {
 		return fmt.Errorf("connect to management server: %w", err)
 	}

--- a/relay/test/benchmark_test.go
+++ b/relay/test/benchmark_test.go
@@ -101,7 +101,7 @@ func transfer(t *testing.T, testData []byte, peerPairs int) {
 
 	clientsSender := make([]*client.Client, peerPairs)
 	for i := 0; i < cap(clientsSender); i++ {
-		c := client.NewClient(serverConnURL, hmacTokenStore, "sender-"+fmt.Sprint(i), iface.DefaultMTU)
+		c := client.NewClient(serverConnURL, hmacTokenStore, "sender-"+fmt.Sprint(i), iface.DefaultMTU, nil)
 		err := c.Connect(ctx)
 		if err != nil {
 			t.Fatalf("failed to connect to server: %s", err)
@@ -111,7 +111,7 @@ func transfer(t *testing.T, testData []byte, peerPairs int) {
 
 	clientsReceiver := make([]*client.Client, peerPairs)
 	for i := 0; i < cap(clientsReceiver); i++ {
-		c := client.NewClient(serverConnURL, hmacTokenStore, "receiver-"+fmt.Sprint(i), iface.DefaultMTU)
+		c := client.NewClient(serverConnURL, hmacTokenStore, "receiver-"+fmt.Sprint(i), iface.DefaultMTU, nil)
 		err := c.Connect(ctx)
 		if err != nil {
 			t.Fatalf("failed to connect to server: %s", err)

--- a/relay/testec2/relay.go
+++ b/relay/testec2/relay.go
@@ -71,7 +71,7 @@ func prepareConnsSender(serverConnURL string, peerPairs int) []net.Conn {
 	ctx := context.Background()
 	clientsSender := make([]*client.Client, peerPairs)
 	for i := 0; i < cap(clientsSender); i++ {
-		c := client.NewClient(serverConnURL, hmacTokenStore, "sender-"+fmt.Sprint(i), iface.DefaultMTU)
+		c := client.NewClient(serverConnURL, hmacTokenStore, "sender-"+fmt.Sprint(i), iface.DefaultMTU, nil)
 		if err := c.Connect(ctx); err != nil {
 			log.Fatalf("failed to connect to server: %s", err)
 		}
@@ -157,7 +157,7 @@ func runReader(conn net.Conn) time.Duration {
 func prepareConnsReceiver(serverConnURL string, peerPairs int) []net.Conn {
 	clientsReceiver := make([]*client.Client, peerPairs)
 	for i := 0; i < cap(clientsReceiver); i++ {
-		c := client.NewClient(serverConnURL, hmacTokenStore, "receiver-"+fmt.Sprint(i), iface.DefaultMTU)
+		c := client.NewClient(serverConnURL, hmacTokenStore, "receiver-"+fmt.Sprint(i), iface.DefaultMTU, nil)
 		err := c.Connect(context.Background())
 		if err != nil {
 			log.Fatalf("failed to connect to server: %s", err)

--- a/shared/management/client/client_test.go
+++ b/shared/management/client/client_test.go
@@ -205,7 +205,7 @@ func TestClient_HealthCheck(t *testing.T) {
 	s, listener := startManagement(t)
 	defer closeManagementSilently(s, listener)
 
-	client, err := NewClient(ctx, listener.Addr().String(), testKey, false)
+	client, err := NewClient(ctx, listener.Addr().String(), testKey, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func TestClient_LoginUnregistered_ShouldThrow_401(t *testing.T) {
 	s, listener := startManagement(t)
 	defer closeManagementSilently(s, listener)
 
-	client, err := NewClient(ctx, listener.Addr().String(), testKey, false)
+	client, err := NewClient(ctx, listener.Addr().String(), testKey, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +247,7 @@ func TestClient_LoginRegistered(t *testing.T) {
 	s, listener := startManagement(t)
 	defer closeManagementSilently(s, listener)
 
-	client, err := NewClient(ctx, listener.Addr().String(), testKey, false)
+	client, err := NewClient(ctx, listener.Addr().String(), testKey, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +272,7 @@ func TestClient_Sync(t *testing.T) {
 	s, listener := startManagement(t)
 	defer closeManagementSilently(s, listener)
 
-	client, err := NewClient(ctx, listener.Addr().String(), testKey, false)
+	client, err := NewClient(ctx, listener.Addr().String(), testKey, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func TestClient_Sync(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	remoteClient, err := NewClient(context.TODO(), listener.Addr().String(), remoteKey, false)
+	remoteClient, err := NewClient(context.TODO(), listener.Addr().String(), remoteKey, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +349,7 @@ func Test_SystemMetaDataFromClient(t *testing.T) {
 	serverAddr := lis.Addr().String()
 	ctx := context.Background()
 
-	testClient, err := NewClient(ctx, serverAddr, testKey, false)
+	testClient, err := NewClient(ctx, serverAddr, testKey, false, nil)
 	if err != nil {
 		t.Fatalf("error while creating testClient: %v", err)
 	}
@@ -479,7 +479,7 @@ func Test_GetDeviceAuthorizationFlow(t *testing.T) {
 	serverAddr := lis.Addr().String()
 	ctx := context.Background()
 
-	client, err := NewClient(ctx, serverAddr, testKey, false)
+	client, err := NewClient(ctx, serverAddr, testKey, false, nil)
 	if err != nil {
 		t.Fatalf("error while creating testClient: %v", err)
 	}
@@ -523,7 +523,7 @@ func Test_GetPKCEAuthorizationFlow(t *testing.T) {
 	serverAddr := lis.Addr().String()
 	ctx := context.Background()
 
-	client, err := NewClient(ctx, serverAddr, testKey, false)
+	client, err := NewClient(ctx, serverAddr, testKey, false, nil)
 	if err != nil {
 		t.Fatalf("error while creating testClient: %v", err)
 	}

--- a/shared/management/client/grpc.go
+++ b/shared/management/client/grpc.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -96,7 +97,7 @@ func MaxRecvMsgSize() int {
 }
 
 // NewClient creates a new client to Management service
-func NewClient(ctx context.Context, addr string, ourPrivateKey wgtypes.Key, tlsEnabled bool) (*GrpcClient, error) {
+func NewClient(ctx context.Context, addr string, ourPrivateKey wgtypes.Key, tlsEnabled bool, mgmtClientCert *tls.Certificate) (*GrpcClient, error) {
 	var conn *grpc.ClientConn
 
 	var extraOpts []grpc.DialOption
@@ -107,7 +108,7 @@ func NewClient(ctx context.Context, addr string, ourPrivateKey wgtypes.Key, tlsE
 
 	operation := func() error {
 		var err error
-		conn, err = nbgrpc.CreateConnection(ctx, addr, tlsEnabled, wsproxy.ManagementComponent, extraOpts...)
+		conn, err = nbgrpc.CreateConnection(ctx, addr, tlsEnabled, wsproxy.ManagementComponent, mgmtClientCert, extraOpts...)
 		if err != nil {
 			return fmt.Errorf("create connection: %w", err)
 		}

--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"sync"
@@ -166,11 +167,12 @@ type Client struct {
 
 	stateSubscription *PeersStateSubscription
 
-	mtu uint16
+	mtu        uint16
+	clientCert *tls.Certificate
 }
 
 // NewClient creates a new client for the relay server. The client is not connected to the server until the Connect
-func NewClient(serverURL string, authTokenStore *auth.TokenStore, peerID string, mtu uint16) *Client {
+func NewClient(serverURL string, authTokenStore *auth.TokenStore, peerID string, mtu uint16, clientCert *tls.Certificate) *Client {
 	hashedID := messages.HashID(peerID)
 	relayLog := log.WithFields(log.Fields{"relay": serverURL})
 
@@ -180,6 +182,7 @@ func NewClient(serverURL string, authTokenStore *auth.TokenStore, peerID string,
 		authTokenStore: authTokenStore,
 		hashedID:       hashedID,
 		mtu:            mtu,
+		clientCert:     clientCert,
 		bufPool: &sync.Pool{
 			New: func() any {
 				buf := make([]byte, bufferSize)

--- a/shared/relay/client/client_test.go
+++ b/shared/relay/client/client_test.go
@@ -68,7 +68,7 @@ func TestClient(t *testing.T) {
 		t.Fatalf("failed to start server: %s", err)
 	}
 	t.Log("alice connecting to server")
-	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU)
+	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)
@@ -76,7 +76,7 @@ func TestClient(t *testing.T) {
 	defer clientAlice.Close()
 
 	t.Log("placeholder connecting to server")
-	clientPlaceHolder := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "clientPlaceHolder", iface.DefaultMTU)
+	clientPlaceHolder := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "clientPlaceHolder", iface.DefaultMTU, nil)
 	err = clientPlaceHolder.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)
@@ -84,7 +84,7 @@ func TestClient(t *testing.T) {
 	defer clientPlaceHolder.Close()
 
 	t.Log("Bob connecting to server")
-	clientBob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "bob", iface.DefaultMTU)
+	clientBob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "bob", iface.DefaultMTU, nil)
 	err = clientBob.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)
@@ -144,7 +144,7 @@ func TestRegistration(t *testing.T) {
 		t.Fatalf("failed to start server: %s", err)
 	}
 
-	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU)
+	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err != nil {
 		_ = srv.Shutdown(ctx)
@@ -184,7 +184,7 @@ func TestRegistrationTimeout(t *testing.T) {
 		_ = fakeTCPListener.Close()
 	}(fakeTCPListener)
 
-	clientAlice := NewClient("127.0.0.1:50201", hmacTokenStore, "alice", iface.DefaultMTU)
+	clientAlice := NewClient("127.0.0.1:50201", hmacTokenStore, "alice", iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err == nil {
 		t.Errorf("failed to connect to server: %s", err)
@@ -227,7 +227,7 @@ func TestEcho(t *testing.T) {
 		t.Fatalf("failed to start server: %s", err)
 	}
 
-	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idAlice, iface.DefaultMTU)
+	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idAlice, iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)
@@ -239,7 +239,7 @@ func TestEcho(t *testing.T) {
 		}
 	}()
 
-	clientBob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idBob, iface.DefaultMTU)
+	clientBob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idBob, iface.DefaultMTU, nil)
 	err = clientBob.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)
@@ -319,7 +319,7 @@ func TestBindToUnavailabePeer(t *testing.T) {
 		t.Fatalf("failed to start server: %s", err)
 	}
 
-	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU)
+	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err != nil {
 		t.Errorf("failed to connect to server: %s", err)
@@ -367,13 +367,13 @@ func TestBindReconnect(t *testing.T) {
 		t.Fatalf("failed to start server: %s", err)
 	}
 
-	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU)
+	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)
 	}
 
-	clientBob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "bob", iface.DefaultMTU)
+	clientBob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "bob", iface.DefaultMTU, nil)
 	err = clientBob.Connect(ctx)
 	if err != nil {
 		t.Errorf("failed to connect to server: %s", err)
@@ -395,7 +395,7 @@ func TestBindReconnect(t *testing.T) {
 		t.Errorf("failed to close client: %s", err)
 	}
 
-	clientAlice = NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU)
+	clientAlice = NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err != nil {
 		t.Errorf("failed to connect to server: %s", err)
@@ -470,13 +470,13 @@ func TestCloseConn(t *testing.T) {
 		t.Fatalf("failed to start server: %s", err)
 	}
 
-	bob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "bob", iface.DefaultMTU)
+	bob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "bob", iface.DefaultMTU, nil)
 	err = bob.Connect(ctx)
 	if err != nil {
 		t.Errorf("failed to connect to server: %s", err)
 	}
 
-	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU)
+	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err != nil {
 		t.Errorf("failed to connect to server: %s", err)
@@ -534,13 +534,13 @@ func TestCloseRelayConn(t *testing.T) {
 		t.Fatalf("failed to start server: %s", err)
 	}
 
-	bob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "bob", iface.DefaultMTU)
+	bob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "bob", iface.DefaultMTU, nil)
 	err = bob.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)
 	}
 
-	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU)
+	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, "alice", iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)
@@ -590,7 +590,7 @@ func TestCloseByServer(t *testing.T) {
 
 	idAlice := "alice"
 	log.Debugf("connect by alice")
-	relayClient := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idAlice, iface.DefaultMTU)
+	relayClient := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idAlice, iface.DefaultMTU, nil)
 	if err = relayClient.Connect(ctx); err != nil {
 		log.Fatalf("failed to connect to server: %s", err)
 	}
@@ -648,7 +648,7 @@ func TestCloseByClient(t *testing.T) {
 
 	idAlice := "alice"
 	log.Debugf("connect by alice")
-	relayClient := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idAlice, iface.DefaultMTU)
+	relayClient := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idAlice, iface.DefaultMTU, nil)
 	err = relayClient.Connect(ctx)
 	if err != nil {
 		log.Fatalf("failed to connect to server: %s", err)
@@ -701,7 +701,7 @@ func TestCloseNotDrainedChannel(t *testing.T) {
 		t.Fatalf("failed to start server: %s", err)
 	}
 
-	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idAlice, iface.DefaultMTU)
+	clientAlice := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idAlice, iface.DefaultMTU, nil)
 	err = clientAlice.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)
@@ -713,7 +713,7 @@ func TestCloseNotDrainedChannel(t *testing.T) {
 		}
 	}()
 
-	clientBob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idBob, iface.DefaultMTU)
+	clientBob := NewClient(serverCfg.ExposedAddress, hmacTokenStore, idBob, iface.DefaultMTU, nil)
 	err = clientBob.Connect(ctx)
 	if err != nil {
 		t.Fatalf("failed to connect to server: %s", err)

--- a/shared/relay/client/dialer/ws/dialopts_generic.go
+++ b/shared/relay/client/dialer/ws/dialopts_generic.go
@@ -2,10 +2,14 @@
 
 package ws
 
-import "github.com/coder/websocket"
+import (
+	"crypto/tls"
 
-func createDialOptions() *websocket.DialOptions {
+	"github.com/coder/websocket"
+)
+
+func createDialOptions(clientCert *tls.Certificate) *websocket.DialOptions {
 	return &websocket.DialOptions{
-		HTTPClient: httpClientNbDialer(),
+		HTTPClient: httpClientNbDialer(clientCert),
 	}
 }

--- a/shared/relay/client/dialer/ws/dialopts_js.go
+++ b/shared/relay/client/dialer/ws/dialopts_js.go
@@ -2,9 +2,14 @@
 
 package ws
 
-import "github.com/coder/websocket"
+import (
+	"crypto/tls"
 
-func createDialOptions() *websocket.DialOptions {
-	// WASM version doesn't support HTTPClient
+	"github.com/coder/websocket"
+)
+
+func createDialOptions(_ *tls.Certificate) *websocket.DialOptions {
+	// WASM version doesn't support HTTPClient or custom TLS config
+	// The browser controls all TLS/certificate handling, so clientCert is ignored
 	return &websocket.DialOptions{}
 }

--- a/shared/relay/client/dialer/ws/ws.go
+++ b/shared/relay/client/dialer/ws/ws.go
@@ -20,6 +20,8 @@ import (
 )
 
 type Dialer struct {
+	// ClientCert is an optional client certificate for mTLS authentication
+	ClientCert *tls.Certificate
 }
 
 func (d Dialer) Protocol() string {
@@ -32,7 +34,7 @@ func (d Dialer) Dial(ctx context.Context, address string) (net.Conn, error) {
 		return nil, err
 	}
 
-	opts := createDialOptions()
+	opts := createDialOptions(d.ClientCert)
 
 	parsedURL, err := url.Parse(wsURL)
 	if err != nil {
@@ -64,7 +66,7 @@ func prepareURL(address string) (string, error) {
 	return strings.Replace(address, "rel", "ws", 1), nil
 }
 
-func httpClientNbDialer() *http.Client {
+func httpClientNbDialer(clientCert *tls.Certificate) *http.Client {
 	customDialer := nbnet.NewDialer()
 
 	certPool, err := x509.SystemCertPool()
@@ -73,13 +75,21 @@ func httpClientNbDialer() *http.Client {
 		certPool = embeddedroots.Get()
 	}
 
+	tlsConfig := &tls.Config{
+		RootCAs: certPool,
+	}
+
+	// Add client certificate if provided (for mTLS)
+	if clientCert != nil {
+		tlsConfig.Certificates = []tls.Certificate{*clientCert}
+		log.Debugf("Using client certificate for mTLS with relay server")
+	}
+
 	customTransport := &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return customDialer.DialContext(ctx, network, addr)
 		},
-		TLSClientConfig: &tls.Config{
-			RootCAs: certPool,
-		},
+		TLSClientConfig: tlsConfig,
 	}
 
 	return &http.Client{

--- a/shared/relay/client/dialers_generic.go
+++ b/shared/relay/client/dialers_generic.go
@@ -13,7 +13,11 @@ import (
 func (c *Client) getDialers() []dialer.DialeFn {
 	if c.mtu > 0 && c.mtu > iface.DefaultMTU {
 		c.log.Infof("MTU %d exceeds default (%d), forcing WebSocket transport to avoid DATAGRAM frame size issues", c.mtu, iface.DefaultMTU)
-		return []dialer.DialeFn{ws.Dialer{}}
+		return []dialer.DialeFn{ws.Dialer{ClientCert: c.clientCert}}
 	}
-	return []dialer.DialeFn{quic.Dialer{}, ws.Dialer{}}
+	if c.clientCert != nil {
+		c.log.Infof("Using client certificate requires websocket dialer.")
+		return []dialer.DialeFn{ws.Dialer{ClientCert: c.clientCert}}
+	}
+	return []dialer.DialeFn{quic.Dialer{}, ws.Dialer{ClientCert: c.clientCert}}
 }

--- a/shared/relay/client/dialers_js.go
+++ b/shared/relay/client/dialers_js.go
@@ -9,5 +9,7 @@ import (
 
 func (c *Client) getDialers() []dialer.DialeFn {
 	// JS/WASM build only uses WebSocket transport
+	// Note: Client certificates (mTLS) are not supported in WASM builds
+	// as the browser controls TLS configuration
 	return []dialer.DialeFn{ws.Dialer{}}
 }

--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -3,6 +3,7 @@ package client
 import (
 	"container/list"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"reflect"
@@ -64,12 +65,13 @@ type Manager struct {
 	onReconnectedListenerFn func()
 	listenerLock            sync.Mutex
 
-	mtu uint16
+	mtu        uint16
+	clientCert *tls.Certificate
 }
 
 // NewManager creates a new manager instance.
 // The serverURL address can be empty. In this case, the manager will not serve.
-func NewManager(ctx context.Context, serverURLs []string, peerID string, mtu uint16) *Manager {
+func NewManager(ctx context.Context, serverURLs []string, peerID string, mtu uint16, clientCert *tls.Certificate) *Manager {
 	tokenStore := &relayAuth.TokenStore{}
 
 	m := &Manager{
@@ -77,11 +79,13 @@ func NewManager(ctx context.Context, serverURLs []string, peerID string, mtu uin
 		peerID:     peerID,
 		tokenStore: tokenStore,
 		mtu:        mtu,
+		clientCert: clientCert,
 		serverPicker: &ServerPicker{
 			TokenStore:        tokenStore,
 			PeerID:            peerID,
 			MTU:               mtu,
 			ConnectionTimeout: defaultConnectionTimeout,
+			ClientCert:        clientCert,
 		},
 		relayClients:            make(map[string]*RelayTrack),
 		onDisconnectedListeners: make(map[string]*list.List),
@@ -258,7 +262,7 @@ func (m *Manager) openConnVia(ctx context.Context, serverAddress, peerKey string
 	m.relayClients[serverAddress] = rt
 	m.relayClientsMutex.Unlock()
 
-	relayClient := NewClient(serverAddress, m.tokenStore, m.peerID, m.mtu)
+	relayClient := NewClient(serverAddress, m.tokenStore, m.peerID, m.mtu, m.clientCert)
 	err := relayClient.Connect(m.ctx)
 	if err != nil {
 		rt.err = err

--- a/shared/relay/client/manager_test.go
+++ b/shared/relay/client/manager_test.go
@@ -26,7 +26,7 @@ func newManagerTestServerConfig(address string) server.Config {
 func TestEmptyURL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	mgr := NewManager(ctx, nil, "alice", iface.DefaultMTU)
+	mgr := NewManager(ctx, nil, "alice", iface.DefaultMTU, nil)
 	err := mgr.Serve()
 	if err == nil {
 		t.Errorf("expected error, got nil")
@@ -91,12 +91,12 @@ func TestForeignConn(t *testing.T) {
 
 	mCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	clientAlice := NewManager(mCtx, toURL(lstCfg1), "alice", iface.DefaultMTU)
+	clientAlice := NewManager(mCtx, toURL(lstCfg1), "alice", iface.DefaultMTU, nil)
 	if err := clientAlice.Serve(); err != nil {
 		t.Fatalf("failed to serve manager: %s", err)
 	}
 
-	clientBob := NewManager(mCtx, toURL(srvCfg2), "bob", iface.DefaultMTU)
+	clientBob := NewManager(mCtx, toURL(srvCfg2), "bob", iface.DefaultMTU, nil)
 	if err := clientBob.Serve(); err != nil {
 		t.Fatalf("failed to serve manager: %s", err)
 	}
@@ -198,12 +198,12 @@ func TestForeginConnClose(t *testing.T) {
 	mCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	mgrBob := NewManager(mCtx, toURL(srvCfg2), "bob", iface.DefaultMTU)
+	mgrBob := NewManager(mCtx, toURL(srvCfg2), "bob", iface.DefaultMTU, nil)
 	if err := mgrBob.Serve(); err != nil {
 		t.Fatalf("failed to serve manager: %s", err)
 	}
 
-	mgr := NewManager(mCtx, toURL(srvCfg1), "alice", iface.DefaultMTU)
+	mgr := NewManager(mCtx, toURL(srvCfg1), "alice", iface.DefaultMTU, nil)
 	err = mgr.Serve()
 	if err != nil {
 		t.Fatalf("failed to serve manager: %s", err)
@@ -283,7 +283,7 @@ func TestForeignAutoClose(t *testing.T) {
 	t.Log("connect to server 1.")
 	mCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	mgr := NewManager(mCtx, toURL(srvCfg1), idAlice, iface.DefaultMTU)
+	mgr := NewManager(mCtx, toURL(srvCfg1), idAlice, iface.DefaultMTU, nil)
 	err = mgr.Serve()
 	if err != nil {
 		t.Fatalf("failed to serve manager: %s", err)
@@ -354,13 +354,13 @@ func TestAutoReconnect(t *testing.T) {
 	mCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	clientBob := NewManager(mCtx, toURL(srvCfg), "bob", iface.DefaultMTU)
+	clientBob := NewManager(mCtx, toURL(srvCfg), "bob", iface.DefaultMTU, nil)
 	err = clientBob.Serve()
 	if err != nil {
 		t.Fatalf("failed to serve manager: %s", err)
 	}
 
-	clientAlice := NewManager(mCtx, toURL(srvCfg), "alice", iface.DefaultMTU)
+	clientAlice := NewManager(mCtx, toURL(srvCfg), "alice", iface.DefaultMTU, nil)
 	err = clientAlice.Serve()
 	if err != nil {
 		t.Fatalf("failed to serve manager: %s", err)
@@ -424,12 +424,12 @@ func TestNotifierDoubleAdd(t *testing.T) {
 	mCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	clientBob := NewManager(mCtx, toURL(listenerCfg1), "bob", iface.DefaultMTU)
+	clientBob := NewManager(mCtx, toURL(listenerCfg1), "bob", iface.DefaultMTU, nil)
 	if err = clientBob.Serve(); err != nil {
 		t.Fatalf("failed to serve manager: %s", err)
 	}
 
-	clientAlice := NewManager(mCtx, toURL(listenerCfg1), "alice", iface.DefaultMTU)
+	clientAlice := NewManager(mCtx, toURL(listenerCfg1), "alice", iface.DefaultMTU, nil)
 	if err = clientAlice.Serve(); err != nil {
 		t.Fatalf("failed to serve manager: %s", err)
 	}

--- a/shared/relay/client/picker.go
+++ b/shared/relay/client/picker.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -29,6 +30,7 @@ type ServerPicker struct {
 	PeerID            string
 	MTU               uint16
 	ConnectionTimeout time.Duration
+	ClientCert        *tls.Certificate
 }
 
 func (sp *ServerPicker) PickServer(parentCtx context.Context) (*Client, error) {
@@ -69,7 +71,7 @@ func (sp *ServerPicker) PickServer(parentCtx context.Context) (*Client, error) {
 
 func (sp *ServerPicker) startConnection(ctx context.Context, resultChan chan connResult, url string) {
 	log.Infof("try to connecting to relay server: %s", url)
-	relayClient := NewClient(url, sp.TokenStore, sp.PeerID, sp.MTU)
+	relayClient := NewClient(url, sp.TokenStore, sp.PeerID, sp.MTU, sp.ClientCert)
 	err := relayClient.Connect(ctx)
 	resultChan <- connResult{
 		RelayClient: relayClient,

--- a/shared/signal/client/client_test.go
+++ b/shared/signal/client/client_test.go
@@ -170,7 +170,7 @@ var _ = Describe("GrpcClient", func() {
 
 func createSignalClient(addr string, key wgtypes.Key) *GrpcClient {
 	var sigTLSEnabled = false
-	client, err := NewClient(context.Background(), addr, key, sigTLSEnabled)
+	client, err := NewClient(context.Background(), addr, key, sigTLSEnabled, nil)
 	if err != nil {
 		Fail("failed creating signal client")
 	}

--- a/shared/signal/client/grpc.go
+++ b/shared/signal/client/grpc.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"sync"
@@ -53,12 +54,12 @@ type GrpcClient struct {
 }
 
 // NewClient creates a new Signal client
-func NewClient(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled bool) (*GrpcClient, error) {
+func NewClient(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled bool, mgmtClientCert *tls.Certificate) (*GrpcClient, error) {
 	var conn *grpc.ClientConn
 
 	operation := func() error {
 		var err error
-		conn, err = nbgrpc.CreateConnection(ctx, addr, tlsEnabled, wsproxy.SignalComponent)
+		conn, err = nbgrpc.CreateConnection(ctx, addr, tlsEnabled, wsproxy.SignalComponent, mgmtClientCert)
 		if err != nil {
 			return fmt.Errorf("create connection: %w", err)
 		}


### PR DESCRIPTION
This PR adds client support for sending a certificate to management/signal/relay backend for mutual authentication (mTLS).

## Background

We've been using NetBird in [eclipse-opendut](https://github.com/eclipse-opendut/opendut/) for over two years now and are grateful for the VPN management that it provides. For internet facing services, we are required to use client certificates (mutual TLS aka mTLS). At the moment we use NetBird behind [traefik](https://doc.traefik.io/traefik/reference/routing-configuration/http/tls/tls-options/#client-authentication-mtls) and are able to configure client certificate verification [here](https://github.com/eclipse-opendut/opendut/blob/a7c2670b34dfb0213e889439d5c391d5f43f5013/.ci/deploy/localenv/data/traefik/config/mtls/mtls.yml#L4).

## Changes

I would like to add support for client certificates in the NetBird client. 

This pull request adds two fields to the configuration input:
```go
// client/internal/profilemanager/config.go
type ConfigInput struct {

	// IDPClientCert holds the mTLS cert/key paths for OAuth PKCE Authorization Flow with the identity provider (SSO)
	IDPClientCert MTLSConfig
	// MgmtClientCert holds the mTLS cert/key paths for connecting to management/signal/relay backend
	MgmtClientCert MTLSConfig

}

// client/internal/profilemanager/config_mtls.go
type MTLSConfig struct {
	CertPath string           `json:",omitempty"`
	KeyPath  string           `json:",omitempty"`
	KeyPair  *tls.Certificate `json:"-"`
}

```
If you configure a certificate path and key path, then the NetBird client will send the client certificate when making requests to the backend (management service, relay service, signal service).
There are already configuration fields present to configure client certificates for the identity provider, contributed in #2188. To avoid breaking existing configuration, I've opted for a descriptive longer name in the configuration. 
Let me know if this is to your liking.

```go
type Config struct {

	// IDPClientCert holds the mTLS cert/key paths for OAuth PKCE Authorization Flow with the identity provider (SSO)
	IDPClientCert MTLSConfig

	// MgmtClientCert holds the mTLS cert/key paths for connecting to management/signal/relay backend
	MgmtClientCert MTLSConfig

	// Deprecated: use IDPClientCert.CertPath instead. Kept for reading legacy config files.
	ClientCertPath string `json:",omitempty"`
	// Deprecated: use IDPClientCert.KeyPath instead. Kept for reading legacy config files.
	ClientCertKeyPath string `json:",omitempty"`
}
```

I have already run tests for [v0.67.1](https://github.com/eclipse-opendut/netbird-build/releases/tag/v0.67.1-e6333229d8f37878c248906b9f11fd6ba3c29e11):
- [Custom releases](https://github.com/eclipse-opendut/netbird-build/releases/)
- [CI Tests](https://github.com/eclipse-opendut/netbird-build/actions/runs/23643505075).
Apart from that I've tested integration within our backend. I haven't tested on other operating systems than linux x86_64.

There are others who have requested more general support for client certificates and a PKI: [mTLS Auth for Proxy Services](https://github.com/netbirdio/netbird/issues/5364).
Adding client-side support is a first step in that direction.


### Checklist
- [x] Is a feature enhancement

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).


Legal notice:
Reimar Stier, reimar.stier@mercedes-benz.com, Mercedes-Benz Tech Innovation GmbH, [provider information](https://github.com/mercedes-benz/foss/blob/main/PROVIDER_INFORMATION.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added optional mutual TLS (mTLS) support for management, signal, and relay connections.
  * Configuration now supports separate identity-provider and management client certificate/key paths.
  * Client certificates are loaded when both paths are provided; browser-based builds continue to rely on browser TLS handling.

* **Bug Fixes**
  * Improved certificate configuration visibility in diagnostic information.

* **Tests**
  * Updated tests and helpers for optional certificate configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->