### PR TITLE
[client] Fix profile config directory permissions

### DIFF
--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -641,11 +641,11 @@ func isPreSharedKeyHidden(preSharedKey *string) bool {
 
 // UpdateConfig update existing configuration according to input configuration and return with the configuration
 func UpdateConfig(input ConfigInput) (*Config, error) {
-	fileExists, err := fileExists(input.ConfigPath)
+	configExists, err := fileExists(input.ConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if config file exists: %w", err)
 	}
-	if !fileExists {
+	if !configExists {
 		return nil, fmt.Errorf("config file %s does not exist", input.ConfigPath)
 	}
 
@@ -654,11 +654,11 @@ func UpdateConfig(input ConfigInput) (*Config, error) {
 
 // UpdateOrCreateConfig reads existing config or generates a new one
 func UpdateOrCreateConfig(input ConfigInput) (*Config, error) {
-	fileExists, err := fileExists(input.ConfigPath)
+	configExists, err := fileExists(input.ConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if config file exists: %w", err)
 	}
-	if !fileExists {
+	if !configExists {
 		log.Infof("generating new config %s", input.ConfigPath)
 		cfg, err := createNewConfig(input)
 		if err != nil {
@@ -798,12 +798,12 @@ func ReadConfig(configPath string) (*Config, error) {
 
 // ReadConfig read config file and return with Config. If it is not exists create a new with default values
 func readConfig(configPath string, createIfMissing bool) (*Config, error) {
-	fileExists, err := fileExists(configPath)
+	configExists, err := fileExists(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if config file exists: %w", err)
 	}
 
-	if fileExists {
+	if configExists {
 		err := util.EnforcePermission(configPath)
 		if err != nil {
 			log.Errorf("failed to enforce permission on config dir: %v", err)
@@ -850,11 +850,11 @@ func DirectWriteOutConfig(path string, config *Config) error {
 // DirectUpdateOrCreateConfig is like UpdateOrCreateConfig but uses direct (non-atomic) writes.
 // Use this on platforms where atomic writes are blocked (e.g., tvOS sandbox).
 func DirectUpdateOrCreateConfig(input ConfigInput) (*Config, error) {
-	fileExists, err := fileExists(input.ConfigPath)
+	configExists, err := fileExists(input.ConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if config file exists: %w", err)
 	}
-	if !fileExists {
+	if !configExists {
 		log.Infof("generating new config %s", input.ConfigPath)
 		cfg, err := createNewConfig(input)
 		if err != nil {

--- a/client/internal/profilemanager/service.go
+++ b/client/internal/profilemanager/service.go
@@ -256,11 +256,11 @@ func (s *ServiceManager) AddProfile(profileName, username string) error {
 	}
 
 	profPath := filepath.Join(configDir, profileName+".json")
-	fileExists, err := fileExists(profPath)
+	profileExists, err := fileExists(profPath)
 	if err != nil {
 		return fmt.Errorf("failed to check if profile exists: %w", err)
 	}
-	if fileExists {
+	if profileExists {
 		return ErrProfileAlreadyExists
 	}
 
@@ -289,11 +289,11 @@ func (s *ServiceManager) RemoveProfile(profileName, username string) error {
 		return fmt.Errorf("cannot remove profile with reserved name: %s", defaultProfileName)
 	}
 	profPath := filepath.Join(configDir, profileName+".json")
-	fileExists, err := fileExists(profPath)
+	profileExists, err := fileExists(profPath)
 	if err != nil {
 		return fmt.Errorf("failed to check if profile exists: %w", err)
 	}
-	if !fileExists {
+	if !profileExists {
 		return ErrProfileNotFound
 	}
 

--- a/client/internal/profilemanager/state.go
+++ b/client/internal/profilemanager/state.go
@@ -20,11 +20,11 @@ func (pm *ProfileManager) GetProfileState(profileName string) (*ProfileState, er
 	}
 
 	stateFile := filepath.Join(configDir, profileName+".state.json")
-	fileExists, err := fileExists(stateFile)
+	stateFileExists, err := fileExists(stateFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if profile state file exists: %w", err)
 	}
-	if !fileExists {
+	if !stateFileExists {
 		return nil, errors.New("profile state file does not exist")
 	}
 


### PR DESCRIPTION
## Describe your changes

This pr fixes : 

- a permission issue when creating the profile config directory for a user. A directory requires read/write **&** execute.
- a logic issue in `fileExists`, indeed cases such as a permission issue would make `stat` fails and therefore the file would be reported as existing whereas it doesn't.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Doc not needed since this is a simple bug fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clearer, more descriptive error messages and earlier surface of existence/check failures for profile and config operations.
  * More robust handling of missing configs/profiles: creation paths now trigger reliably when allowed.
  * Adjusted per-user config directory permissions to ensure correct access behavior.

* **New Features**
  * Option to specify a custom profiles directory for greater configuration flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->