### PR TITLE
[client] Use atomic write/rename pattern for ssh config

### DIFF
--- a/client/ssh/config/manager.go
+++ b/client/ssh/config/manager.go
@@ -225,13 +225,18 @@ func (m *Manager) buildHostPatterns(peer PeerSSHInfo) []string {
 
 func (m *Manager) writeSSHConfig(sshConfig string) error {
 	sshConfigPath := filepath.Join(m.sshConfigDir, m.sshConfigFile)
+	sshConfigPathTmp := sshConfigPath + ".tmp"
 
 	if err := os.MkdirAll(m.sshConfigDir, 0755); err != nil {
 		return fmt.Errorf("create SSH config directory %s: %w", m.sshConfigDir, err)
 	}
 
-	if err := writeFileWithTimeout(sshConfigPath, []byte(sshConfig), 0644); err != nil {
+	if err := writeFileWithTimeout(sshConfigPathTmp, []byte(sshConfig), 0644); err != nil {
 		return fmt.Errorf("write SSH config file %s: %w", sshConfigPath, err)
+	}
+
+	if err := os.Rename(sshConfigPathTmp, sshConfigPath); err != nil {
+		return fmt.Errorf("rename ssh config %s -> %s: %w", sshConfigPathTmp, sshConfigPath, err)
 	}
 
 	log.Infof("Created NetBird SSH client config: %s", sshConfigPath)


### PR DESCRIPTION
otherwise, ssh can fail due while the config file is being written and incomplete.

## Describe your changes

We've seen some errors running `ssh` when netbird is managing /etc/ssh_config.d/99-netbird.conf -- `ssh` might read an incomplete file if the netbird client happens to be in the middle of writing to it.

## Issue ticket number and link

none

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This is a bug fix and does not need to be documented separately.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH configuration file writing process for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->