### PR TITLE
[client] Add --disable-networks flag to block network selection

### DIFF
--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -75,6 +75,7 @@ var (
 	mtu                     uint16
 	profilesDisabled        bool
 	updateSettingsDisabled  bool
+	networksDisabled        bool
 
 	rootCmd = &cobra.Command{
 		Use:          "netbird",

--- a/client/cmd/service.go
+++ b/client/cmd/service.go
@@ -44,6 +44,7 @@ func init() {
 	serviceCmd.AddCommand(runCmd, startCmd, stopCmd, restartCmd, svcStatusCmd, installCmd, uninstallCmd, reconfigureCmd, resetParamsCmd)
 	serviceCmd.PersistentFlags().BoolVar(&profilesDisabled, "disable-profiles", false, "Disables profiles feature. If enabled, the client will not be able to change or edit any profile. To persist this setting, use: netbird service install --disable-profiles")
 	serviceCmd.PersistentFlags().BoolVar(&updateSettingsDisabled, "disable-update-settings", false, "Disables update settings feature. If enabled, the client will not be able to change or edit any settings. To persist this setting, use: netbird service install --disable-update-settings")
+	serviceCmd.PersistentFlags().BoolVar(&networksDisabled, "disable-networks", false, "Disables network selection. If enabled, the client will not allow listing, selecting, or deselecting networks. To persist, use: netbird service install --disable-networks")
 
 	rootCmd.PersistentFlags().StringVarP(&serviceName, "service", "s", defaultServiceName, "Netbird system service name")
 	serviceEnvDesc := `Sets extra environment variables for the service. ` +

--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -61,7 +61,7 @@ func (p *program) Start(svc service.Service) error {
 			}
 		}
 
-		serverInstance := server.New(p.ctx, util.FindFirstLogPath(logFiles), configPath, profilesDisabled, updateSettingsDisabled)
+		serverInstance := server.New(p.ctx, util.FindFirstLogPath(logFiles), configPath, profilesDisabled, updateSettingsDisabled, networksDisabled)
 		if err := serverInstance.Start(); err != nil {
 			log.Fatalf("failed to start daemon: %v", err)
 		}

--- a/client/cmd/service_installer.go
+++ b/client/cmd/service_installer.go
@@ -59,6 +59,10 @@ func buildServiceArguments() []string {
 		args = append(args, "--disable-update-settings")
 	}
 
+	if networksDisabled {
+		args = append(args, "--disable-networks")
+	}
+
 	return args
 }
 

--- a/client/cmd/service_params.go
+++ b/client/cmd/service_params.go
@@ -28,6 +28,7 @@ type serviceParams struct {
 	LogFiles              []string          `json:"log_files,omitempty"`
 	DisableProfiles       bool              `json:"disable_profiles,omitempty"`
 	DisableUpdateSettings bool              `json:"disable_update_settings,omitempty"`
+	DisableNetworks       bool              `json:"disable_networks,omitempty"`
 	ServiceEnvVars        map[string]string `json:"service_env_vars,omitempty"`
 }
 
@@ -78,6 +79,7 @@ func currentServiceParams() *serviceParams {
 		LogFiles:              logFiles,
 		DisableProfiles:       profilesDisabled,
 		DisableUpdateSettings: updateSettingsDisabled,
+		DisableNetworks:       networksDisabled,
 	}
 
 	if len(serviceEnvVars) > 0 {
@@ -140,6 +142,10 @@ func applyServiceParams(cmd *cobra.Command, params *serviceParams) {
 
 	if !serviceCmd.PersistentFlags().Changed("disable-update-settings") {
 		updateSettingsDisabled = params.DisableUpdateSettings
+	}
+
+	if !serviceCmd.PersistentFlags().Changed("disable-networks") {
+		networksDisabled = params.DisableNetworks
 	}
 
 	applyServiceEnvParams(cmd, params)

--- a/client/cmd/service_params_test.go
+++ b/client/cmd/service_params_test.go
@@ -535,6 +535,7 @@ func fieldToGlobalVar(field string) string {
 		"LogFiles":              "logFiles",
 		"DisableProfiles":       "profilesDisabled",
 		"DisableUpdateSettings": "updateSettingsDisabled",
+		"DisableNetworks":       "networksDisabled",
 		"ServiceEnvVars":        "serviceEnvVars",
 	}
 	if v, ok := m[field]; ok {

--- a/client/cmd/testutil_test.go
+++ b/client/cmd/testutil_test.go
@@ -152,7 +152,7 @@ func startClientDaemon(
 	s := grpc.NewServer()
 
 	server := client.New(ctx,
-		"", "", false, false)
+		"", "", false, false, false)
 	if err := server.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/client/proto/daemon.pb.go
+++ b/client/proto/daemon.pb.go
@@ -4979,6 +4979,7 @@ type GetFeaturesResponse struct {
 	state                 protoimpl.MessageState `protogen:"open.v1"`
 	DisableProfiles       bool                   `protobuf:"varint,1,opt,name=disable_profiles,json=disableProfiles,proto3" json:"disable_profiles,omitempty"`
 	DisableUpdateSettings bool                   `protobuf:"varint,2,opt,name=disable_update_settings,json=disableUpdateSettings,proto3" json:"disable_update_settings,omitempty"`
+	DisableNetworks       bool                   `protobuf:"varint,3,opt,name=disable_networks,json=disableNetworks,proto3" json:"disable_networks,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -5023,6 +5024,13 @@ func (x *GetFeaturesResponse) GetDisableProfiles() bool {
 func (x *GetFeaturesResponse) GetDisableUpdateSettings() bool {
 	if x != nil {
 		return x.DisableUpdateSettings
+	}
+	return false
+}
+
+func (x *GetFeaturesResponse) GetDisableNetworks() bool {
+	if x != nil {
+		return x.DisableNetworks
 	}
 	return false
 }
@@ -6472,10 +6480,11 @@ const file_daemon_proto_rawDesc = "" +
 	"\f_profileNameB\v\n" +
 	"\t_username\"\x10\n" +
 	"\x0eLogoutResponse\"\x14\n" +
-	"\x12GetFeaturesRequest\"x\n" +
+	"\x12GetFeaturesRequest\"\xa3\x01\n" +
 	"\x13GetFeaturesResponse\x12)\n" +
 	"\x10disable_profiles\x18\x01 \x01(\bR\x0fdisableProfiles\x126\n" +
-	"\x17disable_update_settings\x18\x02 \x01(\bR\x15disableUpdateSettings\"\x16\n" +
+	"\x17disable_update_settings\x18\x02 \x01(\bR\x15disableUpdateSettings\x12)\n" +
+	"\x10disable_networks\x18\x03 \x01(\bR\x0fdisableNetworks\"\x16\n" +
 	"\x14TriggerUpdateRequest\"M\n" +
 	"\x15TriggerUpdateResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x1a\n" +

--- a/client/proto/daemon.proto
+++ b/client/proto/daemon.proto
@@ -727,6 +727,7 @@ message GetFeaturesRequest{}
 message GetFeaturesResponse{
   bool disable_profiles = 1;
   bool disable_update_settings = 2;
+  bool disable_networks = 3;
 }
 
 message TriggerUpdateRequest {}

--- a/client/server/network.go
+++ b/client/server/network.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"golang.org/x/exp/maps"
+	"google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
 
 	"github.com/netbirdio/netbird/client/proto"
 	"github.com/netbirdio/netbird/route"
@@ -26,6 +28,10 @@ type selectRoute struct {
 func (s *Server) ListNetworks(context.Context, *proto.ListNetworksRequest) (*proto.ListNetworksResponse, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	if s.networksDisabled {
+		return nil, gstatus.Errorf(codes.Unavailable, errNetworksDisabled)
+	}
 
 	if s.connectClient == nil {
 		return nil, fmt.Errorf("not connected")
@@ -118,6 +124,10 @@ func (s *Server) SelectNetworks(_ context.Context, req *proto.SelectNetworksRequ
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	if s.networksDisabled {
+		return nil, gstatus.Errorf(codes.Unavailable, errNetworksDisabled)
+	}
+
 	if s.connectClient == nil {
 		return nil, fmt.Errorf("not connected")
 	}
@@ -163,6 +173,10 @@ func (s *Server) SelectNetworks(_ context.Context, req *proto.SelectNetworksRequ
 func (s *Server) DeselectNetworks(_ context.Context, req *proto.SelectNetworksRequest) (*proto.SelectNetworksResponse, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	if s.networksDisabled {
+		return nil, gstatus.Errorf(codes.Unavailable, errNetworksDisabled)
+	}
 
 	if s.connectClient == nil {
 		return nil, fmt.Errorf("not connected")

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -53,6 +53,7 @@ const (
 	errRestoreResidualState   = "failed to restore residual state: %v"
 	errProfilesDisabled       = "profiles are disabled, you cannot use this feature without profiles enabled"
 	errUpdateSettingsDisabled = "update settings are disabled, you cannot use this feature without update settings enabled"
+	errNetworksDisabled       = "network selection is disabled by the administrator"
 )
 
 var ErrServiceNotUp = errors.New("service is not up")
@@ -88,6 +89,7 @@ type Server struct {
 	profileManager         *profilemanager.ServiceManager
 	profilesDisabled       bool
 	updateSettingsDisabled bool
+	networksDisabled       bool
 
 	sleepHandler *sleephandler.SleepHandler
 
@@ -104,7 +106,7 @@ type oauthAuthFlow struct {
 }
 
 // New server instance constructor.
-func New(ctx context.Context, logFile string, configFile string, profilesDisabled bool, updateSettingsDisabled bool) *Server {
+func New(ctx context.Context, logFile string, configFile string, profilesDisabled bool, updateSettingsDisabled bool, networksDisabled bool) *Server {
 	s := &Server{
 		rootCtx:                ctx,
 		logFile:                logFile,
@@ -113,6 +115,7 @@ func New(ctx context.Context, logFile string, configFile string, profilesDisable
 		profileManager:         profilemanager.NewServiceManager(configFile),
 		profilesDisabled:       profilesDisabled,
 		updateSettingsDisabled: updateSettingsDisabled,
+		networksDisabled:       networksDisabled,
 		jwtCache:               newJWTCache(),
 	}
 	agent := &serverAgent{s}
@@ -1628,6 +1631,7 @@ func (s *Server) GetFeatures(ctx context.Context, msg *proto.GetFeaturesRequest)
 	features := &proto.GetFeaturesResponse{
 		DisableProfiles:       s.checkProfilesDisabled(),
 		DisableUpdateSettings: s.checkUpdateSettingsDisabled(),
+		DisableNetworks:       s.networksDisabled,
 	}
 
 	return features, nil

--- a/client/server/server_test.go
+++ b/client/server/server_test.go
@@ -103,7 +103,7 @@ func TestConnectWithRetryRuns(t *testing.T) {
 		t.Fatalf("failed to set active profile state: %v", err)
 	}
 
-	s := New(ctx, "debug", "", false, false)
+	s := New(ctx, "debug", "", false, false, false)
 
 	s.config = config
 
@@ -164,7 +164,7 @@ func TestServer_Up(t *testing.T) {
 		t.Fatalf("failed to set active profile state: %v", err)
 	}
 
-	s := New(ctx, "console", "", false, false)
+	s := New(ctx, "console", "", false, false, false)
 	err = s.Start()
 	require.NoError(t, err)
 
@@ -234,7 +234,7 @@ func TestServer_SubcribeEvents(t *testing.T) {
 		t.Fatalf("failed to set active profile state: %v", err)
 	}
 
-	s := New(ctx, "console", "", false, false)
+	s := New(ctx, "console", "", false, false, false)
 
 	err = s.Start()
 	require.NoError(t, err)

--- a/client/server/setconfig_test.go
+++ b/client/server/setconfig_test.go
@@ -53,7 +53,7 @@ func TestSetConfig_AllFieldsSaved(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	s := New(ctx, "console", "", false, false)
+	s := New(ctx, "console", "", false, false, false)
 
 	rosenpassEnabled := true
 	rosenpassPermissive := true

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -1097,13 +1097,13 @@ func (s *serviceClient) onTrayReady() {
 		s.getSrvConfig()
 		time.Sleep(100 * time.Millisecond) // To prevent race condition caused by systray not being fully initialized and ignoring setIcon
 		for {
+			// Check features before status so menus respect disable flags before being enabled
+			s.checkAndUpdateFeatures()
+
 			err := s.updateStatus()
 			if err != nil {
 				log.Errorf("error while updating status: %v", err)
 			}
-
-			// Check features periodically to handle daemon restarts
-			s.checkAndUpdateFeatures()
 
 			time.Sleep(2 * time.Second)
 		}

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -314,6 +314,7 @@ type serviceClient struct {
 	lastNotifiedVersion  string
 	settingsEnabled      bool
 	profilesEnabled      bool
+	networksEnabled      bool
 	showNetworks         bool
 	wNetworks            fyne.Window
 	wProfiles            fyne.Window
@@ -368,6 +369,7 @@ func newServiceClient(args *newServiceClientArgs) *serviceClient {
 
 		showAdvancedSettings: args.showSettings,
 		showNetworks:         args.showNetworks,
+		networksEnabled:      true,
 	}
 
 	s.eventHandler = newEventHandler(s)
@@ -920,8 +922,10 @@ func (s *serviceClient) updateStatus() error {
 			s.mStatus.SetIcon(s.icConnectedDot)
 			s.mUp.Disable()
 			s.mDown.Enable()
-			s.mNetworks.Enable()
-			s.mExitNode.Enable()
+			if s.networksEnabled {
+				s.mNetworks.Enable()
+				s.mExitNode.Enable()
+			}
 			s.startExitNodeRefresh()
 			systrayIconState = true
 		case status.Status == string(internal.StatusConnecting):
@@ -1297,6 +1301,19 @@ func (s *serviceClient) checkAndUpdateFeatures() {
 		if s.profilesEnabled != profilesEnabled {
 			s.profilesEnabled = profilesEnabled
 			s.mProfile.setEnabled(profilesEnabled)
+		}
+	}
+
+	// Update networks and exit node menus based on current features
+	networksEnabled := features == nil || !features.DisableNetworks
+	if s.networksEnabled != networksEnabled {
+		s.networksEnabled = networksEnabled
+		if networksEnabled {
+			s.mNetworks.Enable()
+			s.mExitNode.Enable()
+		} else {
+			s.mNetworks.Disable()
+			s.mExitNode.Disable()
 		}
 	}
 }

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -1305,16 +1305,13 @@ func (s *serviceClient) checkAndUpdateFeatures() {
 	}
 
 	// Update networks and exit node menus based on current features
-	networksEnabled := features == nil || !features.DisableNetworks
-	if s.networksEnabled != networksEnabled {
-		s.networksEnabled = networksEnabled
-		if networksEnabled {
-			s.mNetworks.Enable()
-			s.mExitNode.Enable()
-		} else {
-			s.mNetworks.Disable()
-			s.mExitNode.Disable()
-		}
+	s.networksEnabled = features == nil || !features.DisableNetworks
+	if s.networksEnabled && s.connected {
+		s.mNetworks.Enable()
+		s.mExitNode.Enable()
+	} else {
+		s.mNetworks.Disable()
+		s.mExitNode.Disable()
 	}
 }
 


### PR DESCRIPTION
## Describe your changes

Add a `--disable-networks` service flag that blocks network and exit node selection at the daemon level. For deployments where users should not modify routing.

- Block ListNetworks, SelectNetworks, and DeselectNetworks RPCs when the flag is set, returning a gRPC Unavailable error
- Add `disable_networks` to the GetFeaturesResponse proto so the UI can hide the Networks and Exit Node menus
- Persist the flag in service.json across reinstalls, following the same pattern as `--disable-profiles` and `--disable-update-settings`

Usage: `netbird service install --disable-networks`

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Flag follows the exact same pattern as existing --disable-profiles and --disable-update-settings which are already documented. Can be added to the same docs page.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --disable-networks CLI flag to disable network listing, selection, and deselection
  * Network-disable setting is persisted and retained across restarts
  * Daemon now reports network-disable capability so clients can react

* **Bug Fixes / UX**
  * Networks and Exit Node menu items enable/disable dynamically based on feature availability
  * Attempts to use networks when disabled now return a clear "networks disabled" error
<!-- end of auto-generated comment: release notes by coderabbit.ai -->