### PR TITLE
DNS-aware dial for HTTP reverse proxy — use NetBird nameservers for hostname resolution

### DIFF
--- a/client/embed/embed.go
+++ b/client/embed/embed.go
@@ -507,3 +507,14 @@ func (c *Client) getNet() (*wgnetstack.Net, netip.Addr, error) {
 
 	return nsnet, addr, nil
 }
+
+// GetDNSAddrPort returns the address of the NetBird DNS resolver for this client.
+// Returns the zero AddrPort and false if the client is not started or the DNS
+// server is not yet initialized.
+func (c *Client) GetDNSAddrPort() (netip.AddrPort, bool) {
+	engine, err := c.getEngine()
+	if err != nil {
+		return netip.AddrPort{}, false
+	}
+	return engine.GetDNSAddrPort()
+}

--- a/client/internal/dns/mock_server.go
+++ b/client/internal/dns/mock_server.go
@@ -53,6 +53,10 @@ func (m *MockServer) DnsIP() netip.Addr {
 	return netip.MustParseAddr("100.10.254.255")
 }
 
+func (m *MockServer) DnsAddrPort() netip.AddrPort {
+	return netip.AddrPortFrom(netip.MustParseAddr("100.10.254.255"), 53)
+}
+
 func (m *MockServer) OnUpdatedHostDNSServer(addrs []netip.AddrPort) {
 	// TODO implement me
 	panic("implement me")

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -51,6 +51,8 @@ type Server interface {
 	Initialize() error
 	Stop()
 	DnsIP() netip.Addr
+	// DnsAddrPort returns the full address (IP + port) of the DNS resolver.
+	DnsAddrPort() netip.AddrPort
 	UpdateDNSServer(serial uint64, update nbdns.Config) error
 	OnUpdatedHostDNSServer(addrs []netip.AddrPort)
 	SearchDomains() []string
@@ -378,6 +380,11 @@ func (s *DefaultServer) Initialize() (err error) {
 // For bind interface, fake DNS resolver address returned (second last IP address from Nebird network)
 func (s *DefaultServer) DnsIP() netip.Addr {
 	return s.service.RuntimeIP()
+}
+
+// DnsAddrPort returns the full address (IP + port) of the DNS resolver.
+func (s *DefaultServer) DnsAddrPort() netip.AddrPort {
+	return netip.AddrPortFrom(s.service.RuntimeIP(), uint16(s.service.RuntimePort()))
 }
 
 // SetFirewall sets the firewall used for DNS port DNAT rules.

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -2070,6 +2070,22 @@ func (e *Engine) GetWgAddr() netip.Addr {
 	return e.wgInterface.Address().IP
 }
 
+// GetDNSAddrPort returns the DNS server address (IP + port) used by this engine.
+// Returns the zero AddrPort and false if the DNS server is not yet initialized.
+func (e *Engine) GetDNSAddrPort() (netip.AddrPort, bool) {
+	e.syncMsgMux.Lock()
+	dnsServer := e.dnsServer
+	e.syncMsgMux.Unlock()
+	if dnsServer == nil {
+		return netip.AddrPort{}, false
+	}
+	addr := dnsServer.DnsAddrPort()
+	if !addr.IsValid() {
+		return netip.AddrPort{}, false
+	}
+	return addr, true
+}
+
 func (e *Engine) RenewTun(fd int) error {
 	e.syncMsgMux.Lock()
 	wgInterface := e.wgInterface

--- a/proxy/internal/roundtrip/dns.go
+++ b/proxy/internal/roundtrip/dns.go
@@ -1,0 +1,91 @@
+package roundtrip
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+)
+
+// dialWithDNSResolution wraps a DialContext function so that target addresses
+// containing hostnames (rather than IPs) are resolved through NetBird's own
+// DNS infrastructure before the connection is dialed.
+//
+// getDNSAddr is called on every dial that requires hostname resolution; it
+// should return the current NetBird DNS server address (IP + port) and true.
+// When the DNS server is not yet available it should return false, in which
+// case resolution falls back to the process-level default resolver.
+//
+// The resolver dials the DNS server using the same underlying dial function
+// (i.e. through the WireGuard netstack), because in userspace / netstack mode
+// the DNS server is reachable only via the virtual WireGuard interface.
+func dialWithDNSResolution(
+	getDNSAddr func() (netip.AddrPort, bool),
+	dial func(ctx context.Context, network, addr string) (net.Conn, error),
+) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			// Malformed address — let the underlying dialer handle or fail it.
+			return dial(ctx, network, addr)
+		}
+
+		// If the host is already an IP literal, skip resolution entirely.
+		if _, err := netip.ParseAddr(host); err == nil {
+			return dial(ctx, network, addr)
+		}
+
+		resolved, err := resolveHost(ctx, host, getDNSAddr, dial)
+		if err != nil {
+			return nil, err
+		}
+
+		return dial(ctx, network, net.JoinHostPort(resolved, port))
+	}
+}
+
+// resolveHost resolves a hostname to its first IPv4/IPv6 address using a
+// custom net.Resolver backed by the NetBird DNS server (when available) or
+// the process-level default resolver as a fallback.
+func resolveHost(
+	ctx context.Context,
+	host string,
+	getDNSAddr func() (netip.AddrPort, bool),
+	dial func(ctx context.Context, network, addr string) (net.Conn, error),
+) (string, error) {
+	resolver := buildResolver(getDNSAddr, dial)
+
+	addrs, err := resolver.LookupHost(ctx, host)
+	if err != nil {
+		return "", fmt.Errorf("dns: resolve %q: %w", host, err)
+	}
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("dns: no addresses returned for %q", host)
+	}
+	return addrs[0], nil
+}
+
+// buildResolver returns a *net.Resolver configured to query the NetBird DNS
+// server via the provided dial function.  If the DNS server address is not
+// yet available, the default system resolver is returned so that the caller
+// can still attempt resolution (useful during client startup).
+func buildResolver(
+	getDNSAddr func() (netip.AddrPort, bool),
+	dial func(ctx context.Context, network, addr string) (net.Conn, error),
+) *net.Resolver {
+	dnsAddr, ok := getDNSAddr()
+	if !ok {
+		return net.DefaultResolver
+	}
+
+	addrStr := dnsAddr.String()
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			// Always use UDP toward the DNS server.  The network and address
+			// arguments passed by net.Resolver are intentionally ignored;
+			// we route through the WireGuard netstack instead.
+			return dial(ctx, "udp", addrStr)
+		},
+	}
+}

--- a/proxy/internal/roundtrip/netbird.go
+++ b/proxy/internal/roundtrip/netbird.go
@@ -276,7 +276,7 @@ func (n *NetBird) createClientEntry(ctx context.Context, accountID types.Account
 	// the client's HTTPClient to avoid issues with request validation that do
 	// not work with reverse proxied requests.
 	transport := &http.Transport{
-		DialContext:           dialWithTimeout(client.DialContext),
+		DialContext:           dialWithDNSResolution(client.GetDNSAddrPort, dialWithTimeout(client.DialContext)),
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          n.transportCfg.maxIdleConns,
 		MaxIdleConnsPerHost:   n.transportCfg.maxIdleConnsPerHost,


### PR DESCRIPTION
### Problem

The HTTP reverse proxy transport (`dialWithDNSResolution` in dns.go) was a stub.  As a result, target URLs that contained **hostnames** (e.g. `https://myapp.netbird.cloud/`) could not be dialled — only literal IP addresses worked.  Users wanting to forward traffic to a domain couldn't do so through a resource group or peer proxy target.

### Solution

Route hostname resolution through NetBird's **own DNS infrastructure** (custom zones, nameserver groups configured in the management UI) instead of the host-OS resolver or a hardcoded list of DNS servers.

The embedded NetBird client already runs an internal DNS server (bound to the last IP of the WireGuard network on port 53 in netstack/userspace mode).  This server already knows about all NetBird-managed zones and upstream nameserver groups.  We now query it directly during each dial that involves a hostname.

current state:
<img width="680" height="608" alt="image" src="https://github.com/user-attachments/assets/9f592903-5578-45fa-ba9d-2945d5f8c319" />

expected result:
<img width="680" height="608" alt="image" src="https://github.com/user-attachments/assets/95deed94-37fa-4017-af6c-4d2539d2aa4a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DNS server address and port retrieval capabilities to the client.
  * Enhanced network operations with automatic hostname resolution that uses the NetBird DNS server when available and falls back to the system default resolver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->