### PR TITLE
[client] Fix IPv6 address formatting in DNS address construction

### DIFF
--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/netip"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -69,7 +70,7 @@ func (s *serviceViaListener) Listen() error {
 		return fmt.Errorf("eval listen address: %w", err)
 	}
 	s.listenIP = s.listenIP.Unmap()
-	s.server.Addr = fmt.Sprintf("%s:%d", s.listenIP, s.listenPort)
+	s.server.Addr = net.JoinHostPort(s.listenIP.String(), strconv.Itoa(int(s.listenPort)))
 	log.Debugf("starting dns on %s", s.server.Addr)
 	go func() {
 		s.setListenerStatus(true)
@@ -186,7 +187,7 @@ func (s *serviceViaListener) testFreePort(port int) (netip.Addr, bool) {
 }
 
 func (s *serviceViaListener) tryToBind(ip netip.Addr, port int) bool {
-	addrString := fmt.Sprintf("%s:%d", ip, port)
+	addrString := net.JoinHostPort(ip.String(), strconv.Itoa(port))
 	udpAddr := net.UDPAddrFromAddrPort(netip.MustParseAddrPort(addrString))
 	probeListener, err := net.ListenUDP("udp", udpAddr)
 	if err != nil {

--- a/client/internal/routemanager/client/client.go
+++ b/client/internal/routemanager/client/client.go
@@ -3,7 +3,9 @@ package client
 import (
 	"context"
 	"fmt"
+	"net"
 	"reflect"
+	"strconv"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -564,7 +566,7 @@ func HandlerFromRoute(params common.HandlerParams) RouteHandler {
 		return dnsinterceptor.New(params)
 	case handlerTypeDynamic:
 		dns := nbdns.NewServiceViaMemory(params.WgInterface)
-		dnsAddr := fmt.Sprintf("%s:%d", dns.RuntimeIP(), dns.RuntimePort())
+		dnsAddr := net.JoinHostPort(dns.RuntimeIP().String(), strconv.Itoa(dns.RuntimePort()))
 		return dynamic.NewRoute(params, dnsAddr)
 	default:
 		return static.NewRoute(params)

--- a/client/internal/routemanager/dnsinterceptor/handler.go
+++ b/client/internal/routemanager/dnsinterceptor/handler.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -249,7 +251,7 @@ func (d *DnsInterceptor) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		r.MsgHdr.AuthenticatedData = true
 	}
 
-	upstream := fmt.Sprintf("%s:%d", upstreamIP.String(), uint16(d.forwarderPort.Load()))
+	upstream := net.JoinHostPort(upstreamIP.String(), strconv.FormatUint(uint64(d.forwarderPort.Load()), 10))
 	ctx, cancel := context.WithTimeout(context.Background(), dnsTimeout)
 	defer cancel()
 


### PR DESCRIPTION
## Summary

Fixes #5601  
Related to #4074

Several places in the DNS client code construct server addresses using `fmt.Sprintf("%s:%d", ip, port)`. This produces malformed addresses when the IP is IPv6, since IPv6 addresses contain colons and need brackets when combined with a port (e.g., `[2606:4700:4700::1111]:53` instead of `2606:4700:4700::1111:53`).

This causes DNS resolution to fail with `dial udp: address 2606:4700:4700::1111:53: too many colons in address` when IPv6 nameservers are configured.

### Changes

Replaced `fmt.Sprintf("%s:%d", ip, port)` with `net.JoinHostPort()` in:

- **`client/internal/routemanager/dnsinterceptor/handler.go`** — upstream DNS address for the DNS interceptor (most critical, directly causes query failures)
- **`client/internal/dns/service_listener.go`** — DNS listener address and port binding probes  
- **`client/internal/routemanager/client/client.go`** — DNS address for dynamic route handlers

`net.JoinHostPort()` is the standard Go idiom for this — it automatically wraps IPv6 addresses in brackets. The rest of the codebase already uses this function in many places (e.g., `peer/worker_ice.go`, `ssh/detection/detection.go`).

## Test plan

- [ ] Verify existing DNS tests still pass (`go test ./client/internal/dns/...`)
- [ ] Verify route manager tests pass (`go test ./client/internal/routemanager/...`)
- [ ] Configure an IPv6 nameserver (e.g., Cloudflare `2606:4700:4700::1111`) and verify DNS queries succeed
- [ ] Verify IPv4 nameserver behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal DNS address handling with standardized formatting utilities, improving code consistency and maintainability across core networking components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->