### PR TITLE
[management] use peer fqdn on https

### DIFF
--- a/management/internals/modules/reverseproxy/service/manager/manager.go
+++ b/management/internals/modules/reverseproxy/service/manager/manager.go
@@ -163,7 +163,9 @@ func (m *Manager) replaceHostByLookup(ctx context.Context, accountID string, s *
 			if target.Protocol == "https" {
 				settings, err := m.accountManager.GetAccountSettings(ctx, accountID, activity.SystemInitiator)
 				if err != nil {
-					return fmt.Errorf("failed to get account settings for DNS domain lookup: %w", err)
+					log.WithContext(ctx).Warnf("failed to get account settings for service %s: %v", s.ID, err)
+					target.Host = unknownHostPlaceholder
+					continue
 				}
 				dnsDomain := m.networkMapController.GetDNSDomain(settings)
 				target.Host = peer.FQDN(dnsDomain)

--- a/management/internals/modules/reverseproxy/service/manager/manager.go
+++ b/management/internals/modules/reverseproxy/service/manager/manager.go
@@ -154,24 +154,7 @@ func (m *Manager) replaceHostByLookup(ctx context.Context, accountID string, s *
 	for _, target := range s.Targets {
 		switch target.TargetType {
 		case service.TargetTypePeer:
-			peer, err := m.store.GetPeerByID(ctx, store.LockingStrengthNone, accountID, target.TargetId)
-			if err != nil {
-				log.WithContext(ctx).Warnf("failed to get peer by id %s for service %s: %v", target.TargetId, s.ID, err)
-				target.Host = unknownHostPlaceholder
-				continue
-			}
-			if target.Protocol == "https" {
-				settings, err := m.accountManager.GetAccountSettings(ctx, accountID, activity.SystemInitiator)
-				if err != nil {
-					log.WithContext(ctx).Warnf("failed to get account settings for service %s: %v", s.ID, err)
-					target.Host = unknownHostPlaceholder
-					continue
-				}
-				dnsDomain := m.networkMapController.GetDNSDomain(settings)
-				target.Host = peer.FQDN(dnsDomain)
-			} else {
-				target.Host = peer.IP.String()
-			}
+			target.Host = m.getPeerTargetHost(ctx, accountID, target)
 		case service.TargetTypeHost:
 			resource, err := m.store.GetNetworkResourceByID(ctx, store.LockingStrengthNone, accountID, target.TargetId)
 			if err != nil {
@@ -196,6 +179,26 @@ func (m *Manager) replaceHostByLookup(ctx context.Context, accountID string, s *
 	}
 
 	return nil
+}
+
+func (m *Manager) getPeerTargetHost(ctx context.Context, accountID string, target *service.Target) string {
+	peer, err := m.store.GetPeerByID(ctx, store.LockingStrengthNone, accountID, target.TargetId)
+	if err != nil {
+		log.WithContext(ctx).Warnf("failed to get peer by id %s for service %s: %v", target.TargetId, target.ServiceID, err)
+		return unknownHostPlaceholder
+	}
+
+	if target.Protocol == "https" {
+		settings, err := m.accountManager.GetAccountSettings(ctx, accountID, activity.SystemInitiator)
+		if err != nil {
+			log.WithContext(ctx).Warnf("failed to get account settings for service %s: %v", target.ServiceID, err)
+			return unknownHostPlaceholder
+		}
+		dnsDomain := m.networkMapController.GetDNSDomain(settings)
+		return peer.FQDN(dnsDomain)
+	}
+
+	return peer.IP.String()
 }
 
 func (m *Manager) GetService(ctx context.Context, accountID, userID, serviceID string) (*service.Service, error) {

--- a/management/internals/modules/reverseproxy/service/manager/manager.go
+++ b/management/internals/modules/reverseproxy/service/manager/manager.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/netbirdio/netbird/management/internals/controllers/network_map"
 	nbpeer "github.com/netbirdio/netbird/management/server/peer"
 
 	resourcetypes "github.com/netbirdio/netbird/management/server/networks/resources/types"
@@ -82,24 +83,26 @@ type CapabilityProvider interface {
 }
 
 type Manager struct {
-	store              store.Store
-	accountManager     account.Manager
-	permissionsManager permissions.Manager
-	proxyController    proxy.Controller
-	capabilities       CapabilityProvider
-	clusterDeriver     ClusterDeriver
-	exposeReaper       *exposeReaper
+	store                store.Store
+	accountManager       account.Manager
+	permissionsManager   permissions.Manager
+	proxyController      proxy.Controller
+	networkMapController network_map.Controller
+	capabilities         CapabilityProvider
+	clusterDeriver       ClusterDeriver
+	exposeReaper         *exposeReaper
 }
 
 // NewManager creates a new service manager.
-func NewManager(store store.Store, accountManager account.Manager, permissionsManager permissions.Manager, proxyController proxy.Controller, capabilities CapabilityProvider, clusterDeriver ClusterDeriver) *Manager {
+func NewManager(store store.Store, accountManager account.Manager, permissionsManager permissions.Manager, proxyController proxy.Controller, capabilities CapabilityProvider, clusterDeriver ClusterDeriver, networkMapController network_map.Controller) *Manager {
 	mgr := &Manager{
-		store:              store,
-		accountManager:     accountManager,
-		permissionsManager: permissionsManager,
-		proxyController:    proxyController,
-		capabilities:       capabilities,
-		clusterDeriver:     clusterDeriver,
+		store:                store,
+		accountManager:       accountManager,
+		permissionsManager:   permissionsManager,
+		proxyController:      proxyController,
+		networkMapController: networkMapController,
+		capabilities:         capabilities,
+		clusterDeriver:       clusterDeriver,
 	}
 	mgr.exposeReaper = &exposeReaper{manager: mgr}
 	return mgr
@@ -157,7 +160,16 @@ func (m *Manager) replaceHostByLookup(ctx context.Context, accountID string, s *
 				target.Host = unknownHostPlaceholder
 				continue
 			}
-			target.Host = peer.IP.String()
+			if target.Protocol == "https" {
+				settings, err := m.accountManager.GetAccountSettings(ctx, accountID, activity.SystemInitiator)
+				if err != nil {
+					return fmt.Errorf("failed to get account settings for DNS domain lookup: %w", err)
+				}
+				dnsDomain := m.networkMapController.GetDNSDomain(settings)
+				target.Host = peer.FQDN(dnsDomain)
+			} else {
+				target.Host = peer.IP.String()
+			}
 		case service.TargetTypeHost:
 			resource, err := m.store.GetNetworkResourceByID(ctx, store.LockingStrengthNone, accountID, target.TargetId)
 			if err != nil {

--- a/management/internals/server/modules.go
+++ b/management/internals/server/modules.go
@@ -197,7 +197,7 @@ func (s *BaseServer) RecordsManager() records.Manager {
 
 func (s *BaseServer) ServiceManager() service.Manager {
 	return Create(s, func() service.Manager {
-		return nbreverseproxy.NewManager(s.Store(), s.AccountManager(), s.PermissionsManager(), s.ServiceProxyController(), s.ProxyManager(), s.ReverseProxyDomainManager())
+		return nbreverseproxy.NewManager(s.Store(), s.AccountManager(), s.PermissionsManager(), s.ServiceProxyController(), s.ProxyManager(), s.ReverseProxyDomainManager(), s.NetworkMapController())
 	})
 }
 

--- a/management/server/http/testing/testing_tools/channel/channel.go
+++ b/management/server/http/testing/testing_tools/channel/channel.go
@@ -115,7 +115,7 @@ func BuildApiBlackBoxWithDBState(t testing_tools.TB, sqlFile string, expectedPee
 	if err != nil {
 		t.Fatalf("Failed to create proxy controller: %v", err)
 	}
-	serviceManager := reverseproxymanager.NewManager(store, am, permissionsManager, serviceProxyController, proxyMgr, domainManager)
+	serviceManager := reverseproxymanager.NewManager(store, am, permissionsManager, serviceProxyController, proxyMgr, domainManager, networkMapController)
 	proxyServiceServer.SetServiceManager(serviceManager)
 	am.SetServiceManager(serviceManager)
 
@@ -244,7 +244,7 @@ func BuildApiBlackBoxWithDBStateAndPeerChannel(t testing_tools.TB, sqlFile strin
 	if err != nil {
 		t.Fatalf("Failed to create proxy controller: %v", err)
 	}
-	serviceManager := reverseproxymanager.NewManager(store, am, permissionsManager, serviceProxyController, proxyMgr, domainManager)
+	serviceManager := reverseproxymanager.NewManager(store, am, permissionsManager, serviceProxyController, proxyMgr, domainManager, networkMapController)
 	proxyServiceServer.SetServiceManager(serviceManager)
 	am.SetServiceManager(serviceManager)
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTPS peer connections now resolve to DNS-based FQDNs derived from network configuration; non-HTTPS peers continue to use IP addresses.

* **Bug Fixes**
  * Improved handling when account settings or peer info cannot be retrieved for secure connections: an unknown-host placeholder is used instead of proceeding with an incorrect host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->