### PR TITLE
[client] Precompile anonymizer regex patterns at package scope

### DIFF
--- a/client/anonymize/anonymize.go
+++ b/client/anonymize/anonymize.go
@@ -14,6 +14,13 @@ import (
 
 const anonTLD = ".domain"
 
+var (
+	domainKeyRegex = regexp.MustCompile(`\bdomain=([^\s,:"]+)`)
+	ipv4Regex      = regexp.MustCompile(`\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b`)
+	ipv6Regex      = regexp.MustCompile(`\b([0-9a-fA-F:]+:+[0-9a-fA-F]{0,4})(?:%[0-9a-zA-Z]+)?(?:\/[0-9]{1,3})?(?::[0-9]{1,5})?\b`)
+	schemeURIRegex = regexp.MustCompile(`(?i)\b(wss?://|rels?://|stuns?:|turns?:|https?://)\S+\b`)
+)
+
 type Anonymizer struct {
 	ipAnonymizer     map[netip.Addr]netip.Addr
 	domainAnonymizer map[string]string
@@ -21,8 +28,6 @@ type Anonymizer struct {
 	currentAnonIPv6  netip.Addr
 	startAnonIPv4    netip.Addr
 	startAnonIPv6    netip.Addr
-
-	domainKeyRegex *regexp.Regexp
 }
 
 func DefaultAddresses() (netip.Addr, netip.Addr) {
@@ -38,8 +43,6 @@ func NewAnonymizer(startIPv4, startIPv6 netip.Addr) *Anonymizer {
 		currentAnonIPv6:  startIPv6,
 		startAnonIPv4:    startIPv4,
 		startAnonIPv6:    startIPv6,
-
-		domainKeyRegex: regexp.MustCompile(`\bdomain=([^\s,:"]+)`),
 	}
 }
 
@@ -168,9 +171,6 @@ func (a *Anonymizer) AnonymizeURI(uri string) string {
 }
 
 func (a *Anonymizer) AnonymizeString(str string) string {
-	ipv4Regex := regexp.MustCompile(`\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b`)
-	ipv6Regex := regexp.MustCompile(`\b([0-9a-fA-F:]+:+[0-9a-fA-F]{0,4})(?:%[0-9a-zA-Z]+)?(?:\/[0-9]{1,3})?(?::[0-9]{1,5})?\b`)
-
 	str = ipv4Regex.ReplaceAllStringFunc(str, a.AnonymizeIPString)
 	str = ipv6Regex.ReplaceAllStringFunc(str, a.AnonymizeIPString)
 
@@ -186,13 +186,11 @@ func (a *Anonymizer) AnonymizeString(str string) string {
 
 // AnonymizeSchemeURI finds and anonymizes URIs with ws, wss, rel, rels, stun, stuns, turn, and turns schemes.
 func (a *Anonymizer) AnonymizeSchemeURI(text string) string {
-	re := regexp.MustCompile(`(?i)\b(wss?://|rels?://|stuns?:|turns?:|https?://)\S+\b`)
-
-	return re.ReplaceAllStringFunc(text, a.AnonymizeURI)
+	return schemeURIRegex.ReplaceAllStringFunc(text, a.AnonymizeURI)
 }
 
 func (a *Anonymizer) AnonymizeDNSLogLine(logEntry string) string {
-	return a.domainKeyRegex.ReplaceAllStringFunc(logEntry, func(match string) string {
+	return domainKeyRegex.ReplaceAllStringFunc(logEntry, func(match string) string {
 		parts := strings.SplitN(match, "=", 2)
 		if len(parts) >= 2 {
 			domain := parts[1]


### PR DESCRIPTION
Avoid compiling regexes on every anonymization call by promoting them to package-level compiled variables.

This reduces per-call CPU and allocation overhead in log/string anonymization paths.

## Describe your changes

- Moved regex patterns in client/anonymize/anonymize.go to package-level compiled variables:
  - `domainKeyRegex`
  - `ipv4Regex`
  - `ipv6Regex`
  - `schemeURIRegex`
 - Removed per-call `regexp.MustCompile(...)` inside:
  - `AnonymizeString`
  - `AnonymizeSchemeURI`
- Kept anonymization behavior unchanged while reducing repeated regex compile work in hot log/string paths.
- Verified with:
  - `go test ./client/anonymize`

## Issue ticket number and link

N/A (performance refactor)

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)
- [ ] 
Reason: internal implementation-only refactor with no API/CLI behavior or user-facing workflow changes.

### Docs PR URL (required if "docs added" is checked)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized regex pattern initialization for improved application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->