### PR TITLE
[proxy] set session cookie path to root

### DIFF
--- a/proxy/internal/auth/middleware.go
+++ b/proxy/internal/auth/middleware.go
@@ -433,6 +433,7 @@ func setSessionCookie(w http.ResponseWriter, token string, expiration time.Durat
 	http.SetCookie(w, &http.Cookie{
 		Name:     auth.SessionCookieName,
 		Value:    token,
+		Path:     "/",
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,

--- a/proxy/internal/auth/middleware_test.go
+++ b/proxy/internal/auth/middleware_test.go
@@ -391,6 +391,15 @@ func TestProtect_SchemeAuthRedirectsWithCookie(t *testing.T) {
 	assert.Equal(t, http.SameSiteLaxMode, sessionCookie.SameSite)
 }
 
+func TestSetSessionCookieHasRootPath(t *testing.T) {
+	w := httptest.NewRecorder()
+	setSessionCookie(w, "test-token", time.Hour)
+
+	cookies := w.Result().Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, "/", cookies[0].Path, "session cookie must be scoped to root so it applies to all paths")
+}
+
 func TestProtect_FailedAuthDoesNotSetCookie(t *testing.T) {
 	mw := NewMiddleware(log.StandardLogger(), nil, nil)
 	kp := generateTestKeyPair(t)


### PR DESCRIPTION
## Describe your changes
Explicitly set `Path: "/"` on the session cookie written by the reverse proxy's auth middleware.

Without an explicit `Path`, browsers default to the path of the request URI that set the cookie ([MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#pathpath-value)). This means a user authenticating at `example.com/app/page` gets a cookie scoped to `/app`, and subsequent requests to sibling paths like `/api` or `/_app/*` are treated as unauthenticated — breaking SPAs, share links, and any service that fetches resources from multiple top-level paths.

This was originally flagged by CodeRabbit during review of #5587 as an outside-diff comment, but wasn't picked up before merge.

## Issue ticket number and link
Closes #5626

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (one-line behavioral fix to existing helper; no user-facing API change)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session cookie scope to apply across all application paths, ensuring consistent session persistence for users navigating throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->