### PR TITLE
[client] Fix mgmProber interface to match unexported GetServerPublicKey

### DIFF
--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -41,7 +41,7 @@ const (
 
 // mgmProber is the subset of management client needed for URL migration probes.
 type mgmProber interface {
-	GetServerPublicKey() (*wgtypes.Key, error)
+	HealthCheck() error
 	Close() error
 }
 

--- a/client/internal/profilemanager/config_test.go
+++ b/client/internal/profilemanager/config_test.go
@@ -17,12 +17,10 @@ import (
 	"github.com/netbirdio/netbird/util"
 )
 
-type mockMgmProber struct {
-	key wgtypes.Key
-}
+type mockMgmProber struct{}
 
-func (m *mockMgmProber) GetServerPublicKey() (*wgtypes.Key, error) {
-	return &m.key, nil
+func (m *mockMgmProber) HealthCheck() error {
+	return nil
 }
 
 func (m *mockMgmProber) Close() error { return nil }
@@ -247,11 +245,7 @@ func TestWireguardPortDefaultVsExplicit(t *testing.T) {
 func TestUpdateOldManagementURL(t *testing.T) {
 	origProber := newMgmProber
 	newMgmProber = func(_ context.Context, _ string, _ wgtypes.Key, _ bool) (mgmProber, error) {
-		key, err := wgtypes.GenerateKey()
-		if err != nil {
-			return nil, err
-		}
-		return &mockMgmProber{key: key.PublicKey()}, nil
+		return &mockMgmProber{}, nil
 	}
 	t.Cleanup(func() { newMgmProber = origProber })
 


### PR DESCRIPTION
Update the mgmProber interface to use HealthCheck() instead of the now-unexported GetServerPublicKey(), aligning with the changes in the management client API.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified management URL migration health-checking mechanism by using a more direct verification approach, reducing unnecessary operations and test complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->