### PR TITLE
[misc] Add CI check for proto version string changes

### DIFF
--- a/.github/workflows/proto-version-check.yml
+++ b/.github/workflows/proto-version-check.yml
@@ -1,0 +1,53 @@
+name: Proto Version Check
+
+on:
+  pull_request:
+    paths:
+      - "**/*.pb.go"
+
+jobs:
+  check-proto-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for proto tool version changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const pbFiles = files.filter(f => f.filename.endsWith('.pb.go') && f.patch);
+            const versionPattern = /^[+-]\s*\/\/\s+protoc(?:-gen-go)?\s+v[\d.]+/;
+            const violations = [];
+
+            for (const file of pbFiles) {
+              const changed = file.patch
+                .split('\n')
+                .filter(line => versionPattern.test(line));
+              if (changed.length > 0) {
+                violations.push({
+                  file: file.filename,
+                  lines: changed,
+                });
+              }
+            }
+
+            if (violations.length > 0) {
+              const details = violations.map(v =>
+                `${v.file}:\n${v.lines.map(l => '  ' + l).join('\n')}`
+              ).join('\n\n');
+
+              core.setFailed(
+                `Proto version strings changed in generated files.\n` +
+                `This usually means the wrong protoc or protoc-gen-go version was used.\n` +
+                `Regenerate with the matching tool versions.\n\n` +
+                details
+              );
+              return;
+            }
+
+            console.log('No proto version string changes detected');

--- a/.github/workflows/proto-version-check.yml
+++ b/.github/workflows/proto-version-check.yml
@@ -13,14 +13,23 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
               per_page: 100,
             });
 
-            const pbFiles = files.filter(f => f.filename.endsWith('.pb.go') && f.patch);
+            const pbFiles = files.filter(f => f.filename.endsWith('.pb.go'));
+            const missingPatch = pbFiles.filter(f => !f.patch).map(f => f.filename);
+            if (missingPatch.length > 0) {
+              core.setFailed(
+                `Cannot inspect patch data for:\n` +
+                missingPatch.map(f => `- ${f}`).join('\n') +
+                `\nThis can happen with very large PRs. Verify proto versions manually.`
+              );
+              return;
+            }
             const versionPattern = /^[+-]\s*\/\/\s+protoc(?:-gen-go)?\s+v[\d.]+/;
             const violations = [];
 


### PR DESCRIPTION
## Describe your changes

Add a PR-only CI check that fails when a `*.pb.go` file changes the `protoc` or `protoc-gen-go` version comment. Catches accidental version drift from regenerating with the wrong tool versions. Non-required check, so you can merge anyway when intentionally upgrading.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated validation workflow for pull requests that modify generated protocol buffer files.
  * The workflow scans PR diffs for protoc/protoc-gen-go version comment lines, reports any per-file matches, and blocks the PR when such changes are detected to surface and detail affected files before merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->