### PR TITLE
[client] Simplify entrypoint by running netbird up unconditionally

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -17,8 +17,7 @@ ENV \
     NETBIRD_BIN="/usr/local/bin/netbird" \
     NB_LOG_FILE="console,/var/log/netbird/client.log" \
     NB_DAEMON_ADDR="unix:///var/run/netbird.sock" \
-    NB_ENTRYPOINT_SERVICE_TIMEOUT="30" \
-    NB_ENTRYPOINT_LOGIN_TIMEOUT="30"
+    NB_ENTRYPOINT_SERVICE_TIMEOUT="30"
 
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 

--- a/client/Dockerfile-rootless
+++ b/client/Dockerfile-rootless
@@ -23,8 +23,7 @@ ENV \
     NB_DAEMON_ADDR="unix:///var/lib/netbird/netbird.sock" \
     NB_LOG_FILE="console,/var/lib/netbird/client.log" \
     NB_DISABLE_DNS="true" \
-    NB_ENTRYPOINT_SERVICE_TIMEOUT="30" \
-    NB_ENTRYPOINT_LOGIN_TIMEOUT="30"
+    NB_ENTRYPOINT_SERVICE_TIMEOUT="30"
 
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
 

--- a/client/cmd/status.go
+++ b/client/cmd/status.go
@@ -218,7 +218,7 @@ func runHealthCheck(cmd *cobra.Command) error {
 	ctx := internal.CtxInitState(cmd.Context())
 
 	isStartup := check == "startup"
-	resp, err := getStatus(ctx, isStartup, isStartup)
+	resp, err := getStatus(ctx, isStartup, false)
 	if err != nil {
 		return err
 	}

--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -2,7 +2,6 @@
 set -eEuo pipefail
 
 : ${NB_ENTRYPOINT_SERVICE_TIMEOUT:="30"}
-: ${NB_ENTRYPOINT_LOGIN_TIMEOUT:="30"}
 NETBIRD_BIN="${NETBIRD_BIN:-"netbird"}"
 export NB_LOG_FILE="${NB_LOG_FILE:-"console,/var/log/netbird/client.log"}"
 service_pids=()
@@ -51,31 +50,10 @@ wait_for_daemon_startup() {
   exit 1
 }
 
-login_if_needed() {
-  local timeout="${1}"
-
-  if "${NETBIRD_BIN}" status --check ready 2>/dev/null; then
-    info "already logged in, skipping 'netbird up'..."
-    return
-  fi
-
-  if [[ "${timeout}" -eq 0 ]]; then
-    info "logging in..."
-    "${NETBIRD_BIN}" up
-    return
-  fi
-
-  local deadline=$((SECONDS + timeout))
-  while [[ "${SECONDS}" -lt "${deadline}" ]]; do
-    if "${NETBIRD_BIN}" status --check ready 2>/dev/null; then
-      info "already logged in, skipping 'netbird up'..."
-      return
-    fi
-    sleep 1
-  done
-
-  info "logging in..."
+connect() {
+  info "running 'netbird up'..."
   "${NETBIRD_BIN}" up
+  return $?
 }
 
 main() {
@@ -85,7 +63,7 @@ main() {
   info "registered new service process 'netbird service run', currently running: ${service_pids[@]@Q}"
 
   wait_for_daemon_startup "${NB_ENTRYPOINT_SERVICE_TIMEOUT}"
-  login_if_needed "${NB_ENTRYPOINT_LOGIN_TIMEOUT}"
+  connect
 
   wait "${service_pids[@]}"
 }


### PR DESCRIPTION
## Describe your changes

- Replace `login_if_needed` polling loop with unconditional `netbird up` call, which is a no-op when already connected

- Remove `NB_ENTRYPOINT_LOGIN_TIMEOUT` env var from entrypoint and both Dockerfiles since it is no longer needed

- Stop running STUN/TURN probes for `--check startup`: the relay status recorder already tracks availability in real time, and `checkStartup` only checks relay connectivity (not STUN/TURN)

## Issue ticket number and link

Follow-up to #5650

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Entrypoint behavior change only. No user-facing CLI or API changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed login timeout environment variable from container configurations
  * Simplified startup logic to unconditionally establish connection after daemon initialization
* **Bug Fixes**
  * Adjusted health-check behavior to skip probe execution during status checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->