### PR TITLE
[client] fix busy-loop in network monitor routing socket on macOS/BSD

### DIFF
--- a/client/internal/networkmonitor/check_change_common.go
+++ b/client/internal/networkmonitor/check_change_common.go
@@ -98,16 +98,21 @@ func parseRouteMessage(buf []byte) (*systemops.Route, error) {
 
 // waitReadable blocks until fd has data to read, or ctx is cancelled.
 func waitReadable(ctx context.Context, fd int) error {
+	var fdset unix.FdSet
+	if fd < 0 || fd/unix.NFDBITS >= len(fdset.Bits) {
+		return fmt.Errorf("fd %d out of range for FdSet", fd)
+	}
+
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
-		fdset := &unix.FdSet{}
+		fdset = unix.FdSet{}
 		fdset.Set(fd)
 		// Use a 1-second timeout so we can re-check ctx periodically.
 		tv := unix.Timeval{Sec: 1}
-		n, err := unix.Select(fd+1, fdset, nil, nil, &tv)
+		n, err := unix.Select(fd+1, &fdset, nil, nil, &tv)
 		if err != nil {
 			if errors.Is(err, unix.EINTR) {
 				continue


### PR DESCRIPTION
After system wakeup, the AF_ROUTE socket created by Go's unix.Socket() is non-blocking, causing unix.Read to return EAGAIN immediately and spin at 100% CPU filling the log with thousands of warnings per second.

Replace the tight read loop with a unix.Select call that blocks until the fd is readable, checking ctx cancellation on each 1-second timeout. Fatal errors (EBADF, EINVAL) now return an error instead of looping.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network route-change monitoring by replacing busy-wait polling with a blocking wait to reduce CPU usage and latency.
  * Added robust error handling and message validation to avoid spurious failures when reading route updates.
  * Better handling of route add/delete events, including matching deletions against configured nexthops and periodic context re-checks for reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->