### PR TITLE
Add NETBIRD_SKIP_MIGRATIONS env var to gate AutoMigrate (HA / multi-master)

### DIFF
--- a/management/internals/server/boot.go
+++ b/management/internals/server/boot.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/netip"
+	"os"
 	"slices"
 	"time"
 
@@ -74,7 +75,7 @@ func (s *BaseServer) CacheStore() cachestore.StoreInterface {
 
 func (s *BaseServer) Store() store.Store {
 	return Create(s, func() store.Store {
-		store, err := store.NewStore(context.Background(), s.Config.StoreConfig.Engine, s.Config.Datadir, s.Metrics(), false)
+		store, err := store.NewStore(context.Background(), s.Config.StoreConfig.Engine, s.Config.Datadir, s.Metrics(), os.Getenv("NETBIRD_SKIP_MIGRATIONS") == "true")
 		if err != nil {
 			log.Fatalf("failed to create store: %v", err)
 		}

--- a/management/server/activity/store/sql_store.go
+++ b/management/server/activity/store/sql_store.go
@@ -62,13 +62,24 @@ func NewSqlStore(ctx context.Context, dataDir string, encryptionKey string) (*St
 		return nil, fmt.Errorf("initialize database: %w", err)
 	}
 
-	if err = migrate(ctx, fieldEncrypt, db); err != nil {
-		return nil, fmt.Errorf("events database migration: %w", err)
-	}
+	// Only honor NETBIRD_SKIP_MIGRATIONS for the Postgres activity store, which
+	// is the one that participates in multi-master logical replication.
+	// A per-node SQLite activity store still needs its schema created on fresh
+	// nodes, so the skip must not apply there.
+	skipMigrations := os.Getenv("NETBIRD_SKIP_MIGRATIONS") == "true" &&
+		os.Getenv(storeEngineEnv) == string(types.PostgresStoreEngine)
 
-	err = db.AutoMigrate(&activity.Event{}, &activity.DeletedUser{})
-	if err != nil {
-		return nil, fmt.Errorf("events auto migrate: %w", err)
+	if !skipMigrations {
+		if err = migrate(ctx, fieldEncrypt, db); err != nil {
+			return nil, fmt.Errorf("events database migration: %w", err)
+		}
+
+		err = db.AutoMigrate(&activity.Event{}, &activity.DeletedUser{})
+		if err != nil {
+			return nil, fmt.Errorf("events auto migrate: %w", err)
+		}
+	} else {
+		log.WithContext(ctx).Info("NETBIRD_SKIP_MIGRATIONS=true and activity store engine is Postgres; skipping events database migration and AutoMigrate/schema updates")
 	}
 
 	return &Store{


### PR DESCRIPTION

### What

Adds support for an opt-in env var `NETBIRD_SKIP_MIGRATIONS=true` that suppresses `gorm.AutoMigrate()` calls at the two production call sites:

- `management/internals/server/boot.go` — main store (`netbird` DB)
- `management/server/activity/store/sql_store.go` — activity / events store (`netbird_events` DB)

Default behavior is unchanged: env var unset → AutoMigrate runs. Single-instance deployments are entirely unaffected.

The internal `skipMigration bool` plumbing already exists in `store.NewStore` and `store.NewSqlStore` — every production caller hardcodes `false`. This PR exposes the existing hook via env var and adds equivalent gating to the activity store, which had no `skipMigration` parameter at all.

### Why

Operators running multi-master Postgres logical replication (Spock, pgactive, BDR) need to control which node runs DDL during a coordinated upgrade. Logical replication replicates DML but **not** DDL — if every node runs `AutoMigrate` simultaneously on startup of a new version, races on DDL execution and partial-schema replication conflicts can break the cluster.

The standard pattern (documented by pgEdge: ["Managing DDL Migrations in a Multi-master Database"](https://www.pgedge.com/blog/managing-ddl-migrations-in-a-multi-master-database)) is to gate ORM auto-migrations behind an env var and run them from one node only during an upgrade window.

This is opt-in. Single-instance Netbird users do not encounter the env var and see no behavior change. Only operators who explicitly choose multi-master (a topology Netbird does not officially support — see #1584) will set it.

### Affected paths

- `management/internals/server/boot.go` (1 line + 1 import)
- `management/server/activity/store/sql_store.go` (5 lines, 1 log message — `os` already imported)

### Geolocation / GeoIP

`management/server/geolocation/database.go:importCsvToSqlite` also calls `AutoMigrate`, but uses **SQLite per-instance** for GeoIP CSV import — not shared across sites — so it does not need gating for multi-master.

### Tests

Existing tests pass `skipMigration: false` explicitly in calls to `NewStore` / `NewSqlStore`. The new env-var read in `boot.go` is at the production call site only (not test code), so test behavior is preserved. The activity-store gate is internal to `NewSqlStore`; tests that need to run against a fresh DB simply leave `NETBIRD_SKIP_MIGRATIONS` unset (default).

### Risk

- *Operator misuse on single-instance:* setting the env var on a single-node deployment skips schema upgrades; queries against new columns fail. Mitigation: the activity-store path logs an info message at startup when the flag is active; documentation should call out that this var is only for multi-master operators.
- *Forgotten flag:* operator sets it for an upgrade, forgets to unset. Mitigation: the recommended deployment pattern is a wrapper entrypoint that sets the env var per-startup based on a marker file (so persistent env-var state is not the norm). Out of scope for this PR.

These risks already exist in any multi-master Postgres deployment. This PR gives operators a tool to manage them; it does not create them.

### Out of scope

- Documenting multi-master HA. That conversation belongs in #1584.
- A higher-level "upgrade orchestration" feature inside the management server. The env var keeps orchestration responsibility with the operator's tooling (Ansible / k8s / etc.).

### Relates to

- #1584 — Netbird Management HA (community discussion)

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the NETBIRD_SKIP_MIGRATIONS environment variable: when set to "true", startup will skip database schema migrations (applies to activity store with Postgres engine).
  * Emits an informational log when migrations are intentionally skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->