### PR TITLE
[proxy] read cert from disk if available instead of cert manager

### DIFF
--- a/proxy/internal/acme/manager.go
+++ b/proxy/internal/acme/manager.go
@@ -205,7 +205,10 @@ func (mgr *Manager) prefetchCertificate(d domain.Domain) {
 			// Drain the ACME goroutine before marking ready — autocert holds
 			// an internal write lock on certState while ACME is in flight.
 			go func() {
-				<-acmeCh
+				select {
+				case <-acmeCh:
+				default:
+				}
 				mgr.recordAndNotify(context.Background(), d, name, cert, 0)
 			}()
 			return


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous certificate prefetch that races live issuance with periodic on-disk cache checks to surface certificates faster.
  * Centralized recording and notification when certificates become available.
  * New on-disk certificate reading and validation to allow immediate use of cached certs.

* **Bug Fixes & Performance**
  * Optimized retrieval by polling disk while fetching in background to reduce latency.
  * Added cancellation and timeout handling to fail stalled certificate operations reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->