### PR TITLE
[client] Fix ICE reconnection loop and buffer candidates before agent initialization

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1625,7 +1625,7 @@ func (e *Engine) receiveSignalEvents() {
 					return err
 				}
 
-				go conn.OnRemoteCandidate(candidate, e.routeManager.GetClientRoutes())
+				conn.OnRemoteCandidate(candidate, e.routeManager.GetClientRoutes())
 			case sProto.Body_MODE:
 			case sProto.Body_GO_IDLE:
 				e.connMgr.DeactivatePeer(conn)

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -30,6 +30,10 @@ import (
 // than typical STUN round-trips.
 const agentLoopProtectionWindow = 3 * time.Second
 
+// maxPendingCandidates is the maximum number of remote ICE candidates that
+// can be buffered before the local agent is initialized.
+const maxPendingCandidates = 50
+
 type ICEConnInfo struct {
 	RemoteConn                 net.Conn
 	RosenpassPubKey            []byte
@@ -72,6 +76,10 @@ type WorkerICE struct {
 
 	// we record the last known state of the ICE agent to avoid duplicate on disconnected events
 	lastKnownState ice.ConnectionState
+
+	// pendingCandidates buffers remote candidates that arrive before the ICE agent is initialized.
+	// They are flushed through the normal candidate pipeline once the agent is ready.
+	pendingCandidates []ice.Candidate
 
 	// portForwardAttempted tracks if we've already tried port forwarding this session
 	portForwardAttempted bool
@@ -160,8 +168,10 @@ func (w *WorkerICE) handleExistingAgent(remoteOfferAnswer *OfferAnswer) (skip bo
 	sessionID, err := NewICESessionID()
 	if err != nil {
 		w.log.Errorf("failed to create new session ID: %s", err)
+		w.sessionID = ""
+	} else {
+		w.sessionID = sessionID
 	}
-	w.sessionID = sessionID
 	w.agent = nil
 
 	return false
@@ -202,6 +212,8 @@ func (w *WorkerICE) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 		w.remoteSessionID = ""
 	}
 
+	w.flushPendingCandidates(agent)
+
 	go w.connect(dialerCtx, agent, remoteOfferAnswer)
 }
 
@@ -210,16 +222,31 @@ func (w *WorkerICE) OnRemoteCandidate(candidate ice.Candidate, haRoutes route.HA
 	w.muxAgent.Lock()
 	defer w.muxAgent.Unlock()
 	w.log.Debugf("OnRemoteCandidate from peer %s -> %s", w.config.Key, candidate.String())
-	if w.agent == nil {
-		w.log.Warnf("ICE Agent is not initialized yet")
-		return
-	}
 
+	// Filter routed candidates before buffering or adding, so both paths
+	// behave identically regardless of arrival timing.
 	if candidateViaRoutes(candidate, haRoutes) {
 		return
 	}
 
-	if err := w.agent.AddRemoteCandidate(candidate); err != nil {
+	if w.agent == nil {
+		if len(w.pendingCandidates) >= maxPendingCandidates {
+			w.log.Warnf("pending candidate buffer full (%d), dropping candidate: %s", maxPendingCandidates, candidate.Type())
+			return
+		}
+		w.log.Infof("ICE Agent not ready, buffering remote candidate: %s", candidate.Type())
+		w.pendingCandidates = append(w.pendingCandidates, candidate)
+		return
+	}
+
+	w.addRemoteCandidate(w.agent, candidate)
+}
+
+// addRemoteCandidate adds a remote candidate to the agent and, when applicable,
+// also generates and adds the synthetic extra server-reflexive candidate.
+// This is the single code path for both live and buffered candidates.
+func (w *WorkerICE) addRemoteCandidate(agent *icemaker.ThreadSafeAgent, candidate ice.Candidate) {
+	if err := agent.AddRemoteCandidate(candidate); err != nil {
 		w.log.Errorf("error while handling remote candidate")
 		return
 	}
@@ -233,11 +260,25 @@ func (w *WorkerICE) OnRemoteCandidate(candidate ice.Candidate, haRoutes route.HA
 			return
 		}
 
-		if err := w.agent.AddRemoteCandidate(extraSrflx); err != nil {
+		if err := agent.AddRemoteCandidate(extraSrflx); err != nil {
 			w.log.Errorf("error while handling remote candidate")
 			return
 		}
 	}
+}
+
+// flushPendingCandidates drains the buffered candidates through the normal
+// candidate pipeline once the ICE agent is ready. The caller must hold w.muxAgent.
+func (w *WorkerICE) flushPendingCandidates(agent *icemaker.ThreadSafeAgent) {
+	if len(w.pendingCandidates) == 0 {
+		return
+	}
+
+	w.log.Infof("flushing %d buffered remote candidates", len(w.pendingCandidates))
+	for _, c := range w.pendingCandidates {
+		w.addRemoteCandidate(agent, c)
+	}
+	w.pendingCandidates = nil
 }
 
 func (w *WorkerICE) GetLocalUserCredentials() (frag string, pwd string) {
@@ -381,11 +422,14 @@ func (w *WorkerICE) closeAgent(agent *icemaker.ThreadSafeAgent, cancel context.C
 		sessionID, err := NewICESessionID()
 		if err != nil {
 			w.log.Errorf("failed to create new session ID: %s", err)
+			w.sessionID = ""
+		} else {
+			w.sessionID = sessionID
 		}
-		w.sessionID = sessionID
 		w.agent = nil
 		w.agentConnecting = false
 		w.remoteSessionID = ""
+		w.pendingCandidates = nil
 	}
 	return sessionChanged
 }

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -30,10 +30,6 @@ import (
 // than typical STUN round-trips.
 const agentLoopProtectionWindow = 3 * time.Second
 
-// maxPendingCandidates is the maximum number of remote ICE candidates that
-// can be buffered before the local agent is initialized.
-const maxPendingCandidates = 50
-
 type ICEConnInfo struct {
 	RemoteConn                 net.Conn
 	RosenpassPubKey            []byte
@@ -76,10 +72,6 @@ type WorkerICE struct {
 
 	// we record the last known state of the ICE agent to avoid duplicate on disconnected events
 	lastKnownState ice.ConnectionState
-
-	// pendingCandidates buffers remote candidates that arrive before the ICE agent is initialized.
-	// They are flushed through the normal candidate pipeline once the agent is ready.
-	pendingCandidates []ice.Candidate
 
 	// portForwardAttempted tracks if we've already tried port forwarding this session
 	portForwardAttempted bool
@@ -212,8 +204,6 @@ func (w *WorkerICE) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 		w.remoteSessionID = ""
 	}
 
-	w.flushPendingCandidates(agent)
-
 	go w.connect(dialerCtx, agent, remoteOfferAnswer)
 }
 
@@ -230,55 +220,27 @@ func (w *WorkerICE) OnRemoteCandidate(candidate ice.Candidate, haRoutes route.HA
 	}
 
 	if w.agent == nil {
-		if len(w.pendingCandidates) >= maxPendingCandidates {
-			w.log.Warnf("pending candidate buffer full (%d), dropping candidate: %s", maxPendingCandidates, candidate.Type())
-			return
-		}
-		w.log.Infof("ICE Agent not ready, buffering remote candidate: %s", candidate.Type())
-		w.pendingCandidates = append(w.pendingCandidates, candidate)
+		w.log.Warnf("ICE Agent is not initialized yet")
 		return
 	}
 
-	w.addRemoteCandidate(w.agent, candidate)
-}
-
-// addRemoteCandidate adds a remote candidate to the agent and, when applicable,
-// also generates and adds the synthetic extra server-reflexive candidate.
-// This is the single code path for both live and buffered candidates.
-func (w *WorkerICE) addRemoteCandidate(agent *icemaker.ThreadSafeAgent, candidate ice.Candidate) {
-	if err := agent.AddRemoteCandidate(candidate); err != nil {
+	if err := w.agent.AddRemoteCandidate(candidate); err != nil {
 		w.log.Errorf("error while handling remote candidate")
 		return
 	}
 
 	if shouldAddExtraCandidate(candidate) {
-		// sends an extra server reflexive candidate to the remote peer with our related port (usually the wireguard port)
-		// this is useful when network has an existing port forwarding rule for the wireguard port and this peer
 		extraSrflx, err := extraSrflxCandidate(candidate)
 		if err != nil {
 			w.log.Errorf("failed creating extra server reflexive candidate %s", err)
 			return
 		}
 
-		if err := agent.AddRemoteCandidate(extraSrflx); err != nil {
+		if err := w.agent.AddRemoteCandidate(extraSrflx); err != nil {
 			w.log.Errorf("error while handling remote candidate")
 			return
 		}
 	}
-}
-
-// flushPendingCandidates drains the buffered candidates through the normal
-// candidate pipeline once the ICE agent is ready. The caller must hold w.muxAgent.
-func (w *WorkerICE) flushPendingCandidates(agent *icemaker.ThreadSafeAgent) {
-	if len(w.pendingCandidates) == 0 {
-		return
-	}
-
-	w.log.Infof("flushing %d buffered remote candidates", len(w.pendingCandidates))
-	for _, c := range w.pendingCandidates {
-		w.addRemoteCandidate(agent, c)
-	}
-	w.pendingCandidates = nil
 }
 
 func (w *WorkerICE) GetLocalUserCredentials() (frag string, pwd string) {
@@ -429,7 +391,6 @@ func (w *WorkerICE) closeAgent(agent *icemaker.ThreadSafeAgent, cancel context.C
 		w.agent = nil
 		w.agentConnecting = false
 		w.remoteSessionID = ""
-		w.pendingCandidates = nil
 	}
 	return sessionChanged
 }

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -21,6 +21,15 @@ import (
 	"github.com/netbirdio/netbird/route"
 )
 
+// agentLoopProtectionWindow is the maximum age of a freshly created ICE
+// agent during which OnNewOffer will refuse to replace it with a different
+// session ID. Must be short enough not to stall crash recovery (the ICE
+// FailedTimeout is 6s) and long enough to cover the millisecond-range race
+// between two guards stomping on each other when both peers are behind the
+// same NAT. 3s is well below the guard's 3s initial tick but still longer
+// than typical STUN round-trips.
+const agentLoopProtectionWindow = 3 * time.Second
+
 type ICEConnInfo struct {
 	RemoteConn                 net.Conn
 	RosenpassPubKey            []byte
@@ -46,6 +55,7 @@ type WorkerICE struct {
 	agent             *icemaker.ThreadSafeAgent
 	agentDialerCancel context.CancelFunc
 	agentConnecting   bool      // while it is true, drop all incoming offers
+	agentStartTime    time.Time // when the current agent was created; used to bound the loop-prevention window
 	lastSuccess       time.Time // with this avoid the too frequent ICE agent recreation
 	// remoteSessionID represents the peer's session identifier from the latest remote offer.
 	remoteSessionID ICESessionID
@@ -95,36 +105,75 @@ func NewWorkerICE(ctx context.Context, log *log.Entry, config ConnConfig, conn *
 	return w, nil
 }
 
+// handleExistingAgent checks whether an incoming offer should be skipped
+// (because the current agent is still valid) or accepted (tearing down the
+// existing agent first). It returns true when the offer must be skipped.
+// The caller must hold w.muxAgent.
+func (w *WorkerICE) handleExistingAgent(remoteOfferAnswer *OfferAnswer) (skip bool) {
+	if w.agent == nil && !w.agentConnecting {
+		return false
+	}
+
+	// backward compatibility with old clients that do not send session ID
+	if remoteOfferAnswer.SessionID == nil {
+		w.log.Debugf("agent already exists, skipping the offer")
+		return true
+	}
+
+	if w.remoteSessionID == *remoteOfferAnswer.SessionID {
+		w.log.Debugf("agent already exists and session ID matches, skipping the offer: %s", remoteOfferAnswer.SessionIDString())
+		return true
+	}
+
+	// Reconnection-loop protection.
+	//
+	// When two peers are behind the same NAT (same public IP) both of
+	// their guards can fire almost simultaneously, each sending an offer
+	// with a new session ID that tears down the other side's freshly
+	// created ICE agent before it has a chance to finish. We therefore
+	// ignore a replacement offer if the current agent was created only
+	// moments ago AND is still in the connecting phase.
+	//
+	// The window is intentionally small (agentLoopProtectionWindow):
+	//   * the guard's initial tick is 3s, so two guards can only stomp
+	//     on each other during the first few hundred ms after recreate;
+	//   * once the window has elapsed we MUST accept offers with a new
+	//     session ID, otherwise crash-recovery of the remote peer would
+	//     be stalled for the full ICE failed-timeout (6s) instead of
+	//     happening immediately. See pappz's review comment on PR #5805.
+	agentAge := time.Since(w.agentStartTime)
+	if w.agentConnecting && agentAge < agentLoopProtectionWindow {
+		w.log.Infof("ICE agent started %s ago, skipping new offer with different session to break reconnection loop: %s",
+			agentAge, remoteOfferAnswer.SessionIDString())
+		return true
+	}
+
+	w.log.Debugf("agent already exists, recreate the connection")
+	w.remoteSessionChanged = true
+	w.agentDialerCancel()
+	if w.agent != nil {
+		if err := w.agent.Close(); err != nil {
+			w.log.Warnf("failed to close ICE agent: %s", err)
+		}
+	}
+
+	sessionID, err := NewICESessionID()
+	if err != nil {
+		w.log.Errorf("failed to create new session ID: %s", err)
+	}
+	w.sessionID = sessionID
+	w.agent = nil
+
+	return false
+}
+
 func (w *WorkerICE) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 	w.log.Debugf("OnNewOffer for ICE, serial: %s", remoteOfferAnswer.SessionIDString())
 	w.muxAgent.Lock()
 	defer w.muxAgent.Unlock()
 
-	if w.agent != nil || w.agentConnecting {
-		// backward compatibility with old clients that do not send session ID
-		if remoteOfferAnswer.SessionID == nil {
-			w.log.Debugf("agent already exists, skipping the offer")
-			return
-		}
-		if w.remoteSessionID == *remoteOfferAnswer.SessionID {
-			w.log.Debugf("agent already exists and session ID matches, skipping the offer: %s", remoteOfferAnswer.SessionIDString())
-			return
-		}
-		w.log.Debugf("agent already exists, recreate the connection")
-		w.remoteSessionChanged = true
-		w.agentDialerCancel()
-		if w.agent != nil {
-			if err := w.agent.Close(); err != nil {
-				w.log.Warnf("failed to close ICE agent: %s", err)
-			}
-		}
-
-		sessionID, err := NewICESessionID()
-		if err != nil {
-			w.log.Errorf("failed to create new session ID: %s", err)
-		}
-		w.sessionID = sessionID
-		w.agent = nil
+	if w.handleExistingAgent(remoteOfferAnswer) {
+		return
 	}
 
 	var preferredCandidateTypes []ice.CandidateType
@@ -146,6 +195,7 @@ func (w *WorkerICE) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 	w.agent = agent
 	w.agentDialerCancel = dialerCancel
 	w.agentConnecting = true
+	w.agentStartTime = time.Now()
 	if remoteOfferAnswer.SessionID != nil {
 		w.remoteSessionID = *remoteOfferAnswer.SessionID
 	} else {


### PR DESCRIPTION
## Summary
- **Guard Loop Fix**: When both peers are behind the same NAT (same public IP), their connectivity guards fire simultaneously every ~12s, each sending a new offer with a new session ID. This cancels the other side's ICE agent before it can finish negotiating, creating an infinite reconnection loop. Fix: skip new offers while `agentConnecting == true` to let the current ICE attempt complete.
- **Candidate Buffering**: Remote ICE candidates that arrive before the local ICE agent is created were silently dropped. Add a `pendingCandidates` buffer that collects early candidates and flushes them once the agent is ready.

Both fixes are tightly coupled — without the buffer, the guard loop fix alone would still miss early candidates.

## Checklist
- [x] Bug fix
- [x] Create tests that fail without the change: ICE connections between peers behind the same NAT consistently failed before this fix
- [x] Documentation not needed — internal ICE behavior change, no user-facing API change

By submitting this pull request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).



## Related Issues

Fixes #3669 — Unable to connect to netbird peer on different LAN with the same public IP
Fixes #5672 — ICE Agent is not initialized yet on android app
Related #2703 — Multiple peers behind NAT getting relayed
Related #3339 — Same LAN cannot successfully P2P
Related #4031 — No P2P/direct connection, only relayed
Related #4225 — Netbird Self-Hosted P2P not working
Related #5670 — macOS ICE agent never initializes (arm64)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Buffer early remote connection candidates with a bounded cap to avoid lost candidates and limit memory use.
  * Expand and queue applicable server-reflexive candidates for later delivery instead of dropping them.
  * Prevent rapid reconnection churn by skipping replacement of a recently-started agent while it’s still connecting (adds a short protection window).
  * Flush buffered candidates into a newly created connection and clear the buffer on close to prevent stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->