### PR TITLE
[management] Add reverse proxy services REST client

### DIFF
--- a/shared/management/client/rest/reverse_proxy_clusters.go
+++ b/shared/management/client/rest/reverse_proxy_clusters.go
@@ -1,0 +1,25 @@
+package rest
+
+import (
+	"context"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+// ReverseProxyClustersAPI APIs for Reverse Proxy Clusters, do not use directly
+type ReverseProxyClustersAPI struct {
+	c *Client
+}
+
+// List lists all available proxy clusters
+func (a *ReverseProxyClustersAPI) List(ctx context.Context) ([]api.ProxyCluster, error) {
+	resp, err := a.c.NewRequest(ctx, "GET", "/api/reverse-proxies/clusters", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	ret, err := parseResponse[[]api.ProxyCluster](resp)
+	return ret, err
+}

--- a/shared/management/client/rest/reverse_proxy_domains.go
+++ b/shared/management/client/rest/reverse_proxy_domains.go
@@ -1,0 +1,72 @@
+package rest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+// ReverseProxyDomainsAPI APIs for Reverse Proxy Domains, do not use directly
+type ReverseProxyDomainsAPI struct {
+	c *Client
+}
+
+// List lists all reverse proxy domains
+func (a *ReverseProxyDomainsAPI) List(ctx context.Context) ([]api.ReverseProxyDomain, error) {
+	resp, err := a.c.NewRequest(ctx, "GET", "/api/reverse-proxies/domains", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	ret, err := parseResponse[[]api.ReverseProxyDomain](resp)
+	return ret, err
+}
+
+// Create creates a new custom domain
+func (a *ReverseProxyDomainsAPI) Create(ctx context.Context, request api.PostApiReverseProxiesDomainsJSONRequestBody) (*api.ReverseProxyDomain, error) {
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := a.c.NewRequest(ctx, "POST", "/api/reverse-proxies/domains", bytes.NewReader(requestBytes), nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	ret, err := parseResponse[api.ReverseProxyDomain](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+// Delete deletes a custom domain
+func (a *ReverseProxyDomainsAPI) Delete(ctx context.Context, domainID string) error {
+	resp, err := a.c.NewRequest(ctx, "DELETE", "/api/reverse-proxies/domains/"+url.PathEscape(domainID), nil, nil)
+	if err != nil {
+		return err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	return nil
+}
+
+// Validate triggers domain ownership validation for a custom domain
+func (a *ReverseProxyDomainsAPI) Validate(ctx context.Context, domainID string) error {
+	resp, err := a.c.NewRequest(ctx, "GET", "/api/reverse-proxies/domains/"+url.PathEscape(domainID)+"/validate", nil, nil)
+	if err != nil {
+		return err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	return nil
+}

--- a/shared/management/client/rest/reverse_proxy_services.go
+++ b/shared/management/client/rest/reverse_proxy_services.go
@@ -1,0 +1,97 @@
+package rest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+// ReverseProxyServicesAPI APIs for Reverse Proxy Services, do not use directly
+type ReverseProxyServicesAPI struct {
+	c *Client
+}
+
+// List lists all reverse proxy services
+func (a *ReverseProxyServicesAPI) List(ctx context.Context) ([]api.Service, error) {
+	resp, err := a.c.NewRequest(ctx, "GET", "/api/reverse-proxies/services", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	ret, err := parseResponse[[]api.Service](resp)
+	return ret, err
+}
+
+// Get retrieves a reverse proxy service by ID
+func (a *ReverseProxyServicesAPI) Get(ctx context.Context, serviceID string) (*api.Service, error) {
+	resp, err := a.c.NewRequest(ctx, "GET", "/api/reverse-proxies/services/"+url.PathEscape(serviceID), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	ret, err := parseResponse[api.Service](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+// Create creates a new reverse proxy service
+func (a *ReverseProxyServicesAPI) Create(ctx context.Context, request api.PostApiReverseProxiesServicesJSONRequestBody) (*api.Service, error) {
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := a.c.NewRequest(ctx, "POST", "/api/reverse-proxies/services", bytes.NewReader(requestBytes), nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	ret, err := parseResponse[api.Service](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+// Update updates a reverse proxy service
+func (a *ReverseProxyServicesAPI) Update(ctx context.Context, serviceID string, request api.PutApiReverseProxiesServicesServiceIdJSONRequestBody) (*api.Service, error) {
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := a.c.NewRequest(ctx, "PUT", "/api/reverse-proxies/services/"+url.PathEscape(serviceID), bytes.NewReader(requestBytes), nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	ret, err := parseResponse[api.Service](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+// Delete deletes a reverse proxy service
+func (a *ReverseProxyServicesAPI) Delete(ctx context.Context, serviceID string) error {
+	resp, err := a.c.NewRequest(ctx, "DELETE", "/api/reverse-proxies/services/"+url.PathEscape(serviceID), nil, nil)
+	if err != nil {
+		return err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Reverse Proxy Services management: list, get, create, update, delete.
  * Reverse Proxy Clusters: list cluster inventory.
  * Reverse Proxy Domains: list, create, delete, validate.
  * REST client now exposes these Reverse Proxy management endpoints.

* **Bug Fixes / Improvements**
  * Improved API error handling and added a helper to detect "not found" responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->