### PR TITLE
[client] Fix WGIface.Close deadlock when DNS filter hook re-enters GetDevice

### DIFF
--- a/client/iface/iface.go
+++ b/client/iface/iface.go
@@ -217,7 +217,6 @@ func (w *WGIface) RemoveAllowedIP(peerKey string, allowedIP netip.Prefix) error 
 // Close closes the tunnel interface
 func (w *WGIface) Close() error {
 	w.mu.Lock()
-	defer w.mu.Unlock()
 
 	var result *multierror.Error
 
@@ -225,7 +224,15 @@ func (w *WGIface) Close() error {
 		result = multierror.Append(result, fmt.Errorf("failed to free WireGuard proxy: %w", err))
 	}
 
-	if err := w.tun.Close(); err != nil {
+	// Release w.mu before calling w.tun.Close(): the underlying
+	// wireguard-go device.Close() waits for its send/receive goroutines
+	// to drain. Some of those goroutines re-enter WGIface methods that
+	// take w.mu (e.g. the packet filter DNS hook calls GetDevice()), so
+	// holding the mutex here would deadlock the shutdown path.
+	tun := w.tun
+	w.mu.Unlock()
+
+	if err := tun.Close(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("failed to close wireguard interface %s: %w", w.Name(), err))
 	}
 

--- a/client/iface/iface_close_test.go
+++ b/client/iface/iface_close_test.go
@@ -1,0 +1,113 @@
+//go:build !android
+
+package iface
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	wgdevice "golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+
+	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/udpmux"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
+	"github.com/netbirdio/netbird/client/iface/wgproxy"
+)
+
+// fakeTunDevice implements WGTunDevice and lets the test control when
+// Close() returns. It mimics the wireguard-go shutdown path, which blocks
+// until its goroutines drain. Some of those goroutines (e.g. the packet
+// filter DNS hook in client/internal/dns) call back into WGIface, so if
+// WGIface.Close() held w.mu across tun.Close() the shutdown would
+// deadlock.
+type fakeTunDevice struct {
+	closeStarted chan struct{}
+	unblockClose chan struct{}
+}
+
+func (f *fakeTunDevice) Create() (device.WGConfigurer, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeTunDevice) Up() (*udpmux.UniversalUDPMuxDefault, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeTunDevice) UpdateAddr(wgaddr.Address) error      { return nil }
+func (f *fakeTunDevice) WgAddress() wgaddr.Address            { return wgaddr.Address{} }
+func (f *fakeTunDevice) MTU() uint16                          { return DefaultMTU }
+func (f *fakeTunDevice) DeviceName() string                   { return "nb-close-test" }
+func (f *fakeTunDevice) FilteredDevice() *device.FilteredDevice { return nil }
+func (f *fakeTunDevice) Device() *wgdevice.Device             { return nil }
+func (f *fakeTunDevice) GetNet() *netstack.Net                { return nil }
+func (f *fakeTunDevice) GetICEBind() device.EndpointManager   { return nil }
+
+func (f *fakeTunDevice) Close() error {
+	close(f.closeStarted)
+	<-f.unblockClose
+	return nil
+}
+
+type fakeProxyFactory struct{}
+
+func (fakeProxyFactory) GetProxy() wgproxy.Proxy { return nil }
+func (fakeProxyFactory) GetProxyPort() uint16    { return 0 }
+func (fakeProxyFactory) Free() error             { return nil }
+
+// TestWGIface_CloseReleasesMutexBeforeTunClose guards against a deadlock
+// that surfaces as a macOS test-timeout in
+// TestDNSPermanent_updateUpstream: WGIface.Close() used to hold w.mu
+// while waiting for the wireguard-go device goroutines to finish, and
+// one of those goroutines (the DNS filter hook) calls back into
+// WGIface.GetDevice() which needs the same mutex. The fix is to drop
+// the lock before tun.Close() returns control.
+func TestWGIface_CloseReleasesMutexBeforeTunClose(t *testing.T) {
+	tun := &fakeTunDevice{
+		closeStarted: make(chan struct{}),
+		unblockClose: make(chan struct{}),
+	}
+	w := &WGIface{
+		tun:            tun,
+		wgProxyFactory: fakeProxyFactory{},
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- w.Close()
+	}()
+
+	select {
+	case <-tun.closeStarted:
+	case <-time.After(2 * time.Second):
+		close(tun.unblockClose)
+		t.Fatal("tun.Close() was never invoked")
+	}
+
+	// Simulate the WireGuard read goroutine calling back into WGIface
+	// via the packet filter's DNS hook. If Close() still held w.mu
+	// during tun.Close(), this would block until the test timeout.
+	getDeviceDone := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = w.GetDevice()
+		close(getDeviceDone)
+	}()
+
+	select {
+	case <-getDeviceDone:
+	case <-time.After(2 * time.Second):
+		close(tun.unblockClose)
+		wg.Wait()
+		t.Fatal("GetDevice() deadlocked while WGIface.Close was closing the tun")
+	}
+
+	close(tun.unblockClose)
+	select {
+	case <-closeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WGIface.Close() never returned after the tun was unblocked")
+	}
+}


### PR DESCRIPTION
## Describe your changes

`WGIface.Close()` takes `w.mu` and holds it across `w.tun.Close()`. The underlying wireguard-go device waits for its send/receive goroutines to drain before returning, and some of those goroutines re-enter `WGIface` during shutdown.

Specifically, the userspace packet filter DNS hook in `client/internal/dns.ServiceViaMemory.filterDNSTraffic` calls `s.wgInterface.GetDevice()` on every packet — which also needs `w.mu`. With `Close` holding the mutex, the read goroutine blocks in `GetDevice`, and `Close` waits forever for that goroutine to exit.

Fix: release `w.mu` before calling `w.tun.Close()`. The remaining steps in `Close` (`waitUntilRemoved`, `Destroy`) only call `w.Name()`, which reads `w.tun.DeviceName()` lock-free, so they don't need the mutex either.

Stack trace from a failing CI run:

```
goroutine 1352 [sync.WaitGroup.Wait, 4 minutes]:
  WGIface.Close  -> holds w.mu
  TunDevice.Close
  wireguard.Device.Close  -> WaitGroup.Wait (blocked)
  TestDNSPermanent_updateUpstream

goroutine 1367 [sync.Mutex.Lock, 4 minutes]:
  WGIface.GetDevice  -> blocked on w.mu
  ServiceViaMemory.filterDNSTraffic.func1
  udpHooksDrop
  filterOutbound
  FilteredDevice.Read
  wireguard.Device.RoutineReadFromTUN
```

This surfaces as a 5-minute timeout on the macOS **Client / Unit** CI job:

```
panic: test timed out after 5m0s
  running tests:
    TestDNSPermanent_updateUpstream (4m54s)
```

Seen e.g. in #5807 and earlier PRs that trigger the macOS runner — the failure is unrelated to those PRs' code paths.

## Issue ticket number and link

No tracking issue; discovered while triaging the flaky macOS CI job referenced above.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal concurrency fix in `client/iface`. The public WGIface API surface and its behavior are unchanged; callers see the same methods with the same contract. No user-visible configuration or workflow changes.

### Docs PR URL (required if "docs added" is checked)
N/A

## Test

New `client/iface/iface_close_test.go` reproduces the deadlock with a fake `WGTunDevice` whose `Close()` blocks on a channel — simulating the wireguard-go goroutine drain. A parallel `GetDevice()` call would block forever under the old code; with the fix it returns immediately.

- Without the fix: `FAIL: TestWGIface_CloseReleasesMutexBeforeTunClose — GetDevice() deadlocked while WGIface.Close was closing the tun`
- With the fix: 20× `go test -race -count=20` clean.

The test does not need `CAP_NET_ADMIN` / `/dev/net/tun`, so it runs on all CI environments including sandboxed containers.