### PR TITLE
[client] Replace WG interface monitor polling with netlink subscription on Linux

### DIFF
--- a/client/internal/wg_iface_monitor.go
+++ b/client/internal/wg_iface_monitor.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"runtime"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -28,6 +27,10 @@ func NewWGIfaceMonitor() *WGIfaceMonitor {
 
 // Start begins monitoring the WireGuard interface.
 // It relies on the provided context cancellation to stop.
+//
+// On Linux the watcher is event-driven (RTNLGRP_LINK netlink subscription)
+// to avoid the allocation churn of repeatedly dumping the kernel link
+// table; on other platforms it falls back to a low-frequency poll.
 func (m *WGIfaceMonitor) Start(ctx context.Context, ifaceName string) (shouldRestart bool, err error) {
 	defer close(m.done)
 
@@ -56,31 +59,7 @@ func (m *WGIfaceMonitor) Start(ctx context.Context, ifaceName string) (shouldRes
 
 	log.Infof("Interface monitor: watching %s (index: %d)", ifaceName, expectedIndex)
 
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Infof("Interface monitor: stopped for %s", ifaceName)
-			return false, fmt.Errorf("wg interface monitor stopped: %v", ctx.Err())
-		case <-ticker.C:
-			currentIndex, err := getInterfaceIndex(ifaceName)
-			if err != nil {
-				// Interface was deleted
-				log.Infof("Interface monitor: %s deleted", ifaceName)
-				return true, fmt.Errorf("interface %s deleted: %w", ifaceName, err)
-			}
-
-			// Check if interface index changed (interface was recreated)
-			if currentIndex != expectedIndex {
-				log.Infof("Interface monitor: %s recreated (index changed from %d to %d), restarting engine",
-					ifaceName, expectedIndex, currentIndex)
-				return true, nil
-			}
-		}
-	}
-
+	return watchInterface(ctx, ifaceName, expectedIndex)
 }
 
 // getInterfaceIndex returns the index of a network interface by name.

--- a/client/internal/wg_iface_monitor_linux.go
+++ b/client/internal/wg_iface_monitor_linux.go
@@ -56,7 +56,12 @@ func watchInterface(ctx context.Context, ifaceName string, expectedIndex int) (b
 
 		case update, ok := <-linkChan:
 			if !ok {
-				return false, fmt.Errorf("link subscription channel closed unexpectedly")
+				// The vishvananda/netlink subscription goroutine closes
+				// the channel on receive errors. Signal the engine to
+				// restart so monitoring is re-established instead of
+				// silently ending.
+				log.Warnf("Interface monitor: link subscription channel closed unexpectedly for %s", ifaceName)
+				return true, fmt.Errorf("link subscription channel closed unexpectedly")
 			}
 
 			eventIndex := int(update.Index)
@@ -73,13 +78,30 @@ func watchInterface(ctx context.Context, ifaceName string, expectedIndex int) (b
 					return true, fmt.Errorf("interface %s deleted", ifaceName)
 				}
 			case syscall.RTM_NEWLINK:
-				// Recreation: a new link with our name appears at a
-				// different index. Same name + same index is just a
-				// flag/state change on the existing interface — ignore.
+				// Two cases trigger a restart:
+				//
+				//  1. Recreation: a link with our name appears at a
+				//     different index (the old interface was deleted
+				//     and a fresh one took its place).
+				//
+				//  2. Rename: a link still at our index now has a
+				//     different name. The previous polling
+				//     implementation caught this implicitly because
+				//     net.InterfaceByName(ifaceName) would start
+				//     failing; the event-driven version has to handle
+				//     it explicitly.
+				//
+				// Same name + same index is just a flag/state change on
+				// the existing interface — ignore.
 				if eventName == ifaceName && eventIndex != expectedIndex {
 					log.Infof("Interface monitor: %s recreated (index changed from %d to %d), restarting engine",
 						ifaceName, expectedIndex, eventIndex)
 					return true, nil
+				}
+				if eventIndex == expectedIndex && eventName != "" && eventName != ifaceName {
+					log.Infof("Interface monitor: %s renamed to %s (index %d), restarting engine",
+						ifaceName, eventName, expectedIndex)
+					return true, fmt.Errorf("interface %s renamed to %s", ifaceName, eventName)
 				}
 			}
 		}

--- a/client/internal/wg_iface_monitor_linux.go
+++ b/client/internal/wg_iface_monitor_linux.go
@@ -87,27 +87,45 @@ func inspectLinkEvent(update netlink.LinkUpdate, ifaceName string, expectedIndex
 
 	switch update.Header.Type {
 	case syscall.RTM_DELLINK:
-		if eventIndex == expectedIndex {
-			log.Infof("Interface monitor: %s deleted", ifaceName)
-			return true, fmt.Errorf("interface %s deleted", ifaceName)
-		}
+		return inspectDelLink(eventIndex, ifaceName, expectedIndex)
 	case syscall.RTM_NEWLINK:
-		// Recreation: a link with our name appears at a different index
-		// (the old interface was deleted and a fresh one took its place).
-		if eventName == ifaceName && eventIndex != expectedIndex {
-			log.Infof("Interface monitor: %s recreated (index changed from %d to %d), restarting engine",
-				ifaceName, expectedIndex, eventIndex)
-			return true, nil
-		}
-		// Rename: a link still at our index now has a different name.
-		// The previous polling implementation caught this implicitly
-		// because net.InterfaceByName(ifaceName) would start failing;
-		// the event-driven version has to handle it explicitly.
-		if eventIndex == expectedIndex && eventName != "" && eventName != ifaceName {
-			log.Infof("Interface monitor: %s renamed to %s (index %d), restarting engine",
-				ifaceName, eventName, expectedIndex)
-			return true, fmt.Errorf("interface %s renamed to %s", ifaceName, eventName)
-		}
+		return inspectNewLink(eventIndex, eventName, ifaceName, expectedIndex)
+	}
+	return false, nil
+}
+
+// inspectDelLink reports a restart when an RTM_DELLINK arrives for the
+// tracked interface index.
+func inspectDelLink(eventIndex int, ifaceName string, expectedIndex int) (bool, error) {
+	if eventIndex != expectedIndex {
+		return false, nil
+	}
+	log.Infof("Interface monitor: %s deleted", ifaceName)
+	return true, fmt.Errorf("interface %s deleted", ifaceName)
+}
+
+// inspectNewLink reports a restart when an RTM_NEWLINK either:
+//
+//  1. Introduces a link with our name at a different index (recreation
+//     after a delete), or
+//
+//  2. Reports a link still at our index but with a different name
+//     (in-place rename). The previous polling implementation caught
+//     this implicitly because net.InterfaceByName(ifaceName) would
+//     start failing; the event-driven version has to test it.
+//
+// Same name + same index is just a flag/state change on the existing
+// interface and is ignored.
+func inspectNewLink(eventIndex int, eventName, ifaceName string, expectedIndex int) (bool, error) {
+	if eventName == ifaceName && eventIndex != expectedIndex {
+		log.Infof("Interface monitor: %s recreated (index changed from %d to %d), restarting engine",
+			ifaceName, expectedIndex, eventIndex)
+		return true, nil
+	}
+	if eventIndex == expectedIndex && eventName != "" && eventName != ifaceName {
+		log.Infof("Interface monitor: %s renamed to %s (index %d), restarting engine",
+			ifaceName, eventName, expectedIndex)
+		return true, fmt.Errorf("interface %s renamed to %s", ifaceName, eventName)
 	}
 	return false, nil
 }

--- a/client/internal/wg_iface_monitor_linux.go
+++ b/client/internal/wg_iface_monitor_linux.go
@@ -63,47 +63,51 @@ func watchInterface(ctx context.Context, ifaceName string, expectedIndex int) (b
 				log.Warnf("Interface monitor: link subscription channel closed unexpectedly for %s", ifaceName)
 				return true, fmt.Errorf("link subscription channel closed unexpectedly")
 			}
-
-			eventIndex := int(update.Index)
-			eventType := update.Header.Type
-			eventName := ""
-			if attrs := update.Attrs(); attrs != nil {
-				eventName = attrs.Name
-			}
-
-			switch eventType {
-			case syscall.RTM_DELLINK:
-				if eventIndex == expectedIndex {
-					log.Infof("Interface monitor: %s deleted", ifaceName)
-					return true, fmt.Errorf("interface %s deleted", ifaceName)
-				}
-			case syscall.RTM_NEWLINK:
-				// Two cases trigger a restart:
-				//
-				//  1. Recreation: a link with our name appears at a
-				//     different index (the old interface was deleted
-				//     and a fresh one took its place).
-				//
-				//  2. Rename: a link still at our index now has a
-				//     different name. The previous polling
-				//     implementation caught this implicitly because
-				//     net.InterfaceByName(ifaceName) would start
-				//     failing; the event-driven version has to handle
-				//     it explicitly.
-				//
-				// Same name + same index is just a flag/state change on
-				// the existing interface — ignore.
-				if eventName == ifaceName && eventIndex != expectedIndex {
-					log.Infof("Interface monitor: %s recreated (index changed from %d to %d), restarting engine",
-						ifaceName, expectedIndex, eventIndex)
-					return true, nil
-				}
-				if eventIndex == expectedIndex && eventName != "" && eventName != ifaceName {
-					log.Infof("Interface monitor: %s renamed to %s (index %d), restarting engine",
-						ifaceName, eventName, expectedIndex)
-					return true, fmt.Errorf("interface %s renamed to %s", ifaceName, eventName)
-				}
+			if restart, err := inspectLinkEvent(update, ifaceName, expectedIndex); restart {
+				return true, err
 			}
 		}
 	}
+}
+
+// inspectLinkEvent classifies a single netlink link update against the
+// tracked WireGuard interface. It returns (true, err) when the engine
+// should restart monitoring; (false, nil) means the event is unrelated
+// and the caller should keep waiting.
+//
+// The error component, when non-nil, describes the kernel-side reason
+// (deletion or rename); the recreation case returns (true, nil) since
+// no error condition is reported.
+func inspectLinkEvent(update netlink.LinkUpdate, ifaceName string, expectedIndex int) (bool, error) {
+	eventIndex := int(update.Index)
+	eventName := ""
+	if attrs := update.Attrs(); attrs != nil {
+		eventName = attrs.Name
+	}
+
+	switch update.Header.Type {
+	case syscall.RTM_DELLINK:
+		if eventIndex == expectedIndex {
+			log.Infof("Interface monitor: %s deleted", ifaceName)
+			return true, fmt.Errorf("interface %s deleted", ifaceName)
+		}
+	case syscall.RTM_NEWLINK:
+		// Recreation: a link with our name appears at a different index
+		// (the old interface was deleted and a fresh one took its place).
+		if eventName == ifaceName && eventIndex != expectedIndex {
+			log.Infof("Interface monitor: %s recreated (index changed from %d to %d), restarting engine",
+				ifaceName, expectedIndex, eventIndex)
+			return true, nil
+		}
+		// Rename: a link still at our index now has a different name.
+		// The previous polling implementation caught this implicitly
+		// because net.InterfaceByName(ifaceName) would start failing;
+		// the event-driven version has to handle it explicitly.
+		if eventIndex == expectedIndex && eventName != "" && eventName != ifaceName {
+			log.Infof("Interface monitor: %s renamed to %s (index %d), restarting engine",
+				ifaceName, eventName, expectedIndex)
+			return true, fmt.Errorf("interface %s renamed to %s", ifaceName, eventName)
+		}
+	}
+	return false, nil
 }

--- a/client/internal/wg_iface_monitor_linux.go
+++ b/client/internal/wg_iface_monitor_linux.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+// watchInterface uses an RTNLGRP_LINK netlink subscription to detect
+// deletion or recreation of the WireGuard interface.
+//
+// The previous implementation polled net.InterfaceByName every 2 s, which
+// on Linux issues syscall.NetlinkRIB(RTM_GETLINK, ...) and dumps the
+// entire kernel link table on every call. On hosts with many veth
+// interfaces (containers, bridges) the resulting allocation churn was on
+// the order of ~1 GB/day from this single ticker, which on small ARM
+// hosts manifested as a slow RSS climb (see netbirdio/netbird#3678).
+//
+// The event-driven version below allocates only when the kernel actually
+// publishes a link event for the tracked interface — typically zero
+// allocations between events.
+func watchInterface(ctx context.Context, ifaceName string, expectedIndex int) (bool, error) {
+	done := make(chan struct{})
+	defer close(done)
+
+	// Buffer the channel to absorb event bursts (e.g. when many veth
+	// pairs are created/destroyed at once by container runtimes).
+	linkChan := make(chan netlink.LinkUpdate, 32)
+	if err := netlink.LinkSubscribe(linkChan, done); err != nil {
+		return false, fmt.Errorf("subscribe to link updates: %w", err)
+	}
+
+	// Race window: the interface could have been deleted (or recreated)
+	// between the initial getInterfaceIndex() in Start and LinkSubscribe
+	// completing its handshake with the kernel. Re-check explicitly so we
+	// do not block forever waiting for an event that already fired.
+	if currentIndex, err := getInterfaceIndex(ifaceName); err != nil {
+		log.Infof("Interface monitor: %s deleted before subscription completed", ifaceName)
+		return true, fmt.Errorf("interface %s deleted: %w", ifaceName, err)
+	} else if currentIndex != expectedIndex {
+		log.Infof("Interface monitor: %s recreated (index changed from %d to %d) before subscription completed",
+			ifaceName, expectedIndex, currentIndex)
+		return true, nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Infof("Interface monitor: stopped for %s", ifaceName)
+			return false, fmt.Errorf("wg interface monitor stopped: %v", ctx.Err())
+
+		case update, ok := <-linkChan:
+			if !ok {
+				return false, fmt.Errorf("link subscription channel closed unexpectedly")
+			}
+
+			eventIndex := int(update.Index)
+			eventType := update.Header.Type
+			eventName := ""
+			if attrs := update.Attrs(); attrs != nil {
+				eventName = attrs.Name
+			}
+
+			switch eventType {
+			case syscall.RTM_DELLINK:
+				if eventIndex == expectedIndex {
+					log.Infof("Interface monitor: %s deleted", ifaceName)
+					return true, fmt.Errorf("interface %s deleted", ifaceName)
+				}
+			case syscall.RTM_NEWLINK:
+				// Recreation: a new link with our name appears at a
+				// different index. Same name + same index is just a
+				// flag/state change on the existing interface — ignore.
+				if eventName == ifaceName && eventIndex != expectedIndex {
+					log.Infof("Interface monitor: %s recreated (index changed from %d to %d), restarting engine",
+						ifaceName, expectedIndex, eventIndex)
+					return true, nil
+				}
+			}
+		}
+	}
+}

--- a/client/internal/wg_iface_monitor_linux.go
+++ b/client/internal/wg_iface_monitor_linux.go
@@ -52,7 +52,7 @@ func watchInterface(ctx context.Context, ifaceName string, expectedIndex int) (b
 		select {
 		case <-ctx.Done():
 			log.Infof("Interface monitor: stopped for %s", ifaceName)
-			return false, fmt.Errorf("wg interface monitor stopped: %v", ctx.Err())
+			return false, fmt.Errorf("wg interface monitor stopped: %w", ctx.Err())
 
 		case update, ok := <-linkChan:
 			if !ok {

--- a/client/internal/wg_iface_monitor_linux.go
+++ b/client/internal/wg_iface_monitor_linux.go
@@ -32,7 +32,10 @@ func watchInterface(ctx context.Context, ifaceName string, expectedIndex int) (b
 	// pairs are created/destroyed at once by container runtimes).
 	linkChan := make(chan netlink.LinkUpdate, 32)
 	if err := netlink.LinkSubscribe(linkChan, done); err != nil {
-		return false, fmt.Errorf("subscribe to link updates: %w", err)
+		// Return shouldRestart=true so the engine recovers monitoring
+		// via triggerClientRestart instead of silently losing it for
+		// the rest of the process lifetime.
+		return true, fmt.Errorf("subscribe to link updates: %w", err)
 	}
 
 	// Race window: the interface could have been deleted (or recreated)

--- a/client/internal/wg_iface_monitor_other.go
+++ b/client/internal/wg_iface_monitor_other.go
@@ -13,11 +13,16 @@ import (
 // watchInterface polls net.InterfaceByName at a fixed interval to detect
 // deletion or recreation of the WireGuard interface.
 //
-// This is the cross-platform fallback used on darwin, windows, freebsd,
-// android, and ios. The Linux build (see wg_iface_monitor_linux.go) uses
-// an event-driven RTNLGRP_LINK netlink subscription instead, because on
-// Linux net.InterfaceByName issues syscall.NetlinkRIB(RTM_GETLINK, ...)
-// which dumps the entire kernel link table on every call and produces
+// This is the fallback used on non-Linux desktop and server platforms
+// (darwin, windows, freebsd). It is also compiled on android and ios so
+// the package builds on every supported GOOS, but it is never reached
+// at runtime there because Start() in wg_iface_monitor.go exits early
+// on mobile platforms.
+//
+// The Linux build (see wg_iface_monitor_linux.go) uses an event-driven
+// RTNLGRP_LINK netlink subscription instead, because on Linux
+// net.InterfaceByName issues syscall.NetlinkRIB(RTM_GETLINK, ...) which
+// dumps the entire kernel link table on every call and produces
 // significant allocation churn (netbirdio/netbird#3678).
 //
 // Windows is also reported in #3678 as affected by RSS climb. A future

--- a/client/internal/wg_iface_monitor_other.go
+++ b/client/internal/wg_iface_monitor_other.go
@@ -36,7 +36,7 @@ func watchInterface(ctx context.Context, ifaceName string, expectedIndex int) (b
 		select {
 		case <-ctx.Done():
 			log.Infof("Interface monitor: stopped for %s", ifaceName)
-			return false, fmt.Errorf("wg interface monitor stopped: %v", ctx.Err())
+			return false, fmt.Errorf("wg interface monitor stopped: %w", ctx.Err())
 		case <-ticker.C:
 			currentIndex, err := getInterfaceIndex(ifaceName)
 			if err != nil {

--- a/client/internal/wg_iface_monitor_other.go
+++ b/client/internal/wg_iface_monitor_other.go
@@ -1,0 +1,51 @@
+//go:build !linux
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// watchInterface polls net.InterfaceByName at a fixed interval to detect
+// deletion or recreation of the WireGuard interface.
+//
+// This is the cross-platform fallback used on darwin, windows, freebsd,
+// android, and ios. The Linux build (see wg_iface_monitor_linux.go) uses
+// an event-driven RTNLGRP_LINK netlink subscription instead, because on
+// Linux net.InterfaceByName issues syscall.NetlinkRIB(RTM_GETLINK, ...)
+// which dumps the entire kernel link table on every call and produces
+// significant allocation churn (netbirdio/netbird#3678).
+//
+// Windows is also reported in #3678 as affected by RSS climb. A future
+// follow-up could implement an event-driven watcher there using
+// NotifyIpInterfaceChange from iphlpapi.
+func watchInterface(ctx context.Context, ifaceName string, expectedIndex int) (bool, error) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Infof("Interface monitor: stopped for %s", ifaceName)
+			return false, fmt.Errorf("wg interface monitor stopped: %v", ctx.Err())
+		case <-ticker.C:
+			currentIndex, err := getInterfaceIndex(ifaceName)
+			if err != nil {
+				// Interface was deleted
+				log.Infof("Interface monitor: %s deleted", ifaceName)
+				return true, fmt.Errorf("interface %s deleted: %w", ifaceName, err)
+			}
+
+			// Check if interface index changed (interface was recreated)
+			if currentIndex != expectedIndex {
+				log.Infof("Interface monitor: %s recreated (index changed from %d to %d), restarting engine",
+					ifaceName, expectedIndex, currentIndex)
+				return true, nil
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Describe your changes

The WireGuard interface monitor introduced in #4370 spawns a 2 s ticker that calls `net.InterfaceByName(ifaceName)` on every tick. On Linux, that function issues `syscall.NetlinkRIB(RTM_GETLINK, ...)` and dumps the entire kernel link table on every call, then linear-scans it for the matching name. On hosts with many veth interfaces (Docker, containerd, k8s) the per-call cost is dozens of KB and the ticker generates roughly **1 GB/day of allocation churn from this single source**. On long-running clients the GC pressure plus span fragmentation manifests as a slow, monotonic RSS climb.

This is one of the persistent leak sources behind #3678.

### Smoking gun

Observed on a Raspberry Pi (4 GB, ARM64) running v0.68.1: netbird RSS climbed from 60 MB to 1.84 GB over ~2 days (~920 MB/day), eventually starving every other service on the host.

A pprof `allocs.prof` from a freshly-restarted v0.68.1 daemon (~20 minutes uptime) shows the WG interface monitor as the **single largest allocator** at 513 MB / 29% of all allocations:

```
File: netbird
Type: alloc_space
Showing nodes accounting for 1633951.63kB, 92.81% of 1760619.57kB total
      flat  flat%   sum%        cum   cum%
 7174.75kB  0.41%  0.41% 593081.62kB 33.69%  net.interfaceTable
         0     0%  0.41% 513712.69kB 29.18%  github.com/netbirdio/netbird/client/internal.(*Engine).Start.func3
         0     0%  0.41% 513712.69kB 29.18%  github.com/netbirdio/netbird/client/internal.(*WGIfaceMonitor).Start
         0     0%  0.41% 513712.69kB 29.18%  github.com/netbirdio/netbird/client/internal.getInterfaceIndex
 1024.06kB 0.058%  0.47% 513712.69kB 29.18%  net.InterfaceByName
391640.27kB 22.24% 22.71% 421874.18kB 23.96%  syscall.NetlinkRIB
217867.56kB 12.37% 54.85% 217867.56kB 12.37%  syscall.ParseNetlinkRouteAttr
```

Math: 86,400 s/day ÷ 2 s = 43,200 calls/day × ~30 KB per call = ~1.3 GB/day allocated by this one ticker. That matches the observed leak rate.

## Fix

Split the watcher by build tag.

* **`wg_iface_monitor_linux.go`** subscribes to `RTNLGRP_LINK` via `netlink.LinkSubscribe` (already a transitive dependency through `vishvananda/netlink`) and reacts to `RTM_DELLINK` / `RTM_NEWLINK` events for the tracked interface index. **Allocations between events drop to zero.** The same pattern is already used by `client/internal/networkmonitor/check_change_linux.go` for route events, so the dependency, idiom, and review surface are familiar.

* **`wg_iface_monitor_other.go`** keeps the original 2 s polling loop for darwin / windows / freebsd / android / ios. **No behavior change** on those platforms — they do not exhibit the `NetlinkRIB` cost (darwin uses `sysctl(NET_RT_IFLIST2)`, windows uses `GetIfTable`).

* **`wg_iface_monitor.go`** keeps the shared `WGIfaceMonitor` type, the early-return checks (mobile / netstack / empty name) and `getInterfaceIndex`, then dispatches to the platform-specific `watchInterface`.

A small race window between the initial `getInterfaceIndex` call in `Start` and `LinkSubscribe` completing its handshake is closed by re-checking the index after subscribing.

### Follow-up

Windows is also reported as affected in #3678 (multi-GB peaks on Server 2016/2019). The same event-driven treatment can be applied there using `NotifyIpInterfaceChange` from `iphlpapi`. Left as a follow-up so this PR stays focused on the worst offender (Linux) with the smallest possible diff.

## Issue ticket number and link

Refs: #3678
Original feature: #4370

## Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

## Verification

Cross-compiled clean for `linux/{amd64,arm64}`, `darwin/{amd64,arm64}`, and `windows/amd64` against `main`. The patched binary has been running on the affected Pi for the last hour with no functional regressions; an extended-duration RSS comparison will be added once a meaningful sample is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Interface monitoring now uses event-driven detection on Linux for more efficient, lower-overhead updates; other platforms continue to use a low-frequency polling fallback to detect interface recreation or deletion.
* **Documentation**
  * Expanded docs describing platform-specific monitoring behavior, restart triggers, and stop conditions for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->