### PR TITLE
[management] Fix missing service columns in pgx account loader

### DIFF
--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -2080,7 +2080,8 @@ func (s *SqlStore) getPostureChecks(ctx context.Context, accountID string) ([]*p
 func (s *SqlStore) getServices(ctx context.Context, accountID string) ([]*rpservice.Service, error) {
 	const serviceQuery = `SELECT id, account_id, name, domain, enabled, auth,
 		meta_created_at, meta_certificate_issued_at, meta_status, proxy_cluster,
-		pass_host_header, rewrite_redirects, session_private_key, session_public_key
+		pass_host_header, rewrite_redirects, session_private_key, session_public_key,
+		mode, listen_port, port_auto_assigned, source, source_peer, terminated
 		FROM services WHERE account_id = $1`
 
 	const targetsQuery = `SELECT id, account_id, service_id, path, host, port, protocol,
@@ -2097,6 +2098,7 @@ func (s *SqlStore) getServices(ctx context.Context, accountID string) ([]*rpserv
 		var auth []byte
 		var createdAt, certIssuedAt sql.NullTime
 		var status, proxyCluster, sessionPrivateKey, sessionPublicKey sql.NullString
+		var mode, source, sourcePeer sql.NullString
 		err := row.Scan(
 			&s.ID,
 			&s.AccountID,
@@ -2112,6 +2114,12 @@ func (s *SqlStore) getServices(ctx context.Context, accountID string) ([]*rpserv
 			&s.RewriteRedirects,
 			&sessionPrivateKey,
 			&sessionPublicKey,
+			&mode,
+			&s.ListenPort,
+			&s.PortAutoAssigned,
+			&source,
+			&sourcePeer,
+			&s.Terminated,
 		)
 		if err != nil {
 			return nil, err
@@ -2142,6 +2150,15 @@ func (s *SqlStore) getServices(ctx context.Context, accountID string) ([]*rpserv
 		}
 		if sessionPublicKey.Valid {
 			s.SessionPublicKey = sessionPublicKey.String
+		}
+		if mode.Valid {
+			s.Mode = mode.String
+		}
+		if source.Valid {
+			s.Source = source.String
+		}
+		if sourcePeer.Valid {
+			s.SourcePeer = sourcePeer.String
 		}
 
 		s.Targets = []*rpservice.Target{}


### PR DESCRIPTION
## Describe your changes

The raw SQL query in `getServices()` was missing several columns added after the initial implementation: `mode`, `listen_port`, `port_auto_assigned`, `source`, `source_peer`, and `terminated`. This caused `svc.Mode` to always be empty when loading services through the pgx account loader, so `createProxyPolicy` defaulted every service to TCP regardless of actual mode. UDP expose services got TCP-only firewall rules, blocking all UDP traffic.

- Add missing columns to the services SELECT query and scan them into the struct

## Issue ticket number and link

See https://github.com/netbirdio/netbird/issues/5734 for similar bug

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Services now include additional configuration details such as mode, port assignments, source information, and termination status when retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->