### PR TITLE
[management] fix race condition in the setup flow that enables creation of multiple owner users

### DIFF
--- a/management/server/instance/manager.go
+++ b/management/server/instance/manager.go
@@ -91,18 +91,18 @@ type DefaultManager struct {
 // NewManager creates a new instance manager.
 // If idpManager is not an EmbeddedIdPManager, setup-related operations will return appropriate defaults.
 func NewManager(ctx context.Context, store store.Store, idpManager idp.Manager) (Manager, error) {
-	embeddedIdp, _ := idpManager.(*idp.EmbeddedIdPManager)
+	embeddedIdp, ok := idpManager.(*idp.EmbeddedIdPManager)
 
 	m := &DefaultManager{
-		store:              store,
-		embeddedIdpManager: embeddedIdp,
-		setupRequired:      false,
+		store:         store,
+		setupRequired: false,
 		httpClient: &http.Client{
 			Timeout: httpTimeout,
 		},
 	}
 
-	if embeddedIdp != nil {
+	if ok && embeddedIdp != nil {
+		m.embeddedIdpManager = embeddedIdp
 		err := m.loadSetupRequired(ctx)
 		if err != nil {
 			return nil, err
@@ -152,12 +152,12 @@ func (m *DefaultManager) IsSetupRequired(_ context.Context) (bool, error) {
 // CreateOwnerUser creates the initial owner user in the embedded IDP.
 func (m *DefaultManager) CreateOwnerUser(ctx context.Context, email, password, name string) (*idp.UserData, error) {
 
-	if err := m.validateSetupInfo(email, password, name); err != nil {
-		return nil, err
-	}
-
 	if m.embeddedIdpManager == nil {
 		return nil, errors.New("embedded IDP is not enabled")
+	}
+
+	if err := m.validateSetupInfo(email, password, name); err != nil {
+		return nil, err
 	}
 
 	m.setupMu.Lock()
@@ -168,7 +168,10 @@ func (m *DefaultManager) CreateOwnerUser(ctx context.Context, email, password, n
 	}
 
 	if err := m.checkSetupRequiredFromDB(ctx); err != nil {
-		m.setupRequired = false
+		var sErr *status.Error
+		if errors.As(err, &sErr) && sErr.Type() == status.PreconditionFailed {
+			m.setupRequired = false
+		}
 		return nil, err
 	}
 
@@ -219,6 +222,9 @@ func (m *DefaultManager) validateSetupInfo(email, password, name string) error {
 	}
 	if len(password) < 8 {
 		return status.Errorf(status.InvalidArgument, "password must be at least 8 characters")
+	}
+	if len(password) > 72 {
+		return status.Errorf(status.InvalidArgument, "password must be at most 72 characters")
 	}
 	return nil
 }

--- a/management/server/instance/manager_test.go
+++ b/management/server/instance/manager_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 type mockIdP struct {
-	mu             sync.Mutex
-	createUserFunc func(ctx context.Context, email, password, name string) (*idp.UserData, error)
-	users          map[string][]*idp.UserData
+	mu              sync.Mutex
+	createUserFunc  func(ctx context.Context, email, password, name string) (*idp.UserData, error)
+	users           map[string][]*idp.UserData
+	getAllAccountsErr error
 }
 
 func (m *mockIdP) CreateUserWithPassword(ctx context.Context, email, password, name string) (*idp.UserData, error) {
@@ -32,6 +33,9 @@ func (m *mockIdP) CreateUserWithPassword(ctx context.Context, email, password, n
 func (m *mockIdP) GetAllAccounts(_ context.Context) (map[string][]*idp.UserData, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.getAllAccountsErr != nil {
+		return nil, m.getAllAccountsErr
+	}
 	return m.users, nil
 }
 
@@ -100,6 +104,39 @@ func TestCreateOwnerUser_IdPError(t *testing.T) {
 
 	required, _ := mgr.IsSetupRequired(context.Background())
 	assert.True(t, required, "setup should still be required after IdP error")
+}
+
+func TestCreateOwnerUser_TransientDBError_DoesNotBlockSetup(t *testing.T) {
+	mgr := newTestManager(&mockIdP{}, &mockStore{err: errors.New("connection refused")})
+
+	_, err := mgr.CreateOwnerUser(context.Background(), "admin@example.com", "password123", "Admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+
+	required, _ := mgr.IsSetupRequired(context.Background())
+	assert.True(t, required, "setup should still be required after transient DB error")
+
+	mgr.store = &mockStore{}
+	userData, err := mgr.CreateOwnerUser(context.Background(), "admin@example.com", "password123", "Admin")
+	require.NoError(t, err)
+	assert.Equal(t, "admin@example.com", userData.Email)
+}
+
+func TestCreateOwnerUser_TransientIdPError_DoesNotBlockSetup(t *testing.T) {
+	idpMock := &mockIdP{getAllAccountsErr: errors.New("connection reset")}
+	mgr := newTestManager(idpMock, &mockStore{})
+
+	_, err := mgr.CreateOwnerUser(context.Background(), "admin@example.com", "password123", "Admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection reset")
+
+	required, _ := mgr.IsSetupRequired(context.Background())
+	assert.True(t, required, "setup should still be required after transient IdP error")
+
+	idpMock.getAllAccountsErr = nil
+	userData, err := mgr.CreateOwnerUser(context.Background(), "admin@example.com", "password123", "Admin")
+	require.NoError(t, err)
+	assert.Equal(t, "admin@example.com", userData.Email)
 }
 
 func TestCreateOwnerUser_DBCheckBlocksConcurrent(t *testing.T) {
@@ -248,6 +285,20 @@ func TestDefaultManager_ValidateSetupRequest(t *testing.T) {
 			email:    "admin@example.com",
 			password: "12345678",
 			userName: "Admin User",
+		},
+		{
+			name:     "password exactly 72 characters",
+			email:    "admin@example.com",
+			password: "aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffgggggggghhhhhhhhiiiiiiii",
+			userName: "Admin User",
+		},
+		{
+			name:        "password too long",
+			email:       "admin@example.com",
+			password:    "aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffgggggggghhhhhhhhiiiiiiiij",
+			userName:    "Admin User",
+			expectError: true,
+			errorMsg:    "password must be at most 72 characters",
 		},
 	}
 


### PR DESCRIPTION
## Describe your changes

this PR fixes a race condition in the setup flow that enables creation of multiple owner users through concurrent unauthenticated /api/setup requests.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

bug fix

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved owner-account creation synchronization to prevent races and ensure setup state is reliable.
  * Added a database-backed double-check during setup and stricter password validation (rejects passwords >72 chars).
  * Safer handling when the embedded identity provider is not available.

* **Tests**
  * Expanded tests for owner creation, including concurrent request scenarios and password boundary cases.
  * Refactored test helpers for clearer, more maintainable tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->