### PR TITLE
[client] Fix SSH server Stop() deadlock with active sessions

### DIFF
--- a/client/ssh/server/server.go
+++ b/client/ssh/server/server.go
@@ -284,19 +284,21 @@ func (s *Server) closeListener(ln net.Listener) {
 // Stop closes the SSH server
 func (s *Server) Stop() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.sshServer == nil {
+	sshServer := s.sshServer
+	if sshServer == nil {
+		s.mu.Unlock()
 		return nil
 	}
+	s.sshServer = nil
+	s.listener = nil
+	s.mu.Unlock()
 
-	if err := s.sshServer.Close(); err != nil {
+	// Close outside the lock: session handlers need s.mu for unregisterSession.
+	if err := sshServer.Close(); err != nil {
 		log.Debugf("close SSH server: %v", err)
 	}
 
-	s.sshServer = nil
-	s.listener = nil
-
+	s.mu.Lock()
 	maps.Clear(s.sessions)
 	maps.Clear(s.pendingAuthJWT)
 	maps.Clear(s.connections)
@@ -307,6 +309,7 @@ func (s *Server) Stop() error {
 		}
 	}
 	maps.Clear(s.remoteForwardListeners)
+	s.mu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
## Describe your changes

`Server.Stop()` deadlocks when SSH sessions are active. `Stop()` holds `s.mu` while calling `sshServer.Close()`, which cancels active sessions and waits for their handlers to return. Those handlers call `unregisterSession()` which needs `s.mu`, causing a circular wait.

- Release `s.mu` before calling `sshServer.Close()`, re-acquire for map cleanup afterward
- Nil `s.sshServer` and `s.listener` under the first lock so concurrent `GetStatus()` sees the server as stopped immediately

Note: `Start()` and `Stop()` are currently serialized by the engine's `syncMsgMux`, so the unlocked window between the two lock sections does not introduce a Start/Stop race.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

No user-facing behavior change, internal deadlock fix.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH server shutdown behavior to ensure proper cleanup of sessions and connections when stopping the server, preventing potential issues during shutdown sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->