### PR TITLE
[client] Fix deadlock in route peer status watcher

### DIFF
--- a/client/internal/routemanager/client/client.go
+++ b/client/internal/routemanager/client/client.go
@@ -263,8 +263,14 @@ func (w *Watcher) watchPeerStatusChanges(ctx context.Context, peerKey string, pe
 		case <-closer:
 			return
 		case routerStates := <-subscription.Events():
-			peerStateUpdate <- routerStates
-			log.Debugf("triggered route state update for Peer: %s", peerKey)
+			select {
+			case peerStateUpdate <- routerStates:
+				log.Debugf("triggered route state update for Peer: %s", peerKey)
+			case <-ctx.Done():
+				return
+			case <-closer:
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
Wrap peerStateUpdate send in a nested select to prevent goroutine blocking when the consumer has exited, which could fill the subscription buffer and deadlock the Status mutex.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced route peer state handling to properly respond to cancellation signals, improving system responsiveness and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->