### PR TITLE
[client] Fix incorrect SSH client config combining Host and Match directives

### DIFF
--- a/client/ssh/config/manager.go
+++ b/client/ssh/config/manager.go
@@ -187,24 +187,23 @@ func (m *Manager) buildPeerConfig(allHostPatterns []string) (string, error) {
 		return "", fmt.Errorf("get NetBird executable path: %w", err)
 	}
 
-	hostLine := strings.Join(deduplicatedPatterns, " ")
-	config := fmt.Sprintf("Host %s\n", hostLine)
-	config += fmt.Sprintf("    Match exec \"%s ssh detect %%h %%p\"\n", execPath)
-	config += "        PreferredAuthentications password,publickey,keyboard-interactive\n"
-	config += "        PasswordAuthentication yes\n"
-	config += "        PubkeyAuthentication yes\n"
-	config += "        BatchMode no\n"
-	config += fmt.Sprintf("        ProxyCommand %s ssh proxy %%h %%p\n", execPath)
-	config += "        StrictHostKeyChecking no\n"
+	hostList := strings.Join(deduplicatedPatterns, ",")
+	config := fmt.Sprintf("Match host \"%s\" exec \"%s ssh detect %%h %%p\"\n", hostList, execPath)
+	config += "    PreferredAuthentications password,publickey,keyboard-interactive\n"
+	config += "    PasswordAuthentication yes\n"
+	config += "    PubkeyAuthentication yes\n"
+	config += "    BatchMode no\n"
+	config += fmt.Sprintf("    ProxyCommand %s ssh proxy %%h %%p\n", execPath)
+	config += "    StrictHostKeyChecking no\n"
 
 	if runtime.GOOS == "windows" {
-		config += "        UserKnownHostsFile NUL\n"
+		config += "    UserKnownHostsFile NUL\n"
 	} else {
-		config += "        UserKnownHostsFile /dev/null\n"
+		config += "    UserKnownHostsFile /dev/null\n"
 	}
 
-	config += "        CheckHostIP no\n"
-	config += "        LogLevel ERROR\n\n"
+	config += "    CheckHostIP no\n"
+	config += "    LogLevel ERROR\n\n"
 
 	return config, nil
 }

--- a/client/ssh/config/manager_test.go
+++ b/client/ssh/config/manager_test.go
@@ -116,6 +116,37 @@ func TestManager_PeerLimit(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "SSH config should not be created with too many peers")
 }
 
+func TestManager_MatchHostFormat(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "netbird-ssh-config-test")
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, os.RemoveAll(tempDir)) }()
+
+	manager := &Manager{
+		sshConfigDir:  filepath.Join(tempDir, "ssh_config.d"),
+		sshConfigFile: "99-netbird.conf",
+	}
+
+	peers := []PeerSSHInfo{
+		{Hostname: "peer1", IP: "100.125.1.1", FQDN: "peer1.nb.internal"},
+		{Hostname: "peer2", IP: "100.125.1.2", FQDN: "peer2.nb.internal"},
+	}
+
+	err = manager.SetupSSHClientConfig(peers)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(manager.sshConfigDir, manager.sshConfigFile)
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	configStr := string(content)
+
+	// Must use "Match host" with comma-separated patterns, not a bare "Host" directive.
+	// A bare "Host" followed by "Match exec" is incorrect per ssh_config(5): the Host block
+	// ends at the next Match keyword, making it a no-op and leaving the Match exec unscoped.
+	assert.NotContains(t, configStr, "\nHost ", "should not use bare Host directive")
+	assert.Contains(t, configStr, "Match host \"100.125.1.1,peer1.nb.internal,peer1,100.125.1.2,peer2.nb.internal,peer2\"",
+		"should use Match host with comma-separated patterns")
+}
+
 func TestManager_ForcedSSHConfig(t *testing.T) {
 	// Set force environment variable
 	t.Setenv(EnvForceSSHConfig, "true")


### PR DESCRIPTION
## Describe your changes

The generated `99-netbird.conf` combined `Host` and `Match exec` incorrectly. Per `ssh_config(5)`, a `Host` block ends at the next `Host` or `Match` keyword, so the `Host` line was a no-op: the `Match exec` block was unscoped, causing `netbird ssh detect` to run for every SSH connection, not just known peers.

- Replace `Host <peers>` + `Match exec` with a single `Match host "<peers>" exec "..."` so SSH checks the host pattern first and only runs the detect command for known NetBird peers
- Add test validating the Match host format

## Issue ticket number and link

Closes #5901

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH configuration generation to use improved directive formatting for host pattern matching.

* **Tests**
  * Added test coverage to validate SSH configuration output format correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->