### PR TITLE
[client] Fix flaky TestServiceLifecycle/Restart on FreeBSD

### DIFF
--- a/client/cmd/service_test.go
+++ b/client/cmd/service_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
@@ -12,6 +14,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestMain intercepts when this test binary is run as a daemon subprocess.
+// On FreeBSD, the rc.d service script runs the binary via daemon(8) -r with
+// "service run ..." arguments. Since the test binary can't handle cobra CLI
+// args, it exits immediately, causing daemon -r to respawn rapidly until
+// hitting the rate limit and exiting. This makes service restart unreliable.
+// Blocking here keeps the subprocess alive until the init system sends SIGTERM.
+func TestMain(m *testing.M) {
+	if len(os.Args) > 2 && os.Args[1] == "service" && os.Args[2] == "run" {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGTERM, os.Interrupt)
+		<-sig
+		return
+	}
+	os.Exit(m.Run())
+}
 
 const (
 	serviceStartTimeout = 10 * time.Second
@@ -78,6 +96,34 @@ func TestServiceLifecycle(t *testing.T) {
 	configPath = fmt.Sprintf("%s/netbird-test-config.json", tempDir)
 	logLevel = "info"
 	daemonAddr = fmt.Sprintf("unix://%s/netbird-test.sock", tempDir)
+
+	// Ensure cleanup even if a subtest fails and Stop/Uninstall subtests don't run.
+	t.Cleanup(func() {
+		cfg, err := newSVCConfig()
+		if err != nil {
+			t.Errorf("cleanup: create service config: %v", err)
+			return
+		}
+		ctxSvc, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		s, err := newSVC(newProgram(ctxSvc, cancel), cfg)
+		if err != nil {
+			t.Errorf("cleanup: create service: %v", err)
+			return
+		}
+
+		// If the subtests already cleaned up, there's nothing to do.
+		if _, err := s.Status(); err != nil {
+			return
+		}
+
+		if err := s.Stop(); err != nil {
+			t.Errorf("cleanup: stop service: %v", err)
+		}
+		if err := s.Uninstall(); err != nil {
+			t.Errorf("cleanup: uninstall service: %v", err)
+		}
+	})
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Describe your changes

Fix flaky `TestServiceLifecycle/Restart` on the FreeBSD CI job. The rc.d service script runs the test binary via `daemon(8) -r` with `service run ...` arguments. Since the test binary can't handle cobra CLI args, it exits immediately, and `daemon -r` respawns it rapidly until hitting FreeBSD's rate limit. By then the daemon has exited, so `service restart` fails with exit code 1.

- Add `TestMain` that detects when the test binary is invoked as a daemon subprocess and blocks on SIGTERM instead of exiting
- Add `t.Cleanup` to ensure the service is stopped and uninstalled even if a subtest fails (previously a Restart failure left the service installed on the VM)

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Test-only change, no user-facing behavior modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced service lifecycle test cleanup and improved signal handling for better test reliability and proper service termination during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->