### PR TITLE
[management] Omit proxy_protocol from API response when false

### DIFF
--- a/management/internals/modules/reverseproxy/service/service.go
+++ b/management/internals/modules/reverseproxy/service/service.go
@@ -262,7 +262,9 @@ func (s *Service) ToAPIResponse() *api.Service {
 		if opts == nil {
 			opts = &api.ServiceTargetOptions{}
 		}
-		opts.ProxyProtocol = &target.ProxyProtocol
+		if target.ProxyProtocol {
+			opts.ProxyProtocol = &target.ProxyProtocol
+		}
 		st.Options = opts
 		apiTargets = append(apiTargets, st)
 	}


### PR DESCRIPTION
## Describe your changes

- Only set `ServiceTargetOptions.ProxyProtocol` in the API response when the value is true, so it gets omitted via `omitempty` when unset

The internal `Target` model uses a plain `bool` for `ProxyProtocol`, which was always assigned to the `*bool` API field. This caused `"proxy_protocol": false` to appear in every service response even when not configured.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

No user-facing behavior change. The field was incorrectly included with a default value; omitting it is the correct behavior per the OpenAPI spec.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reverse proxy configuration API response to exclude the `proxy_protocol` option when disabled, providing cleaner and more accurate API outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->