### PR TITLE
[client] Fix duplicate log lines in containers

### DIFF
--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -103,7 +103,7 @@ func (p *program) Stop(srv service.Service) error {
 
 // Common setup for service control commands
 func setupServiceControlCommand(cmd *cobra.Command, ctx context.Context, cancel context.CancelFunc) (service.Service, error) {
-	SetFlagsFromEnvVars(rootCmd)
+	// rootCmd env vars are already applied by PersistentPreRunE.
 	SetFlagsFromEnvVars(serviceCmd)
 
 	cmd.SetOut(cmd.OutOrStdout())

--- a/util/log.go
+++ b/util/log.go
@@ -43,7 +43,13 @@ func InitLogger(logger *log.Logger, logLevel string, logs ...string) error {
 	var writers []io.Writer
 	logFmt := os.Getenv("NB_LOG_FORMAT")
 
+	seen := make(map[string]bool, len(logs))
 	for _, logPath := range logs {
+		if seen[logPath] {
+			continue
+		}
+		seen[logPath] = true
+
 		switch logPath {
 		case LogSyslog:
 			AddSyslogHookToLogger(logger)


### PR DESCRIPTION
## Describe your changes

After #5425 added `PersistentPreRunE` with `SetFlagsFromEnvVars(cmd.Root())` to `rootCmd`, the `setupServiceControlCommand` function was still calling `SetFlagsFromEnvVars(rootCmd)` a second time. Because pflag's `StringSlice.Set()` appends after the first call (`changed` flag), this doubled `logFiles` entries. With `NB_LOG_FILE=console,/path/to/file`, `InitLogger` created `io.MultiWriter(os.Stderr, lumberjack, os.Stderr, lumberjack)`, writing every log line to stderr twice.

Fix: remove the redundant `SetFlagsFromEnvVars(rootCmd)` call and add dedup in `InitLogger` as defense in depth.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Bug fix for duplicate log output, no user-facing behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate log path processing in the logging initialization system.
  * Updated environment variable initialization flow for command configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->