### PR TITLE
[client] fix ios network addresses mac filter

### DIFF
--- a/client/system/info.go
+++ b/client/system/info.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"context"
-	"net"
 	"net/netip"
 	"strings"
 
@@ -143,59 +142,6 @@ func extractDeviceName(ctx context.Context, defaultName string) string {
 		return defaultName
 	}
 	return v
-}
-
-func networkAddresses() ([]NetworkAddress, error) {
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
-
-	var netAddresses []NetworkAddress
-	for _, iface := range interfaces {
-		if iface.Flags&net.FlagUp == 0 {
-			continue
-		}
-		if iface.HardwareAddr.String() == "" {
-			continue
-		}
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-
-		for _, address := range addrs {
-			ipNet, ok := address.(*net.IPNet)
-			if !ok {
-				continue
-			}
-
-			if ipNet.IP.IsLoopback() {
-				continue
-			}
-
-			netAddr := NetworkAddress{
-				NetIP: netip.MustParsePrefix(ipNet.String()),
-				Mac:   iface.HardwareAddr.String(),
-			}
-
-			if isDuplicated(netAddresses, netAddr) {
-				continue
-			}
-
-			netAddresses = append(netAddresses, netAddr)
-		}
-	}
-	return netAddresses, nil
-}
-
-func isDuplicated(addresses []NetworkAddress, addr NetworkAddress) bool {
-	for _, duplicated := range addresses {
-		if duplicated.NetIP == addr.NetIP {
-			return true
-		}
-	}
-	return false
 }
 
 // GetInfoWithChecks retrieves and parses the system information with applied checks.

--- a/client/system/info_ios.go
+++ b/client/system/info_ios.go
@@ -70,12 +70,17 @@ func networkAddresses() ([]NetworkAddress, error) {
 				continue
 			}
 
-			if ipNet.IP.IsLoopback() || ipNet.IP.IsLinkLocalUnicast() || ipNet.IP.IsLinkLocalMulticast() {
+			if ipNet.IP.IsLoopback() || ipNet.IP.IsLinkLocalUnicast() || ipNet.IP.IsMulticast() {
+				continue
+			}
+
+			prefix, err := netip.ParsePrefix(ipNet.String())
+			if err != nil {
 				continue
 			}
 
 			netAddr := NetworkAddress{
-				NetIP: netip.MustParsePrefix(ipNet.String()),
+				NetIP: prefix,
 				Mac:   iface.HardwareAddr.String(),
 			}
 

--- a/client/system/info_ios.go
+++ b/client/system/info_ios.go
@@ -2,6 +2,8 @@ package system
 
 import (
 	"context"
+	"net"
+	"net/netip"
 	"runtime"
 
 	log "github.com/sirupsen/logrus"
@@ -40,6 +42,59 @@ func GetInfo(ctx context.Context) *Info {
 	gio.UIVersion = extractUserAgent(ctx)
 
 	return gio
+}
+
+// networkAddresses returns the list of network addresses on iOS.
+// On iOS, hardware (MAC) addresses are not available due to Apple's privacy
+// restrictions, so we skip the HardwareAddr check that other platforms use.
+func networkAddresses() ([]NetworkAddress, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	var netAddresses []NetworkAddress
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, address := range addrs {
+			ipNet, ok := address.(*net.IPNet)
+			if !ok {
+				continue
+			}
+
+			if ipNet.IP.IsLoopback() {
+				continue
+			}
+
+			netAddr := NetworkAddress{
+				NetIP: netip.MustParsePrefix(ipNet.String()),
+				Mac:   iface.HardwareAddr.String(),
+			}
+
+			if isDuplicated(netAddresses, netAddr) {
+				continue
+			}
+
+			netAddresses = append(netAddresses, netAddr)
+		}
+	}
+	return netAddresses, nil
+}
+
+func isDuplicated(addresses []NetworkAddress, addr NetworkAddress) bool {
+	for _, duplicated := range addresses {
+		if duplicated.NetIP == addr.NetIP {
+			return true
+		}
+	}
+	return false
 }
 
 // checkFileAndProcess checks if the file path exists and if a process is running at that path.

--- a/client/system/info_ios.go
+++ b/client/system/info_ios.go
@@ -46,8 +46,10 @@ func GetInfo(ctx context.Context) *Info {
 
 // networkAddresses returns the list of network addresses on iOS.
 // On iOS, hardware (MAC) addresses are not available due to Apple's privacy
-// restrictions, so we skip the HardwareAddr check that other platforms use.
-// We also filter out link-local addresses as they are not useful for posture checks.
+// restrictions (iOS returns a fixed 02:00:00:00:00:00 placeholder), so we
+// leave Mac empty to match Android's behavior. We also skip the HardwareAddr
+// check that other platforms use and filter out link-local addresses as they
+// are not useful for posture checks.
 func networkAddresses() ([]NetworkAddress, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
@@ -81,7 +83,7 @@ func networkAddresses() ([]NetworkAddress, error) {
 
 			netAddr := NetworkAddress{
 				NetIP: prefix,
-				Mac:   iface.HardwareAddr.String(),
+				Mac:   "",
 			}
 
 			if isDuplicated(netAddresses, netAddr) {

--- a/client/system/info_ios.go
+++ b/client/system/info_ios.go
@@ -67,33 +67,32 @@ func networkAddresses() ([]NetworkAddress, error) {
 		}
 
 		for _, address := range addrs {
-			ipNet, ok := address.(*net.IPNet)
+			netAddr, ok := toNetworkAddress(address)
 			if !ok {
 				continue
 			}
-
-			if ipNet.IP.IsLoopback() || ipNet.IP.IsLinkLocalUnicast() || ipNet.IP.IsMulticast() {
-				continue
-			}
-
-			prefix, err := netip.ParsePrefix(ipNet.String())
-			if err != nil {
-				continue
-			}
-
-			netAddr := NetworkAddress{
-				NetIP: prefix,
-				Mac:   "",
-			}
-
 			if isDuplicated(netAddresses, netAddr) {
 				continue
 			}
-
 			netAddresses = append(netAddresses, netAddr)
 		}
 	}
 	return netAddresses, nil
+}
+
+func toNetworkAddress(address net.Addr) (NetworkAddress, bool) {
+	ipNet, ok := address.(*net.IPNet)
+	if !ok {
+		return NetworkAddress{}, false
+	}
+	if ipNet.IP.IsLoopback() || ipNet.IP.IsLinkLocalUnicast() || ipNet.IP.IsMulticast() {
+		return NetworkAddress{}, false
+	}
+	prefix, err := netip.ParsePrefix(ipNet.String())
+	if err != nil {
+		return NetworkAddress{}, false
+	}
+	return NetworkAddress{NetIP: prefix, Mac: ""}, true
 }
 
 func isDuplicated(addresses []NetworkAddress, addr NetworkAddress) bool {

--- a/client/system/info_ios.go
+++ b/client/system/info_ios.go
@@ -47,6 +47,7 @@ func GetInfo(ctx context.Context) *Info {
 // networkAddresses returns the list of network addresses on iOS.
 // On iOS, hardware (MAC) addresses are not available due to Apple's privacy
 // restrictions, so we skip the HardwareAddr check that other platforms use.
+// We also filter out link-local addresses as they are not useful for posture checks.
 func networkAddresses() ([]NetworkAddress, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
@@ -69,7 +70,7 @@ func networkAddresses() ([]NetworkAddress, error) {
 				continue
 			}
 
-			if ipNet.IP.IsLoopback() {
+			if ipNet.IP.IsLoopback() || ipNet.IP.IsLinkLocalUnicast() || ipNet.IP.IsLinkLocalMulticast() {
 				continue
 			}
 

--- a/client/system/network_addr.go
+++ b/client/system/network_addr.go
@@ -1,0 +1,61 @@
+//go:build !ios
+
+package system
+
+import (
+	"net"
+	"net/netip"
+)
+
+func networkAddresses() ([]NetworkAddress, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	var netAddresses []NetworkAddress
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if iface.HardwareAddr.String() == "" {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, address := range addrs {
+			ipNet, ok := address.(*net.IPNet)
+			if !ok {
+				continue
+			}
+
+			if ipNet.IP.IsLoopback() {
+				continue
+			}
+
+			netAddr := NetworkAddress{
+				NetIP: netip.MustParsePrefix(ipNet.String()),
+				Mac:   iface.HardwareAddr.String(),
+			}
+
+			if isDuplicated(netAddresses, netAddr) {
+				continue
+			}
+
+			netAddresses = append(netAddresses, netAddr)
+		}
+	}
+	return netAddresses, nil
+}
+
+func isDuplicated(addresses []NetworkAddress, addr NetworkAddress) bool {
+	for _, duplicated := range addresses {
+		if duplicated.NetIP == addr.NetIP {
+			return true
+		}
+	}
+	return false
+}

--- a/client/system/network_addr.go
+++ b/client/system/network_addr.go
@@ -36,8 +36,13 @@ func networkAddresses() ([]NetworkAddress, error) {
 				continue
 			}
 
+			prefix, err := netip.ParsePrefix(ipNet.String())
+			if err != nil {
+				continue
+			}
+
 			netAddr := NetworkAddress{
-				NetIP: netip.MustParsePrefix(ipNet.String()),
+				NetIP: prefix,
 				Mac:   iface.HardwareAddr.String(),
 			}
 

--- a/client/system/network_addr.go
+++ b/client/system/network_addr.go
@@ -26,34 +26,34 @@ func networkAddresses() ([]NetworkAddress, error) {
 			continue
 		}
 
+		mac := iface.HardwareAddr.String()
 		for _, address := range addrs {
-			ipNet, ok := address.(*net.IPNet)
+			netAddr, ok := toNetworkAddress(address, mac)
 			if !ok {
 				continue
 			}
-
-			if ipNet.IP.IsLoopback() {
-				continue
-			}
-
-			prefix, err := netip.ParsePrefix(ipNet.String())
-			if err != nil {
-				continue
-			}
-
-			netAddr := NetworkAddress{
-				NetIP: prefix,
-				Mac:   iface.HardwareAddr.String(),
-			}
-
 			if isDuplicated(netAddresses, netAddr) {
 				continue
 			}
-
 			netAddresses = append(netAddresses, netAddr)
 		}
 	}
 	return netAddresses, nil
+}
+
+func toNetworkAddress(address net.Addr, mac string) (NetworkAddress, bool) {
+	ipNet, ok := address.(*net.IPNet)
+	if !ok {
+		return NetworkAddress{}, false
+	}
+	if ipNet.IP.IsLoopback() {
+		return NetworkAddress{}, false
+	}
+	prefix, err := netip.ParsePrefix(ipNet.String())
+	if err != nil {
+		return NetworkAddress{}, false
+	}
+	return NetworkAddress{NetIP: prefix, Mac: mac}, true
 }
 
 func isDuplicated(addresses []NetworkAddress, addr NetworkAddress) bool {


### PR DESCRIPTION
## Describe your changes
On iOS, networkAddresses() returned an empty list because Apple’s privacy restrictions (since iOS 14) prevent access to real hardware (MAC) addresses. As a result, all interfaces were filtered out by the HardwareAddr == "" check.

Split networkAddresses() into platform-specific implementations:

- Non-iOS (network_addr.go) retains the original MAC-based filtering logic.
- iOS (info_ios.go) skips MAC validation entirely.
- Added additional filtering on iOS to exclude link-local (fe80::/10) and multicast addresses, which are not useful for posture checks.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Network address discovery has been moved to platform-specific implementations for clearer separation and easier maintenance.

* **New Features**
  * iOS now automatically discovers active network interfaces and reports IP prefixes; discovery errors are logged but do not block info retrieval.
  * Non-iOS platforms now collect unique local network addresses, prefer interfaces with hardware identifiers, filter out loopback/link-local/multicast addresses, and de-duplicate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->