### PR TITLE
[client] Fix exit node masquerade overrides per-route masquerade=false setting

### DIFF
--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -529,6 +529,9 @@ func (r *router) addNoMasqPostRoutingRule(pair firewall.RouterPair) error {
 		if err := r.iptablesClient.DeleteIfExists(tableNat, chainRTNAT, rule...); err != nil {
 			return fmt.Errorf("remove existing no-masq rule before reinstall: %w", err)
 		}
+		if err := r.decrementSetCounter(rule); err != nil {
+			log.Warnf("decrement set counter for reinstalled rule %s: %v", ruleKey, err)
+		}
 		delete(r.rules, ruleKey)
 	}
 

--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -259,16 +259,21 @@ func (r *router) AddNatRule(pair firewall.RouterPair) error {
 		}
 	}
 
-	if !pair.Masquerade {
-		return nil
-	}
+	if pair.Masquerade {
+		if err := r.addNatRule(pair); err != nil {
+			return fmt.Errorf("add nat rule: %w", err)
+		}
 
-	if err := r.addNatRule(pair); err != nil {
-		return fmt.Errorf("add nat rule: %w", err)
-	}
-
-	if err := r.addNatRule(firewall.GetInversePair(pair)); err != nil {
-		return fmt.Errorf("add inverse nat rule: %w", err)
+		if err := r.addNatRule(firewall.GetInversePair(pair)); err != nil {
+			return fmt.Errorf("add inverse nat rule: %w", err)
+		}
+	} else {
+		// Insert a RETURN rule at the head of the postrouting NAT chain for this
+		// destination, preventing the exit node's catch-all masquerade from
+		// rewriting the source IP for routes with masquerade disabled.
+		if err := r.addNoMasqPostRoutingRule(pair); err != nil {
+			return fmt.Errorf("add no-masquerade postrouting rule: %w", err)
+		}
 	}
 
 	r.updateState()
@@ -285,6 +290,19 @@ func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
 
 		if err := r.removeNatRule(firewall.GetInversePair(pair)); err != nil {
 			return fmt.Errorf("remove inverse nat rule: %w", err)
+		}
+	} else {
+		ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
+		if rule, exists := r.rules[ruleKey]; exists {
+			if err := r.iptablesClient.DeleteIfExists(tableNat, chainRTNAT, rule...); err != nil {
+				return fmt.Errorf("remove no-masquerade return rule: %w", err)
+			}
+			delete(r.rules, ruleKey)
+			if err := r.decrementSetCounter(rule); err != nil {
+				return fmt.Errorf("decrement ipset counter: %w", err)
+			}
+		} else {
+			log.Debugf("no-masquerade postrouting rule %s not found", ruleKey)
 		}
 	}
 
@@ -500,6 +518,31 @@ func (r *router) cleanupDataPlaneMark() error {
 	}
 
 	return nberrors.FormatErrorOrNil(merr)
+}
+
+// addNoMasqPostRoutingRule inserts a RETURN rule at position 1 of the postrouting
+// NAT chain for the given destination. This ensures routes with masquerade=false
+// are not masqueraded by the exit node's catch-all mark-based masquerade rule.
+func (r *router) addNoMasqPostRoutingRule(pair firewall.RouterPair) error {
+	ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
+	if _, exists := r.rules[ruleKey]; exists {
+		return nil
+	}
+
+	destExp, err := r.applyNetwork("-d", pair.Destination, nil)
+	if err != nil {
+		return fmt.Errorf("apply destination: %w", err)
+	}
+
+	rule := append(destExp, "-j", "RETURN")
+
+	if err := r.iptablesClient.Insert(tableNat, chainRTNAT, 1, rule...); err != nil {
+		return fmt.Errorf("add no-masquerade return rule for %s: %w", pair.Destination, err)
+	}
+
+	r.rules[ruleKey] = rule
+	r.updateState()
+	return nil
 }
 
 func (r *router) addPostroutingRules() error {

--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -268,11 +268,15 @@ func (r *router) AddNatRule(pair firewall.RouterPair) error {
 			return fmt.Errorf("add inverse nat rule: %w", err)
 		}
 	} else {
-		// Insert a RETURN rule at the head of the postrouting NAT chain for this
-		// destination, preventing the exit node's catch-all masquerade from
-		// rewriting the source IP for routes with masquerade disabled.
+		// Insert RETURN rules at the head of the postrouting NAT chain for both directions,
+		// preventing the exit node's catch-all masquerade from rewriting the source IP
+		// for routes with masquerade disabled.
 		if err := r.addNoMasqPostRoutingRule(pair); err != nil {
 			return fmt.Errorf("add no-masquerade postrouting rule: %w", err)
+		}
+
+		if err := r.addNoMasqPostRoutingRule(firewall.GetInversePair(pair)); err != nil {
+			return fmt.Errorf("add inverse no-masquerade postrouting rule: %w", err)
 		}
 	}
 
@@ -292,17 +296,12 @@ func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
 			return fmt.Errorf("remove inverse nat rule: %w", err)
 		}
 	} else {
-		ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
-		if rule, exists := r.rules[ruleKey]; exists {
-			if err := r.iptablesClient.DeleteIfExists(tableNat, chainRTNAT, rule...); err != nil {
-				return fmt.Errorf("remove no-masquerade return rule: %w", err)
-			}
-			delete(r.rules, ruleKey)
-			if err := r.decrementSetCounter(rule); err != nil {
-				return fmt.Errorf("decrement ipset counter: %w", err)
-			}
-		} else {
-			log.Debugf("no-masquerade postrouting rule %s not found", ruleKey)
+		if err := r.removeNoMasqPostRoutingRule(pair); err != nil {
+			return err
+		}
+
+		if err := r.removeNoMasqPostRoutingRule(firewall.GetInversePair(pair)); err != nil {
+			return err
 		}
 	}
 
@@ -521,12 +520,16 @@ func (r *router) cleanupDataPlaneMark() error {
 }
 
 // addNoMasqPostRoutingRule inserts a RETURN rule at position 1 of the postrouting
-// NAT chain for the given destination. This ensures routes with masquerade=false
-// are not masqueraded by the exit node's catch-all mark-based masquerade rule.
+// NAT chain for the given destination. The mark match scopes the rule to exit-node
+// traffic only, ensuring routes with masquerade=false are not masqueraded by the
+// exit node's catch-all mark-based masquerade rule.
 func (r *router) addNoMasqPostRoutingRule(pair firewall.RouterPair) error {
 	ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
-	if _, exists := r.rules[ruleKey]; exists {
-		return nil
+	if rule, exists := r.rules[ruleKey]; exists {
+		if err := r.iptablesClient.DeleteIfExists(tableNat, chainRTNAT, rule...); err != nil {
+			return fmt.Errorf("remove existing no-masq rule before reinstall: %w", err)
+		}
+		delete(r.rules, ruleKey)
 	}
 
 	destExp, err := r.applyNetwork("-d", pair.Destination, nil)
@@ -534,13 +537,45 @@ func (r *router) addNoMasqPostRoutingRule(pair firewall.RouterPair) error {
 		return fmt.Errorf("apply destination: %w", err)
 	}
 
-	rule := append(destExp, "-j", "RETURN")
+	// Select the correct fwmark based on traffic direction:
+	// forward (wt0→eth0) uses PreroutingFwmarkMasquerade,
+	// inverse (eth0→wt0) uses PreroutingFwmarkMasqueradeReturn.
+	markValue := uint32(nbnet.PreroutingFwmarkMasquerade)
+	if pair.Inverse {
+		markValue = nbnet.PreroutingFwmarkMasqueradeReturn
+	}
+
+	// Match exit-node mark + destination, then RETURN to skip the blanket masquerade.
+	rule := []string{"-m", "mark", "--mark", fmt.Sprintf("%#x", markValue)}
+	rule = append(rule, destExp...)
+	rule = append(rule, "-j", "RETURN")
 
 	if err := r.iptablesClient.Insert(tableNat, chainRTNAT, 1, rule...); err != nil {
 		return fmt.Errorf("add no-masquerade return rule for %s: %w", pair.Destination, err)
 	}
 
 	r.rules[ruleKey] = rule
+	return nil
+}
+
+func (r *router) removeNoMasqPostRoutingRule(pair firewall.RouterPair) error {
+	ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
+
+	rule, exists := r.rules[ruleKey]
+	if !exists {
+		log.Debugf("no-masquerade postrouting rule %s not found", ruleKey)
+		return nil
+	}
+
+	if err := r.iptablesClient.DeleteIfExists(tableNat, chainRTNAT, rule...); err != nil {
+		return fmt.Errorf("remove no-masquerade return rule %s: %w", ruleKey, err)
+	}
+	delete(r.rules, ruleKey)
+
+	if err := r.decrementSetCounter(rule); err != nil {
+		return fmt.Errorf("decrement ipset counter for %s: %w", ruleKey, err)
+	}
+
 	return nil
 }
 

--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -541,7 +541,6 @@ func (r *router) addNoMasqPostRoutingRule(pair firewall.RouterPair) error {
 	}
 
 	r.rules[ruleKey] = rule
-	r.updateState()
 	return nil
 }
 

--- a/client/firewall/manager/firewall.go
+++ b/client/firewall/manager/firewall.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	ForwardingFormatPrefix = "netbird-fwd-"
-	ForwardingFormat       = "netbird-fwd-%s-%t"
-	PreroutingFormat       = "netbird-prerouting-%s-%t"
-	NatFormat              = "netbird-nat-%s-%t"
+	ForwardingFormatPrefix  = "netbird-fwd-"
+	ForwardingFormat        = "netbird-fwd-%s-%t"
+	PreroutingFormat        = "netbird-prerouting-%s-%t"
+	NatFormat               = "netbird-nat-%s-%t"
+	NoMasqPostRoutingFormat = "netbird-no-masq-postrouting-%s-%t"
 )
 
 // Rule abstraction should be implemented by each firewall manager

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -778,17 +778,17 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 // masqueraded. The return fires before the blanket masquerade rule because
 // InsertRule places it at chain position 0.
 func (r *router) addNoMasqPostRoutingRule(pair firewall.RouterPair) error {
+	ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
+	if _, exists := r.rules[ruleKey]; exists {
+		return nil
+	}
+
 	destExp, err := r.applyNetwork(pair.Destination, nil, false)
 	if err != nil {
 		return fmt.Errorf("apply destination: %w", err)
 	}
 
 	exprs := append(destExp, &expr.Verdict{Kind: expr.VerdictReturn})
-
-	ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
-	if _, exists := r.rules[ruleKey]; exists {
-		return nil
-	}
 
 	r.rules[ruleKey] = r.conn.InsertRule(&nftables.Rule{
 		Table:    r.workTable,
@@ -1415,13 +1415,10 @@ func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
 	} else {
 		ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
 		if rule, exists := r.rules[ruleKey]; exists {
-			if err := r.conn.DelRule(rule); err != nil {
+			if err := r.deleteNftRule(rule, ruleKey); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("remove no-masquerade postrouting rule: %w", err))
-			} else {
-				delete(r.rules, ruleKey)
-				if err := r.decrementSetCounter(rule); err != nil {
-					merr = multierror.Append(merr, fmt.Errorf("decrement set counter for no-masq rule: %w", err))
-				}
+			} else if err := r.decrementSetCounter(rule); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("decrement set counter for no-masq rule: %w", err))
 			}
 		} else {
 			log.Debugf("no-masquerade postrouting rule %s not found", ruleKey)

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -1414,21 +1414,8 @@ func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
 			merr = multierror.Append(merr, fmt.Errorf("remove inverse prerouting rule: %w", err))
 		}
 	} else {
-		ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
-		if rule, exists := r.rules[ruleKey]; exists {
-			if rule.Handle == 0 {
-				log.Warnf("no-masquerade postrouting rule %s has no handle, removing stale entry", ruleKey)
-				if err := r.decrementSetCounter(rule); err != nil {
-					log.Warnf("decrement set counter for stale no-masq rule %s: %v", ruleKey, err)
-				}
-				delete(r.rules, ruleKey)
-			} else if err := r.deleteNftRule(rule, ruleKey); err != nil {
-				merr = multierror.Append(merr, fmt.Errorf("remove no-masquerade postrouting rule: %w", err))
-			} else if err := r.decrementSetCounter(rule); err != nil {
-				merr = multierror.Append(merr, fmt.Errorf("decrement set counter for no-masq rule: %w", err))
-			}
-		} else {
-			log.Debugf("no-masquerade postrouting rule %s not found", ruleKey)
+		if err := r.removeNoMasqPostRoutingRule(pair); err != nil {
+			merr = multierror.Append(merr, err)
 		}
 	}
 
@@ -1473,6 +1460,35 @@ func (r *router) removeNatRule(pair firewall.RouterPair) error {
 
 	if err := r.decrementSetCounter(rule); err != nil {
 		return fmt.Errorf("decrement set counter: %w", err)
+	}
+
+	return nil
+}
+
+func (r *router) removeNoMasqPostRoutingRule(pair firewall.RouterPair) error {
+	ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
+
+	rule, exists := r.rules[ruleKey]
+	if !exists {
+		log.Debugf("no-masquerade postrouting rule %s not found", ruleKey)
+		return nil
+	}
+
+	if rule.Handle == 0 {
+		log.Warnf("no-masquerade postrouting rule %s has no handle, removing stale entry", ruleKey)
+		if err := r.decrementSetCounter(rule); err != nil {
+			log.Warnf("decrement set counter for stale no-masq rule %s: %v", ruleKey, err)
+		}
+		delete(r.rules, ruleKey)
+		return nil
+	}
+
+	if err := r.deleteNftRule(rule, ruleKey); err != nil {
+		return fmt.Errorf("remove no-masquerade postrouting rule: %w", err)
+	}
+
+	if err := r.decrementSetCounter(rule); err != nil {
+		return fmt.Errorf("decrement set counter for no-masq rule: %w", err)
 	}
 
 	return nil

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -663,12 +663,17 @@ func (r *router) AddNatRule(pair firewall.RouterPair) error {
 			return fmt.Errorf("add inverse nat rule: %w", err)
 		}
 	} else {
-		// Insert a return verdict in the postrouting NAT chain for this destination.
-		// This prevents the exit node's catch-all masquerade rule (which marks all wt0
-		// traffic with PreroutingFwmarkMasquerade) from rewriting the source IP for
-		// routes that explicitly have masquerade disabled.
+		// Insert return verdicts in the postrouting NAT chain for both traffic directions.
+		// This prevents the exit node's catch-all masquerade rules from rewriting the
+		// source IP for routes that explicitly have masquerade disabled.
+		// Forward direction: wt0→eth0 traffic marked with PreroutingFwmarkMasquerade.
+		// Inverse direction: eth0→wt0 traffic marked with PreroutingFwmarkMasqueradeReturn.
 		if err := r.addNoMasqPostRoutingRule(pair); err != nil {
 			return fmt.Errorf("add no-masquerade postrouting rule: %w", err)
+		}
+
+		if err := r.addNoMasqPostRoutingRule(firewall.GetInversePair(pair)); err != nil {
+			return fmt.Errorf("add inverse no-masquerade postrouting rule: %w", err)
 		}
 	}
 
@@ -687,6 +692,7 @@ func (r *router) rollbackRules(pair firewall.RouterPair) {
 		firewall.GenKey(firewall.PreroutingFormat, pair),
 		firewall.GenKey(firewall.PreroutingFormat, firewall.GetInversePair(pair)),
 		firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair),
+		firewall.GenKey(firewall.NoMasqPostRoutingFormat, firewall.GetInversePair(pair)),
 	}
 	for _, key := range keys {
 		rule, ok := r.rules[key]
@@ -776,12 +782,14 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 // NAT chain for the given destination. This ensures that when an exit node
 // (0.0.0.0/0, masquerade=true) is active alongside routes with masquerade=false,
 // the exit node's catch-all mark rule does not cause those destinations to be
-// masqueraded. The return fires before the blanket masquerade rule because
-// InsertRule places it at chain position 0.
+// masqueraded. The mark match scopes the rule to exit-node traffic only.
+// InsertRule places it at chain position 0, before the blanket masquerade rule.
 func (r *router) addNoMasqPostRoutingRule(pair firewall.RouterPair) error {
 	ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
 	if _, exists := r.rules[ruleKey]; exists {
-		return nil
+		if err := r.removeNoMasqPostRoutingRule(pair); err != nil {
+			return fmt.Errorf("remove existing no-masq rule before reinstall: %w", err)
+		}
 	}
 
 	destExp, err := r.applyNetwork(pair.Destination, nil, false)
@@ -789,7 +797,26 @@ func (r *router) addNoMasqPostRoutingRule(pair firewall.RouterPair) error {
 		return fmt.Errorf("apply destination: %w", err)
 	}
 
-	exprs := append(destExp, &expr.Verdict{Kind: expr.VerdictReturn})
+	// Select the correct fwmark based on traffic direction:
+	// forward (wt0→eth0) uses PreroutingFwmarkMasquerade,
+	// inverse (eth0→wt0) uses PreroutingFwmarkMasqueradeReturn.
+	markValue := uint32(nbnet.PreroutingFwmarkMasquerade)
+	if pair.Inverse {
+		markValue = nbnet.PreroutingFwmarkMasqueradeReturn
+	}
+
+	// Match only packets carrying the exit-node masquerade mark, then match the
+	// destination, then return — skipping the blanket masquerade rule below.
+	exprs := []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyMARK, Register: 1},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     binaryutil.NativeEndian.PutUint32(markValue),
+		},
+	}
+	exprs = append(exprs, destExp...)
+	exprs = append(exprs, &expr.Verdict{Kind: expr.VerdictReturn})
 
 	r.rules[ruleKey] = r.conn.InsertRule(&nftables.Rule{
 		Table:    r.workTable,
@@ -1415,6 +1442,10 @@ func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
 		}
 	} else {
 		if err := r.removeNoMasqPostRoutingRule(pair); err != nil {
+			merr = multierror.Append(merr, err)
+		}
+
+		if err := r.removeNoMasqPostRoutingRule(firewall.GetInversePair(pair)); err != nil {
 			merr = multierror.Append(merr, err)
 		}
 	}

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -686,6 +686,7 @@ func (r *router) rollbackRules(pair firewall.RouterPair) {
 		firewall.GenKey(firewall.ForwardingFormat, pair),
 		firewall.GenKey(firewall.PreroutingFormat, pair),
 		firewall.GenKey(firewall.PreroutingFormat, firewall.GetInversePair(pair)),
+		firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair),
 	}
 	for _, key := range keys {
 		rule, ok := r.rules[key]
@@ -1415,7 +1416,13 @@ func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
 	} else {
 		ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
 		if rule, exists := r.rules[ruleKey]; exists {
-			if err := r.deleteNftRule(rule, ruleKey); err != nil {
+			if rule.Handle == 0 {
+				log.Warnf("no-masquerade postrouting rule %s has no handle, removing stale entry", ruleKey)
+				if err := r.decrementSetCounter(rule); err != nil {
+					log.Warnf("decrement set counter for stale no-masq rule %s: %v", ruleKey, err)
+				}
+				delete(r.rules, ruleKey)
+			} else if err := r.deleteNftRule(rule, ruleKey); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("remove no-masquerade postrouting rule: %w", err))
 			} else if err := r.decrementSetCounter(rule); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("decrement set counter for no-masq rule: %w", err))

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -662,6 +662,14 @@ func (r *router) AddNatRule(pair firewall.RouterPair) error {
 		if err := r.addNatRule(firewall.GetInversePair(pair)); err != nil {
 			return fmt.Errorf("add inverse nat rule: %w", err)
 		}
+	} else {
+		// Insert a return verdict in the postrouting NAT chain for this destination.
+		// This prevents the exit node's catch-all masquerade rule (which marks all wt0
+		// traffic with PreroutingFwmarkMasquerade) from rewriting the source IP for
+		// routes that explicitly have masquerade disabled.
+		if err := r.addNoMasqPostRoutingRule(pair); err != nil {
+			return fmt.Errorf("add no-masquerade postrouting rule: %w", err)
+		}
 	}
 
 	if err := r.conn.Flush(); err != nil {
@@ -756,6 +764,35 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 	r.rules[ruleKey] = r.conn.InsertRule(&nftables.Rule{
 		Table:    r.workTable,
 		Chain:    r.chains[chainNameManglePrerouting],
+		Exprs:    exprs,
+		UserData: []byte(ruleKey),
+	})
+
+	return nil
+}
+
+// addNoMasqPostRoutingRule inserts a return verdict at the head of the postrouting
+// NAT chain for the given destination. This ensures that when an exit node
+// (0.0.0.0/0, masquerade=true) is active alongside routes with masquerade=false,
+// the exit node's catch-all mark rule does not cause those destinations to be
+// masqueraded. The return fires before the blanket masquerade rule because
+// InsertRule places it at chain position 0.
+func (r *router) addNoMasqPostRoutingRule(pair firewall.RouterPair) error {
+	destExp, err := r.applyNetwork(pair.Destination, nil, false)
+	if err != nil {
+		return fmt.Errorf("apply destination: %w", err)
+	}
+
+	exprs := append(destExp, &expr.Verdict{Kind: expr.VerdictReturn})
+
+	ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
+	if _, exists := r.rules[ruleKey]; exists {
+		return nil
+	}
+
+	r.rules[ruleKey] = r.conn.InsertRule(&nftables.Rule{
+		Table:    r.workTable,
+		Chain:    r.chains[chainNameRoutingNat],
 		Exprs:    exprs,
 		UserData: []byte(ruleKey),
 	})
@@ -1374,6 +1411,20 @@ func (r *router) RemoveNatRule(pair firewall.RouterPair) error {
 
 		if err := r.removeNatRule(firewall.GetInversePair(pair)); err != nil {
 			merr = multierror.Append(merr, fmt.Errorf("remove inverse prerouting rule: %w", err))
+		}
+	} else {
+		ruleKey := firewall.GenKey(firewall.NoMasqPostRoutingFormat, pair)
+		if rule, exists := r.rules[ruleKey]; exists {
+			if err := r.conn.DelRule(rule); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("remove no-masquerade postrouting rule: %w", err))
+			} else {
+				delete(r.rules, ruleKey)
+				if err := r.decrementSetCounter(rule); err != nil {
+					merr = multierror.Append(merr, fmt.Errorf("decrement set counter for no-masq rule: %w", err))
+				}
+			}
+		} else {
+			log.Debugf("no-masquerade postrouting rule %s not found", ruleKey)
 		}
 	}
 


### PR DESCRIPTION
## Problem

When a peer acts as both an **exit node** (`0.0.0.0/0`) and a **routing peer** for specific subnets with masquerade disabled, the exit node's postrouting masquerade rule fires for all traffic — silently ignoring the per-route `masquerade=false` setting.

**Root cause:** `addNatRule()` sets fwmark `PreroutingFwmarkMasquerade` on all `wt0` traffic for the exit node. `addPostroutingRules()` then masquerades everything carrying that mark, regardless of per-route settings. There is no mechanism for a per-route `masquerade=false` to opt out of this blanket rule.

**Practical effect:** A client routing through an exit node cannot reach services that rely on the original source IP being preserved (e.g. firewall rules matching the client's NetBird IP, IPsec policies, per-device ACLs). All traffic appears to arrive from the routing peer's WireGuard interface IP instead.

This was reported in #2751 and is related to #4542.

## Fix

When `masquerade=false` for a route pair, insert a `RETURN` verdict at the **head** of the postrouting NAT chain (`netbird-rt-postrouting`) matching the route's destination prefix. This short-circuits evaluation before the exit node's catch-all masquerade rule fires.

Both the **nftables** and **iptables** backends are updated:

- New constant `NoMasqPostRoutingFormat` in `firewall/manager/firewall.go`
- New `addNoMasqPostRoutingRule()` in both `nftables/router_linux.go` and `iptables/router_linux.go`
- `AddNatRule()` / `RemoveNatRule()` updated to manage the return rule when `masquerade=false`

The rule is keyed and tracked in `r.rules` the same way as existing NAT rules, so it is correctly removed on route deletion or peer disconnect.

## Test scenario

1. Configure peer A as exit node (`0.0.0.0/0`, masquerade cannot be disabled)
2. Configure peer B as routing peer for `192.168.0.0/24` with masquerade=OFF
3. From a client behind the exit node, send traffic to `192.168.0.1`
4. **Before fix:** traffic arrives at `192.168.0.1` with src = peer B's WireGuard IP (masqueraded)
5. **After fix:** traffic arrives with the client's original NetBird IP preserved

## Related issues

- Closes #5683
- Closes #2751
- Related: #4542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added destination-scoped "no-masquerade" postrouting rules for both directions to provide finer NAT control across Linux routing backends.

* **Bug Fixes**
  * Improved insertion ordering, deduplication, rollback, and cleanup of no-masquerade postrouting rules.
  * Graceful handling and removal of missing or stale rule entries to prevent leftover state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->