### PR TITLE
[management] Prevent deletion of groups linked to flow groups

### DIFF
--- a/management/server/group.go
+++ b/management/server/group.go
@@ -647,7 +647,7 @@ func validateDeleteGroup(ctx context.Context, transaction store.Store, group *ty
 	}
 
 	if slices.Contains(flowGroups, group.ID) {
-		return &GroupLinkError{"settings", "traffic event groups"}
+		return &GroupLinkError{"settings", "traffic event logging"}
 	}
 
 	if isLinked, linkedRoute := isGroupLinkedToRoute(ctx, transaction, group.AccountID, group.ID); isLinked {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Groups linked to traffic event logging configurations are now protected from accidental deletion. Users attempting to delete such groups will receive a clear error message.

* **Tests**
  * Added test coverage for group deletion protection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->