### PR TITLE
[client] Fix Android DNS routes lost after TUN rebuild

### DIFF
--- a/client/internal/routemanager/notifier/notifier_android.go
+++ b/client/internal/routemanager/notifier/notifier_android.go
@@ -31,26 +31,11 @@ func (n *Notifier) SetListener(listener listener.NetworkChangeListener) {
 	n.listener = listener
 }
 
+// SetInitialClientRoutes stores the full initial route set (including fake IP blocks)
+// and a separate comparison set (without fake IP blocks) for diff detection.
 func (n *Notifier) SetInitialClientRoutes(initialRoutes []*route.Route, routesForComparison []*route.Route) {
-	// initialRoutes contains fake IP block for interface configuration
-	filteredInitial := make([]*route.Route, 0)
-	for _, r := range initialRoutes {
-		if r.IsDynamic() {
-			continue
-		}
-		filteredInitial = append(filteredInitial, r)
-	}
-	n.initialRoutes = filteredInitial
-
-	// routesForComparison excludes fake IP block for comparison with new routes
-	filteredComparison := make([]*route.Route, 0)
-	for _, r := range routesForComparison {
-		if r.IsDynamic() {
-			continue
-		}
-		filteredComparison = append(filteredComparison, r)
-	}
-	n.currentRoutes = filteredComparison
+	n.initialRoutes = filterStatic(initialRoutes)
+	n.currentRoutes = filterStatic(routesForComparison)
 }
 
 func (n *Notifier) OnNewRoutes(idMap route.HAMap) {
@@ -83,11 +68,41 @@ func (n *Notifier) notify() {
 		return
 	}
 
-	routeStrings := n.routesToStrings(n.currentRoutes)
+	allRoutes := slices.Clone(n.currentRoutes)
+	allRoutes = append(allRoutes, n.extraInitialRoutes()...)
+
+	routeStrings := n.routesToStrings(allRoutes)
 	sort.Strings(routeStrings)
 	go func(l listener.NetworkChangeListener) {
-		l.OnNetworkChanged(strings.Join(n.addIPv6RangeIfNeeded(routeStrings, n.currentRoutes), ","))
+		l.OnNetworkChanged(strings.Join(n.addIPv6RangeIfNeeded(routeStrings, allRoutes), ","))
 	}(n.listener)
+}
+
+// extraInitialRoutes returns initialRoutes whose network prefix is absent
+// from currentRoutes (e.g. the fake IP block added at setup time).
+func (n *Notifier) extraInitialRoutes() []*route.Route {
+	currentNets := make(map[netip.Prefix]struct{}, len(n.currentRoutes))
+	for _, r := range n.currentRoutes {
+		currentNets[r.Network] = struct{}{}
+	}
+
+	var extra []*route.Route
+	for _, r := range n.initialRoutes {
+		if _, ok := currentNets[r.Network]; !ok {
+			extra = append(extra, r)
+		}
+	}
+	return extra
+}
+
+func filterStatic(routes []*route.Route) []*route.Route {
+	out := make([]*route.Route, 0, len(routes))
+	for _, r := range routes {
+		if !r.IsDynamic() {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 func (n *Notifier) routesToStrings(routes []*route.Route) []string {


### PR DESCRIPTION
## Describe your changes

When Android receives a route update from management, the TUN interface is rebuilt with the new route list. The notify() method was only sending currentRoutes (which excludes the fake IP block), so the fake IP block route (240.0.0.0/8) was dropped from the TUN after the first route update. Traffic to fake IPs then had no route to the TUN and went nowhere.

- Merge extra initial routes (fake IP blocks) into every route notification sent to the Android listener
- Extract `filterStatic` helper and `extraInitialRoutes` to keep the logic clean

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network route notifications on Android to include initial setup routes alongside active routes, ensuring comprehensive route reflection during network changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->