### PR TITLE
[management] network map tests

### DIFF
--- a/management/server/types/networkmap_benchmark_test.go
+++ b/management/server/types/networkmap_benchmark_test.go
@@ -3,13 +3,10 @@ package types_test
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"testing"
-	"time"
 
 	nbdns "github.com/netbirdio/netbird/dns"
-	nbpeer "github.com/netbirdio/netbird/management/server/peer"
 	"github.com/netbirdio/netbird/management/server/types"
 )
 
@@ -29,34 +26,15 @@ var defaultScales = []benchmarkScale{
 	{"30000peers_300groups", 30000, 300},
 }
 
-// ──────────────────────────────────────────────────────────────────────────────
-// Single Peer Network Map Generation
-// ──────────────────────────────────────────────────────────────────────────────
 func skipCIBenchmark(b *testing.B) {
 	if os.Getenv("CI") == "true" {
 		b.Skip("Skipping benchmark in CI")
 	}
 }
 
-// BenchmarkNetworkMapGeneration_Legacy benchmarks the legacy GetPeerNetworkMap for a single peer.
-func BenchmarkNetworkMapGeneration_Legacy(b *testing.B) {
-	skipCIBenchmark(b)
-	for _, scale := range defaultScales {
-		b.Run(scale.name, func(b *testing.B) {
-			account, validatedPeers := scalableTestAccount(scale.peers, scale.groups)
-			ctx := context.Background()
-			resourcePolicies := account.GetResourcePoliciesMap()
-			routers := account.GetResourceRoutersMap()
-			groupIDToUserIDs := account.GetActiveGroupUsers()
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
-				_ = account.GetPeerNetworkMap(ctx, "peer-0", nbdns.CustomZone{}, nil, validatedPeers, resourcePolicies, routers, nil, groupIDToUserIDs)
-			}
-		})
-	}
-}
+// ──────────────────────────────────────────────────────────────────────────────
+// Single Peer Network Map Generation
+// ──────────────────────────────────────────────────────────────────────────────
 
 // BenchmarkNetworkMapGeneration_Components benchmarks the components-based approach for a single peer.
 func BenchmarkNetworkMapGeneration_Components(b *testing.B) {
@@ -73,24 +51,6 @@ func BenchmarkNetworkMapGeneration_Components(b *testing.B) {
 			b.ResetTimer()
 			for range b.N {
 				_ = account.GetPeerNetworkMapFromComponents(ctx, "peer-0", nbdns.CustomZone{}, nil, validatedPeers, resourcePolicies, routers, nil, groupIDToUserIDs)
-			}
-		})
-	}
-}
-
-// BenchmarkNetworkMapGeneration_Builder benchmarks the builder approach for a single peer.
-func BenchmarkNetworkMapGeneration_Builder(b *testing.B) {
-	skipCIBenchmark(b)
-	for _, scale := range defaultScales {
-		b.Run(scale.name, func(b *testing.B) {
-			account, validatedPeers := scalableTestAccount(scale.peers, scale.groups)
-			ctx := context.Background()
-			builder := types.NewNetworkMapBuilder(account, validatedPeers)
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
-				_ = builder.GetPeerNetworkMap(ctx, "peer-0", nbdns.CustomZone{}, nil, validatedPeers, nil)
 			}
 		})
 	}
@@ -119,19 +79,6 @@ func BenchmarkNetworkMapGeneration_AllPeers(b *testing.B) {
 			peerIDs = append(peerIDs, peerID)
 		}
 
-		b.Run("legacy/"+scale.name, func(b *testing.B) {
-			resourcePolicies := account.GetResourcePoliciesMap()
-			routers := account.GetResourceRoutersMap()
-			groupIDToUserIDs := account.GetActiveGroupUsers()
-			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
-				for _, peerID := range peerIDs {
-					_ = account.GetPeerNetworkMap(ctx, peerID, nbdns.CustomZone{}, nil, validatedPeers, resourcePolicies, routers, nil, groupIDToUserIDs)
-				}
-			}
-		})
-
 		b.Run("components/"+scale.name, func(b *testing.B) {
 			resourcePolicies := account.GetResourcePoliciesMap()
 			routers := account.GetResourceRoutersMap()
@@ -144,38 +91,12 @@ func BenchmarkNetworkMapGeneration_AllPeers(b *testing.B) {
 				}
 			}
 		})
-
-		b.Run("builder/"+scale.name, func(b *testing.B) {
-			builder := types.NewNetworkMapBuilder(account, validatedPeers)
-			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
-				for _, peerID := range peerIDs {
-					_ = builder.GetPeerNetworkMap(ctx, peerID, nbdns.CustomZone{}, nil, validatedPeers, nil)
-				}
-			}
-		})
 	}
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Sub-operations
 // ──────────────────────────────────────────────────────────────────────────────
-
-// BenchmarkNetworkMapGeneration_BuilderInit benchmarks builder cache initialization.
-func BenchmarkNetworkMapGeneration_BuilderInit(b *testing.B) {
-	skipCIBenchmark(b)
-	for _, scale := range defaultScales {
-		b.Run(scale.name, func(b *testing.B) {
-			account, validatedPeers := scalableTestAccount(scale.peers, scale.groups)
-			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
-				_ = types.NewNetworkMapBuilder(account, validatedPeers)
-			}
-		})
-	}
-}
 
 // BenchmarkNetworkMapGeneration_ComponentsCreation benchmarks components extraction.
 func BenchmarkNetworkMapGeneration_ComponentsCreation(b *testing.B) {
@@ -242,47 +163,6 @@ func BenchmarkNetworkMapGeneration_PrecomputeMaps(b *testing.B) {
 			b.ResetTimer()
 			for range b.N {
 				_ = account.GetActiveGroupUsers()
-			}
-		})
-	}
-}
-
-// BenchmarkNetworkMapGeneration_BuilderIncrementalAdd benchmarks only the OnPeerAddedIncremental call.
-func BenchmarkNetworkMapGeneration_BuilderIncrementalAdd(b *testing.B) {
-	skipCIBenchmark(b)
-	for _, scale := range defaultScales {
-		b.Run(scale.name, func(b *testing.B) {
-			account, validatedPeers := scalableTestAccount(scale.peers, scale.groups)
-			builder := types.NewNetworkMapBuilder(account, validatedPeers)
-
-			// Pre-create peer structs to avoid allocation noise in the timed section
-			newPeers := make([]*nbpeer.Peer, b.N)
-			newPeerIDs := make([]string, b.N)
-			for i := range b.N {
-				newPeerIDs[i] = fmt.Sprintf("peer-new-%d", i)
-				newPeers[i] = &nbpeer.Peer{
-					ID: newPeerIDs[i], IP: net.IP{100, 65, byte(i / 256), byte(i % 256)},
-					Key: fmt.Sprintf("key-%s", newPeerIDs[i]), DNSLabel: fmt.Sprintf("peernew%d", i),
-					Status: &nbpeer.PeerStatus{Connected: true, LastSeen: time.Now()},
-					UserID: "user-admin", Meta: nbpeer.PeerSystemMeta{WtVersion: "0.40.0", GoOS: "linux"},
-				}
-			}
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := range b.N {
-				pid := newPeerIDs[i]
-				account.Peers[pid] = newPeers[i]
-				account.Groups["group-all"].Peers = append(account.Groups["group-all"].Peers, pid)
-				validatedPeers[pid] = struct{}{}
-
-				_ = builder.OnPeerAddedIncremental(account, pid)
-
-				b.StopTimer()
-				delete(account.Peers, pid)
-				account.Groups["group-all"].Peers = account.Groups["group-all"].Peers[:len(account.Groups["group-all"].Peers)-1]
-				delete(validatedPeers, pid)
-				b.StartTimer()
 			}
 		})
 	}

--- a/management/server/types/networkmap_components_correctness_test.go
+++ b/management/server/types/networkmap_components_correctness_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"sort"
 	"testing"
 	"time"
 
@@ -251,15 +250,6 @@ func buildScalableTestAccount(numPeers, numGroups int, withDefaultPolicy bool) (
 // componentsNetworkMap is a convenience wrapper for GetPeerNetworkMapFromComponents.
 func componentsNetworkMap(account *types.Account, peerID string, validatedPeers map[string]struct{}) *types.NetworkMap {
 	return account.GetPeerNetworkMapFromComponents(
-		context.Background(), peerID, nbdns.CustomZone{}, nil,
-		validatedPeers, account.GetResourcePoliciesMap(), account.GetResourceRoutersMap(),
-		nil, account.GetActiveGroupUsers(),
-	)
-}
-
-// legacyNetworkMap is a convenience wrapper for GetPeerNetworkMap.
-func legacyNetworkMap(account *types.Account, peerID string, validatedPeers map[string]struct{}) *types.NetworkMap {
-	return account.GetPeerNetworkMap(
 		context.Background(), peerID, nbdns.CustomZone{}, nil,
 		validatedPeers, account.GetResourcePoliciesMap(), account.GetResourceRoutersMap(),
 		nil, account.GetActiveGroupUsers(),
@@ -806,37 +796,27 @@ func TestComponents_SSHNotEnabledWithoutPolicy(t *testing.T) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// 10. LEGACY vs COMPONENTS CONSISTENCY
+// 10. CROSS-PEER CONSISTENCY
 // ──────────────────────────────────────────────────────────────────────────────
 
-func TestComponents_LegacyVsComponentsConsistency(t *testing.T) {
-	account, validatedPeers := scalableTestAccount(100, 5)
-
-	legacy := legacyNetworkMap(account, "peer-0", validatedPeers)
-	comp := componentsNetworkMap(account, "peer-0", validatedPeers)
-	require.NotNil(t, legacy)
-	require.NotNil(t, comp)
-
-	assert.Equal(t, len(legacy.Peers), len(comp.Peers), "peer count mismatch")
-	assert.Equal(t, len(legacy.OfflinePeers), len(comp.OfflinePeers), "offline peer count mismatch")
-	assert.Equal(t, legacy.DNSConfig.ServiceEnable, comp.DNSConfig.ServiceEnable, "DNS config mismatch")
-	assert.Equal(t, legacy.Network.Serial, comp.Network.Serial, "network serial mismatch")
-	assert.Equal(t, legacy.EnableSSH, comp.EnableSSH, "SSH enable mismatch")
-
-	legacyPeerIDs := make([]string, 0, len(legacy.Peers))
-	for _, p := range legacy.Peers {
-		legacyPeerIDs = append(legacyPeerIDs, p.ID)
+// TestComponents_AllPeersGetValidMaps verifies that every validated peer gets a
+// non-nil map with a consistent network serial and non-empty peer list.
+func TestComponents_AllPeersGetValidMaps(t *testing.T) {
+	account, validatedPeers := scalableTestAccount(50, 5)
+	for peerID := range account.Peers {
+		if _, validated := validatedPeers[peerID]; !validated {
+			continue
+		}
+		nm := componentsNetworkMap(account, peerID, validatedPeers)
+		require.NotNil(t, nm, "network map should not be nil for %s", peerID)
+		assert.Equal(t, account.Network.Serial, nm.Network.Serial, "serial mismatch for %s", peerID)
+		assert.NotEmpty(t, nm.Peers, "validated peer %s should see other peers", peerID)
 	}
-	compPeerIDs := make([]string, 0, len(comp.Peers))
-	for _, p := range comp.Peers {
-		compPeerIDs = append(compPeerIDs, p.ID)
-	}
-	sort.Strings(legacyPeerIDs)
-	sort.Strings(compPeerIDs)
-	assert.Equal(t, legacyPeerIDs, compPeerIDs, "peer IDs should match")
 }
 
-func TestComponents_LargeScaleConsistency(t *testing.T) {
+// TestComponents_LargeScaleMapGeneration verifies that components can generate maps
+// at larger scales without errors and with consistent output.
+func TestComponents_LargeScaleMapGeneration(t *testing.T) {
 	scales := []struct{ peers, groups int }{
 		{500, 20},
 		{1000, 50},
@@ -846,37 +826,13 @@ func TestComponents_LargeScaleConsistency(t *testing.T) {
 			account, validatedPeers := scalableTestAccount(s.peers, s.groups)
 			testPeers := []string{"peer-0", fmt.Sprintf("peer-%d", s.peers/4), fmt.Sprintf("peer-%d", s.peers/2)}
 			for _, peerID := range testPeers {
-				legacy := legacyNetworkMap(account, peerID, validatedPeers)
-				comp := componentsNetworkMap(account, peerID, validatedPeers)
-				assert.Equal(t, len(legacy.Peers), len(comp.Peers), "peer count mismatch for %s", peerID)
-				assert.Equal(t, len(legacy.OfflinePeers), len(comp.OfflinePeers), "offline count mismatch for %s", peerID)
-				assert.Equal(t, len(legacy.Routes), len(comp.Routes), "routes count mismatch for %s", peerID)
+				nm := componentsNetworkMap(account, peerID, validatedPeers)
+				require.NotNil(t, nm, "network map should not be nil for %s", peerID)
+				assert.NotEmpty(t, nm.Peers, "peer %s should see other peers at scale", peerID)
+				assert.NotEmpty(t, nm.Routes, "peer %s should have routes at scale", peerID)
+				assert.Equal(t, account.Network.Serial, nm.Network.Serial, "serial mismatch for %s", peerID)
 			}
 		})
-	}
-}
-
-func TestComponents_BuilderConsistency(t *testing.T) {
-	account, validatedPeers := scalableTestAccount(100, 5)
-	comp := componentsNetworkMap(account, "peer-0", validatedPeers)
-	builder := types.NewNetworkMapBuilder(account, validatedPeers)
-	builderMap := builder.GetPeerNetworkMap(context.Background(), "peer-0", nbdns.CustomZone{}, nil, validatedPeers, nil)
-	require.NotNil(t, comp)
-	require.NotNil(t, builderMap)
-	assert.Equal(t, len(comp.Peers), len(builderMap.Peers), "peer count mismatch")
-	assert.Equal(t, len(comp.OfflinePeers), len(builderMap.OfflinePeers), "offline count mismatch")
-	assert.Equal(t, comp.DNSConfig.ServiceEnable, builderMap.DNSConfig.ServiceEnable, "DNS mismatch")
-}
-
-func TestComponents_AllPeersMapConsistency(t *testing.T) {
-	account, validatedPeers := scalableTestAccount(50, 5)
-	for peerID := range account.Peers {
-		if _, validated := validatedPeers[peerID]; !validated {
-			continue
-		}
-		legacy := legacyNetworkMap(account, peerID, validatedPeers)
-		comp := componentsNetworkMap(account, peerID, validatedPeers)
-		assert.Equal(t, len(legacy.Peers), len(comp.Peers), "peer count mismatch for %s", peerID)
 	}
 }
 


### PR DESCRIPTION
## Describe your changes
# Network Map Test Inventory

Complete inventory of all tests under `management/` that test network map functionality directly or indirectly.

Last verified: all tests passing on branch `nm/tests`.

---

## DIRECT TESTS

Tests that call `GetPeerNetworkMapFromComponents`, `GetPeerNetworkMapComponents`, `CalculateNetworkMapFromComponents`, `GetPeerNetworkMap`, `NewNetworkMapBuilder`, or directly construct/validate `NetworkMap` structs.

### `management/server/types/networkmap_components_correctness_test.go` (NEW — 46 tests)

Tests use `scalableTestAccount()` (with default allow policy) or `scalableTestAccountWithoutDefaultPolicy()` (isolated, feature-specific connectivity only).

| # | Test | Features Covered |
|---|------|-----------------|
| 1 | `TestComponents_PeerVisibility` | Peers, visibility filtering, validated peers |
| 2 | `TestComponents_PeerDoesNotSeeItself` | Peers, self-exclusion |
| 3 | `TestComponents_IntraGroupConnectivity` | Peers, Groups, same-group visibility |
| 4 | `TestComponents_CrossGroupConnectivity` | Peers, Groups, Policies, cross-group visibility (isolated) |
| 5 | `TestComponents_BidirectionalPolicy` | Policies, bidirectional rules (isolated) |
| 6 | `TestComponents_ExpiredPeerInOfflineList` | Expiration, OfflinePeers, Settings |
| 7 | `TestComponents_ExpirationDisabledSetting` | Account Settings, Expiration toggle |
| 8 | `TestComponents_LoginExpiration_PeerLevel` | Per-peer login expiration |
| 9 | `TestComponents_NetworkSerial` | Network serial propagation |
| 10 | `TestComponents_NonValidatedPeerExcluded` | Peer validation filtering |
| 11 | `TestComponents_NonValidatedTargetPeerGetsEmptyMap` | Validation, empty map for non-validated target |
| 12 | `TestComponents_NonExistentPeerGetsEmptyMap` | Nonexistent peer handling |
| 13 | `TestComponents_FirewallRulesGenerated` | Firewall rules, Policies |
| 14 | `TestComponents_DropPolicyGeneratesDropRules` | DROP action firewall rules |
| 15 | `TestComponents_DisabledPolicyIgnored` | Disabled policies produce no rules/peers |
| 16 | `TestComponents_PortPolicy` | Port-specific firewall rules |
| 17 | `TestComponents_PortRangePolicy` | Port range firewall rules (requires peer >= 0.48.0) |
| 18 | `TestComponents_FirewallRuleDirection` | IN/OUT direction on firewall rules |
| 19 | `TestComponents_RoutesIncluded` | Routes in network map |
| 20 | `TestComponents_DisabledRouteExcluded` | Disabled routes filtered out |
| 21 | `TestComponents_RoutesFirewallRulesForACG` | Route firewall rules for AccessControlGroups |
| 22 | `TestComponents_HARouteDeduplication` | HA routes deduplicated into single entry per HA group |
| 23 | `TestComponents_NetworkResourceRoutes_RouterPeer` | Network resources, router peer sees source peers |
| 24 | `TestComponents_NetworkResourceRoutes_SourcePeerSeesRouterPeer` | Source peer sees router peer |
| 25 | `TestComponents_DisabledNetworkResourceIgnored` | Disabled network resources excluded |
| 26 | `TestComponents_PostureCheckFiltering_PassingPeer` | Posture check pass (version >= min), has resource routes |
| 27 | `TestComponents_PostureCheckFiltering_FailingPeer` | Posture check fail sees fewer peers than passing peer (isolated) |
| 28 | `TestComponents_MultiplePostureChecks` | Multiple posture checks (version + OS), passing/failing verified (isolated) |
| 29 | `TestComponents_DNSConfigEnabled` | DNS enabled, nameserver groups populated |
| 30 | `TestComponents_DNSDisabledByManagementGroup` | DNS disabled via DisabledManagementGroups |
| 31 | `TestComponents_DNSNameServerGroupDistribution` | NS groups distributed to correct groups only |
| 32 | `TestComponents_DNSCustomZone` | Custom DNS zone records |
| 33 | `TestComponents_SSHPolicy` | SSH policy enables SSH, AuthorizedGroups |
| 34 | `TestComponents_SSHNotEnabledWithoutPolicy` | SSH disabled without explicit SSH policy |
| 35 | `TestComponents_AllPeersGetValidMaps` | All 50 validated peers get non-nil maps with correct serial |
| 36 | `TestComponents_LargeScaleMapGeneration` | 500/1000 peer map generation works with correct output |
| 37 | `TestComponents_PeerAsSourceResource` | SourceResource.Type=Peer targets specific peer |
| 38 | `TestComponents_PeerAsDestinationResource` | DestinationResource.Type=Peer targets specific peer (isolated) |
| 39 | `TestComponents_MultipleRulesPerPolicy` | Policy with 2 rules generates both sets of firewall rules |
| 40 | `TestComponents_SSHAuthorizedUsersContent` | AuthorizedUsers map has correct machine user mappings |
| 41 | `TestComponents_SSHLegacyImpliedSSH` | ALL protocol + SSHEnabled peer implies SSH access |
| 42 | `TestComponents_RouteDefaultPermit` | Route without ACG gets 0.0.0.0/0 default permit |
| 43 | `TestComponents_MultipleRoutersPerNetwork` | Network resource with 2 routers, source sees both (isolated) |
| 44 | `TestComponents_PeerIsNameserverExcludedFromNSGroup` | Peer serving as NS excluded from its own NS group |
| 45 | `TestComponents_DomainNetworkResource` | Domain-type network resource, source sees router (isolated) |
| 46 | `TestComponents_DisabledRuleInEnabledPolicy` | Enabled rule generates FW, disabled rule does not |

### `management/server/types/networkmap_golden_test.go` (existing — 6 tests + 4 benchmarks)

| Test | Features Covered |
|------|-----------------|
| `TestGetPeerNetworkMap_Golden` | Legacy vs builder golden file comparison (all features) |
| `TestGetPeerNetworkMap_Golden_WithNewPeer` | Incremental peer add via builder |
| `TestGetPeerNetworkMap_Golden_WithNewRoutingPeer` | Router peer add via builder |
| `TestGetPeerNetworkMap_Golden_WithDeletedPeer` | Peer deletion, offline list |
| `TestGetPeerNetworkMap_Golden_WithDeletedRouterPeer` | Router peer deletion |
| `TestGetPeerNetworkMap_Golden_New_WithOnPeerAddedRouter_Batched` | Batched router add |
| `BenchmarkGetPeerNetworkMap` | Old vs new builder, 100 peers |
| `BenchmarkGetPeerNetworkMap_AfterPeerAdded` | After peer add |
| `BenchmarkGetPeerNetworkMap_AfterRouterPeerAdded` | After router peer add |
| `BenchmarkGetPeerNetworkMap_AfterPeerDeleted` | After peer deletion |

### `management/server/types/networkmap_comparison_test.go` (existing — 2 tests + 4 benchmarks)

| Test | Features Covered |
|------|-----------------|
| `TestNetworkMapComponents_CompareWithLegacy` | Legacy vs components structural comparison |
| `TestNetworkMapComponents_GoldenFileComparison` | Golden file JSON comparison |
| `BenchmarkLegacyNetworkMap` | Legacy, 100 peers |
| `BenchmarkComponentsNetworkMap` | Components, 100 peers |
| `BenchmarkComponentsCreation` | Components extraction only |
| `BenchmarkCalculationFromComponents` | Calculation from components only |

### `management/server/types/account_test.go` (existing — 17 tests)

| Test | Features Covered |
|------|-----------------|
| `Test_GetResourceRoutersMap` | Resource routers map helper |
| `Test_GetResourcePoliciesMap` | Resource policies map helper |
| `Test_AddNetworksRoutingPeersAddsMissingPeers` | Router peer injection into peer list |
| `Test_AddNetworksRoutingPeersIgnoresExistingPeers` | Router peer dedup |
| `Test_AddNetworksRoutingPeersAddsExpiredPeers` | Expired router handling |
| `Test_AddNetworksRoutingPeersExcludesSelf` | Self-exclusion in routing |
| `Test_AddNetworksRoutingPeersHandlesNoMissingPeers` | No-op when all present |
| `Test_NetworksNetMapGenWithNoPostureChecks` | Resources without posture checks |
| `Test_NetworksNetMapGenWithPostureChecks` | Resources with posture check (pass) |
| `Test_NetworksNetMapGenWithNoMatchedPostureChecks` | Resources with posture check (fail) |
| `Test_NetworksNetMapGenWithTwoPoliciesAndPostureChecks` | Two policies + posture |
| `Test_NetworksNetMapGenWithTwoPostureChecks` | Two posture checks on one resource |
| `Test_NetworksNetMapGenShouldExcludeOtherRouters` | Router isolation between networks |
| `Test_ExpandPortsAndRanges_SSHRuleExpansion` | SSH port expansion logic |
| `Test_GetActiveGroupUsers` | Active group users map |
| `Test_FilterZoneRecordsForPeers` | DNS zone record filtering |
| `Test_filterPeerAppliedZones` | Zone application filtering |

### `management/server/account_test.go` (existing — 2 tests)

| Test | Features Covered |
|------|-----------------|
| `TestAccount_GetPeerNetworkMap` | Expiration, OfflinePeers, Settings |
| `TestAccount_GetRoutesToSync` | Route sync, HA dedup |

### `management/server/route_test.go` (existing — 3 tests)

| Test | Features Covered |
|------|-----------------|
| `TestGetNetworkMap_RouteSyncPeerGroups` | Routes with peer groups in netmap |
| `TestGetNetworkMap_RouteSync` | Route synchronization in netmap |
| `TestAccount_GetPeerNetworkResourceFirewallRules` | Resource firewall rules |

### `management/server/peer_test.go` (existing — 1 test)

| Test | Features Covered |
|------|-----------------|
| `TestToSyncResponse` | Full proto conversion (Peers, Routes, DNS, SSH, FW rules, Settings) |

### `management/server/types/networkmap_benchmark_test.go` (NEW — 7 benchmarks)

All benchmarks are skipped in CI (`skipCIBenchmark`). Run locally with `go test -bench=...`.

| Benchmark | Features Covered |
|-----------|-----------------|
| `BenchmarkNetworkMapGeneration_Components` | Components, 100-30k peers |
| `BenchmarkNetworkMapGeneration_AllPeers` | All-peers update (components), 100-5k |
| `BenchmarkNetworkMapGeneration_ComponentsCreation` | Components extraction, 100-30k |
| `BenchmarkNetworkMapGeneration_ComponentsCalculation` | Calculation from components, 100-30k |
| `BenchmarkNetworkMapGeneration_PrecomputeMaps` | ResourcePoliciesMap, ResourceRoutersMap, ActiveGroupUsers |
| `BenchmarkNetworkMapGeneration_GroupScaling` | 1-500 groups at 1000 peers |
| `BenchmarkNetworkMapGeneration_PeerScaling` | 50-30k peers at fixed ratio |

---

## INDIRECT TESTS

Tests that trigger network map generation through higher-level operations (LoginPeer, SyncPeer, AddPeer, UpdateAccountPeers, etc.).

### `management/server/peer_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestAccountManager_GetNetworkMap` | GetNetworkMap | Peers, Groups |
| `TestAccountManager_GetNetworkMap_Experimental` | GetNetworkMap (experimental) | Peers, Builder |
| `TestAccountManager_GetNetworkMapWithPolicy` | GetNetworkMap + policies | Peers, Groups, Policies |
| `TestAccountManager_GetPeerNetwork` | GetPeerNetwork | Network info |
| `TestDefaultAccountManager_GetPeers` | GetPeers | Peers, validation |
| `TestPeerAccountPeersUpdate` | UpdatePeer -> UpdateAccountPeers | Peers, Groups, Expiration |
| `TestUpdateAccountPeers` | UpdateAccountPeers | All features |
| `TestUpdateAccountPeers_Experimental` | UpdateAccountPeers (experimental) | Builder |
| `Test_LoginPeer` | LoginPeer -> netmap | Peers, DNS, Routes, SSH |
| `Test_RegisterPeerByUser` | AddPeer -> netmap | Peers, Groups |
| `Test_RegisterPeerBySetupKey` | AddPeer -> netmap | Peers, Groups, SetupKeys |
| `Test_AddPeer` | AddPeer -> netmap | Peers, Groups |
| `TestAddPeer_UserPendingApprovalBlocked` | AddPeer + approval | Peers, Approval |
| `TestAddPeer_ApprovedUserCanAddPeers` | AddPeer + approval | Peers, Approval |
| `TestLoginPeer_UserPendingApprovalBlocked` | LoginPeer + approval | Peers, Approval |
| `TestLoginPeer_ApprovedUserCanLogin` | LoginPeer + approval | Peers, Approval |
| `TestHandleUserAddedPeer` | OnPeerAddedByUser | Peers, Events |
| `TestHandleSetupKeyAddedPeer` | OnPeerAddedBySetupKey | Peers, SetupKeys |
| `TestProcessPeerAddAuth` | AddPeer auth | Peers, Auth |
| `BenchmarkGetPeers` | GetPeers | Peers (50-5000) |
| `BenchmarkUpdateAccountPeers` | UpdateAccountPeers | All features (50-5000) |

### `management/server/account_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestAccountManager_AddPeer` | AddPeer | Peers, Groups |
| `TestAccountManager_AddPeerWithUserID` | AddPeer | Peers, UserID |
| `TestAccountManager_NetworkUpdates_DeletePeer` | DeletePeer -> UpdateAccountPeers | Peers, Deletion |
| `TestAccountManager_NetworkUpdates_DeletePeer_Experimental` | DeletePeer (experimental) | Peers, Builder |
| `TestDefaultAccountManager_UpdatePeer_PeerLoginExpiration` | UpdatePeer -> expiration | Peers, Expiration, Settings |
| `TestDefaultAccountManager_UpdateAccountSettings_PeerLoginExpiration` | Settings -> expiration | Settings, Expiration |
| `TestDefaultAccountManager_UpdateAccountSettings_PeerApproval` | Settings -> approval | Settings, Approval |
| `TestDefaultAccountManager_UpdatePeerIP` | UpdatePeerIP | Peers, IP |
| `BenchmarkSyncAndMarkPeer` | SyncAndMarkPeer | All features (50-5000) |
| `BenchmarkLoginPeer_ExistingPeer` | LoginPeer (existing) | All features (50-5000) |
| `BenchmarkLoginPeer_NewPeer` | LoginPeer (new) | All features (50-5000) |

### `management/server/dns_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestGetNetworkMap_DNSConfigSync` | GetNetworkMap with DNS updates | DNS, Nameservers |
| `TestDNSAccountPeersUpdate` | SaveDNSSettings -> UpdateAccountPeers | DNS, Nameservers |

### `management/server/route_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestRouteAccountPeersUpdate` | SaveRoute -> UpdateAccountPeers | Routes, Firewall |

### `management/server/group_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestGroupAccountPeersUpdate` | SaveGroup -> UpdateAccountPeers | Groups, Policies |

### `management/server/policy_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestPolicyAccountPeersUpdate` | SavePolicy -> UpdateAccountPeers | Policies, Firewall |

### `management/server/nameserver_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestNameServerAccountPeersUpdate` | SaveNameServerGroup -> UpdateAccountPeers | DNS, Nameservers |

### `management/server/setupkey_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestSetupKeyAccountPeersUpdate` | SaveSetupKey -> UpdateAccountPeers | SetupKeys, Groups |

### `management/server/posture_checks_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestPostureCheckAccountPeersUpdate` | SavePostureCheck -> UpdateAccountPeers | PostureChecks |

### `management/server/user_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `TestUserAccountPeersUpdate` | SaveUser -> UpdateAccountPeers | Users, Groups |

### `management/server/management_test.go` (gRPC integration)

| Test | Trigger | Features |
|------|---------|----------|
| `TestSyncNewPeerConfiguration` | gRPC Sync | Peers, Config |
| `TestSyncThreePeers` | gRPC Sync (3 peers) | Peers, Groups |
| `TestSyncNewPeerUpdate` | gRPC Sync + new peer | Peers, Updates |
| `TestSync10PeersGetUpdates` | gRPC Sync (10 peers) | Peers, Policies, Routes |
| `TestConcurrentPeersNoDuplicateIPs` | Concurrent gRPC Sync | Peers, IP alloc, Concurrency |

### `management/server/management_proto_test.go`

| Test | Trigger | Features |
|------|---------|----------|
| `Test_LoginPerformance` | LoginPeer perf test | Login, Peers |

### HTTP Handler Integration Tests (`management/server/http/testing/integration/`)

| Test | File | Features |
|------|------|----------|
| `Test_Peers_GetAll` | peers_handler | Peers |
| `Test_Peers_GetById` | peers_handler | Peers |
| `Test_Peers_Update` | peers_handler | Peers -> UpdateAccountPeers |
| `Test_Peers_Delete` | peers_handler | Peers -> UpdateAccountPeers |
| `Test_Peers_GetAccessiblePeers` | peers_handler | Peers, Access control |
| `Test_Groups_GetAll` | groups_handler | Groups |
| `Test_Groups_Update` | groups_handler | Groups -> UpdateAccountPeers |
| `Test_Groups_Delete` | groups_handler | Groups -> UpdateAccountPeers |
| `Test_Routes_GetAll` | routes_handler | Routes |
| `Test_Routes_Create` | routes_handler | Routes -> UpdateAccountPeers |
| `Test_Routes_Update` | routes_handler | Routes -> UpdateAccountPeers |
| `Test_Routes_Delete` | routes_handler | Routes -> UpdateAccountPeers |
| `Test_Policies_GetAll` | policies_handler | Policies |
| `Test_Policies_Create` | policies_handler | Policies -> UpdateAccountPeers |
| `Test_Policies_Update` | policies_handler | Policies -> UpdateAccountPeers |
| `Test_Policies_Delete` | policies_handler | Policies -> UpdateAccountPeers |
| `Test_DnsSettings_Update` | dns_handler | DNS -> UpdateAccountPeers |
| `Test_Nameservers_GetAll` | dns_handler | DNS, Nameservers |
| `Test_Nameservers_Create` | dns_handler | DNS -> UpdateAccountPeers |
| `Test_Nameservers_Update` | dns_handler | DNS -> UpdateAccountPeers |
| `Test_Nameservers_Delete` | dns_handler | DNS -> UpdateAccountPeers |
| `Test_NetworkResources_*` (6 tests) | networks_handler | Network Resources, CRUD |
| `Test_NetworkRouters_*` (6 tests) | networks_handler | Network Routers, CRUD |

### HTTP Handler Benchmarks (`management/server/http/testing/benchmarks/`) (require `-tags=benchmark`)

| Benchmark | Features |
|-----------|----------|
| `BenchmarkPeersHandler_*` (Create/Update/GetOne/GetAll/Delete) | Peers API (XS to XL: 5-25000 peers) |
| `BenchmarkSetupKeysHandler_*` | SetupKeys API |
| `BenchmarkUsersHandler_*` | Users API |

### Store Benchmarks (`management/server/store/`)

| Benchmark | Features |
|-----------|----------|
| `BenchmarkGetAccount` | Account loading (200 peers, 30 groups, 50 policies) |
| `BenchmarkGetAccountPeers` | Peer querying |
| `BenchmarkTest_StoreWrite` / `BenchmarkTest_StoreRead` | Store I/O |

---

## FEATURE COVERAGE MATRIX

| Feature | Direct Tests | Indirect Tests | Gaps |
|---------|-------------|----------------|------|
| **Peers** (visibility, self-exclusion) | 46+ tests | 20+ tests | None |
| **Groups** (intra/cross-group, isolated) | 5 tests | 10+ tests | None |
| **Policies** (accept/drop, ports, ranges, direction, disabled rules) | 9 tests | 5+ tests | None |
| **Firewall Rules** | 9 tests | 3+ tests | None |
| **Routes** (enabled/disabled, HA dedup, ACG) | 4 tests | 3+ tests | None |
| **Route Firewall Rules** | 2 tests | 1+ tests | None |
| **Network Resources** (router, source, disabled) | 3 tests | 12+ tests | None |
| **Multiple Routers** | 1 test | None | None |
| **Domain Resources** | 1 test | None | None |
| **Posture Checks** (pass/fail, multiple, isolated) | 3 tests + 5 in account_test | 1 test | None |
| **DNS** (enabled/disabled, NS groups, custom zones) | 4 tests | 2+ tests | None |
| **Nameserver Self-Exclusion** | 1 test | None | None |
| **SSH** (policy, legacy, authorized users) | 4 tests | None | None |
| **Peer Expiration** (login, per-peer, settings) | 3 tests | 3+ tests | None |
| **Account Settings** (serial, expiration toggle) | 2 tests | 2+ tests | None |
| **Peer Validation** (non-validated, nonexistent) | 3 tests | None | None |
| **Peer-as-Resource** (source/destination) | 2 tests | None | None |
| **Multiple Rules per Policy** | 1 test | None | None |
| **Disabled Rule in Enabled Policy** | 1 test | None | None |
| **Route Default Permit** (no ACG) | 1 test | None | None |
| **Cross-Peer Consistency** | 2 tests | None | None |
| **ToSyncResponse** (proto conversion) | 1 test | 5+ gRPC tests | No benchmark at scale |
| **ForwardingRules** | None | None | Populated by proxy controller, not components |
| **Extra DNS Labels** | None | None | Minor, peer-level feature |
| **Inactivity Expiration** | None | None | Handled by account manager, not components |

---

## SUMMARY

- **Direct tests**: 77 (46 new correctness + 6 golden + 2 comparison + 17 types/account_test + 2 account_test + 3 route_test + 1 peer_test)
- **Direct benchmarks**: 15 (7 new + 4 golden + 4 comparison)
- **Indirect tests**: 65+
- **Grand total**: 157+ tests exercising network map functionality

### Test isolation notes

Tests marked "(isolated)" use `scalableTestAccountWithoutDefaultPolicy()` which omits the blanket
group-all allow rule, ensuring the test validates feature-specific connectivity rather than passing
vacuously through the catch-all policy. All new benchmarks use `skipCIBenchmark()` to avoid running
in CI environments.


## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive benchmark suite for network-map generation covering single-peer, all-peers, component creation, component calculation, precomputed maps, and scaling analyses across varied peer/group sizes.
  * Added extensive correctness tests with a scalable account builder exercising peer visibility, policies (firewall/SSH/routes), DNS/network resources, posture checks, login expiration, and components-vs-legacy output consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->