### PR TITLE
[management] Add static connectors to combined server 

### DIFF
--- a/combined/cmd/config.go
+++ b/combined/cmd/config.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
+	"github.com/netbirdio/netbird/idp/dex"
 	"github.com/netbirdio/netbird/management/server/idp"
 	"github.com/netbirdio/netbird/management/server/types"
 	"github.com/netbirdio/netbird/util"
@@ -140,6 +141,7 @@ type AuthConfig struct {
 	DashboardRedirectURIs []string          `yaml:"dashboardRedirectURIs"`
 	CLIRedirectURIs       []string          `yaml:"cliRedirectURIs"`
 	Owner                 *AuthOwnerConfig  `yaml:"owner,omitempty"`
+	StaticConnectors      []dex.Connector   `yaml:"staticConnectors,omitempty"`
 }
 
 // AuthStorageConfig contains auth storage settings
@@ -592,6 +594,7 @@ func (c *CombinedConfig) buildEmbeddedIdPConfig(mgmt ManagementConfig) (*idp.Emb
 		},
 		DashboardRedirectURIs: mgmt.Auth.DashboardRedirectURIs,
 		CLIRedirectURIs:       mgmt.Auth.CLIRedirectURIs,
+		StaticConnectors:      mgmt.Auth.StaticConnectors,
 	}
 
 	if mgmt.Auth.Owner != nil && mgmt.Auth.Owner.Email != "" {

--- a/idp/dex/config.go
+++ b/idp/dex/config.go
@@ -163,10 +163,10 @@ func (p *Password) UnmarshalYAML(node *yaml.Node) error {
 
 // Connector is a connector configuration that can unmarshal YAML dynamically.
 type Connector struct {
-	Type   string                 `yaml:"type" json:"type"`
-	Name   string                 `yaml:"name" json:"name"`
-	ID     string                 `yaml:"id" json:"id"`
-	Config map[string]interface{} `yaml:"config" json:"config"`
+	Type   string         `yaml:"type" json:"type"`
+	Name   string         `yaml:"name" json:"name"`
+	ID     string         `yaml:"id" json:"id"`
+	Config map[string]any `yaml:"config" json:"config"`
 }
 
 // ToStorageConnector converts a Connector to storage.Connector type.


### PR DESCRIPTION
## Describe your changes

With the release of #5586 we now allow users to setup static connectors through management.json, which allows them to provision OIDC entries directly through config, this PR introduces the same capability for the combined server.

Example config.yaml:
```yaml

server:
  listenAddress: ":80"
  exposedAddress: "https://example.com:443"
  stunPorts:
    - 3478
  metricsPort: 9090
  healthcheckAddress: ":9000"
  logLevel: "info"
  logFile: "console"

  authSecret: "secret"
  dataDir: "/var/lib/netbird"

  auth:
    localAuthDisabled: true
    issuer: "https://example.com/oauth2"
    signKeyRefreshEnabled: true
    dashboardRedirectURIs:
      - "https://example.com/nb-auth"
      - "https://example.com/nb-silent-auth"
    cliRedirectURIs:
      - "http://localhost:53000/"
    staticConnectors:
      - type: keycloak
        name: keycloak
        id: keycloak
        config:
          issuer: "https://keycloak.domain.com/realms/netbird"
          clientID: clientId
          clientSecret: secret
          redirectURI: https://example.com/oauth2/callback


      - type: authentik
        name: authentik
        id: authentik
        config:
          issuer: https://authentik.domain.com/application/o/netbird/
          clientID: clientId
          clientSecret: secret
          redirectURI: https://example.com/oauth2/callback

  reverseProxy:
    trustedHTTPProxies:
      - "172.30.0.10/32"

  store:
    engine: "sqlite"
    encryptionKey: secretKey
```
### Caveats
- config.yaml parameters will override any "dashboard" change if the management server restarts
- first user to log-in is the owner, no way to change this programatically


### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring static connectors in authentication settings.

* **Refactor**
  * Updated internal data type definitions for improved code maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->