### PR TITLE
[misc] Add GPG signing key support for  rpm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,13 +169,10 @@ jobs:
       - name: Install OS build dependencies
         run: sudo apt update && sudo apt install -y -q gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
 
-      - name: Decode GPG signing keys
+      - name: Decode GPG signing key
         env:
-          GPG_DEB_PRIVATE_KEY: ${{ secrets.GPG_DEB_PRIVATE_KEY }}
           GPG_RPM_PRIVATE_KEY: ${{ secrets.GPG_RPM_PRIVATE_KEY }}
         run: |
-          echo "$GPG_DEB_PRIVATE_KEY" | base64 -d > /tmp/gpg-deb-signing-key.asc
-          echo "GPG_DEB_KEY_FILE=/tmp/gpg-deb-signing-key.asc" >> $GITHUB_ENV
           echo "$GPG_RPM_PRIVATE_KEY" | base64 -d > /tmp/gpg-rpm-signing-key.asc
           echo "GPG_RPM_KEY_FILE=/tmp/gpg-rpm-signing-key.asc" >> $GITHUB_ENV
 
@@ -196,13 +193,24 @@ jobs:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           UPLOAD_DEBIAN_SECRET: ${{ secrets.PKG_UPLOAD_SECRET }}
           UPLOAD_YUM_SECRET: ${{ secrets.PKG_UPLOAD_SECRET }}
-          GPG_DEB_KEY_FILE: ${{ env.GPG_DEB_KEY_FILE }}
           GPG_RPM_KEY_FILE: ${{ env.GPG_RPM_KEY_FILE }}
-          NFPM_NETBIRD_DEB_PASSPHRASE: ${{ secrets.GPG_DEB_PASSPHRASE }}
           NFPM_NETBIRD_RPM_PASSPHRASE: ${{ secrets.GPG_RPM_PASSPHRASE }}
-      - name: Clean up GPG keys
+      - name: Verify RPM signatures
+        run: |
+          docker run --rm -v $(pwd)/dist:/dist fedora:41 bash -c '
+            dnf install -y -q rpm-sign curl >/dev/null 2>&1
+            curl -sSL https://pkgs.netbird.io/yum/repodata/repomd.xml.key -o /tmp/rpm-pub.key
+            rpm --import /tmp/rpm-pub.key
+            echo "=== Verifying RPM signatures ==="
+            for rpm_file in /dist/*amd64*.rpm; do
+              [ -f "$rpm_file" ] || continue
+              echo "--- $(basename $rpm_file) ---"
+              rpm -K "$rpm_file"
+            done
+          '
+      - name: Clean up GPG key
         if: always()
-        run: rm -f /tmp/gpg-deb-signing-key.asc /tmp/gpg-rpm-signing-key.asc
+        run: rm -f /tmp/gpg-rpm-signing-key.asc
       - name: Tag and push PR images (amd64 only)
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
@@ -282,13 +290,10 @@ jobs:
       - name: Install dependencies
         run: sudo apt update && sudo apt install -y -q libappindicator3-dev gir1.2-appindicator3-0.1 libxxf86vm-dev gcc-mingw-w64-x86-64
 
-      - name: Decode GPG signing keys
+      - name: Decode GPG signing key
         env:
-          GPG_DEB_PRIVATE_KEY: ${{ secrets.GPG_DEB_PRIVATE_KEY }}
           GPG_RPM_PRIVATE_KEY: ${{ secrets.GPG_RPM_PRIVATE_KEY }}
         run: |
-          echo "$GPG_DEB_PRIVATE_KEY" | base64 -d > /tmp/gpg-deb-signing-key.asc
-          echo "GPG_DEB_KEY_FILE=/tmp/gpg-deb-signing-key.asc" >> $GITHUB_ENV
           echo "$GPG_RPM_PRIVATE_KEY" | base64 -d > /tmp/gpg-rpm-signing-key.asc
           echo "GPG_RPM_KEY_FILE=/tmp/gpg-rpm-signing-key.asc" >> $GITHUB_ENV
 
@@ -316,13 +321,24 @@ jobs:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           UPLOAD_DEBIAN_SECRET: ${{ secrets.PKG_UPLOAD_SECRET }}
           UPLOAD_YUM_SECRET: ${{ secrets.PKG_UPLOAD_SECRET }}
-          GPG_DEB_KEY_FILE: ${{ env.GPG_DEB_KEY_FILE }}
           GPG_RPM_KEY_FILE: ${{ env.GPG_RPM_KEY_FILE }}
-          NFPM_NETBIRD_UI_DEB_PASSPHRASE: ${{ secrets.GPG_DEB_PASSPHRASE }}
           NFPM_NETBIRD_UI_RPM_PASSPHRASE: ${{ secrets.GPG_RPM_PASSPHRASE }}
-      - name: Clean up GPG keys
+      - name: Verify RPM signatures
+        run: |
+          docker run --rm -v $(pwd)/dist:/dist fedora:41 bash -c '
+            dnf install -y -q rpm-sign curl >/dev/null 2>&1
+            curl -sSL https://pkgs.netbird.io/yum/repodata/repomd.xml.key -o /tmp/rpm-pub.key
+            rpm --import /tmp/rpm-pub.key
+            echo "=== Verifying RPM signatures ==="
+            for rpm_file in /dist/*.rpm; do
+              [ -f "$rpm_file" ] || continue
+              echo "--- $(basename $rpm_file) ---"
+              rpm -K "$rpm_file"
+            done
+          '
+      - name: Clean up GPG key
         if: always()
-        run: rm -f /tmp/gpg-deb-signing-key.asc /tmp/gpg-rpm-signing-key.asc
+        run: rm -f /tmp/gpg-rpm-signing-key.asc
       - name: upload non tags for debug purposes
         uses: actions/upload-artifact@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -180,10 +180,6 @@ nfpms:
     scripts:
       postinstall: "release_files/post_install.sh"
       preremove: "release_files/pre_remove.sh"
-    deb:
-      signature:
-        key_file: '{{ if index .Env "GPG_DEB_KEY_FILE" }}{{ .Env.GPG_DEB_KEY_FILE }}{{ end }}'
-        type: origin
 
   - maintainer: Netbird <dev@netbird.io>
     description: Netbird client.

--- a/.goreleaser_ui.yaml
+++ b/.goreleaser_ui.yaml
@@ -76,10 +76,6 @@ nfpms:
         dst: /usr/share/pixmaps/netbird.png
     dependencies:
       - netbird
-    deb:
-      signature:
-        key_file: '{{ if index .Env "GPG_DEB_KEY_FILE" }}{{ .Env.GPG_DEB_KEY_FILE }}{{ end }}'
-        type: origin
 
   - maintainer: Netbird <dev@netbird.io>
     description: Netbird client UI.


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DEB and RPM packages (main and UI releases) are now GPG-signed to improve package authenticity.

* **Chores**
  * Release workflows updated to import temporary signing keys in CI, pass signing inputs into release steps, and remove keys after signing.
  * Packaging metadata extended to include signature configuration for both DEB and RPM artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->