### PR TITLE
[client] Prefer systemd-resolved stub over file mode regardless of resolv.conf header

### DIFF
--- a/client/internal/dns/file_parser_unix.go
+++ b/client/internal/dns/file_parser_unix.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	defaultResolvConfPath = "/etc/resolv.conf"
+	nsswitchConfPath      = "/etc/nsswitch.conf"
 )
 
 type resolvConf struct {

--- a/client/internal/dns/host_unix.go
+++ b/client/internal/dns/host_unix.go
@@ -46,12 +46,12 @@ type restoreHostManager interface {
 }
 
 func newHostManager(wgInterface string) (hostManager, error) {
-	osManager, err := getOSDNSManagerType()
+	osManager, reason, err := getOSDNSManagerType()
 	if err != nil {
 		return nil, fmt.Errorf("get os dns manager type: %w", err)
 	}
 
-	log.Infof("System DNS manager discovered: %s", osManager)
+	log.Infof("System DNS manager discovered: %s (%s)", osManager, reason)
 	mgr, err := newHostManagerFromType(wgInterface, osManager)
 	// need to explicitly return nil mgr on error to avoid returning a non-nil interface containing a nil value
 	if err != nil {
@@ -74,18 +74,22 @@ func newHostManagerFromType(wgInterface string, osManager osManagerType) (restor
 	}
 }
 
-func getOSDNSManagerType() (osManagerType, error) {
+func getOSDNSManagerType() (osManagerType, string, error) {
+	resolved := isSystemdResolvedRunning()
+	nss := isLibnssResolveUsed()
+	stub := checkStub()
+
 	// Prefer systemd-resolved whenever it owns libc resolution, regardless of
 	// who wrote /etc/resolv.conf. File-mode rewrites do not affect lookups
 	// that go through nss-resolve, and in foreign mode they can loop back
 	// through resolved as an upstream.
-	if isSystemdResolvedRunning() && (isLibnssResolveUsed() || checkStub()) {
-		return systemdManager, nil
+	if resolved && (nss || stub) {
+		return systemdManager, fmt.Sprintf("systemd-resolved active (nss-resolve=%t, stub=%t)", nss, stub), nil
 	}
 
 	file, err := os.Open(defaultResolvConfPath)
 	if err != nil {
-		return 0, fmt.Errorf("unable to open %s for checking owner, got error: %w", defaultResolvConfPath, err)
+		return 0, "", fmt.Errorf("unable to open %s for checking owner, got error: %w", defaultResolvConfPath, err)
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
@@ -100,27 +104,27 @@ func getOSDNSManagerType() (osManagerType, error) {
 			continue
 		}
 		if text[0] != '#' {
-			return fileManager, nil
+			return fileManager, "no recognized header in resolv.conf", nil
 		}
 		if strings.Contains(text, fileGeneratedResolvConfContentHeader) {
-			return netbirdManager, nil
+			return netbirdManager, "netbird-managed resolv.conf header detected", nil
 		}
 		if strings.Contains(text, "NetworkManager") && isDbusListenerRunning(networkManagerDest, networkManagerDbusObjectNode) && isNetworkManagerSupported() {
-			return networkManager, nil
+			return networkManager, "NetworkManager header + supported version on dbus", nil
 		}
 		if strings.Contains(text, "resolvconf") {
 			if isSystemdResolveConfMode() {
-				return systemdManager, nil
+				return systemdManager, "resolvconf header in systemd-resolved compatibility mode", nil
 			}
 
-			return resolvConfManager, nil
+			return resolvConfManager, "resolvconf header detected", nil
 		}
 	}
 	if err := scanner.Err(); err != nil && err != io.EOF {
-		return 0, fmt.Errorf("scan: %w", err)
+		return 0, "", fmt.Errorf("scan: %w", err)
 	}
 
-	return fileManager, nil
+	return fileManager, fmt.Sprintf("no manager matched (resolved=%t, nss-resolve=%t, stub=%t)", resolved, nss, stub), nil
 }
 
 // checkStub reports whether systemd-resolved's stub (127.0.0.53) is listed

--- a/client/internal/dns/host_unix.go
+++ b/client/internal/dns/host_unix.go
@@ -97,6 +97,7 @@ func getOSDNSManagerType() (osManagerType, string, error) {
 		}
 	}()
 
+	var rejected []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		text := scanner.Text()
@@ -104,13 +105,16 @@ func getOSDNSManagerType() (osManagerType, string, error) {
 			continue
 		}
 		if text[0] != '#' {
-			return fileManager, "no recognized header in resolv.conf", nil
+			break
 		}
 		if strings.Contains(text, fileGeneratedResolvConfContentHeader) {
 			return netbirdManager, "netbird-managed resolv.conf header detected", nil
 		}
-		if strings.Contains(text, "NetworkManager") && isDbusListenerRunning(networkManagerDest, networkManagerDbusObjectNode) && isNetworkManagerSupported() {
-			return networkManager, "NetworkManager header + supported version on dbus", nil
+		if strings.Contains(text, "NetworkManager") {
+			if isDbusListenerRunning(networkManagerDest, networkManagerDbusObjectNode) && isNetworkManagerSupported() {
+				return networkManager, "NetworkManager header + supported version on dbus", nil
+			}
+			rejected = append(rejected, "NetworkManager header (no dbus or unsupported version)")
 		}
 		if strings.Contains(text, "resolvconf") {
 			if isSystemdResolveConfMode() {
@@ -124,7 +128,11 @@ func getOSDNSManagerType() (osManagerType, string, error) {
 		return 0, "", fmt.Errorf("scan: %w", err)
 	}
 
-	return fileManager, fmt.Sprintf("no manager matched (resolved=%t, nss-resolve=%t, stub=%t)", resolved, nss, stub), nil
+	reason := fmt.Sprintf("no manager matched (resolved=%t, nss-resolve=%t, stub=%t)", resolved, nss, stub)
+	if len(rejected) > 0 {
+		reason += "; rejected: " + strings.Join(rejected, ", ")
+	}
+	return fileManager, reason, nil
 }
 
 // checkStub reports whether systemd-resolved's stub (127.0.0.53) is listed

--- a/client/internal/dns/host_unix.go
+++ b/client/internal/dns/host_unix.go
@@ -75,13 +75,11 @@ func newHostManagerFromType(wgInterface string, osManager osManagerType) (restor
 }
 
 func getOSDNSManagerType() (osManagerType, error) {
-	// If systemd-resolved is serving on 127.0.0.53, prefer it regardless of
-	// who owns /etc/resolv.conf. NetworkManager often rewrites resolv.conf with
-	// its own header while still deferring resolution to systemd-resolved, and
-	// falling back to file mode there snapshots 127.0.0.53 as the fallback
-	// upstream. systemd-resolved in foreign mode re-reads /etc/resolv.conf and
-	// ingests our address as global DNS, which closes the loop.
-	if isSystemdResolvedRunning() && checkStub() {
+	// Prefer systemd-resolved whenever it owns libc resolution, regardless of
+	// who wrote /etc/resolv.conf. File-mode rewrites do not affect lookups
+	// that go through nss-resolve, and in foreign mode they can loop back
+	// through resolved as an upstream.
+	if isSystemdResolvedRunning() && (isLibnssResolveUsed() || checkStub()) {
 		return systemdManager, nil
 	}
 
@@ -125,13 +123,9 @@ func getOSDNSManagerType() (osManagerType, error) {
 	return fileManager, nil
 }
 
-// checkStub reports whether systemd-resolved's stub address (127.0.0.53) is
-// listed in /etc/resolv.conf. A true return value signals that callers should
-// prefer systemd-resolved; it does not make the final manager decision by
-// itself (non-stub systems still fall through to the header scanner).
-// On parse failure we assume the stub is present to avoid dropping into file
-// mode while resolved is active, which would re-ingest NetBird's address as
-// an upstream and form a resolution loop.
+// checkStub reports whether systemd-resolved's stub (127.0.0.53) is listed
+// in /etc/resolv.conf. On parse failure we assume it is, to avoid dropping
+// into file mode while resolved is active.
 func checkStub() bool {
 	rConf, err := parseDefaultResolvConf()
 	if err != nil {
@@ -146,5 +140,38 @@ func checkStub() bool {
 		}
 	}
 
+	return false
+}
+
+// isLibnssResolveUsed reports whether nss-resolve is listed before dns on
+// the hosts: line of /etc/nsswitch.conf. When it is, libc lookups are
+// delegated to systemd-resolved regardless of /etc/resolv.conf.
+func isLibnssResolveUsed() bool {
+	bs, err := os.ReadFile(nsswitchConfPath)
+	if err != nil {
+		log.Debugf("read %s: %v", nsswitchConfPath, err)
+		return false
+	}
+	return parseNsswitchResolveAhead(bs)
+}
+
+func parseNsswitchResolveAhead(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		if i := strings.IndexByte(line, '#'); i >= 0 {
+			line = line[:i]
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "hosts:" {
+			continue
+		}
+		for _, module := range fields[1:] {
+			switch module {
+			case "dns":
+				return false
+			case "resolve":
+				return true
+			}
+		}
+	}
 	return false
 }

--- a/client/internal/dns/host_unix.go
+++ b/client/internal/dns/host_unix.go
@@ -125,11 +125,17 @@ func getOSDNSManagerType() (osManagerType, error) {
 	return fileManager, nil
 }
 
-// checkStub checks if the stub resolver is disabled in systemd-resolved. If it is disabled, we fall back to file manager.
+// checkStub reports whether systemd-resolved's stub address (127.0.0.53) is
+// listed in /etc/resolv.conf. A true return value signals that callers should
+// prefer systemd-resolved; it does not make the final manager decision by
+// itself (non-stub systems still fall through to the header scanner).
+// On parse failure we assume the stub is present to avoid dropping into file
+// mode while resolved is active, which would re-ingest NetBird's address as
+// an upstream and form a resolution loop.
 func checkStub() bool {
 	rConf, err := parseDefaultResolvConf()
 	if err != nil {
-		log.Warnf("failed to parse resolv conf: %s", err)
+		log.Warnf("failed to parse resolv conf, assuming stub is active: %s", err)
 		return true
 	}
 

--- a/client/internal/dns/host_unix.go
+++ b/client/internal/dns/host_unix.go
@@ -87,13 +87,32 @@ func getOSDNSManagerType() (osManagerType, string, error) {
 		return systemdManager, fmt.Sprintf("systemd-resolved active (nss-resolve=%t, stub=%t)", nss, stub), nil
 	}
 
+	mgr, reason, rejected, err := scanResolvConfHeader()
+	if err != nil {
+		return 0, "", err
+	}
+	if reason != "" {
+		return mgr, reason, nil
+	}
+
+	fallback := fmt.Sprintf("no manager matched (resolved=%t, nss-resolve=%t, stub=%t)", resolved, nss, stub)
+	if len(rejected) > 0 {
+		fallback += "; rejected: " + strings.Join(rejected, ", ")
+	}
+	return fileManager, fallback, nil
+}
+
+// scanResolvConfHeader walks /etc/resolv.conf header comments and returns the
+// matching manager. If reason is empty the caller should pick file mode and
+// use rejected for diagnostics.
+func scanResolvConfHeader() (osManagerType, string, []string, error) {
 	file, err := os.Open(defaultResolvConfPath)
 	if err != nil {
-		return 0, "", fmt.Errorf("unable to open %s for checking owner, got error: %w", defaultResolvConfPath, err)
+		return 0, "", nil, fmt.Errorf("unable to open %s for checking owner, got error: %w", defaultResolvConfPath, err)
 	}
 	defer func() {
-		if err := file.Close(); err != nil {
-			log.Errorf("close file %s: %s", defaultResolvConfPath, err)
+		if cerr := file.Close(); cerr != nil {
+			log.Errorf("close file %s: %s", defaultResolvConfPath, cerr)
 		}
 	}()
 
@@ -107,32 +126,37 @@ func getOSDNSManagerType() (osManagerType, string, error) {
 		if text[0] != '#' {
 			break
 		}
-		if strings.Contains(text, fileGeneratedResolvConfContentHeader) {
-			return netbirdManager, "netbird-managed resolv.conf header detected", nil
-		}
-		if strings.Contains(text, "NetworkManager") {
-			if isDbusListenerRunning(networkManagerDest, networkManagerDbusObjectNode) && isNetworkManagerSupported() {
-				return networkManager, "NetworkManager header + supported version on dbus", nil
-			}
-			rejected = append(rejected, "NetworkManager header (no dbus or unsupported version)")
-		}
-		if strings.Contains(text, "resolvconf") {
-			if isSystemdResolveConfMode() {
-				return systemdManager, "resolvconf header in systemd-resolved compatibility mode", nil
-			}
-
-			return resolvConfManager, "resolvconf header detected", nil
+		if mgr, reason, rej := matchResolvConfHeader(text); reason != "" {
+			return mgr, reason, nil, nil
+		} else if rej != "" {
+			rejected = append(rejected, rej)
 		}
 	}
 	if err := scanner.Err(); err != nil && err != io.EOF {
-		return 0, "", fmt.Errorf("scan: %w", err)
+		return 0, "", nil, fmt.Errorf("scan: %w", err)
 	}
+	return 0, "", rejected, nil
+}
 
-	reason := fmt.Sprintf("no manager matched (resolved=%t, nss-resolve=%t, stub=%t)", resolved, nss, stub)
-	if len(rejected) > 0 {
-		reason += "; rejected: " + strings.Join(rejected, ", ")
+// matchResolvConfHeader inspects a single comment line. Returns either a
+// definitive (manager, reason) or a non-empty rejected diagnostic.
+func matchResolvConfHeader(text string) (osManagerType, string, string) {
+	if strings.Contains(text, fileGeneratedResolvConfContentHeader) {
+		return netbirdManager, "netbird-managed resolv.conf header detected", ""
 	}
-	return fileManager, reason, nil
+	if strings.Contains(text, "NetworkManager") {
+		if isDbusListenerRunning(networkManagerDest, networkManagerDbusObjectNode) && isNetworkManagerSupported() {
+			return networkManager, "NetworkManager header + supported version on dbus", ""
+		}
+		return 0, "", "NetworkManager header (no dbus or unsupported version)"
+	}
+	if strings.Contains(text, "resolvconf") {
+		if isSystemdResolveConfMode() {
+			return systemdManager, "resolvconf header in systemd-resolved compatibility mode", ""
+		}
+		return resolvConfManager, "resolvconf header detected", ""
+	}
+	return 0, "", ""
 }
 
 // checkStub reports whether systemd-resolved's stub (127.0.0.53) is listed

--- a/client/internal/dns/host_unix.go
+++ b/client/internal/dns/host_unix.go
@@ -75,6 +75,16 @@ func newHostManagerFromType(wgInterface string, osManager osManagerType) (restor
 }
 
 func getOSDNSManagerType() (osManagerType, error) {
+	// If systemd-resolved is serving on 127.0.0.53, prefer it regardless of
+	// who owns /etc/resolv.conf. NetworkManager often rewrites resolv.conf with
+	// its own header while still deferring resolution to systemd-resolved, and
+	// falling back to file mode there snapshots 127.0.0.53 as the fallback
+	// upstream. systemd-resolved in foreign mode re-reads /etc/resolv.conf and
+	// ingests our address as global DNS, which closes the loop.
+	if isSystemdResolvedRunning() && checkStub() {
+		return systemdManager, nil
+	}
+
 	file, err := os.Open(defaultResolvConfPath)
 	if err != nil {
 		return 0, fmt.Errorf("unable to open %s for checking owner, got error: %w", defaultResolvConfPath, err)
@@ -99,13 +109,6 @@ func getOSDNSManagerType() (osManagerType, error) {
 		}
 		if strings.Contains(text, "NetworkManager") && isDbusListenerRunning(networkManagerDest, networkManagerDbusObjectNode) && isNetworkManagerSupported() {
 			return networkManager, nil
-		}
-		if strings.Contains(text, "systemd-resolved") && isSystemdResolvedRunning() {
-			if checkStub() {
-				return systemdManager, nil
-			} else {
-				return fileManager, nil
-			}
 		}
 		if strings.Contains(text, "resolvconf") {
 			if isSystemdResolveConfMode() {

--- a/client/internal/dns/host_unix_test.go
+++ b/client/internal/dns/host_unix_test.go
@@ -1,0 +1,76 @@
+//go:build (linux && !android) || freebsd
+
+package dns
+
+import "testing"
+
+func TestParseNsswitchResolveAhead(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			name: "resolve before dns with action token",
+			in:   "hosts: mymachines resolve [!UNAVAIL=return] files myhostname dns\n",
+			want: true,
+		},
+		{
+			name: "dns before resolve",
+			in:   "hosts: files mdns4_minimal [NOTFOUND=return] dns resolve\n",
+			want: false,
+		},
+		{
+			name: "debian default with only dns",
+			in:   "hosts: files mdns4_minimal [NOTFOUND=return] dns mymachines\n",
+			want: false,
+		},
+		{
+			name: "neither resolve nor dns",
+			in:   "hosts: files myhostname\n",
+			want: false,
+		},
+		{
+			name: "no hosts line",
+			in:   "passwd: files systemd\ngroup: files systemd\n",
+			want: false,
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: false,
+		},
+		{
+			name: "comments and blank lines ignored",
+			in:   "# comment\n\n# another\nhosts: resolve dns\n",
+			want: true,
+		},
+		{
+			name: "trailing inline comment",
+			in:   "hosts: resolve [!UNAVAIL=return] dns # fallback\n",
+			want: true,
+		},
+		{
+			name: "hosts token must be the first field",
+			in:   "  hosts: resolve dns\n",
+			want: true,
+		},
+		{
+			name: "other db line mentioning resolve is ignored",
+			in:   "networks: resolve\nhosts: dns\n",
+			want: false,
+		},
+		{
+			name: "only resolve, no dns",
+			in:   "hosts: files resolve\n",
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseNsswitchResolveAhead([]byte(tt.in)); got != tt.want {
+				t.Errorf("parseNsswitchResolveAhead() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes

On Arch (and similar setups where NetworkManager owns `/etc/resolv.conf` while systemd-resolved is the actual resolver), NetBird detection used to fall through to file mode. File mode then snapshots `127.0.0.53` from resolv.conf as fallback upstream, and resolved in foreign mode re-ingests our address as a global upstream; closing the loop.

Detect systemd-resolved up front: pick it whenever resolved is running and either the stub is listed in resolv.conf or `nss-resolve` precedes `dns` in `/etc/nsswitch.conf` (so libc lookups go through resolved regardless of resolv.conf contents). Other headers fall through to the existing scanner unchanged.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal detection logic; no user-facing behavior change beyond picking the correct DNS manager.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS manager detection on Unix: more reliable preference for systemd-resolved when present, clearer handling of stub resolvers, refined parsing of resolv.conf headers, and clearer fallback/explanation strings when no manager matches.

* **Tests**
  * Added unit tests covering parsing of nsswitch-style hosts entries to detect "resolve" vs "dns" ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->