### PR TITLE
[client] Error out on netbird expose when block inbound is enabled

### DIFF
--- a/client/cmd/expose.go
+++ b/client/cmd/expose.go
@@ -14,6 +14,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/status"
 
 	"github.com/netbirdio/netbird/client/internal/expose"
 	"github.com/netbirdio/netbird/client/proto"
@@ -201,7 +202,7 @@ func exposeFn(cmd *cobra.Command, args []string) error {
 
 	stream, err := client.ExposeService(ctx, req)
 	if err != nil {
-		return fmt.Errorf("expose service: %w", err)
+		return fmt.Errorf("expose service: %v", status.Convert(err).Message())
 	}
 
 	if err := handleExposeReady(cmd, stream, port); err != nil {
@@ -236,7 +237,7 @@ func toExposeProtocol(exposeProtocol string) (proto.ExposeProtocol, error) {
 func handleExposeReady(cmd *cobra.Command, stream proto.DaemonService_ExposeServiceClient, port uint64) error {
 	event, err := stream.Recv()
 	if err != nil {
-		return fmt.Errorf("receive expose event: %w", err)
+		return fmt.Errorf("receive expose event: %v", status.Convert(err).Message())
 	}
 
 	ready, ok := event.Event.(*proto.ExposeServiceEvent_Ready)

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1837,6 +1837,11 @@ func (e *Engine) GetExposeManager() *expose.Manager {
 	return e.exposeManager
 }
 
+// IsBlockInbound returns whether inbound connections are blocked.
+func (e *Engine) IsBlockInbound() bool {
+	return e.config.BlockInbound
+}
+
 // GetClientMetrics returns the client metrics
 func (e *Engine) GetClientMetrics() *metrics.ClientMetrics {
 	return e.clientMetrics

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -1359,6 +1359,10 @@ func (s *Server) ExposeService(req *proto.ExposeServiceRequest, srv proto.Daemon
 		return gstatus.Errorf(codes.FailedPrecondition, "engine not initialized")
 	}
 
+	if engine.IsBlockInbound() {
+		return gstatus.Errorf(codes.FailedPrecondition, "expose requires inbound connections but 'block inbound' is enabled, disable it first")
+	}
+
 	mgr := engine.GetExposeManager()
 	if mgr == nil {
 		return gstatus.Errorf(codes.Internal, "expose manager not available")


### PR DESCRIPTION
## Describe your changes

When `block inbound` is enabled, no ACL allow rules are installed on the WireGuard interface, so all inbound traffic is dropped. Running `netbird expose` in this state silently creates a service that is unreachable. This adds an early check that returns a clear error instead.

- Reject `ExposeService` RPC when block inbound is enabled
- Strip gRPC error wrapper in expose CLI for cleaner output

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expose service now enforces a precondition check: users must disable "block inbound" to use the expose functionality. Attempting to expose with inbound connections blocked will return a clear error message requesting the setting be disabled.
  * Improved error message formatting for service failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->