### PR TITLE
[management] Validate account ID in URL matches authenticated account

### DIFF
--- a/management/server/http/handlers/accounts/accounts_handler.go
+++ b/management/server/http/handlers/accounts/accounts_handler.go
@@ -237,12 +237,17 @@ func (h *handler) updateAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, userID := userAuth.AccountId, userAuth.UserId
+	accountID, userID := userAuth.AccountId, userAuth.UserId
 
 	vars := mux.Vars(r)
-	accountID := vars["accountId"]
-	if len(accountID) == 0 {
+	reqAccountID := vars["accountId"]
+	if len(reqAccountID) == 0 {
 		util.WriteError(r.Context(), status.Errorf(status.InvalidArgument, "invalid accountID ID"), w)
+		return
+	}
+
+	if reqAccountID != accountID {
+		util.WriteError(r.Context(), status.Errorf(status.PermissionDenied, "requested account ID does not match authenticated account"), w)
 		return
 	}
 
@@ -310,6 +315,8 @@ func (h *handler) deleteAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	accountID := userAuth.AccountId
+
 	vars := mux.Vars(r)
 	targetAccountID := vars["accountId"]
 	if len(targetAccountID) == 0 {
@@ -317,7 +324,12 @@ func (h *handler) deleteAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = h.accountManager.DeleteAccount(r.Context(), targetAccountID, userAuth.UserId)
+	if targetAccountID != accountID {
+		util.WriteError(r.Context(), status.Errorf(status.PermissionDenied, "requested account ID does not match authenticated account"), w)
+		return
+	}
+
+	err = h.accountManager.DeleteAccount(r.Context(), accountID, userAuth.UserId)
 	if err != nil {
 		util.WriteError(r.Context(), err, w)
 		return

--- a/management/server/http/handlers/accounts/accounts_handler_test.go
+++ b/management/server/http/handlers/accounts/accounts_handler_test.go
@@ -271,6 +271,15 @@ func TestAccounts_AccountsHandler(t *testing.T) {
 			expectedStatus: http.StatusUnprocessableEntity,
 			expectedArray:  false,
 		},
+		{
+			name:           "PutAccount with mismatched accountId returns forbidden",
+			expectedBody:   false,
+			requestType:    http.MethodPut,
+			requestPath:    "/api/accounts/different_account_id",
+			requestBody:    bytes.NewBufferString("{\"settings\": {\"peer_login_expiration\": 15552000,\"peer_login_expiration_enabled\": true},\"onboarding\": {\"onboarding_flow_pending\": true,\"signup_form_pending\": true}}"),
+			expectedStatus: http.StatusForbidden,
+			expectedArray:  false,
+		},
 	}
 
 	for _, tc := range tt {
@@ -329,4 +338,33 @@ func TestAccounts_AccountsHandler(t *testing.T) {
 			assert.Equal(t, tc.expectedSettings, actual.Settings)
 		})
 	}
+}
+
+func TestDeleteAccount_CrossAccountForbidden(t *testing.T) {
+	accountID := "test_account"
+	adminUser := types.NewAdminUser("test_user")
+
+	handler := initAccountsTestData(t, &types.Account{
+		Id:      accountID,
+		Domain:  "hotmail.com",
+		Network: types.NewNetwork(),
+		Users: map[string]*types.User{
+			adminUser.Id: adminUser,
+		},
+		Settings: &types.Settings{},
+	})
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/accounts/different_account_id", nil)
+	req = nbcontext.SetUserAuthInRequest(req, auth.UserAuth{
+		UserId:    adminUser.Id,
+		AccountId: accountID,
+		Domain:    "hotmail.com",
+	})
+
+	router := mux.NewRouter()
+	router.HandleFunc("/api/accounts/{accountId}", handler.deleteAccount).Methods("DELETE")
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusForbidden, recorder.Code, "cross-account delete should be forbidden")
 }


### PR DESCRIPTION
## Summary
- The `updateAccount` and `deleteAccount` handlers extracted `accountId` from the URL parameter without validating it against the authenticated user's account from the auth context. Every other handler in the codebase (users, groups, routes, peers, dns) uses `userAuth.AccountId` from the auth context — these two were the only ones trusting the URL parameter.
- Added explicit validation that the URL `accountId` matches `userAuth.AccountId`, returning 403 if they differ.
- The backend `ValidateUserPermissions` check mitigates single-account exploitation, but handlers should enforce this as defense-in-depth.

## Test plan
- [x] `PutAccount with mismatched accountId returns forbidden` — URL has different accountId than auth context → 403
- [x] `TestDeleteAccount_CrossAccountForbidden` — DELETE with mismatched accountId → 403
- [x] All 9 existing account handler tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened account access control to ensure users can only update or delete their own accounts. Attempts to modify accounts belonging to other users now return permission denied responses.

* **Tests**
  * Added comprehensive test coverage for cross-account access restriction scenarios during account updates and deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->