### PR TITLE
[client] Fix clearing service env vars with --service-env ""

### DIFF
--- a/client/cmd/service.go
+++ b/client/cmd/service.go
@@ -48,6 +48,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&serviceName, "service", "s", defaultServiceName, "Netbird system service name")
 	serviceEnvDesc := `Sets extra environment variables for the service. ` +
 		`You can specify a comma-separated list of KEY=VALUE pairs. ` +
+		`New keys are merged with previously saved env vars; existing keys are overwritten. ` +
+		`Use --service-env "" to clear all saved env vars. ` +
 		`E.g. --service-env NB_LOG_LEVEL=debug,CUSTOM_VAR=value`
 
 	installCmd.Flags().StringSliceVar(&serviceEnvVars, "service-env", nil, serviceEnvDesc)

--- a/client/cmd/service_params.go
+++ b/client/cmd/service_params.go
@@ -82,7 +82,7 @@ func currentServiceParams() *serviceParams {
 
 	if len(serviceEnvVars) > 0 {
 		parsed, err := parseServiceEnvVars(serviceEnvVars)
-		if err == nil && len(parsed) > 0 {
+		if err == nil {
 			params.ServiceEnvVars = parsed
 		}
 	}
@@ -146,27 +146,38 @@ func applyServiceParams(cmd *cobra.Command, params *serviceParams) {
 }
 
 // applyServiceEnvParams merges saved service environment variables.
-// If --service-env was explicitly set, explicit values win on key conflict
-// but saved keys not in the explicit set are carried over.
+// If --service-env was explicitly set with values, explicit values win on key
+// conflict but saved keys not in the explicit set are carried over.
+// If --service-env was explicitly set to empty, all saved env vars are cleared.
 // If --service-env was not set, saved env vars are used entirely.
 func applyServiceEnvParams(cmd *cobra.Command, params *serviceParams) {
-	if len(params.ServiceEnvVars) == 0 {
-		return
-	}
-
 	if !cmd.Flags().Changed("service-env") {
-		// No explicit env vars: rebuild serviceEnvVars from saved params.
-		serviceEnvVars = envMapToSlice(params.ServiceEnvVars)
+		if len(params.ServiceEnvVars) > 0 {
+			// No explicit env vars: rebuild serviceEnvVars from saved params.
+			serviceEnvVars = envMapToSlice(params.ServiceEnvVars)
+		}
 		return
 	}
 
-	// Explicit env vars were provided: merge saved values underneath.
+	// Flag was explicitly set: parse what the user provided.
 	explicit, err := parseServiceEnvVars(serviceEnvVars)
 	if err != nil {
 		cmd.PrintErrf("Warning: parse explicit service env vars for merge: %v\n", err)
 		return
 	}
 
+	// If the user passed an empty value (e.g. --service-env ""), clear all
+	// saved env vars rather than merging.
+	if len(explicit) == 0 {
+		serviceEnvVars = nil
+		return
+	}
+
+	if len(params.ServiceEnvVars) == 0 {
+		return
+	}
+
+	// Merge saved values underneath explicit ones.
 	merged := make(map[string]string, len(params.ServiceEnvVars)+len(explicit))
 	maps.Copy(merged, params.ServiceEnvVars)
 	maps.Copy(merged, explicit) // explicit wins on conflict

--- a/client/cmd/service_params_test.go
+++ b/client/cmd/service_params_test.go
@@ -327,6 +327,41 @@ func TestApplyServiceEnvParams_NotChanged(t *testing.T) {
 	assert.Equal(t, map[string]string{"FROM_SAVED": "val"}, result)
 }
 
+func TestApplyServiceEnvParams_ExplicitEmptyClears(t *testing.T) {
+	origServiceEnvVars := serviceEnvVars
+	t.Cleanup(func() { serviceEnvVars = origServiceEnvVars })
+
+	// Simulate --service-env "" which produces [""] in the slice.
+	serviceEnvVars = []string{""}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("service-env", nil, "")
+	require.NoError(t, cmd.Flags().Set("service-env", ""))
+
+	saved := &serviceParams{
+		ServiceEnvVars: map[string]string{"OLD_VAR": "should_be_cleared"},
+	}
+
+	applyServiceEnvParams(cmd, saved)
+
+	assert.Nil(t, serviceEnvVars, "explicit empty --service-env should clear all saved env vars")
+}
+
+func TestCurrentServiceParams_EmptyEnvVarsAfterParse(t *testing.T) {
+	origServiceEnvVars := serviceEnvVars
+	t.Cleanup(func() { serviceEnvVars = origServiceEnvVars })
+
+	// Simulate --service-env "" which produces [""] in the slice.
+	serviceEnvVars = []string{""}
+
+	params := currentServiceParams()
+
+	// After parsing, the empty string is skipped, resulting in an empty map.
+	// The map should still be set (not nil) so it overwrites saved values.
+	assert.NotNil(t, params.ServiceEnvVars, "empty env vars should produce empty map, not nil")
+	assert.Empty(t, params.ServiceEnvVars, "no valid env vars should be parsed from empty string")
+}
+
 // TestServiceParams_FieldsCoveredInFunctions ensures that all serviceParams fields are
 // referenced in both currentServiceParams() and applyServiceParams(). If a new field is
 // added to serviceParams but not wired into these functions, this test fails.


### PR DESCRIPTION
## Describe your changes

Passing `--service-env ""` to `netbird service reconfigure` was supposed to clear all saved environment variables but didn't work. The empty string parsed to an empty map, which was then silently dropped, leaving the old saved vars intact.

- Allow `--service-env ""` to clear all saved service env vars from service.json and the service configuration
- Update CLI help text to document the merge and clear behavior

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

CLI help text updated inline. No external docs needed for a bug fix.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service environment variables can now be cleared by passing `--service-env ""`

* **Bug Fixes**
  * Improved handling of empty environment variable values and merging behavior with previously saved variables

* **Tests**
  * Added test coverage for clearing saved service environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->