### PR TITLE
[management] revert ctx dependency in get account with backpressure

### DIFF
--- a/management/server/account_request_buffer.go
+++ b/management/server/account_request_buffer.go
@@ -63,20 +63,11 @@ func (ac *AccountRequestBuffer) GetAccountWithBackpressure(ctx context.Context, 
 
 	log.WithContext(ctx).Tracef("requesting account %s with backpressure", accountID)
 	startTime := time.Now()
+	ac.getAccountRequestCh <- req
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case ac.getAccountRequestCh <- req:
-	}
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case result := <-req.ResultChan:
-		log.WithContext(ctx).Tracef("got account with backpressure after %s", time.Since(startTime))
-		return result.Account, result.Err
-	}
+	result := <-req.ResultChan
+	log.WithContext(ctx).Tracef("got account with backpressure after %s", time.Since(startTime))
+	return result.Account, result.Err
 }
 
 func (ac *AccountRequestBuffer) processGetAccountBatch(ctx context.Context, accountID string) {


### PR DESCRIPTION
## Describe your changes
the pr revert ctx cancel dependency on GetAccountWithBackpressure 

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

bug fix 

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified account request handling to change cancellation behavior during request transmission and result retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->