### PR TITLE
[client] Add TTL-based cache refresh for management DNS resolver

### DIFF
--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -18,14 +18,16 @@ import (
 )
 
 const (
-	dnsTimeout = 5 * time.Second
-	defaultTTL = 300 * time.Second
+	dnsTimeout          = 5 * time.Second
+	defaultTTL          = 300 * time.Second
+	refreshBackoff      = 30 * time.Second // wait time after failed refresh attempt
 )
 
 // cachedRecord holds DNS records with their cache timestamp.
 type cachedRecord struct {
-	records  []dns.RR
-	cachedAt time.Time
+	records           []dns.RR
+	cachedAt          time.Time
+	lastFailedRefresh *time.Time // timestamp of last failed refresh attempt, nil if never failed
 }
 
 // Resolver caches critical NetBird infrastructure domains
@@ -192,6 +194,7 @@ func (m *Resolver) AddDomain(ctx context.Context, d domain.Domain) error {
 
 // refreshDomain refreshes a stale cached domain using DefaultResolver.
 // On failure, it returns the stale records to avoid breaking connectivity.
+// A backoff mechanism prevents repeated blocking refresh attempts after failures.
 func (m *Resolver) refreshDomain(question dns.Question, stale *cachedRecord) []dns.RR {
 	m.refreshMutex.Lock()
 	defer m.refreshMutex.Unlock()
@@ -201,10 +204,17 @@ func (m *Resolver) refreshDomain(question dns.Question, stale *cachedRecord) []d
 		return stale.records
 	}
 
+	// Check if we're in backoff period after a failed refresh
+	if stale.lastFailedRefresh != nil && time.Since(*stale.lastFailedRefresh) < refreshBackoff {
+		return stale.records
+	}
+
 	d, _ := domain.FromString(question.Name)
 
 	if err := m.AddDomain(context.Background(), d); err != nil {
 		log.Warnf("failed to refresh domain=%s: %v, serving stale cache", d.SafeString(), err)
+		now := time.Now()
+		stale.lastFailedRefresh = &now
 		return stale.records
 	}
 

--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -83,7 +83,7 @@ func (m *Resolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	// Check if cache entry is stale (TTL expired)
 	var records []dns.RR
 	if time.Since(cached.cachedAt) > defaultTTL {
-		records = m.refreshDomain(question, cached)
+		records = m.refreshDomain(question)
 	} else {
 		records = cached.records
 	}
@@ -195,18 +195,27 @@ func (m *Resolver) AddDomain(ctx context.Context, d domain.Domain) error {
 // refreshDomain refreshes a stale cached domain using DefaultResolver.
 // On failure, it returns the stale records to avoid breaking connectivity.
 // A backoff mechanism prevents repeated blocking refresh attempts after failures.
-func (m *Resolver) refreshDomain(question dns.Question, stale *cachedRecord) []dns.RR {
+func (m *Resolver) refreshDomain(question dns.Question) []dns.RR {
 	m.refreshMutex.Lock()
 	defer m.refreshMutex.Unlock()
 
-	// Double-check if still stale after acquiring lock
-	if time.Since(stale.cachedAt) <= defaultTTL {
-		return stale.records
+	// Re-read from map after acquiring lock to check if another goroutine refreshed
+	m.mutex.RLock()
+	current, found := m.records[question]
+	m.mutex.RUnlock()
+
+	if !found {
+		return nil
+	}
+
+	// Check if already refreshed by another goroutine
+	if time.Since(current.cachedAt) <= defaultTTL {
+		return current.records
 	}
 
 	// Check if we're in backoff period after a failed refresh
-	if stale.lastFailedRefresh != nil && time.Since(*stale.lastFailedRefresh) < refreshBackoff {
-		return stale.records
+	if current.lastFailedRefresh != nil && time.Since(*current.lastFailedRefresh) < refreshBackoff {
+		return current.records
 	}
 
 	d, _ := domain.FromString(question.Name)
@@ -214,8 +223,8 @@ func (m *Resolver) refreshDomain(question dns.Question, stale *cachedRecord) []d
 	if err := m.AddDomain(context.Background(), d); err != nil {
 		log.Warnf("failed to refresh domain=%s: %v, serving stale cache", d.SafeString(), err)
 		now := time.Now()
-		stale.lastFailedRefresh = &now
-		return stale.records
+		current.lastFailedRefresh = &now
+		return current.records
 	}
 
 	m.mutex.RLock()
@@ -225,8 +234,8 @@ func (m *Resolver) refreshDomain(question dns.Question, stale *cachedRecord) []d
 	if !found {
 		// DNS returned no records for this type, preserve stale with backoff
 		now := time.Now()
-		stale.lastFailedRefresh = &now
-		return stale.records
+		current.lastFailedRefresh = &now
+		return current.records
 	}
 
 	log.Infof("refreshed cached domain=%s", d.SafeString())

--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -223,6 +223,9 @@ func (m *Resolver) refreshDomain(question dns.Question, stale *cachedRecord) []d
 	m.mutex.RUnlock()
 
 	if !found {
+		// DNS returned no records for this type, preserve stale with backoff
+		now := time.Now()
+		stale.lastFailedRefresh = &now
 		return stale.records
 	}
 

--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -17,14 +17,24 @@ import (
 	"github.com/netbirdio/netbird/shared/management/domain"
 )
 
-const dnsTimeout = 5 * time.Second
+const (
+	dnsTimeout = 5 * time.Second
+	defaultTTL = 300 * time.Second
+)
+
+// cachedRecord holds DNS records with their cache timestamp.
+type cachedRecord struct {
+	records  []dns.RR
+	cachedAt time.Time
+}
 
 // Resolver caches critical NetBird infrastructure domains
 type Resolver struct {
-	records       map[dns.Question][]dns.RR
+	records       map[dns.Question]*cachedRecord
 	mgmtDomain    *domain.Domain
 	serverDomains *dnsconfig.ServerDomains
 	mutex         sync.RWMutex
+	refreshMutex  sync.Mutex // prevents concurrent refresh of the same domain
 }
 
 type ipsResponse struct {
@@ -35,7 +45,7 @@ type ipsResponse struct {
 // NewResolver creates a new management domains cache resolver.
 func NewResolver() *Resolver {
 	return &Resolver{
-		records: make(map[dns.Question][]dns.RR),
+		records: make(map[dns.Question]*cachedRecord),
 	}
 }
 
@@ -60,12 +70,20 @@ func (m *Resolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	m.mutex.RLock()
-	records, found := m.records[question]
+	cached, found := m.records[question]
 	m.mutex.RUnlock()
 
 	if !found {
 		m.continueToNext(w, r)
 		return
+	}
+
+	// Check if cache entry is stale (TTL expired)
+	var records []dns.RR
+	if time.Since(cached.cachedAt) > defaultTTL {
+		records = m.refreshDomain(question, cached)
+	} else {
+		records = cached.records
 	}
 
 	resp := &dns.Msg{}
@@ -118,7 +136,7 @@ func (m *Resolver) AddDomain(ctx context.Context, d domain.Domain) error {
 					Name:   dnsName,
 					Rrtype: dns.TypeA,
 					Class:  dns.ClassINET,
-					Ttl:    300,
+					Ttl:    uint32(defaultTTL.Seconds()),
 				},
 				A: ip.AsSlice(),
 			}
@@ -129,7 +147,7 @@ func (m *Resolver) AddDomain(ctx context.Context, d domain.Domain) error {
 					Name:   dnsName,
 					Rrtype: dns.TypeAAAA,
 					Class:  dns.ClassINET,
-					Ttl:    300,
+					Ttl:    uint32(defaultTTL.Seconds()),
 				},
 				AAAA: ip.AsSlice(),
 			}
@@ -137,6 +155,7 @@ func (m *Resolver) AddDomain(ctx context.Context, d domain.Domain) error {
 		}
 	}
 
+	now := time.Now()
 	m.mutex.Lock()
 
 	if len(aRecords) > 0 {
@@ -145,7 +164,10 @@ func (m *Resolver) AddDomain(ctx context.Context, d domain.Domain) error {
 			Qtype:  dns.TypeA,
 			Qclass: dns.ClassINET,
 		}
-		m.records[aQuestion] = aRecords
+		m.records[aQuestion] = &cachedRecord{
+			records:  aRecords,
+			cachedAt: now,
+		}
 	}
 
 	if len(aaaaRecords) > 0 {
@@ -154,7 +176,10 @@ func (m *Resolver) AddDomain(ctx context.Context, d domain.Domain) error {
 			Qtype:  dns.TypeAAAA,
 			Qclass: dns.ClassINET,
 		}
-		m.records[aaaaQuestion] = aaaaRecords
+		m.records[aaaaQuestion] = &cachedRecord{
+			records:  aaaaRecords,
+			cachedAt: now,
+		}
 	}
 
 	m.mutex.Unlock()
@@ -163,6 +188,36 @@ func (m *Resolver) AddDomain(ctx context.Context, d domain.Domain) error {
 		d.SafeString(), len(aRecords), len(aaaaRecords))
 
 	return nil
+}
+
+// refreshDomain refreshes a stale cached domain using DefaultResolver.
+// On failure, it returns the stale records to avoid breaking connectivity.
+func (m *Resolver) refreshDomain(question dns.Question, stale *cachedRecord) []dns.RR {
+	m.refreshMutex.Lock()
+	defer m.refreshMutex.Unlock()
+
+	// Double-check if still stale after acquiring lock
+	if time.Since(stale.cachedAt) <= defaultTTL {
+		return stale.records
+	}
+
+	d, _ := domain.FromString(question.Name)
+
+	if err := m.AddDomain(context.Background(), d); err != nil {
+		log.Warnf("failed to refresh domain=%s: %v, serving stale cache", d.SafeString(), err)
+		return stale.records
+	}
+
+	m.mutex.RLock()
+	newCached, found := m.records[question]
+	m.mutex.RUnlock()
+
+	if !found {
+		return stale.records
+	}
+
+	log.Infof("refreshed cached domain=%s", d.SafeString())
+	return newCached.records
 }
 
 func lookupIPWithExtraTimeout(ctx context.Context, d domain.Domain) ([]netip.Addr, error) {


### PR DESCRIPTION
## Describe your changes

Add TTL expiration mechanism to MgmtCacheResolver to handle DDNS IP changes. When cache entries expire (300s TTL), refresh synchronously using net.DefaultResolver. On refresh failure, serve stale cache to maintain connectivity.

Fixes #5113

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/5113

## Stack

<!-- branch-stack -->

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS resolver caching with per-entry timestamps, TTL-based expiration, and automatic refresh of stale records. Failed refreshes now trigger a backoff while continuing to serve stale records for reliability. New logic also records insertion times and applies consistent TTLs to cached responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->