### PR TITLE
[self-hosted] fix(getting-started): Infinite healthcheck loop with existing traefik

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -214,7 +214,20 @@ get_upstream_host() {
 
 wait_management_proxy() {
   local proxy_container="${1:-traefik}"
+  local use_docker_logs=false
   set +e
+
+  if [[ "$proxy_container" == "detect-traefik" ]]; then
+    proxy_container=$(docker ps --format "{{.ID}}\t{{.Image}}\t{{.Ports}}" \
+    | awk -F'\t' '$2 ~ /traefik/ && $3 ~ /:(80|443)->/ {print $1; exit}')
+
+    if [[ -z "$proxy_container" ]]; then
+      echo "Warning: could not auto-detect Traefik container, log output will be skipped on timeout." > /dev/stderr
+    else
+      use_docker_logs=true
+    fi
+  fi
+
   echo -n "Waiting for NetBird server to become ready"
   counter=1
   while true; do
@@ -225,7 +238,13 @@ wait_management_proxy() {
     if [[ $counter -eq 60 ]]; then
       echo ""
       echo "Taking too long. Checking logs..."
-      $DOCKER_COMPOSE_COMMAND logs --tail=20 "$proxy_container"
+      if [[ -n "$proxy_container" ]]; then
+        if [[ "$use_docker_logs" == "true" ]]; then
+          docker logs --tail=20 "$proxy_container"
+        else
+          $DOCKER_COMPOSE_COMMAND logs --tail=20 "$proxy_container"
+        fi
+      fi
       $DOCKER_COMPOSE_COMMAND logs --tail=20 netbird-server
     fi
     echo -n " ."
@@ -461,7 +480,7 @@ start_services_and_show_instructions() {
     $DOCKER_COMPOSE_COMMAND up -d
 
     sleep 3
-    wait_management_direct
+    wait_management_proxy detect-traefik
 
     echo -e "$MSG_DONE"
     print_post_setup_instructions


### PR DESCRIPTION
## Describe your changes
Fixed an infinite wait loop when using an existing Traefik instance (option `[1]`). `wait_management_direct` was called for this case, which checks `http://127.0.0.1:8081` , a port never exposed on the host by `render_docker_compose_traefik`. This caused the script to loop indefinitely despite `netbird-server` being fully healthy.

Replaced `wait_management_direct` with `wait_management_proxy` for type 1, and extended `wait_management_proxy` to support auto-detection of the external Traefik container ID (by image name and exposed ports 80/443) when called with `detect-traefik`.

## Issue ticket number and link
#5869
[Issue](https://github.com/netbirdio/netbird/issues/5869)

## Stack
Installed with this script on a VPS with an existing Traefik instance

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:
- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Fixes the installation script only, no public API or feature changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:
https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of Traefik during setup to simplify reverse-proxy configuration.

* **Bug Fixes**
  * Timeout logging now only includes proxy logs when a proxy is detected, reducing noise.
  * External Traefik startup flow updated to use automatic detection for more reliable readiness checks and clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->