### PR TITLE
[self-hosted] Remove extra proxy domain from getting started

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -182,44 +182,6 @@ read_enable_proxy() {
   return 0
 }
 
-read_proxy_domain() {
-  local suggested_proxy="proxy.${BASE_DOMAIN}"
-
-  echo "" > /dev/stderr
-  echo "NOTE: The proxy domain must be different from the management domain ($NETBIRD_DOMAIN)" > /dev/stderr
-  echo "to avoid TLS certificate conflicts." > /dev/stderr
-  echo "" > /dev/stderr
-  echo "You also need to add a wildcard DNS record for the proxy domain," > /dev/stderr
-  echo "e.g. *.${suggested_proxy} pointing to the same server domain as $NETBIRD_DOMAIN with a CNAME record." > /dev/stderr
-  echo "" > /dev/stderr
-  echo -n "Enter the domain for the NetBird Proxy (e.g. ${suggested_proxy}): " > /dev/stderr
-  read -r READ_PROXY_DOMAIN < /dev/tty
-
-  if [[ -z "$READ_PROXY_DOMAIN" ]]; then
-    echo "The proxy domain cannot be empty." > /dev/stderr
-    read_proxy_domain
-    return
-  fi
-
-  if [[ "$READ_PROXY_DOMAIN" == "$NETBIRD_DOMAIN" ]]; then
-    echo "" > /dev/stderr
-    echo "WARNING: The proxy domain cannot be the same as the management domain ($NETBIRD_DOMAIN)." > /dev/stderr
-    read_proxy_domain
-    return
-  fi
-
-  echo ${READ_PROXY_DOMAIN} | grep ${NETBIRD_DOMAIN} > /dev/null
-  if [[ $? -eq 0 ]]; then
-    echo "" > /dev/stderr
-    echo "WARNING: The proxy domain cannot be a subdomain of the management domain ($NETBIRD_DOMAIN)." > /dev/stderr
-    read_proxy_domain
-    return
-  fi
-
-  echo "$READ_PROXY_DOMAIN"
-  return 0
-}
-
 read_traefik_acme_email() {
   echo "" > /dev/stderr
   echo "Enter your email for Let's Encrypt certificate notifications." > /dev/stderr
@@ -334,7 +296,6 @@ initialize_default_values() {
 
   # NetBird Proxy configuration
   ENABLE_PROXY="false"
-  PROXY_DOMAIN=""
   PROXY_TOKEN=""
   return 0
 }
@@ -364,9 +325,6 @@ configure_reverse_proxy() {
   if [[ "$REVERSE_PROXY_TYPE" == "0" ]]; then
     TRAEFIK_ACME_EMAIL=$(read_traefik_acme_email)
     ENABLE_PROXY=$(read_enable_proxy)
-    if [[ "$ENABLE_PROXY" == "true" ]]; then
-      PROXY_DOMAIN=$(read_proxy_domain)
-    fi
   fi
 
   # Handle external Traefik-specific prompts (option 1)
@@ -813,7 +771,7 @@ NB_PROXY_MANAGEMENT_ADDRESS=http://netbird-server:80
 # Allow insecure gRPC connection to management (required for internal Docker network)
 NB_PROXY_ALLOW_INSECURE=true
 # Public URL where this proxy is reachable (used for cluster registration)
-NB_PROXY_DOMAIN=$PROXY_DOMAIN
+NB_PROXY_DOMAIN=$NETBIRD_DOMAIN
 NB_PROXY_ADDRESS=:8443
 NB_PROXY_TOKEN=$PROXY_TOKEN
 NB_PROXY_CERTIFICATE_DIRECTORY=/certs
@@ -1203,8 +1161,7 @@ print_builtin_traefik_instructions() {
     echo "  The proxy handles its own TLS certificates via ACME TLS-ALPN-01 challenge."
     echo "  Point your proxy domain to this server's domain address like in the examples below:"
     echo ""
-    echo "  $PROXY_DOMAIN      CNAME    $NETBIRD_DOMAIN"
-    echo "  *.$PROXY_DOMAIN    CNAME    $NETBIRD_DOMAIN"
+    echo "  *.$NETBIRD_DOMAIN    CNAME    $NETBIRD_DOMAIN"
     echo ""
   fi
   return 0


### PR DESCRIPTION
## Describe your changes
<img width="763" height="614" alt="image" src="https://github.com/user-attachments/assets/b7645892-01a4-45f4-b8ea-99c39175a24f" />
<img width="750" height="685" alt="image" src="https://github.com/user-attachments/assets/e6aaa916-4090-4d08-bf7a-30b4834dcc78" />

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/648


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the installation and setup process by automating proxy domain configuration.
  * Users no longer need to manually specify a proxy domain during setup; it is now automatically derived from the primary domain setting.
  * Updated configuration instructions and environment rendering to reflect simplified proxy domain handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->