### PR TITLE
[client] Restart engine when peer IP address changes

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -993,7 +993,7 @@ func (e *Engine) updateConfig(conf *mgmProto.PeerConfig) error {
 		log.Infof("peer IP address changed from %s to %s, restarting client", e.wgInterface.Address().String(), conf.Address)
 		_ = CtxGetState(e.ctx).Wrap(ErrResetConnection)
 		e.clientCancel()
-		return nil
+		return ErrResetConnection
 	}
 
 	if conf.GetSshConfig() != nil {


### PR DESCRIPTION
## Describe your changes

When management reallocates peer IPs (e.g. after a network range change), the client now restarts the engine instead of just logging the change. The firewall, route manager, and other components cache the old address, so a restart is needed for the new IP to take effect.

Uses the same `ErrResetConnection` + `clientCancel()` pattern as the network monitor and interface monitor restarts.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Not needed: no user-facing API or configuration change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of network interface address changes: the client now performs a clean restart to apply new IP configurations, ensuring updates take effect reliably.
  * Enhanced restart behavior and logging for clearer diagnostics and more robust connection recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->