### PR TITLE
fix(dns): kill DnsCache svchost to flush stale NRPT policy on Windows

### DIFF
--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -408,7 +408,9 @@ func (r *registryConfigurator) restoreHostDNS() error {
 		return fmt.Errorf("remove interface registry key: %w", err)
 	}
 
-	go r.flushDNSCache()
+	// Flush synchronously before killing DnsCache to avoid a race condition
+	// where the async flush targets a process that is already being terminated.
+	r.flushDNSCache()
 
 	if err := killDNSCacheProcess(); err != nil {
 		log.Warnf("failed to kill DnsCache process for NRPT flush, DNS may require reboot to clear: %v", err)
@@ -497,6 +499,11 @@ func refreshGroupPolicy() error {
 // forcing a cold reload of NRPT policy from registry. This is necessary because
 // DnsCache ignores PARAMCHANGE signals on many Windows builds (NOT_PAUSABLE),
 // and retains stale NRPT rules in memory even after registry keys are deleted.
+//
+// Note: This terminates the entire svchost.exe process, which may include other
+// services in the same process group. Windows Service Control Manager will
+// automatically respawn affected services. There may be a brief interruption
+// or state loss in co-hosted services during respawn.
 func killDNSCacheProcess() error {
 	scm, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
 	if err != nil {
@@ -526,17 +533,37 @@ func killDNSCacheProcess() error {
 
 	pid := status.ProcessId
 	if pid == 0 {
-		return fmt.Errorf("DnsCache PID is 0")
+		// DnsCache is not running — no stale rules to worry about,
+		// next start will read clean registry.
+		log.Debug("DnsCache service not running, no process to kill")
+		return nil
 	}
 
-	handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, pid)
+	handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE|windows.SYNCHRONIZE, false, pid)
 	if err != nil {
 		return fmt.Errorf("open process %d: %w", pid, err)
 	}
 	defer windows.CloseHandle(handle)
 
-	log.Infof("killing DnsCache svchost PID %d to flush NRPT policy from memory", pid)
-	return windows.TerminateProcess(handle, 0)
+	log.Warnf("killing DnsCache svchost PID %d to flush stale NRPT policy from memory — co-hosted services will be briefly interrupted and respawned by SCM", pid)
+
+	if err := windows.TerminateProcess(handle, 0); err != nil {
+		return fmt.Errorf("terminate process %d: %w", pid, err)
+	}
+
+	// Wait for the process to fully exit before returning, so the caller
+	// can be confident the next DnsCache start will read clean registry.
+	event, err := windows.WaitForSingleObject(handle, 3000) // 3 second timeout
+	if err != nil {
+		return fmt.Errorf("wait for process %d termination: %w", pid, err)
+	}
+	if event == uint32(windows.WAIT_TIMEOUT) {
+		log.Warnf("DnsCache process %d termination timed out after 3s", pid)
+		return fmt.Errorf("timed out waiting for DnsCache process %d to terminate", pid)
+	}
+
+	log.Infof("DnsCache process %d terminated, NRPT policy will reload from clean registry on respawn", pid)
+	return nil
 }
 
 func closer(closer io.Closer) {

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -10,9 +10,11 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"github.com/hashicorp/go-multierror"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 
 	nberrors "github.com/netbirdio/netbird/client/errors"
@@ -408,6 +410,10 @@ func (r *registryConfigurator) restoreHostDNS() error {
 
 	go r.flushDNSCache()
 
+	if err := killDNSCacheProcess(); err != nil {
+		log.Warnf("failed to kill DnsCache process for NRPT flush, DNS may require reboot to clear: %v", err)
+	}
+
 	return nil
 }
 
@@ -485,6 +491,52 @@ func refreshGroupPolicy() error {
 	}
 
 	return nil
+}
+
+// killDNSCacheProcess terminates the svchost process hosting the DnsCache service,
+// forcing a cold reload of NRPT policy from registry. This is necessary because
+// DnsCache ignores PARAMCHANGE signals on many Windows builds (NOT_PAUSABLE),
+// and retains stale NRPT rules in memory even after registry keys are deleted.
+func killDNSCacheProcess() error {
+	scm, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
+	if err != nil {
+		return fmt.Errorf("open SCM: %w", err)
+	}
+	defer windows.CloseServiceHandle(scm)
+
+	svcName, _ := syscall.UTF16PtrFromString("Dnscache")
+	svc, err := windows.OpenService(scm, svcName, windows.SERVICE_QUERY_STATUS)
+	if err != nil {
+		return fmt.Errorf("open DnsCache service: %w", err)
+	}
+	defer windows.CloseServiceHandle(svc)
+
+	var status windows.SERVICE_STATUS_PROCESS
+	var bytesNeeded uint32
+	err = windows.QueryServiceStatusEx(
+		svc,
+		windows.SC_STATUS_PROCESS_INFO,
+		(*byte)(unsafe.Pointer(&status)),
+		uint32(unsafe.Sizeof(status)),
+		&bytesNeeded,
+	)
+	if err != nil {
+		return fmt.Errorf("query DnsCache status: %w", err)
+	}
+
+	pid := status.ProcessId
+	if pid == 0 {
+		return fmt.Errorf("DnsCache PID is 0")
+	}
+
+	handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, pid)
+	if err != nil {
+		return fmt.Errorf("open process %d: %w", pid, err)
+	}
+	defer windows.CloseHandle(handle)
+
+	log.Infof("killing DnsCache svchost PID %d to flush NRPT policy from memory", pid)
+	return windows.TerminateProcess(handle, 0)
 }
 
 func closer(closer io.Closer) {


### PR DESCRIPTION
After removing NRPT registry keys on disconnect, DnsCache retains stale rules in memory on Windows builds where the service is NOT_PAUSABLE and ignores PARAMCHANGE signals. This causes DNS queries for NetBird domains to continue resolving to the dead forwarder IP until reboot.

Fix by terminating the svchost process hosting DnsCache after registry cleanup, forcing a cold reload of NRPT policy from the now-clean registry. Windows Service Host respawns DnsCache immediately.

Fixes #5579

## Describe your changes

After `removeDNSMatchPolicies()` deletes NRPT registry keys on disconnect, the `DnsCache` service on many Windows 10/11 builds retains the stale rules in memory. The service reports `NOT_PAUSABLE` and silently ignores `SERVICE_CONTROL_PARAMCHANGE`, so the existing `DnsFlushResolverCache` call has no effect on loaded policy. This can be confirmed with `Get-DnsClientNrptPolicy -Effective` — stale rules pointing at the dead NetBird forwarder IP remain visible after disconnect despite the registry being clean.

This fix adds `killDNSCacheProcess()` which terminates the svchost process hosting DnsCache after registry cleanup. Windows Service Host respawns DnsCache immediately, and the fresh instance reads from the now-clean registry. Network connectivity is not interrupted.

## Issue ticket number and link

- #5579 https://github.com/netbirdio/netbird/issues/5579

## Stack
<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:
- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal Windows service lifecycle fix with no user-facing behaviour change)

### Docs PR URL (required if "docs added" is checked)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS cache handling on Windows so DNS configuration and policy changes (NRPT) take effect immediately by forcing a fresh resolver instance.
  * If the forced refresh cannot be completed, the system logs a non-fatal warning instead of failing the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->