### PR TITLE
[client] Replace iOS DNS IsPrivate heuristic with route checker

### DIFF
--- a/client/internal/dns/mock_server.go
+++ b/client/internal/dns/mock_server.go
@@ -85,6 +85,11 @@ func (m *MockServer) PopulateManagementDomain(mgmtURL *url.URL) error {
 	return nil
 }
 
+// SetRouteChecker mock implementation of SetRouteChecker from Server interface
+func (m *MockServer) SetRouteChecker(func(netip.Addr) bool) {
+	// Mock implementation - no-op
+}
+
 // BeginBatch mock implementation of BeginBatch from Server interface
 func (m *MockServer) BeginBatch() {
 	// Mock implementation - no-op

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -57,6 +57,7 @@ type Server interface {
 	ProbeAvailability()
 	UpdateServerConfig(domains dnsconfig.ServerDomains) error
 	PopulateManagementDomain(mgmtURL *url.URL) error
+	SetRouteChecker(func(netip.Addr) bool)
 }
 
 type nsGroupsByDomain struct {
@@ -104,6 +105,7 @@ type DefaultServer struct {
 
 	statusRecorder *peer.Status
 	stateManager   *statemanager.Manager
+	routeMatch     func(netip.Addr) bool
 
 	probeMu     sync.Mutex
 	probeCancel context.CancelFunc
@@ -227,6 +229,14 @@ func newDefaultServer(
 	dnsService.RegisterMux(".", handlerChain)
 
 	return defaultServer
+}
+
+// SetRouteChecker sets the function used by upstream resolvers to determine
+// whether an IP is routed through the tunnel.
+func (s *DefaultServer) SetRouteChecker(f func(netip.Addr) bool) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.routeMatch = f
 }
 
 // RegisterHandler registers a handler for the given domains with the given priority.
@@ -743,6 +753,7 @@ func (s *DefaultServer) registerFallback(config HostDNSConfig) {
 		log.Errorf("failed to create upstream resolver for original nameservers: %v", err)
 		return
 	}
+	handler.routeMatch = s.routeMatch
 
 	for _, ns := range originalNameservers {
 		if ns == config.ServerIP {
@@ -852,6 +863,7 @@ func (s *DefaultServer) createHandlersForDomainGroup(domainGroup nsGroupsByDomai
 		if err != nil {
 			return nil, fmt.Errorf("create upstream resolver: %v", err)
 		}
+		handler.routeMatch = s.routeMatch
 
 		for _, ns := range nsGroup.NameServers {
 			if ns.NSType != nbdns.UDPNameServerType {
@@ -1036,6 +1048,7 @@ func (s *DefaultServer) addHostRootZone() {
 		log.Errorf("unable to create a new upstream resolver, error: %v", err)
 		return
 	}
+	handler.routeMatch = s.routeMatch
 
 	handler.upstreamServers = maps.Keys(hostDNSServers)
 	handler.deactivate = func(error) {}

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -70,6 +70,7 @@ type upstreamResolverBase struct {
 	deactivate     func(error)
 	reactivate     func()
 	statusRecorder *peer.Status
+	routeMatch     func(netip.Addr) bool
 }
 
 type upstreamFailure struct {

--- a/client/internal/dns/upstream_ios.go
+++ b/client/internal/dns/upstream_ios.go
@@ -65,11 +65,13 @@ func (u *upstreamResolverIOS) exchange(ctx context.Context, upstream string, r *
 	} else {
 		upstreamIP = upstreamIP.Unmap()
 	}
-	if u.lNet.Contains(upstreamIP) || upstreamIP.IsPrivate() {
-		log.Debugf("using private client to query upstream: %s", upstream)
+	needsPrivate := u.lNet.Contains(upstreamIP) ||
+		(u.routeMatch != nil && u.routeMatch(upstreamIP))
+	if needsPrivate {
+		log.Debugf("using private client to query %s via upstream %s", r.Question[0].Name, upstream)
 		client, err = GetClientPrivate(u.lIP, u.interfaceName, timeout)
 		if err != nil {
-			return nil, 0, fmt.Errorf("error while creating private client: %s", err)
+			return nil, 0, fmt.Errorf("create private client: %s", err)
 		}
 	}
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -499,6 +499,17 @@ func (e *Engine) Start(netbirdConfig *mgmProto.NetbirdConfig, mgmtURL *url.URL) 
 
 	e.routeManager.SetRouteChangeListener(e.mobileDep.NetworkChangeListener)
 
+	e.dnsServer.SetRouteChecker(func(ip netip.Addr) bool {
+		for _, routes := range e.routeManager.GetClientRoutes() {
+			for _, r := range routes {
+				if r.Network.Contains(ip) {
+					return true
+				}
+			}
+		}
+		return false
+	})
+
 	if err = e.wgInterfaceCreate(); err != nil {
 		log.Errorf("failed creating tunnel interface %s: [%s]", e.config.WgIfaceName, err.Error())
 		e.close()


### PR DESCRIPTION
## Describe your changes

- Replace `IsPrivate()` heuristic in iOS upstream DNS resolver with a route checker function that queries actual client routes from the route manager
- Add `SetRouteChecker` to the DNS `Server` interface, wired up from the engine after route manager creation

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented route-aware DNS resolution that enables intelligent routing decisions based on client-configured network routes. The system can now match upstream DNS resolvers against configured route networks, replacing purely network-type-based decisions with route-aware logic. This improves DNS query handling in split-DNS and complex multi-route network configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->