### PR TITLE
[client] Fix flaky TestUpdateOldManagementURL in CI

### DIFF
--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -39,6 +39,18 @@ const (
 	DefaultAdminURL = "https://app.netbird.io:443"
 )
 
+// mgmProber is the subset of management client needed for URL migration probes.
+type mgmProber interface {
+	GetServerPublicKey() (*wgtypes.Key, error)
+	Close() error
+}
+
+// newMgmProber creates a management client for probing URL reachability.
+// Overridden in tests to avoid real network calls.
+var newMgmProber = func(ctx context.Context, addr string, key wgtypes.Key, tlsEnabled bool) (mgmProber, error) {
+	return mgm.NewClient(ctx, addr, key, tlsEnabled)
+}
+
 var DefaultInterfaceBlacklist = []string{
 	iface.WgInterfaceDefault, "wt", "utun", "tun0", "zt", "ZeroTier", "wg", "ts",
 	"Tailscale", "tailscale", "docker", "veth", "br-", "lo",
@@ -753,14 +765,13 @@ func UpdateOldManagementURL(ctx context.Context, config *Config, configPath stri
 		return config, err
 	}
 
-	client, err := mgm.NewClient(ctx, newURL.Host, key, mgmTlsEnabled)
+	client, err := newMgmProber(ctx, newURL.Host, key, mgmTlsEnabled)
 	if err != nil {
 		log.Infof("couldn't switch to the new Management %s", newURL.String())
 		return config, err
 	}
 	defer func() {
-		err = client.Close()
-		if err != nil {
+		if err := client.Close(); err != nil {
 			log.Warnf("failed to close the Management service client %v", err)
 		}
 	}()

--- a/client/internal/profilemanager/config_test.go
+++ b/client/internal/profilemanager/config_test.go
@@ -10,11 +10,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/internal/routemanager/dynamic"
 	"github.com/netbirdio/netbird/util"
 )
+
+type mockMgmProber struct {
+	key wgtypes.Key
+}
+
+func (m *mockMgmProber) GetServerPublicKey() (*wgtypes.Key, error) {
+	return &m.key, nil
+}
+
+func (m *mockMgmProber) Close() error { return nil }
 
 func TestGetConfig(t *testing.T) {
 	// case 1: new default config has to be generated
@@ -234,6 +245,16 @@ func TestWireguardPortDefaultVsExplicit(t *testing.T) {
 }
 
 func TestUpdateOldManagementURL(t *testing.T) {
+	origProber := newMgmProber
+	newMgmProber = func(_ context.Context, _ string, _ wgtypes.Key, _ bool) (mgmProber, error) {
+		key, err := wgtypes.GenerateKey()
+		if err != nil {
+			return nil, err
+		}
+		return &mockMgmProber{key: key.PublicKey()}, nil
+	}
+	t.Cleanup(func() { newMgmProber = origProber })
+
 	tests := []struct {
 		name                  string
 		previousManagementURL string
@@ -273,18 +294,17 @@ func TestUpdateOldManagementURL(t *testing.T) {
 				ConfigPath:    configPath,
 			})
 			require.NoError(t, err, "failed to create testing config")
-			previousStats, err := os.Stat(configPath)
-			require.NoError(t, err, "failed to create testing config stats")
+			previousContent, err := os.ReadFile(configPath)
+			require.NoError(t, err, "failed to read initial config")
 			resultConfig, err := UpdateOldManagementURL(context.TODO(), config, configPath)
 			require.NoError(t, err, "got error when updating old management url")
 			require.Equal(t, tt.expectedManagementURL, resultConfig.ManagementURL.String())
-			newStats, err := os.Stat(configPath)
-			require.NoError(t, err, "failed to create testing config stats")
-			switch tt.fileShouldNotChange {
-			case true:
-				require.Equal(t, previousStats.ModTime(), newStats.ModTime(), "file should not change")
-			case false:
-				require.NotEqual(t, previousStats.ModTime(), newStats.ModTime(), "file should have changed")
+			newContent, err := os.ReadFile(configPath)
+			require.NoError(t, err, "failed to read updated config")
+			if tt.fileShouldNotChange {
+				require.Equal(t, string(previousContent), string(newContent), "file should not change")
+			} else {
+				require.NotEqual(t, string(previousContent), string(newContent), "file should have changed")
 			}
 		})
 	}


### PR DESCRIPTION
## Describe your changes

- Mock the management gRPC client in `TestUpdateOldManagementURL` so it no longer makes real network calls to `api.netbird.io`, which times out in CI
- Replace `ModTime`-based file change detection with content comparison, since the mock completes fast enough that writes can land within the same filesystem timestamp granularity

## Issue ticket number and link

Fixes flaky `Client / Unit` CI failures on linux-amd64, linux-386, and FreeBSD runners (observed in #5697).

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Test-only change, no user-facing behavior affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure and assertions for management configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->