### PR TITLE
[management] fix resource and router changes not propagating to peers

### DIFF
--- a/management/server/networks/manager.go
+++ b/management/server/networks/manager.go
@@ -177,7 +177,7 @@ func (m *managerImpl) DeleteNetwork(ctx context.Context, accountID, userID, netw
 		event()
 	}
 
-	go m.accountManager.UpdateAccountPeers(ctx, accountID)
+	go m.accountManager.UpdateAccountPeers(context.WithoutCancel(ctx), accountID)
 
 	return nil
 }

--- a/management/server/networks/resources/manager.go
+++ b/management/server/networks/resources/manager.go
@@ -162,7 +162,7 @@ func (m *managerImpl) CreateResource(ctx context.Context, userID string, resourc
 		event()
 	}
 
-	go m.accountManager.UpdateAccountPeers(ctx, resource.AccountID)
+	go m.accountManager.UpdateAccountPeers(context.WithoutCancel(ctx), resource.AccountID)
 
 	return resource, nil
 }
@@ -270,7 +270,7 @@ func (m *managerImpl) UpdateResource(ctx context.Context, userID string, resourc
 		}
 	}()
 
-	go m.accountManager.UpdateAccountPeers(ctx, resource.AccountID)
+	go m.accountManager.UpdateAccountPeers(context.WithoutCancel(ctx), resource.AccountID)
 
 	return resource, nil
 }
@@ -352,7 +352,7 @@ func (m *managerImpl) DeleteResource(ctx context.Context, accountID, userID, net
 		event()
 	}
 
-	go m.accountManager.UpdateAccountPeers(ctx, accountID)
+	go m.accountManager.UpdateAccountPeers(context.WithoutCancel(ctx), accountID)
 
 	return nil
 }

--- a/management/server/networks/routers/manager.go
+++ b/management/server/networks/routers/manager.go
@@ -119,7 +119,7 @@ func (m *managerImpl) CreateRouter(ctx context.Context, userID string, router *t
 
 	m.accountManager.StoreEvent(ctx, userID, router.ID, router.AccountID, activity.NetworkRouterCreated, router.EventMeta(network))
 
-	go m.accountManager.UpdateAccountPeers(ctx, router.AccountID)
+	go m.accountManager.UpdateAccountPeers(context.WithoutCancel(ctx), router.AccountID)
 
 	return router, nil
 }
@@ -183,7 +183,7 @@ func (m *managerImpl) UpdateRouter(ctx context.Context, userID string, router *t
 
 	m.accountManager.StoreEvent(ctx, userID, router.ID, router.AccountID, activity.NetworkRouterUpdated, router.EventMeta(network))
 
-	go m.accountManager.UpdateAccountPeers(ctx, router.AccountID)
+	go m.accountManager.UpdateAccountPeers(context.WithoutCancel(ctx), router.AccountID)
 
 	return router, nil
 }
@@ -217,7 +217,7 @@ func (m *managerImpl) DeleteRouter(ctx context.Context, accountID, userID, netwo
 
 	event()
 
-	go m.accountManager.UpdateAccountPeers(ctx, accountID)
+	go m.accountManager.UpdateAccountPeers(context.WithoutCancel(ctx), accountID)
 
 	return nil
 }


### PR DESCRIPTION
## Describe your changes

Goroutines in the networks package called `UpdateAccountPeers` with the HTTP request context. After the response was sent, the request context was cancelled, causing `GetAccountWithBackpressure` to return `ctx.Err()` and silently drop the peer notification.

Fix by passing `context.WithoutCancel(ctx)` to these goroutines so they survive the request lifecycle while still inheriting trace/log values.

Group handlers were unaffected because they call `UpdateAccountPeers` synchronously before the response is returned.

Curious to hear if this is as desired. I've verified the changes on my NetBird setup.

## Issue ticket number and link

Fixes #5813

## Stack

<!-- branch-stack -->

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

Bugfix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where peer updates could be interrupted when creating, updating, or deleting networks, resources, and routers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->