### PR TITLE
Update config.yaml.example

### DIFF
--- a/combined/config.yaml.example
+++ b/combined/config.yaml.example
@@ -93,10 +93,11 @@ server:
     # OAuth2 redirect URIs for CLI
     cliRedirectURIs:
       - "http://localhost:53000/"
-    # Optional initial admin user (password should be hashed, try "echo "initial-password" | htpasswd -BinC 10 admin | cut -d: -f2") 
+    # Optional initial admin user (password should be hashed)
+    # To generate a hash: echo "Your-Password123" | htpasswd -BinC 10 admin | cut -d: -f2
     # owner:
     #   email: "admin@example.com"
-    #   password: "$2y$10$1KWri.ZNuXW6xgp6r9qbDe9p1HHmIqIIwbY1tkcj6xpwbbvLuHn/W"
+    #   password: "$2y$10$gKprbg9gHeWonzRQRdLVUORQ8Dn88IW.EbAsfQfRtpL8rJ4L48sXO"
 
 
   # Store configuration


### PR DESCRIPTION
password in template is not a hashed value and needs to be

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x ] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved server authentication guidance for initial admin setup: clarified that passwords must be stored hashed, added an example using bcrypt, and included an htpasswd-based command reference to help generate secure hashed passwords.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->