### PR TITLE
[fix] try NETBIRD_DATASTORE_ENC_KEY from setup.env first

### DIFF
--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -233,12 +233,12 @@ if [ "$NETBIRD_DASH_AUTH_USE_AUDIENCE" = "false" ]; then
     export NETBIRD_AUTH_PKCE_AUDIENCE=
 fi
 
+export NETBIRD_DATASTORE_ENC_KEY=$NETBIRD_DATASTORE_ENC_KEY
 # Read the encryption key
 if test -f 'management.json'; then
-    encKey=$(jq -r  ".DataStoreEncryptionKey" management.json)
+    encKey=$(jq -r ".DataStoreEncryptionKey" management.json)
     if [[ "$encKey" != "null" ]]; then
         export NETBIRD_DATASTORE_ENC_KEY=$encKey
-
     fi
 fi
 


### PR DESCRIPTION
## Describe your changes
In case there is no DataStoreEncryptionKey in management.json we wouldn't have NETBIRD_DATASTORE_ENC_KEY set so we other have DataStoreEncryptionKey empty or with fresh generated base64 despite DATASTORE already exist and encrypted with another key.
My change is allowing to get encryption key from setup.env so even with netbird recreation we would have all data(routes, setup keys, peers etc) still there(unless we destroy DB with it)
## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/5426
## Stack

<!-- branch-stack -->

### Checklist
- [ *] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)
As I understood multi container setup considered outdated so don't see a point adding it.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated encryption key variable handling in configuration initialization scripts for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->