### PR TITLE
Fix embedded IdP metrics to count local and generic OIDC users

### DIFF
--- a/management/server/metrics/selfhosted.go
+++ b/management/server/metrics/selfhosted.go
@@ -294,9 +294,9 @@ func (w *Worker) generateProperties(ctx context.Context) properties {
 							localUsers++
 						} else {
 							idpUsers++
-							idpType := extractIdpType(idpID)
-							embeddedIdpTypes[idpType]++
 						}
+						idpType := extractIdpType(idpID)
+						embeddedIdpTypes[idpType]++
 					}
 				}
 			}
@@ -531,6 +531,9 @@ func createPostRequest(ctx context.Context, endpoint string, payloadStr string) 
 // Connector IDs are formatted as "<type>-<xid>" (e.g., "okta-abc123", "zitadel-xyz").
 // Returns the type prefix, or "oidc" if no known prefix is found.
 func extractIdpType(connectorID string) string {
+	if connectorID == "local" {
+		return "local"
+	}
 	idx := strings.LastIndex(connectorID, "-")
 	if idx <= 0 {
 		return "oidc"

--- a/management/server/metrics/selfhosted_test.go
+++ b/management/server/metrics/selfhosted_test.go
@@ -29,6 +29,7 @@ func (mockDatasource) GetAllConnectedPeers() map[string]struct{} {
 func (mockDatasource) GetAllAccounts(_ context.Context) []*types.Account {
 	localUserID := dex.EncodeDexUserID("10", "local")
 	idpUserID := dex.EncodeDexUserID("20", "zitadel-d5uv82dra0haedlf6kv0")
+	oidcUserID := dex.EncodeDexUserID("30", "d6jvvp69kmnc73c9pl40")
 	return []*types.Account{
 		{
 			Id:       "1",
@@ -206,6 +207,13 @@ func (mockDatasource) GetAllAccounts(_ context.Context) []*types.Account {
 						"1": {},
 					},
 				},
+				oidcUserID: {
+					Id:            oidcUserID,
+					IsServiceUser: false,
+					PATs: map[string]*types.PersonalAccessToken{
+						"1": {},
+					},
+				},
 			},
 			Networks: []*networkTypes.Network{
 				{
@@ -278,14 +286,14 @@ func TestGenerateProperties(t *testing.T) {
 	if properties["rules"] != 4 {
 		t.Errorf("expected 4 rules, got %d", properties["rules"])
 	}
-	if properties["users"] != 2 {
-		t.Errorf("expected 1 users, got %d", properties["users"])
+	if properties["users"] != 3 {
+		t.Errorf("expected 3 users, got %d", properties["users"])
 	}
 	if properties["setup_keys_usage"] != 2 {
 		t.Errorf("expected 1 setup_keys_usage, got %d", properties["setup_keys_usage"])
 	}
-	if properties["pats"] != 4 {
-		t.Errorf("expected 4 personal_access_tokens, got %d", properties["pats"])
+	if properties["pats"] != 5 {
+		t.Errorf("expected 5 personal_access_tokens, got %d", properties["pats"])
 	}
 	if properties["peers_ssh_enabled"] != 2 {
 		t.Errorf("expected 2 peers_ssh_enabled, got %d", properties["peers_ssh_enabled"])
@@ -369,14 +377,20 @@ func TestGenerateProperties(t *testing.T) {
 	if properties["local_users_count"] != 1 {
 		t.Errorf("expected 1 local_users_count, got %d", properties["local_users_count"])
 	}
-	if properties["idp_users_count"] != 1 {
-		t.Errorf("expected 1 idp_users_count, got %d", properties["idp_users_count"])
+	if properties["idp_users_count"] != 2 {
+		t.Errorf("expected 2 idp_users_count, got %d", properties["idp_users_count"])
+	}
+	if properties["embedded_idp_users_local"] != 1 {
+		t.Errorf("expected 1 embedded_idp_users_local, got %v", properties["embedded_idp_users_local"])
 	}
 	if properties["embedded_idp_users_zitadel"] != 1 {
 		t.Errorf("expected 1 embedded_idp_users_zitadel, got %v", properties["embedded_idp_users_zitadel"])
 	}
-	if properties["embedded_idp_count"] != 1 {
-		t.Errorf("expected 1 embedded_idp_count, got %v", properties["embedded_idp_count"])
+	if properties["embedded_idp_users_oidc"] != 1 {
+		t.Errorf("expected 1 embedded_idp_users_oidc, got %v", properties["embedded_idp_users_oidc"])
+	}
+	if properties["embedded_idp_count"] != 3 {
+		t.Errorf("expected 3 embedded_idp_count, got %v", properties["embedded_idp_count"])
 	}
 
 	if properties["services"] != 2 {
@@ -436,7 +450,8 @@ func TestExtractIdpType(t *testing.T) {
 		{"microsoft-abc123", "microsoft"},
 		{"authentik-abc123", "authentik"},
 		{"keycloak-d5uv82dra0haedlf6kv0", "keycloak"},
-		{"local", "oidc"},
+		{"local", "local"},
+		{"d6jvvp69kmnc73c9pl40", "oidc"},
 		{"", "oidc"},
 	}
 


### PR DESCRIPTION
Entire-Checkpoint: 39f0b252e2a9

## Describe your changes

- Fix extractIdpType to return "local" for local connector IDs instead of "oidc", and "oidc" for generic OIDC connectors (bare xid, no type prefix)
  - Include local users in embeddedIdpTypes map so embedded_idp_count and embedded_idp_users_local metrics are emitted
  - Add generic OIDC user (no-prefix connector) to test data to cover all three connector types

  What was broken

  - embedded_idp_count excluded local as a type, understating the number of configured IdP types
  - No embedded_idp_users_local metric was emitted despite local users being tracked separately
  - extractIdpType("local") would have returned "oidc" (wrong) if ever called directly


## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved metrics tracking for embedded Identity Provider types in self-hosted deployments.
* Enhanced distinction between local and OIDC identity providers in telemetry data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->