### PR TITLE
Allow to install netbird in noninteractive way

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -201,7 +201,7 @@ read_enable_proxy() {
 
 read_traefik_acme_email() {
   if [[ -n "${NETBIRD_LETSENCRYPT_EMAIL:-}" ]]; then
-    if [[ ! "$NETBIRD_LETSENCRYPT_EMAIL" =~ ^[^@]+@[^@]+\.[^@]+$ ]]; then
+    if [[ ! "$NETBIRD_LETSENCRYPT_EMAIL" =~ ^[^[:space:]@]+@[^[:space:]@]+\.[^[:space:]@]+$ ]]; then
       echo "Invalid NETBIRD_LETSENCRYPT_EMAIL value: '$NETBIRD_LETSENCRYPT_EMAIL'. Must be a valid email address." > /dev/stderr
       exit 1
     fi

--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -83,6 +83,15 @@ read_nb_domain() {
 }
 
 read_reverse_proxy_type() {
+  if [[ -n "${NETBIRD_REVERSE_PROXY:-}" ]]; then
+    if [[ ! "$NETBIRD_REVERSE_PROXY" =~ ^[0-5]$ ]]; then
+      echo "Invalid NETBIRD_REVERSE_PROXY value: '$NETBIRD_REVERSE_PROXY'. Must be 0-5." > /dev/stderr
+      exit 1
+    fi
+    echo "$NETBIRD_REVERSE_PROXY"
+    return 0
+  fi
+
   echo "" > /dev/stderr
   echo "Which reverse proxy will you use?" > /dev/stderr
   echo "  [0] Traefik (recommended - automatic TLS, included in Docker Compose)" > /dev/stderr
@@ -167,6 +176,14 @@ read_proxy_docker_network() {
 }
 
 read_enable_proxy() {
+  if [[ -n "${NETBIRD_ENABLE_PROXY:-}" ]]; then
+    if [[ ! "$NETBIRD_ENABLE_PROXY" =~ ^(true|false)$ ]]; then
+      echo "Invalid NETBIRD_ENABLE_PROXY value: '$NETBIRD_ENABLE_PROXY'. Must be true or false." > /dev/stderr
+      exit 1
+    fi
+    echo "$NETBIRD_ENABLE_PROXY"
+    return 0
+  fi
   echo "" > /dev/stderr
   echo "Do you want to enable the NetBird Proxy service?" > /dev/stderr
   echo "The proxy allows you to selectively expose internal NetBird network resources" > /dev/stderr
@@ -183,6 +200,14 @@ read_enable_proxy() {
 }
 
 read_traefik_acme_email() {
+  if [[ -n "${NETBIRD_LETSENCRYPT_EMAIL:-}" ]]; then
+    if [[ ! "$NETBIRD_LETSENCRYPT_EMAIL" =~ ^[^@]+@[^@]+\.[^@]+$ ]]; then
+      echo "Invalid NETBIRD_LETSENCRYPT_EMAIL value: '$NETBIRD_LETSENCRYPT_EMAIL'. Must be a valid email address." > /dev/stderr
+      exit 1
+    fi
+    echo "$NETBIRD_LETSENCRYPT_EMAIL"
+    return 0
+  fi
   echo "" > /dev/stderr
   echo "Enter your email for Let's Encrypt certificate notifications." > /dev/stderr
   echo -n "Email address: " > /dev/stderr


### PR DESCRIPTION
Add validation for NETBIRD environment variables

## Describe your changes
This changes will allow to provision netbird in noninteractive way. Might be helpful in ansible environment. 

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)
It was working partially. Now default path may be provision without any terminal input.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The setup script now accepts environment variables (for reverse proxy type, enabling the proxy, and LetsEncrypt email), allowing fully non-interactive deployments. Provided values are validated; invalid values produce clear errors and cause the setup to exit. When valid values are present, interactive prompts are skipped and the provided settings are applied automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->