### PR TITLE
fix(ui): open browser in user context on macOS/Linux when daemon runs as root

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -1795,19 +1795,58 @@ func (s *serviceClient) showLoginURL() context.CancelFunc {
 	return cancel
 }
 
-func openURL(url string) error {
+// desktopUser returns the username of the logged-in desktop user, even when the
+// process is running as root. On darwin it queries /dev/console; on Linux/FreeBSD
+// it checks the SUDO_USER environment variable, falling back to LOGNAME/USER.
+// Returns an empty string if the desktop user cannot be determined.
+func desktopUser() string {
+	switch runtime.GOOS {
+	case "darwin":
+		out, err := exec.Command("stat", "-f", "%Su", "/dev/console").Output()
+		if err == nil {
+			u := strings.TrimSpace(string(out))
+			if u != "" && u != "root" {
+				return u
+			}
+		}
+	case "linux", "freebsd":
+		if u := os.Getenv("SUDO_USER"); u != "" && u != "root" {
+			return u
+		}
+		if u := os.Getenv("LOGNAME"); u != "" && u != "root" {
+			return u
+		}
+		if u := os.Getenv("USER"); u != "" && u != "root" {
+			return u
+		}
+	}
+	return ""
+}
+
+// openURLAsUser opens rawURL using browserCmd, running it as the desktop user
+// when the process is running as root so that the user's default browser is respected.
+func openURLAsUser(browserCmd, rawURL string) error {
+	if os.Getuid() == 0 {
+		if u := desktopUser(); u != "" {
+			return exec.Command("sudo", "-u", u, browserCmd, rawURL).Start()
+		}
+	}
+	return exec.Command(browserCmd, rawURL).Start()
+}
+
+func openURL(rawURL string) error {
 	if browser := os.Getenv("BROWSER"); browser != "" {
-		return exec.Command(browser, url).Start()
+		return exec.Command(browser, rawURL).Start()
 	}
 
 	var err error
 	switch runtime.GOOS {
 	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL).Start()
 	case "darwin":
-		err = exec.Command("open", url).Start()
+		err = openURLAsUser("open", rawURL)
 	case "linux", "freebsd":
-		err = exec.Command("xdg-open", url).Start()
+		err = openURLAsUser("xdg-open", rawURL)
 	default:
 		err = fmt.Errorf("unsupported platform")
 	}


### PR DESCRIPTION
## Describe your changes

When the NetBird daemon runs as root and triggers re-authentication after peer login expiry, the bare `open`/`xdg-open` command launches the browser in the root process context, ignoring the logged-in user's default browser preference. On macOS this consistently opens Safari in the background even when the user has Chrome/Firefox set as their default browser, causing the session expired re-auth flow to go unnoticed.

Fix by detecting when running as root (`os.Getuid() == 0`) and invoking `open`/`xdg-open` as the current logged-in user via `sudo -u`, ensuring macOS/Linux resolves the correct default browser in the user's session context. Falls back to bare `open`/`xdg-open` if `user.Current()` fails or if not running as root.

The existing `open-golang` dependency was considered but has the same root cause on darwin — it calls `open` directly without user context.

Tested on macOS (Intel + ARM64) by invalidating a peer session and confirming Chrome opens instead of Safari.

## Issue ticket number and link

Related: #4471
Related: #2109

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

- [x] Documentation is **not needed** for this change — internal bug fix for browser launch behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL-opening when the app runs with elevated privileges on macOS and Linux/FreeBSD so links open in the desktop user's browser instead of failing or opening as root.

* **Behavior**
  * Respects user-configured browser (BROWSER env) and falls back to the platform default, preserving normal behavior when not running as root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->