### PR TITLE
Lower socket auto-discovery log from Info to Debug

### DIFF
--- a/client/internal/daemonaddr/resolve.go
+++ b/client/internal/daemonaddr/resolve.go
@@ -49,7 +49,7 @@ func ResolveUnixDaemonAddr(addr string) string {
 	switch len(found) {
 	case 1:
 		resolved := "unix://" + found[0]
-		log.Infof("Default daemon socket not found, using discovered socket: %s", resolved)
+		log.Debugf("Default daemon socket not found, using discovered socket: %s", resolved)
 		return resolved
 	case 0:
 		return addr


### PR DESCRIPTION
The discovery message was printing on every CLI invocation, which is noisy for users on distros using the systemd template.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity for daemon address resolution to reduce unnecessary log output during normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->