### PR TITLE
[management] use realip for proxy registration

### DIFF
--- a/management/internals/shared/grpc/proxy.go
+++ b/management/internals/shared/grpc/proxy.go
@@ -18,7 +18,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
 	"github.com/netbirdio/netbird/shared/management/domain"
@@ -177,11 +176,7 @@ func (s *ProxyServiceServer) SetProxyController(proxyController proxy.Controller
 func (s *ProxyServiceServer) GetMappingUpdate(req *proto.GetMappingUpdateRequest, stream proto.ProxyService_GetMappingUpdateServer) error {
 	ctx := stream.Context()
 
-	peerInfo := ""
-	if p, ok := peer.FromContext(ctx); ok {
-		peerInfo = p.Addr.String()
-	}
-
+	peerInfo := PeerIPFromContext(ctx)
 	log.Infof("New proxy connection from %s", peerInfo)
 
 	proxyID := req.GetProxyId()

--- a/management/internals/shared/grpc/proxy_auth.go
+++ b/management/internals/shared/grpc/proxy_auth.go
@@ -107,7 +107,7 @@ func NewProxyAuthInterceptors(tokenStore proxyTokenStore) (grpc.UnaryServerInter
 }
 
 func (i *proxyAuthInterceptor) validateProxyToken(ctx context.Context) (*types.ProxyAccessToken, error) {
-	clientIP := peerIPFromContext(ctx)
+	clientIP := PeerIPFromContext(ctx)
 
 	if clientIP != "" && i.failureLimiter.isLimited(clientIP) {
 		return nil, status.Errorf(codes.ResourceExhausted, "too many failed authentication attempts")

--- a/management/internals/shared/grpc/proxy_auth_ratelimit.go
+++ b/management/internals/shared/grpc/proxy_auth_ratelimit.go
@@ -115,9 +115,9 @@ func (l *authFailureLimiter) stop() {
 	l.cancel()
 }
 
-// peerIPFromContext extracts the client IP from the gRPC context.
+// PeerIPFromContext extracts the client IP from the gRPC context.
 // Uses realip (from trusted proxy headers) first, falls back to the transport peer address.
-func peerIPFromContext(ctx context.Context) clientIP {
+func PeerIPFromContext(ctx context.Context) string {
 	if addr, ok := realip.FromContext(ctx); ok {
 		return addr.String()
 	}


### PR DESCRIPTION
## Describe your changes
In LB setups the current design would use the LBs IP addr instead of the actual proxies IP address.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal proxy IP extraction handling across authentication modules for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->