### PR TITLE
[proxy] direct redirect to SSO

### DIFF
--- a/proxy/internal/auth/middleware.go
+++ b/proxy/internal/auth/middleware.go
@@ -358,6 +358,12 @@ func (mw *Middleware) authenticateWithSchemes(w http.ResponseWriter, r *http.Req
 			cd.SetAuthMethod(attemptedMethod)
 		}
 	}
+
+	if oidcURL, ok := methods[auth.MethodOIDC.String()]; ok && len(methods) == 1 && oidcURL != "" {
+		http.Redirect(w, r, oidcURL, http.StatusFound)
+		return
+	}
+
 	web.ServeHTTP(w, r, map[string]any{"methods": methods}, http.StatusUnauthorized)
 }
 

--- a/proxy/internal/auth/middleware_test.go
+++ b/proxy/internal/auth/middleware_test.go
@@ -761,6 +761,56 @@ func TestCheckIPRestrictions_NilGeoWithCountryRules(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rr.Code, "country restrictions with nil geo must deny")
 }
 
+func TestProtect_OIDCOnlyRedirectsDirectly(t *testing.T) {
+	mw := NewMiddleware(log.StandardLogger(), nil, nil)
+	kp := generateTestKeyPair(t)
+
+	oidcURL := "https://idp.example.com/authorize?client_id=abc"
+	scheme := &stubScheme{
+		method: auth.MethodOIDC,
+		authFn: func(_ *http.Request) (string, string, error) {
+			return "", oidcURL, nil
+		},
+	}
+	require.NoError(t, mw.AddDomain("example.com", []Scheme{scheme}, kp.PublicKey, time.Hour, "", "", nil))
+
+	handler := mw.Protect(newPassthroughHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code, "should redirect directly to IdP")
+	assert.Equal(t, oidcURL, rec.Header().Get("Location"))
+}
+
+func TestProtect_OIDCWithOtherMethodShowsLoginPage(t *testing.T) {
+	mw := NewMiddleware(log.StandardLogger(), nil, nil)
+	kp := generateTestKeyPair(t)
+
+	oidcScheme := &stubScheme{
+		method: auth.MethodOIDC,
+		authFn: func(_ *http.Request) (string, string, error) {
+			return "", "https://idp.example.com/authorize", nil
+		},
+	}
+	pinScheme := &stubScheme{
+		method: auth.MethodPIN,
+		authFn: func(_ *http.Request) (string, string, error) {
+			return "", "pin", nil
+		},
+	}
+	require.NoError(t, mw.AddDomain("example.com", []Scheme{oidcScheme, pinScheme}, kp.PublicKey, time.Hour, "", "", nil))
+
+	handler := mw.Protect(newPassthroughHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, "should show login page when multiple methods exist")
+}
+
 // mockAuthenticator is a minimal mock for the authenticator gRPC interface
 // used by the Header scheme.
 type mockAuthenticator struct {


### PR DESCRIPTION
## Describe your changes
This PR will change the behavior of the proxy to forward directly to the SSO if it's the only auth method configured.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OIDC authentication now redirects directly to the identity provider when configured as the only authentication method, streamlining the login flow.
  * When multiple authentication methods are configured, users continue to access the login page to select their preferred authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->