### PR TITLE
fix: add netlink.RouteGet() fallback for ICE/P2P on devices with policy-based routing

### DIFF
--- a/client/internal/routemanager/systemops/route_fallback_linux.go
+++ b/client/internal/routemanager/systemops/route_fallback_linux.go
@@ -1,0 +1,58 @@
+//go:build linux && !android
+
+package systemops
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+// getNextHopViaNetlink uses netlink.RouteGet() to determine the next hop for a destination IP.
+// Unlike go-netroute which only reads the main routing table, netlink.RouteGet() asks the kernel
+// to perform an actual routing decision, respecting policy routing rules (ip rule) and all tables.
+// This is needed on devices like UniFi gateways where the default route lives in a separate
+// policy routing table (e.g., 201.eth4) rather than in the main table.
+func getNextHopViaNetlink(ip netip.Addr) (Nexthop, error) {
+	dst := ip.AsSlice()
+	routes, err := netlink.RouteGet(net.IP(dst))
+	if err != nil {
+		return Nexthop{}, fmt.Errorf("netlink.RouteGet(%s): %w", ip, err)
+	}
+	if len(routes) == 0 {
+		return Nexthop{}, fmt.Errorf("no route to %s via netlink", ip)
+	}
+
+	route := routes[0]
+
+	var intf *net.Interface
+	if route.LinkIndex > 0 {
+		intf, err = net.InterfaceByIndex(route.LinkIndex)
+		if err != nil {
+			log.Debugf("Failed to get interface for index %d: %v", route.LinkIndex, err)
+		}
+	}
+
+	if route.Gw != nil {
+		addr, err := ipToAddr(route.Gw, intf)
+		if err != nil {
+			return Nexthop{}, fmt.Errorf("convert gateway to address: %w", err)
+		}
+		log.Debugf("Policy routing fallback: route to %s via gw %s (table %d, iface %v)", ip, route.Gw, route.Table, intf)
+		return Nexthop{IP: addr, Intf: intf}, nil
+	}
+
+	if route.Src != nil {
+		addr, err := ipToAddr(route.Src, intf)
+		if err != nil {
+			return Nexthop{}, fmt.Errorf("convert source to address: %w", err)
+		}
+		log.Debugf("Policy routing fallback: route to %s via src %s (table %d, iface %v)", ip, route.Src, route.Table, intf)
+		return Nexthop{IP: addr, Intf: intf}, nil
+	}
+
+	return Nexthop{Intf: intf}, nil
+}

--- a/client/internal/routemanager/systemops/route_fallback_other.go
+++ b/client/internal/routemanager/systemops/route_fallback_other.go
@@ -1,0 +1,12 @@
+//go:build !linux || android
+
+package systemops
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+func getNextHopViaNetlink(ip netip.Addr) (Nexthop, error) {
+	return Nexthop{}, fmt.Errorf("netlink route fallback not available on this platform")
+}

--- a/client/internal/routemanager/systemops/systemops_generic.go
+++ b/client/internal/routemanager/systemops/systemops_generic.go
@@ -345,8 +345,16 @@ func GetNextHop(ip netip.Addr) (Nexthop, error) {
 	}
 	intf, gateway, preferredSrc, err := r.Route(ip.AsSlice())
 	if err != nil {
-		log.Debugf("Failed to get route for %s: %v", ip, err)
-		return Nexthop{}, vars.ErrRouteNotFound
+		// Fallback to netlink.RouteGet() which respects policy routing tables.
+		// go-netroute only reads the main table, but devices like UniFi gateways
+		// keep the default route in a separate policy routing table.
+		log.Debugf("Failed to get route for %s via go-netroute: %v, trying netlink fallback", ip, err)
+		nexthop, nlErr := getNextHopViaNetlink(ip)
+		if nlErr != nil {
+			log.Debugf("Netlink fallback also failed for %s: %v", ip, nlErr)
+			return Nexthop{}, vars.ErrRouteNotFound
+		}
+		return nexthop, nil
 	}
 
 	log.Debugf("Route for %s: interface %v nexthop %v, preferred source %v", ip, intf, gateway, preferredSrc)

--- a/sharedsock/sock_linux.go
+++ b/sharedsock/sock_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/libp2p/go-netroute"
 	"github.com/mdlayher/socket"
 	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 
@@ -315,7 +316,13 @@ func (s *SharedSocket) WriteTo(buf []byte, rAddr net.Addr) (n int, err error) {
 
 	_, _, src, err := s.router.Route(rUDPAddr.IP)
 	if err != nil {
-		return 0, fmt.Errorf("got an error while checking route, err: %w", err)
+		// Fallback to netlink.RouteGet() which respects policy routing tables.
+		// go-netroute only reads the main table, but devices like UniFi gateways
+		// keep the default route in a separate policy routing table.
+		src, err = routeGetSource(rUDPAddr.IP)
+		if err != nil {
+			return 0, fmt.Errorf("got an error while checking route, err: %w", err)
+		}
 	}
 
 	rSockAddr, conn, nwLayer := s.getWriterObjects(src, rUDPAddr.IP)
@@ -331,6 +338,24 @@ func (s *SharedSocket) WriteTo(buf []byte, rAddr net.Addr) (n int, err error) {
 	bufser := buffer.Bytes()
 
 	return 0, conn.Sendto(context.TODO(), bufser, 0, rSockAddr)
+}
+
+// routeGetSource uses netlink.RouteGet to determine the preferred source IP for a destination.
+// This respects policy routing tables (ip rule), unlike go-netroute which only reads the main table.
+func routeGetSource(dst net.IP) (net.IP, error) {
+	routes, err := netlink.RouteGet(dst)
+	if err != nil {
+		return nil, fmt.Errorf("netlink.RouteGet(%s): %w", dst, err)
+	}
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("no route to %s", dst)
+	}
+	src := routes[0].Src
+	if src == nil {
+		return nil, fmt.Errorf("no source address for route to %s", dst)
+	}
+	log.Debugf("Policy routing fallback: route to %s via src %s (table %d, iface idx %d)", dst, src, routes[0].Table, routes[0].LinkIndex)
+	return src, nil
 }
 
 // getWriterObjects returns the specific IP version objects that are used to build a packet and send it using the raw socket


### PR DESCRIPTION
## Problem

On devices using policy-based routing (e.g., Ubiquiti UniFi gateways), the default route is not in the `main` routing table but in a separate policy table (e.g., `201.eth4`). NetBird uses `go-netroute` for route lookups, which only reads the main table via `syscall.NetlinkRIB(RTM_GETROUTE, AF_UNSPEC)`. This causes two failures:

1. **`SharedSocket.WriteTo()`** (`sharedsock/sock_linux.go`) — calls `s.router.Route()` to determine source IP for raw UDP packets. Fails with `Route referenced unknown interface`.
2. **`GetNextHop()`** (`systemops_generic.go`) — called via write hooks when ICE sends packets. Same failure.

**Result:** All STUN and ICE connectivity-check packets are dropped. Local candidates are gathered and remote candidates are received, but no packets can be sent. ICE always times out and falls back to relay. Normal TCP traffic (management/signal/relay) works fine because standard Go `net.Dial` lets the kernel handle routing.

### Example routing setup (UXG-Max)
\\\
# ip route show table main
192.168.1.0/24 dev br0 proto kernel scope link src 192.168.1.1
(... only directly connected subnets, NO default route)

# ip route show table 201.eth4
default via <gateway> dev eth4 proto dhcp metric 200

# ip rule show
0:     from all lookup local
32000: from all lookup main
32766: from all lookup 201.eth4
32767: from all lookup default
\\\

### Key log lines
\\\
DEBG systemops_generic.go:348: Failed to get route for <IP>: Route referenced unknown interface
ice WARNING: Failed get server reflexive address: failed to send STUN packet: got an error while checking route, err: Route referenced unknown interface
ice INFO: Failed to send packet: got an error while checking route, err: Route referenced unknown interface
(repeated hundreds of times for every peer)
\\\

## Fix

Adds a `netlink.RouteGet()` fallback when `go-netroute`'s `Route()` fails. `netlink.RouteGet()` asks the kernel to perform the actual routing decision, respecting policy routing rules (`ip rule`) and all tables — exactly matching what happens for real packets.

### Changes
- **`sharedsock/sock_linux.go`** — `WriteTo()`: when `s.router.Route()` fails, fall back to `netlink.RouteGet()` for source IP resolution
- **`systemops_generic.go`** — `GetNextHop()`: same fallback pattern
- **`route_fallback_linux.go`** (new) — Linux-specific `getNextHopViaNetlink()` using `netlink.RouteGet()`
- **`route_fallback_other.go`** (new) — no-op stub for non-Linux platforms

### Safety
- Fallback only activates when `go-netroute` fails — devices with standard routing are completely unaffected
- `vishvananda/netlink` is already a dependency
- `netlink.RouteGet()` is the standard kernel route query mechanism on Linux

## Testing

**Tested and confirmed working** on Ubiquiti UXG-Max (kernel `5.4.213-ui-ipq5322`, ARM64):
- Before: all 5 peers `Connection type: Relayed`, ICE candidates `-/-`
- After: peers switch to `Connection type: P2P`

## Affected platforms
- Ubiquiti UXG-Max, UXG-Enterprise, UDM Pro (firmware 4.0+)
- Likely all UniFi OS gateway devices
- OpenWRT devices with `mwan3` or custom policy routing
- Any Linux device where the default route is in a non-main routing table

## Related issues
- #5551 — Separate: `iptable_raw` crash on kernels without the module
- #2530 — Teltonika RutOS, possibly same underlying cause
- #2512 — OpenWRT, `connect: invalid argument`
- #2116 — UniFi UDM Pro firmware 4.0

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced routing system with improved fallback mechanisms for more reliable network connectivity on Linux
  * Improved source IP address determination when routing network packets
  * Better cross-platform compatibility with graceful error handling when standard route lookups fail
  * More robust network packet handling with enhanced source address selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->