### PR TITLE
[client] allow setting DNSLabels on client embed

### DIFF
--- a/client/embed/embed.go
+++ b/client/embed/embed.go
@@ -22,6 +22,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	sshcommon "github.com/netbirdio/netbird/client/ssh"
 	"github.com/netbirdio/netbird/client/system"
+	"github.com/netbirdio/netbird/shared/management/domain"
 	mgmProto "github.com/netbirdio/netbird/shared/management/proto"
 )
 
@@ -88,6 +89,8 @@ type Options struct {
 	// If nil, the existing config MTU (if non-zero) is preserved; otherwise it defaults to 1280.
 	// Set to a higher value (e.g. 1400) if carrying QUIC or other protocols that require larger datagrams.
 	MTU *uint16
+	// DNSLabels defines additional DNS labels configured in the peer.
+	DNSLabels []string
 }
 
 // validateCredentials checks that exactly one credential type is provided
@@ -153,9 +156,14 @@ func New(opts Options) (*Client, error) {
 		}
 	}
 
+	var err error
+	var parsedLabels domain.List
+	if parsedLabels, err = domain.FromStringList(opts.DNSLabels); err != nil {
+		return nil, fmt.Errorf("invalid dns labels: %w", err)
+	}
+
 	t := true
 	var config *profilemanager.Config
-	var err error
 	input := profilemanager.ConfigInput{
 		ConfigPath:          opts.ConfigPath,
 		ManagementURL:       opts.ManagementURL,
@@ -165,6 +173,7 @@ func New(opts Options) (*Client, error) {
 		BlockInbound:        &opts.BlockInbound,
 		WireguardPort:       opts.WireguardPort,
 		MTU:                 opts.MTU,
+		DNSLabels:           parsedLabels,
 	}
 	if opts.ConfigPath != "" {
 		config, err = profilemanager.UpdateOrCreateConfig(input)


### PR DESCRIPTION
## Describe your changes
This allow you to set the DNSLabels on the embedded client in Go.

## Issue ticket number and link
n/a

## Stack
n/a

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

There's currently no much docs on the embed client, if needed - please let me know how you'd like to have it documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional DNS labels for peers via a new option; labels are parsed and included in generated client configuration to be applied at creation time.

* **Bug Fixes**
  * Validation added for DNS labels during client creation; invalid labels now produce a clear error and prevent an invalid configuration from being applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->