### PR TITLE
[client] Fix ipv6 address in quic server

### DIFF
--- a/shared/relay/client/dialer/quic/quic.go
+++ b/shared/relay/client/dialer/quic/quic.go
@@ -89,7 +89,7 @@ func prepareURL(address string) (string, error) {
 	finalHost, finalPort, err := net.SplitHostPort(host)
 	if err != nil {
 		if strings.Contains(err.Error(), "missing port") {
-			return net.JoinHostPort(host, defaultPort), nil
+			return net.JoinHostPort(strings.Trim(host, "[]"), defaultPort), nil
 		}
 
 		// return any other split error as is


### PR DESCRIPTION
## Describe your changes

Fix IPv6 address construction in QUIC relay dialer

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved construction of host:port network addresses to handle bracketed hosts and missing ports more robustly.
  * Preserves existing error behavior for unsupported schemes and other split errors.
  * Small, low-risk internal change aimed at increasing reliability of connection address handling without altering public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->