### PR TITLE
[client] Populate NetworkAddresses on iOS for posture checks

### DIFF
--- a/client/system/info_ios.go
+++ b/client/system/info_ios.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"runtime"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/netbirdio/netbird/version"
 )
 
-// UpdateStaticInfoAsync is a no-op on Android as there is no static info to update
+// UpdateStaticInfoAsync is a no-op on iOS as there is no static info to update
 func UpdateStaticInfoAsync() {
 	// do nothing
 }
@@ -15,11 +17,24 @@ func UpdateStaticInfoAsync() {
 // GetInfo retrieves and parses the system information
 func GetInfo(ctx context.Context) *Info {
 
-	// Convert fixed-size byte arrays to Go strings
 	sysName := extractOsName(ctx, "sysName")
 	swVersion := extractOsVersion(ctx, "swVersion")
 
-	gio := &Info{Kernel: sysName, OSVersion: swVersion, Platform: "unknown", OS: sysName, GoOS: runtime.GOOS, CPUs: runtime.NumCPU(), KernelVersion: swVersion}
+	addrs, err := networkAddresses()
+	if err != nil {
+		log.Warnf("failed to discover network addresses: %s", err)
+	}
+
+	gio := &Info{
+		Kernel:           sysName,
+		OSVersion:        swVersion,
+		Platform:         "unknown",
+		OS:               sysName,
+		GoOS:             runtime.GOOS,
+		CPUs:             runtime.NumCPU(),
+		KernelVersion:    swVersion,
+		NetworkAddresses: addrs,
+	}
 	gio.Hostname = extractDeviceName(ctx, "hostname")
 	gio.NetbirdVersion = version.NetbirdVersion()
 	gio.UIVersion = extractUserAgent(ctx)


### PR DESCRIPTION
## Summary

The iOS `GetInfo()` function never populated `NetworkAddresses`, causing the `peer_network_range_check` posture check to fail for all iOS clients. The management server received empty `NetworkAddresses` and either blocked the peer entirely or could not evaluate network-based policies.

This adds the same `networkAddresses()` call that macOS, Linux, Windows, and FreeBSD already use. The function is available in the shared `info.go` and works on iOS via `net.Interfaces()`.

## Changes

- `client/system/info_ios.go`: Call `networkAddresses()` and populate `NetworkAddresses` field in the `Info` struct, matching the pattern used by all other platforms

## Related Issues

Fixes #3968 — Posture checks peer network range failed on iPhone
Fixes #4657 — iOS Client loses all routes when Posture Checks are enabled

## Testing

This change cannot be tested without macOS + Xcode. However:
- The `networkAddresses()` function is already compiled into the iOS binary (shared `info.go`)
- The same function works correctly on macOS, Linux, Windows, FreeBSD, and Android
- `net.Interfaces()` is available on iOS and returns interface information within the Network Extension sandbox

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network address detection now available for iOS devices

* **Bug Fixes**
  * Corrected platform reference in code documentation
  * Enhanced error handling for network discovery processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->