### PR TITLE
[doc] Add netbird-tg-bot to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ See a complete [architecture overview](https://docs.netbird.io/about-netbird/how
 -  [NetBird installer script](https://github.com/physk/netbird-installer)
 -  [NetBird ansible collection by Dominion Solutions](https://galaxy.ansible.com/ui/repo/published/dominion_solutions/netbird/)
 -  [netbird-tui](https://github.com/n0pashkov/netbird-tui) — terminal UI for managing NetBird peers, routes, and settings
+-  [netbird-tg-bot](https://github.com/n0pashkov/netbird-tg-bot) — Telegram bot for managing NetBird network remotely
 
 **Note**: The `main` branch may be in an *unstable or even broken state* during development.
 For stable versions, see [releases](https://github.com/netbirdio/netbird/releases).


### PR DESCRIPTION
## Describe your changes

Added [netbird-tg-bot](https://github.com/n0pashkov/netbird-tg-bot) to the Community projects section of the README — a Telegram bot for managing NetBird network remotely (peers, groups, setup keys, users, routes, policies, events) via the NetBird REST API.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

README-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added netbird-tg-bot to the Community projects list in README, a Telegram bot for NetBird network management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->