### PR TITLE
[client] Skip down interfaces in network address collection for posture checks

### DIFF
--- a/client/firewall/uspfilter/localip.go
+++ b/client/firewall/uspfilter/localip.go
@@ -144,6 +144,8 @@ func (m *localIPManager) UpdateLocalIPs(iface common.IFaceMapper) (err error) {
 	if err != nil {
 		log.Warnf("failed to get interfaces: %v", err)
 	} else {
+		// TODO: filter out down interfaces (net.FlagUp). Also handle the reverse
+		// case where an interface comes up between refreshes.
 		for _, intf := range interfaces {
 			m.processInterface(intf, &newIPv4Bitmap, ipv4Set, &ipv4Addresses)
 		}

--- a/client/system/info.go
+++ b/client/system/info.go
@@ -153,6 +153,9 @@ func networkAddresses() ([]NetworkAddress, error) {
 
 	var netAddresses []NetworkAddress
 	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
 		if iface.HardwareAddr.String() == "" {
 			continue
 		}


### PR DESCRIPTION
## Describe your changes

The `networkAddresses()` function in `client/system/info.go` reports IPs from all interfaces regardless of state. On Windows, disconnected adapters retain stale DHCP addresses, so the "Peer Network Range" posture check matches those addresses against deny rules and blocks the peer entirely (0 peers, 0 routes).

- Filter out interfaces without `net.FlagUp` before collecting addresses for peer system metadata
- Leave a TODO on `localip.go` which has the same issue independently

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/1743

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

No user-facing behavior change in docs, the client simply stops reporting addresses from down interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network interface filtering to exclude inactive network interfaces from system information.

* **Chores**
  * Added planning notes for enhanced network interface detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->