### PR TITLE
[self-hosted] Use cscli lapi status for CrowdSec readiness check in installer

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -472,7 +472,7 @@ start_services_and_show_instructions() {
       if [[ "$ENABLE_CROWDSEC" == "true" ]]; then
         echo "Registering CrowdSec bouncer..."
         local cs_retries=0
-        while ! $DOCKER_COMPOSE_COMMAND exec -T crowdsec cscli capi status >/dev/null 2>&1; do
+        while ! $DOCKER_COMPOSE_COMMAND exec -T crowdsec cscli lapi status >/dev/null 2>&1; do
           cs_retries=$((cs_retries + 1))
           if [[ $cs_retries -ge 30 ]]; then
             echo "WARNING: CrowdSec did not become ready. Skipping CrowdSec setup." > /dev/stderr


### PR DESCRIPTION
## Describe your changes

The installer's CrowdSec readiness loop gated bouncer registration on `cscli capi status`, which checks Central API (CAPI) connectivity. Bouncer registration is a purely local operation against LAPI, so a CAPI 403 (e.g. rate limit, misconfiguration) would cause the installer to skip CrowdSec setup unnecessarily. Switch the wait to `cscli lapi status` to match the container healthcheck.

## Issue ticket number and link

Related: #5944

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Docs on main already reference `cscli lapi status` (netbirdio/docs#709).

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the CrowdSec service health check validation during startup initialization to verify the appropriate API status endpoint, ensuring accurate service readiness detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->