### PR TITLE
fix: close stale relay connection on ErrConnAlreadyExists to recover …

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -619,6 +619,15 @@ func (conn *Conn) onWGDisconnected() {
 	case conntype.Relay:
 		conn.workerRelay.CloseConn()
 		conn.handleRelayDisconnectedLocked()
+		// When running over relay, workerICE is not closed so its session ID is
+		// never rotated. The next offer would carry the same session ID, causing
+		// the remote peer to skip ICE agent recreation (it already has an agent
+		// for that session) and reuse stale candidates — preventing recovery
+		// after a NAT IP change (e.g. PPPoE reconnect). Force a new session ID
+		// so the remote peer creates a fresh ICE agent with current candidates.
+		if conn.workerICE != nil {
+			conn.workerICE.ResetSessionID()
+		}
 	case conntype.ICEP2P, conntype.ICETurn:
 		conn.workerICE.Close()
 	default:

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -617,6 +617,10 @@ func (conn *Conn) onWGDisconnected() {
 	// Close the active connection based on current priority
 	switch conn.currentConnPriority {
 	case conntype.Relay:
+		// Mark the relay conn entry as stale so the next OnNewOffer closes
+		// and reopens it instead of reusing a dead pipe. MarkStale covers
+		// the case where CloseConn is a no-op (e.g. relayedConn already nil).
+		conn.workerRelay.MarkStale()
 		conn.workerRelay.CloseConn()
 		conn.handleRelayDisconnectedLocked()
 		// When running over relay, workerICE is not closed so its session ID is

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -633,6 +633,15 @@ func (conn *Conn) onWGDisconnected() {
 			conn.workerICE.ResetSessionID()
 		}
 	case conntype.ICEP2P, conntype.ICETurn:
+		// WorkerICE.Close() sets agent=nil before pion's ICE library fires
+		// ConnectionStateClosed. By the time onConnectionStateChange runs
+		// closeAgent(), the w.agent==agent guard fails and the session ID
+		// is not rotated. Without rotation, the next offer carries the same
+		// session ID and the remote peer skips ICE agent recreation in
+		// OnNewOffer (sessionID match), reusing stale candidates from the
+		// previous network state. Rotate explicitly here so the remote peer
+		// always recreates its agent after a WG timeout on ICE.
+		conn.workerICE.ResetSessionID()
 		conn.workerICE.Close()
 	default:
 		conn.Log.Debugf("No active connection to close on WG timeout")

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -249,6 +249,24 @@ func (w *WorkerICE) SessionID() ICESessionID {
 	return w.sessionID
 }
 
+// ResetSessionID generates a new session ID and clears the remote session ID.
+// This must be called when the WireGuard handshake times out while using a relay
+// connection, so that the next ICE offer carries a fresh session ID and the remote
+// peer recreates its ICE agent with up-to-date candidates instead of skipping the
+// offer because the session ID matches the previous (failed) attempt.
+func (w *WorkerICE) ResetSessionID() {
+	w.muxAgent.Lock()
+	defer w.muxAgent.Unlock()
+
+	sessionID, err := NewICESessionID()
+	if err != nil {
+		w.log.Errorf("failed to create new session ID: %s", err)
+		return
+	}
+	w.sessionID = sessionID
+	w.remoteSessionID = ""
+}
+
 // will block until connection succeeded
 // but it won't release if ICE Agent went into Disconnected or Failed state,
 // so we have to cancel it with the provided context once agent detected a broken connection

--- a/client/internal/peer/worker_relay.go
+++ b/client/internal/peer/worker_relay.go
@@ -64,11 +64,17 @@ func (w *WorkerRelay) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 	relayedConn, err := w.relayManager.OpenConn(w.peerCtx, srv, w.config.Key)
 	if err != nil {
 		if errors.Is(err, relayClient.ErrConnAlreadyExists) {
-			w.log.Debugf("handled offer by reusing existing relay connection")
+			w.log.Infof("relay conn already exists, closing stale conn and retrying")
+			w.relayManager.CloseConnByPeerKey(w.config.Key)
+			relayedConn, err = w.relayManager.OpenConn(w.peerCtx, srv, w.config.Key)
+			if err != nil {
+				w.log.Errorf("failed to reopen connection via Relay after closing stale: %s", err)
+				return
+			}
+		} else {
+			w.log.Errorf("failed to open connection via Relay: %s", err)
 			return
 		}
-		w.log.Errorf("failed to open connection via Relay: %s", err)
-		return
 	}
 
 	w.relayLock.Lock()

--- a/client/internal/peer/worker_relay.go
+++ b/client/internal/peer/worker_relay.go
@@ -65,7 +65,7 @@ func (w *WorkerRelay) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 	if err != nil {
 		if errors.Is(err, relayClient.ErrConnAlreadyExists) {
 			w.log.Infof("relay conn already exists, closing stale conn and retrying")
-			w.relayManager.CloseConnByPeerKey(w.config.Key)
+			w.relayManager.CloseConnByPeerKey(srv, w.config.Key)
 			relayedConn, err = w.relayManager.OpenConn(w.peerCtx, srv, w.config.Key)
 			if err != nil {
 				w.log.Errorf("failed to reopen connection via Relay after closing stale: %s", err)

--- a/client/internal/peer/worker_relay.go
+++ b/client/internal/peer/worker_relay.go
@@ -63,6 +63,11 @@ func (w *WorkerRelay) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 
 	relayedConn, err := w.relayManager.OpenConn(w.peerCtx, srv, w.config.Key)
 	if err != nil {
+		// ErrConnAlreadyExists here means the conn map was not cleaned up after the
+		// previous session (e.g. remote NAT IP change with no relay-level close event).
+		// Guard only triggers OnNewOffer after detecting a disconnect, so the existing
+		// entry is stale by contract. Close it and open a fresh conn to match the
+		// remote peer's state.
 		if errors.Is(err, relayClient.ErrConnAlreadyExists) {
 			w.log.Infof("relay conn already exists, closing stale conn and retrying")
 			w.relayManager.CloseConnByPeerKey(srv, w.config.Key)

--- a/client/internal/peer/worker_relay.go
+++ b/client/internal/peer/worker_relay.go
@@ -30,6 +30,14 @@ type WorkerRelay struct {
 	relayLock   sync.Mutex
 
 	relaySupportedOnRemotePeer atomic.Bool
+
+	// relayConnStale is set to true when an event indicates that the current
+	// relay connection entry in the relay client's conns map is no longer
+	// backed by a live peer session (e.g. local WG handshake timeout, relay
+	// server close event, explicit CloseConn). When OnNewOffer observes
+	// ErrConnAlreadyExists, it only closes the stale entry if this flag is
+	// set; otherwise it bails out and reuses the existing healthy connection.
+	relayConnStale atomic.Bool
 }
 
 func NewWorkerRelay(ctx context.Context, log *log.Entry, ctrl bool, config ConnConfig, conn *Conn, relayManager *relayClient.Manager) *WorkerRelay {
@@ -63,19 +71,25 @@ func (w *WorkerRelay) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 
 	relayedConn, err := w.relayManager.OpenConn(w.peerCtx, srv, w.config.Key)
 	if err != nil {
-		// ErrConnAlreadyExists here means the conn map was not cleaned up after the
-		// previous session (e.g. remote NAT IP change with no relay-level close event).
-		// Guard only triggers OnNewOffer after detecting a disconnect, so the existing
-		// entry is stale by contract. Close it and open a fresh conn to match the
-		// remote peer's state.
 		if errors.Is(err, relayClient.ErrConnAlreadyExists) {
-			w.log.Infof("relay conn already exists, closing stale conn and retrying")
+			// Only tear down the existing conn if something previously marked
+			// it as stale (local WG handshake timeout, relay server close, or
+			// explicit CloseConn). Without that signal, the existing conn is
+			// assumed healthy and is reused — unconditional close on every
+			// colliding offer causes an infinite tear-down/rebuild loop when
+			// the remote peer sends rapid successive offers.
+			if !w.relayConnStale.Load() {
+				w.log.Debugf("relay conn already exists and is not marked stale, reusing")
+				return
+			}
+			w.log.Infof("relay conn already exists and is marked stale, closing and retrying")
 			w.relayManager.CloseConnByPeerKey(srv, w.config.Key)
 			relayedConn, err = w.relayManager.OpenConn(w.peerCtx, srv, w.config.Key)
 			if err != nil {
 				w.log.Errorf("failed to reopen connection via Relay after closing stale: %s", err)
 				return
 			}
+			w.relayConnStale.Store(false)
 		} else {
 			w.log.Errorf("failed to open connection via Relay: %s", err)
 			return
@@ -120,9 +134,19 @@ func (w *WorkerRelay) CloseConn() {
 		return
 	}
 
+	w.relayConnStale.Store(true)
 	if err := w.relayedConn.Close(); err != nil {
 		w.log.Warnf("failed to close relay connection: %v", err)
 	}
+}
+
+// MarkStale marks the relay connection entry as stale so that the next
+// OnNewOffer call with ErrConnAlreadyExists will tear it down and open a
+// fresh one. Callers signal staleness from outside the relay client path,
+// e.g. when the local WG handshake watcher fires while the relay is the
+// active transport.
+func (w *WorkerRelay) MarkStale() {
+	w.relayConnStale.Store(true)
 }
 
 func (w *WorkerRelay) isRelaySupported(answer *OfferAnswer) bool {
@@ -140,5 +164,6 @@ func (w *WorkerRelay) preferredRelayServer(myRelayAddress, remoteRelayAddress st
 }
 
 func (w *WorkerRelay) onRelayClientDisconnected() {
+	w.relayConnStale.Store(true)
 	go w.conn.onRelayDisconnected()
 }

--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -627,6 +627,27 @@ func (c *Client) closeConn(containerRef *connContainer, id messages.PeerID) erro
 	return nil
 }
 
+// CloseConnByPeerKey closes an existing relay connection for the given peer key,
+// removing it from the internal connection map so a new one can be opened.
+func (c *Client) CloseConnByPeerKey(peerKey string) {
+	peerID := messages.HashID(peerKey)
+	c.mu.Lock()
+	container, ok := c.conns[peerID]
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+
+	c.log.Infof("force closing stale relay connection for peer: %s", peerID)
+	delete(c.conns, peerID)
+	c.mu.Unlock()
+
+	if err := c.stateSubscription.UnsubscribeStateChange([]messages.PeerID{peerID}); err != nil {
+		c.log.Errorf("failed to unsubscribe from peer state change: %s", err)
+	}
+	container.close()
+}
+
 func (c *Client) close(gracefullyExit bool) error {
 	c.readLoopMutex.Lock()
 	defer c.readLoopMutex.Unlock()

--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -168,8 +168,19 @@ func (m *Manager) CloseConnByPeerKey(serverAddress, peerKey string) {
 	m.relayClientsMutex.RLock()
 	rt, ok := m.relayClients[serverAddress]
 	m.relayClientsMutex.RUnlock()
-	if ok && rt.relayClient != nil {
-		rt.relayClient.CloseConnByPeerKey(peerKey)
+	if !ok {
+		return
+	}
+
+	// rt.relayClient is initialized in openConnVia under rt.Lock(); take rt.RLock()
+	// to read it safely, then release before calling CloseConnByPeerKey to avoid
+	// holding the track lock across a potentially blocking call.
+	rt.RLock()
+	relayClient := rt.relayClient
+	rt.RUnlock()
+
+	if relayClient != nil {
+		relayClient.CloseConnByPeerKey(peerKey)
 	}
 }
 

--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -147,6 +147,18 @@ func (m *Manager) OpenConn(ctx context.Context, serverAddress, peerKey string) (
 	return netConn, err
 }
 
+// CloseConnByPeerKey closes an existing relay connection for the given peer key
+// so that a subsequent OpenConn can create a fresh one.
+func (m *Manager) CloseConnByPeerKey(peerKey string) {
+	m.relayClientMu.RLock()
+	defer m.relayClientMu.RUnlock()
+
+	if m.relayClient == nil {
+		return
+	}
+	m.relayClient.CloseConnByPeerKey(peerKey)
+}
+
 // Ready returns true if the home Relay client is connected to the relay server.
 func (m *Manager) Ready() bool {
 	m.relayClientMu.RLock()

--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -148,15 +148,29 @@ func (m *Manager) OpenConn(ctx context.Context, serverAddress, peerKey string) (
 }
 
 // CloseConnByPeerKey closes an existing relay connection for the given peer key
-// so that a subsequent OpenConn can create a fresh one.
-func (m *Manager) CloseConnByPeerKey(peerKey string) {
+// on the relay client associated with serverAddress, so that a subsequent
+// OpenConn can create a fresh one.
+func (m *Manager) CloseConnByPeerKey(serverAddress, peerKey string) {
 	m.relayClientMu.RLock()
-	defer m.relayClientMu.RUnlock()
+	homeClient := m.relayClient
+	m.relayClientMu.RUnlock()
 
-	if m.relayClient == nil {
+	if homeClient == nil {
 		return
 	}
-	m.relayClient.CloseConnByPeerKey(peerKey)
+
+	homeAddr, err := homeClient.ServerInstanceURL()
+	if err == nil && homeAddr == serverAddress {
+		homeClient.CloseConnByPeerKey(peerKey)
+		return
+	}
+
+	m.relayClientsMutex.RLock()
+	rt, ok := m.relayClients[serverAddress]
+	m.relayClientsMutex.RUnlock()
+	if ok && rt.relayClient != nil {
+		rt.relayClient.CloseConnByPeerKey(peerKey)
+	}
 }
 
 // Ready returns true if the home Relay client is connected to the relay server.


### PR DESCRIPTION
## Describe your changes

Fix peer reconnection loops after a network event (PPPoE reconnect, NAT/conntrack flush, IP rotation) leaves transport state stale on either the relay or ICE path. Both manifest as the WireGuard tunnel going silent while the client UI reports `Connected`, with the connection never recovering on its own.

This PR addresses two distinct but related failure modes observed in production on a peer behind PPPoE NAT (Raspberry Pi) talking to a peer with a public IP (Oracle Cloud).

### Problem 1 - Relay path: stale `ErrConnAlreadyExists` reuse

When the peer is running over relay and a network event invalidates the existing relay session, `WorkerRelay.OnNewOffer` calls `relayManager.OpenConn` which returns `ErrConnAlreadyExists` because the relay client still holds a map entry for the peer key. The previous behavior was to silently bail out and reuse that entry - which is dead.

**Fix (commits 1–4, 6):**
- On `ErrConnAlreadyExists`, close the existing relay conn and reopen it.
- Route `CloseConnByPeerKey` to the correct relay client (home vs. foreign server).
- Take `rt.RLock()` when reading `RelayTrack.relayClient` to avoid a race with `openConnVia()` which initializes that field under `rt.Lock()`.
- Gate the close-and-retry behind a `relayConnStale atomic.Bool` flag so we only tear down when something has signaled that the entry is no longer backed by a live peer session. Without this gate, rapid successive offers from the remote peer cause an infinite tear-down/rebuild loop (observed: 3608 cycles in ~1 hour, ~9 Mbit/s of constant traffic).
- Signal sources for the stale flag: `conn.onWGDisconnected` (Relay path), `WorkerRelay.CloseConn`, `WorkerRelay.onRelayClientDisconnected`.

### Problem 2 - ICE path: session ID not rotated on WG timeout

When WireGuard handshake times out while running over ICE, `onWGDisconnected` calls `workerICE.Close()`. `Close()` sets `w.agent = nil` synchronously **before** pion's ICE library fires the asynchronous `ConnectionStateClosed` event. By the time `onConnectionStateChange` runs `closeAgent()`, the `w.agent == agent` guard fails (`w.agent` is already `nil`) and the session ID is **not rotated**.

Without rotation, the next ICE offer carries the same local session ID. The remote peer in `OnNewOffer` compares `remoteSessionID` against the incoming offer's `SessionID`, finds them equal, and **skips agent recreation** - reusing the existing agent and its stale candidates from the broken network state.

**Observed in production:** 30s reconnect loop with the same offer session ID logged 70+ times in a row, "ICE connection succeeded" on every cycle, WG handshake never recovering. UI shows `Connected, P2P` while last successful WG handshake is 40+ minutes old.

**Fix (commit 5):** Rotate the session ID explicitly in `onWGDisconnected` for the ICE case (mirroring the existing Relay-path behavior we added in commit 1) so the remote peer always recreates its ICE agent after a WG timeout on ICE.

### Test plan

- [x] Local build passes (`go build ./...`)
- [x] Deployed on two production peers (RPi behind PPPoE NAT, OCI public IP) for live testing
- [x] Verified stable P2P connection with WG handshake refreshing on the normal 3-minute cadence (no regression)
- [x] Verified no infinite tear-down loop on relay-active peer (the bug introduced by the v1 fix and resolved in v2)
- [x] **Validated against multiple real PPPoE reconnects with public IP rotation**: tunnel recovered automatically in a single `ICE → Relay → ICE` transition (~4 seconds), no loop, WG handshake refreshed normally on the 3-minute cadence afterwards. Stable for hours post-event.

### Caveat: unrelated Rosenpass interaction

During testing we hit a separate failure mode where Rosenpass (post-quantum PSK) was enabled in permissive mode on both peers. After an IP change, the WG tunnel could not recover because the local PSK state diverged from the remote peer's PSK (one side had a Rosenpass-managed PSK, the other had none). This produced the same external symptom (silent tunnel, UI says `Connected`) but is **not addressed by this PR** - the fixes here only cover the relay/ICE transport state. With Rosenpass disabled, both fixes recovered the tunnel cleanly across multiple PPPoE cycles. Filing the Rosenpass interaction as a separate issue.

### Notes

The two problems share the same trigger (network event invalidates per-peer state without invalidating the local control plane) but live in different transports, so the fixes are orthogonal. Each is necessary on its own:
- Without the relay fix, peers stuck on relay loop the relay close/reopen cycle.
- Without the ICE fix, peers that fall back to relay then re-establish ICE get pinned to a stale ICE agent on the remote side.

Both fixes are strictly defensive - they can only fire on `ErrConnAlreadyExists` (relay) or after a WG handshake timeout (ICE), so there's no behavior change on the happy path.

## Issue ticket number and link

N/A - bug discovered in production, no pre-existing issue.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This is an internal recovery-path fix in the peer connection state machine. No public API, CLI flag, config field, or user-visible behavior changes - the fixes are strictly defensive and only fire on specific error conditions (`ErrConnAlreadyExists` for relay, WG handshake timeout for ICE). Nothing to document for end users or operators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved connection timeout handling to better recover from WireGuard handshake and ICE/TURN failures by resetting session negotiation and retrying stale relay connections.
  * Enhanced peer connection stability through more robust relay connection cleanup and retry logic during connection collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->