### PR TITLE
[management] Enforce peer or peer groups requirement for network routers

### DIFF
--- a/management/server/http/handlers/networks/routers_handler.go
+++ b/management/server/http/handlers/networks/routers_handler.go
@@ -105,6 +105,12 @@ func (h *routersHandler) createRouter(w http.ResponseWriter, r *http.Request) {
 	router.NetworkID = networkID
 	router.AccountID = accountID
 	router.Enabled = true
+
+	if err := router.Validate(); err != nil {
+		util.WriteErrorResponse(err.Error(), http.StatusBadRequest, w)
+		return
+	}
+
 	router, err = h.routersManager.CreateRouter(r.Context(), userID, router)
 	if err != nil {
 		util.WriteError(r.Context(), err, w)
@@ -156,6 +162,11 @@ func (h *routersHandler) updateRouter(w http.ResponseWriter, r *http.Request) {
 	router.NetworkID = mux.Vars(r)["networkId"]
 	router.ID = mux.Vars(r)["routerId"]
 	router.AccountID = accountID
+
+	if err := router.Validate(); err != nil {
+		util.WriteErrorResponse(err.Error(), http.StatusBadRequest, w)
+		return
+	}
 
 	router, err = h.routersManager.UpdateRouter(r.Context(), userID, router)
 	if err != nil {

--- a/management/server/http/testing/integration/networks_handler_integration_test.go
+++ b/management/server/http/testing/integration/networks_handler_integration_test.go
@@ -1170,13 +1170,17 @@ func Test_NetworkRouters_Create(t *testing.T) {
 				Metric:     100,
 				Enabled:    true,
 			},
-			expectedStatus: http.StatusOK,
-			verifyResponse: func(t *testing.T, router *api.NetworkRouter) {
-				t.Helper()
-				assert.NotEmpty(t, router.Id)
-				assert.Equal(t, peerID, *router.Peer)
-				assert.Equal(t, 1, len(*router.PeerGroups))
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:      "Create router without peer and peer_groups",
+			networkId: "testNetworkId",
+			requestBody: &api.NetworkRouterRequest{
+				Masquerade: true,
+				Metric:     100,
+				Enabled:    true,
 			},
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name:      "Create router in non-existing network",
@@ -1341,13 +1345,18 @@ func Test_NetworkRouters_Update(t *testing.T) {
 				Metric:     100,
 				Enabled:    true,
 			},
-			expectedStatus: http.StatusOK,
-			verifyResponse: func(t *testing.T, router *api.NetworkRouter) {
-				t.Helper()
-				assert.Equal(t, "testRouterId", router.Id)
-				assert.Equal(t, peerID, *router.Peer)
-				assert.Equal(t, 1, len(*router.PeerGroups))
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:      "Update router without peer and peer_groups",
+			networkId: "testNetworkId",
+			routerId:  "testRouterId",
+			requestBody: &api.NetworkRouterRequest{
+				Masquerade: true,
+				Metric:     100,
+				Enabled:    true,
 			},
+			expectedStatus: http.StatusBadRequest,
 		},
 	}
 

--- a/management/server/networks/routers/manager.go
+++ b/management/server/networks/routers/manager.go
@@ -81,7 +81,7 @@ func (m *managerImpl) GetAllRoutersInAccount(ctx context.Context, accountID, use
 
 func (m *managerImpl) CreateRouter(ctx context.Context, userID string, router *types.NetworkRouter) (*types.NetworkRouter, error) {
 	if err := router.Validate(); err != nil {
-		return nil, status.Errorf(status.InvalidArgument, "invalid router: %s", err)
+		return nil, status.Errorf(status.InvalidArgument, "%s", err)
 	}
 
 	ok, err := m.permissionsManager.ValidateUserPermissions(ctx, router.AccountID, userID, modules.Networks, operations.Create)
@@ -151,7 +151,7 @@ func (m *managerImpl) GetRouter(ctx context.Context, accountID, userID, networkI
 
 func (m *managerImpl) UpdateRouter(ctx context.Context, userID string, router *types.NetworkRouter) (*types.NetworkRouter, error) {
 	if err := router.Validate(); err != nil {
-		return nil, status.Errorf(status.InvalidArgument, "invalid router: %s", err)
+		return nil, status.Errorf(status.InvalidArgument, "%s", err)
 	}
 
 	ok, err := m.permissionsManager.ValidateUserPermissions(ctx, router.AccountID, userID, modules.Networks, operations.Update)

--- a/management/server/networks/routers/manager.go
+++ b/management/server/networks/routers/manager.go
@@ -80,6 +80,10 @@ func (m *managerImpl) GetAllRoutersInAccount(ctx context.Context, accountID, use
 }
 
 func (m *managerImpl) CreateRouter(ctx context.Context, userID string, router *types.NetworkRouter) (*types.NetworkRouter, error) {
+	if err := router.Validate(); err != nil {
+		return nil, status.Errorf(status.InvalidArgument, "invalid router: %s", err)
+	}
+
 	ok, err := m.permissionsManager.ValidateUserPermissions(ctx, router.AccountID, userID, modules.Networks, operations.Create)
 	if err != nil {
 		return nil, status.NewPermissionValidationError(err)
@@ -146,6 +150,10 @@ func (m *managerImpl) GetRouter(ctx context.Context, accountID, userID, networkI
 }
 
 func (m *managerImpl) UpdateRouter(ctx context.Context, userID string, router *types.NetworkRouter) (*types.NetworkRouter, error) {
+	if err := router.Validate(); err != nil {
+		return nil, status.Errorf(status.InvalidArgument, "invalid router: %s", err)
+	}
+
 	ok, err := m.permissionsManager.ValidateUserPermissions(ctx, router.AccountID, userID, modules.Networks, operations.Update)
 	if err != nil {
 		return nil, status.NewPermissionValidationError(err)

--- a/management/server/networks/routers/manager.go
+++ b/management/server/networks/routers/manager.go
@@ -80,10 +80,6 @@ func (m *managerImpl) GetAllRoutersInAccount(ctx context.Context, accountID, use
 }
 
 func (m *managerImpl) CreateRouter(ctx context.Context, userID string, router *types.NetworkRouter) (*types.NetworkRouter, error) {
-	if err := router.Validate(); err != nil {
-		return nil, status.Errorf(status.InvalidArgument, "%s", err)
-	}
-
 	ok, err := m.permissionsManager.ValidateUserPermissions(ctx, router.AccountID, userID, modules.Networks, operations.Create)
 	if err != nil {
 		return nil, status.NewPermissionValidationError(err)
@@ -150,10 +146,6 @@ func (m *managerImpl) GetRouter(ctx context.Context, accountID, userID, networkI
 }
 
 func (m *managerImpl) UpdateRouter(ctx context.Context, userID string, router *types.NetworkRouter) (*types.NetworkRouter, error) {
-	if err := router.Validate(); err != nil {
-		return nil, status.Errorf(status.InvalidArgument, "%s", err)
-	}
-
 	ok, err := m.permissionsManager.ValidateUserPermissions(ctx, router.AccountID, userID, modules.Networks, operations.Update)
 	if err != nil {
 		return nil, status.NewPermissionValidationError(err)

--- a/management/server/networks/routers/types/router.go
+++ b/management/server/networks/routers/types/router.go
@@ -21,11 +21,7 @@ type NetworkRouter struct {
 }
 
 func NewNetworkRouter(accountID string, networkID string, peer string, peerGroups []string, masquerade bool, metric int, enabled bool) (*NetworkRouter, error) {
-	if peer != "" && len(peerGroups) > 0 {
-		return nil, errors.New("peer and peerGroups cannot be set at the same time")
-	}
-
-	return &NetworkRouter{
+	r := &NetworkRouter{
 		ID:         xid.New().String(),
 		AccountID:  accountID,
 		NetworkID:  networkID,
@@ -34,7 +30,25 @@ func NewNetworkRouter(accountID string, networkID string, peer string, peerGroup
 		Masquerade: masquerade,
 		Metric:     metric,
 		Enabled:    enabled,
-	}, nil
+	}
+
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (n *NetworkRouter) Validate() error {
+	if n.Peer != "" && len(n.PeerGroups) > 0 {
+		return errors.New("peer and peer_groups cannot be set at the same time")
+	}
+
+	if n.Peer == "" && len(n.PeerGroups) == 0 {
+		return errors.New("either peer or peer_groups must be provided")
+	}
+
+	return nil
 }
 
 func (n *NetworkRouter) ToAPIResponse() *api.NetworkRouter {

--- a/management/server/networks/routers/types/router_test.go
+++ b/management/server/networks/routers/types/router_test.go
@@ -38,7 +38,7 @@ func TestNewNetworkRouter(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:          "Valid with no peer or peerGroups",
+			name:          "Invalid with no peer or peerGroups",
 			networkID:     "network-3",
 			accountID:     "account-3",
 			peer:          "",
@@ -46,7 +46,18 @@ func TestNewNetworkRouter(t *testing.T) {
 			masquerade:    true,
 			metric:        300,
 			enabled:       true,
-			expectedError: false,
+			expectedError: true,
+		},
+		{
+			name:          "Invalid with empty peerGroups slice",
+			networkID:     "network-5",
+			accountID:     "account-5",
+			peer:          "",
+			peerGroups:    []string{},
+			masquerade:    true,
+			metric:        500,
+			enabled:       true,
+			expectedError: true,
 		},
 
 		// Invalid cases


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Router creation and update now validate inputs and return Bad Request for invalid configurations. Routers must specify either a peer or peer groups (mutually exclusive) and cannot omit both; invalid requests are rejected with an error response.

* **Tests**
  * Integration and unit tests updated to cover the new router validation rules and invalid-request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->