### PR TITLE
[self-hosted] Add selfhosted scaling note

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -1154,7 +1154,16 @@ print_builtin_traefik_instructions() {
   echo "  - $NETBIRD_STUN_PORT/udp   (STUN - required for NAT traversal)"
   if [[ "$ENABLE_PROXY" == "true" ]]; then
     echo "  - 51820/udp (WIREGUARD - (optional) for P2P proxy connections)"
-    echo ""
+  fi
+  echo ""
+  echo "This setup is ideal for homelabs and smaller organization deployments."
+  echo "For enterprise environments requiring high availability and advanced integrations,"
+  echo "consider a commercial on-prem license or scaling your open source deployment:"
+  echo ""
+  echo "  Commercial license: https://netbird.io/pricing#on-prem"
+  echo "  Scaling guide:      https://docs.netbird.io/scaling-your-self-hosted-deployment"
+  echo ""
+  if [[ "$ENABLE_PROXY" == "true" ]]; then
     echo "NetBird Proxy:"
     echo "  The proxy service is enabled and running."
     echo "  Any domain NOT matching $NETBIRD_DOMAIN will be passed through to the proxy."


### PR DESCRIPTION
Entire-Checkpoint: 7d03435efeeb

- Adds a note after the "NETBIRD SETUP COMPLETE" output informing users that this setup is ideal for homelabs and smaller organizations                                                                                          
- Points enterprise users to the commercial on-prem license and the self-hosted scaling guide


## Describe your changes
<img width="618" height="469" alt="Screenshot 2026-04-01 at 19 17 29" src="https://github.com/user-attachments/assets/b6ad01e9-1197-47d1-bd80-d02493752f4f" />

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)
https://github.com/netbirdio/docs/pull/678

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced post-setup instruction formatting for improved clarity
  * Added guidance tailored for homelabs and smaller organizations
  * Included information on commercial on-premise licensing and scaling resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->