### PR TITLE
[management] Fix DNS peer IP corruption to ::1 during migration

### DIFF
--- a/management/server/migration/migration.go
+++ b/management/server/migration/migration.go
@@ -187,8 +187,7 @@ func MigrateNetIPFieldFromBlobToJSON[T any](ctx context.Context, db *gorm.DB, fi
 
 			columnIpValue := net.IP(blobValue)
 			if net.ParseIP(columnIpValue.String()) == nil {
-				log.WithContext(ctx).Debugf("failed to parse %s as ip, fallback to ipv6 loopback", oldColumnName)
-				columnIpValue = net.IPv6loopback
+				return fmt.Errorf("failed to parse blob value as valid IP for column %s, row ID %v", oldColumnName, row["id"])
 			}
 
 			jsonValue, err := json.Marshal(columnIpValue)

--- a/management/server/migration/migration_test.go
+++ b/management/server/migration/migration_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -210,6 +211,35 @@ func TestMigrateNetIPFieldFromBlobToJSON_WithJSONData(t *testing.T) {
 	var jsonStr string
 	db.Model(&nbpeer.Peer{}).Select("location_connection_ip").First(&jsonStr)
 	assert.JSONEq(t, `"10.0.0.1"`, jsonStr, "Data should be unchanged")
+}
+
+func TestMigrateNetIPFieldFromBlobToJSON_WithInvalidBlobData(t *testing.T) {
+	// Use an isolated temp file database to avoid shared state with other tests
+	dbFile := filepath.Join(t.TempDir(), "invalid_ip_test.db")
+	db, err := gorm.Open(sqlite.Open(dbFile), &gorm.Config{})
+	require.NoError(t, err, "Failed to open isolated database")
+
+	t.Cleanup(func() {
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			sqlDB.Close()
+		}
+	})
+
+	err = db.AutoMigrate(&types.Account{}, &nbpeer.Peer{})
+	require.NoError(t, err, "Failed to auto-migrate tables")
+
+	err = db.Save(&types.Account{Id: "123"}).Error
+	require.NoError(t, err, "Failed to insert account")
+
+	// Insert a peer with deliberately invalid/corrupt blob IP data
+	err = db.Exec(`INSERT INTO peers (id, account_id, ip, "key") VALUES (?, ?, ?, ?)`,
+		"peer-invalid", "123", "corrupt-not-an-ip", "testkey").Error
+	require.NoError(t, err, "Failed to insert peer with invalid IP")
+
+	err = migration.MigrateNetIPFieldFromBlobToJSON[nbpeer.Peer](context.Background(), db, "ip", "idx_peers_account_id_ip")
+	require.Error(t, err, "Migration should fail for invalid IP blob data instead of silently using a fallback")
+	assert.Contains(t, err.Error(), "failed to parse blob value as valid IP")
 }
 
 func TestMigrateSetupKeyToHashedSetupKey_ForPlainKey(t *testing.T) {

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -519,6 +519,11 @@ func (a *Account) GetPeersCustomZone(ctx context.Context, dnsDomain string) nbdn
 			continue
 		}
 
+		if peer.IP == nil || peer.IP.To4() == nil || peer.IP.IsLoopback() || peer.IP.IsUnspecified() {
+			merr = multierror.Append(merr, fmt.Errorf("peer %s has invalid IP for A record: %v", peer.DNSLabel, peer.IP))
+			continue
+		}
+
 		sb.Grow(len(peer.DNSLabel) + len(domainSuffix))
 		sb.WriteString(peer.DNSLabel)
 		sb.WriteString(domainSuffix)

--- a/management/server/types/account_test.go
+++ b/management/server/types/account_test.go
@@ -1939,3 +1939,54 @@ func Test_filterPeerAppliedZones(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPeersCustomZone_InvalidIPs(t *testing.T) {
+	account := &Account{
+		Id: "testAccount",
+		Peers: map[string]*nbpeer.Peer{
+			"valid": {
+				ID:        "valid",
+				DNSLabel:  "valid-peer",
+				IP:        net.IP{100, 64, 0, 1},
+				AccountID: "testAccount",
+				Key:       "validKey",
+			},
+			"ipv6-loopback": {
+				ID:        "ipv6-loopback",
+				DNSLabel:  "loopback-peer",
+				IP:        net.IPv6loopback,
+				AccountID: "testAccount",
+				Key:       "loopbackKey",
+			},
+			"nil-ip": {
+				ID:        "nil-ip",
+				DNSLabel:  "nil-peer",
+				IP:        nil,
+				AccountID: "testAccount",
+				Key:       "nilKey",
+			},
+			"ipv4-loopback": {
+				ID:        "ipv4-loopback",
+				DNSLabel:  "v4loop-peer",
+				IP:        net.IP{127, 0, 0, 1},
+				AccountID: "testAccount",
+				Key:       "v4loopKey",
+			},
+			"unspecified": {
+				ID:        "unspecified",
+				DNSLabel:  "unspecified-peer",
+				IP:        net.IPv4zero,
+				AccountID: "testAccount",
+				Key:       "unspecKey",
+			},
+		},
+	}
+
+	zone := account.GetPeersCustomZone(context.Background(), "netbird.cloud")
+
+	// Only the valid peer should produce a record
+	require.Len(t, zone.Records, 1, "only valid peer should produce a DNS record")
+	assert.Equal(t, "valid-peer.netbird.cloud", zone.Records[0].Name)
+	assert.Equal(t, "100.64.0.1", zone.Records[0].RData)
+	assert.Equal(t, int(dns.TypeA), zone.Records[0].Type)
+}


### PR DESCRIPTION
## Summary
- **Root cause fix:** The blob-to-JSON migration for peer IPs silently fell back to `net.IPv6loopback` (`::1`) when parsing failed, permanently corrupting the peer's IP in the database. Replaced with an error return so invalid data is caught at migration time.
- **Defense-in-depth:** Added IP validation in `GetPeersCustomZone` — peers with nil, IPv6, loopback, or unspecified IPs are now skipped with a logged error instead of generating invalid A records that `miekg/dns` silently rejects.
- **No client-side changes needed:** The local resolver's AAAA handling already correctly returns NODATA when only A records exist.

## Impact
Peers with corrupted IPs (e.g. from failed blob migration on hosts with IPv6 disabled) would lose their DNS records entirely. On Windows clients, this broke mapped drives because Windows would fall through to upstream DNS and prefer IPv6 loopback over the correct WireGuard IP.

## Test plan
- [x] `TestMigrateNetIPFieldFromBlobToJSON_WithInvalidBlobData` — verifies migration fails on corrupt IP blobs instead of silently using `::1`
- [x] `TestGetPeersCustomZone_InvalidIPs` — verifies peers with nil/IPv6/loopback/unspecified IPs are skipped
- [x] All existing migration tests pass (17/17)
- [x] All existing account types tests pass (78/78)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during IP field migration: invalid IP data now returns detailed error messages identifying the affected row instead of silently applying default values.
  * Added IP validation in DNS zone generation: peer IPs are now validated to ensure they are valid IPv4 addresses and properly formatted before DNS record creation.

* **Tests**
  * Added test coverage for invalid IP data handling during migrations and DNS operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->