### PR TITLE
[client] Fix SSH JWT auth failure with Azure Entra ID iat backdating

### DIFF
--- a/client/ssh/server/server.go
+++ b/client/ssh/server/server.go
@@ -46,8 +46,10 @@ const (
 	cmdSFTP             = "<sftp>"
 	cmdNonInteractive   = "<idle>"
 
-	// DefaultJWTMaxTokenAge is the default maximum age for JWT tokens accepted by the SSH server
-	DefaultJWTMaxTokenAge = 5 * 60
+	// DefaultJWTMaxTokenAge is the default maximum age for JWT tokens accepted by the SSH server.
+	// Set to 10 minutes to accommodate identity providers like Azure Entra ID
+	// that backdate the iat claim by up to 5 minutes.
+	DefaultJWTMaxTokenAge = 10 * 60
 )
 
 var (


### PR DESCRIPTION
Increase DefaultJWTMaxTokenAge from 5 to 10 minutes to accommodate identity providers like Azure Entra ID that backdate the iat claim by up to 5 minutes, causing tokens to be immediately rejected.

Fixes #5449

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended JWT token validation timeout from 5 to 10 minutes, improving authentication stability and reducing token expiration-related failures in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->