### PR TITLE
Omit proxy_protocol from API response when false

### DIFF
--- a/management/internals/modules/reverseproxy/service/service.go
+++ b/management/internals/modules/reverseproxy/service/service.go
@@ -262,7 +262,9 @@ func (s *Service) ToAPIResponse() *api.Service {
 		if opts == nil {
 			opts = &api.ServiceTargetOptions{}
 		}
-		opts.ProxyProtocol = &target.ProxyProtocol
+		if target.ProxyProtocol {
+			opts.ProxyProtocol = &target.ProxyProtocol
+		}
 		st.Options = opts
 		apiTargets = append(apiTargets, st)
 	}


### PR DESCRIPTION
## Summary
- Only set `opts.ProxyProtocol` in the API response when the value is `true`
- The internal `Target` model uses a plain `bool`, which was always being assigned to the `*bool` API field, causing `"proxy_protocol": false` to appear in every response even when not configured
- This caused Terraform ImportStateVerify mismatches in the provider

## Test plan
- Verify existing reverse proxy service tests pass
- Create a service without proxy_protocol, confirm the field is absent from the GET response
- Create a service with proxy_protocol=true, confirm it appears in the response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API response to exclude ProxyProtocol when not applicable, reducing unnecessary response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->