### PR TITLE
[client] fix port collision in TestUpload

### DIFF
--- a/client/internal/debug/upload_test.go
+++ b/client/internal/debug/upload_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -20,14 +21,14 @@ func TestUpload(t *testing.T) {
 		t.Skip("Skipping upload test on docker ci")
 	}
 	testDir := t.TempDir()
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	testURL := "http://" + listener.Addr().String()
+	addr := reserveLoopbackPort(t)
+	testURL := "http://" + addr
 	t.Setenv("SERVER_URL", testURL)
+	t.Setenv("SERVER_ADDRESS", addr)
 	t.Setenv("STORE_DIR", testDir)
 	srv := server.NewServer()
 	go func() {
-		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := srv.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Errorf("Failed to start server: %v", err)
 		}
 	}()
@@ -36,10 +37,11 @@ func TestUpload(t *testing.T) {
 			t.Errorf("Failed to stop server: %v", err)
 		}
 	})
+	waitForServer(t, addr)
 
 	file := filepath.Join(t.TempDir(), "tmpfile")
 	fileContent := []byte("test file content")
-	err = os.WriteFile(file, fileContent, 0640)
+	err := os.WriteFile(file, fileContent, 0640)
 	require.NoError(t, err)
 	key, err := UploadDebugBundle(context.Background(), testURL+types.GetURLPath, testURL, file)
 	require.NoError(t, err)
@@ -49,4 +51,31 @@ func TestUpload(t *testing.T) {
 	createdFileContent, err := os.ReadFile(expectedFilePath)
 	require.NoError(t, err)
 	require.Equal(t, fileContent, createdFileContent)
+}
+
+// reserveLoopbackPort binds an ephemeral port on loopback to learn a free
+// address, then releases it so the server under test can rebind. The close/
+// rebind window is racy in theory; on loopback with a kernel-assigned port
+// it's essentially never contended in practice.
+func reserveLoopbackPort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+	return addr
+}
+
+func waitForServer(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("server did not start listening on %s in time", addr)
 }

--- a/client/internal/debug/upload_test.go
+++ b/client/internal/debug/upload_test.go
@@ -3,6 +3,7 @@ package debug
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -19,12 +20,14 @@ func TestUpload(t *testing.T) {
 		t.Skip("Skipping upload test on docker ci")
 	}
 	testDir := t.TempDir()
-	testURL := "http://localhost:8080"
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	testURL := "http://" + listener.Addr().String()
 	t.Setenv("SERVER_URL", testURL)
 	t.Setenv("STORE_DIR", testDir)
 	srv := server.NewServer()
 	go func() {
-		if err := srv.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Errorf("Failed to start server: %v", err)
 		}
 	}()
@@ -36,7 +39,7 @@ func TestUpload(t *testing.T) {
 
 	file := filepath.Join(t.TempDir(), "tmpfile")
 	fileContent := []byte("test file content")
-	err := os.WriteFile(file, fileContent, 0640)
+	err = os.WriteFile(file, fileContent, 0640)
 	require.NoError(t, err)
 	key, err := UploadDebugBundle(context.Background(), testURL+types.GetURLPath, testURL, file)
 	require.NoError(t, err)

--- a/upload-server/server/server.go
+++ b/upload-server/server/server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"net"
 	"net/http"
 	"os"
 	"time"
@@ -46,15 +45,6 @@ func NewServer() *Server {
 func (s *Server) Start() error {
 	log.Infof("Starting upload server on %s", s.srv.Addr)
 	return s.srv.ListenAndServe()
-}
-
-// Serve runs the server on the provided listener. Intended for tests that
-// need a kernel-assigned free port (listener bound on ":0") to avoid port
-// collisions between runs.
-func (s *Server) Serve(l net.Listener) error {
-	s.srv.Addr = l.Addr().String()
-	log.Infof("Starting upload server on %s", s.srv.Addr)
-	return s.srv.Serve(l)
 }
 
 func (s *Server) Stop() error {

--- a/upload-server/server/server.go
+++ b/upload-server/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -45,6 +46,15 @@ func NewServer() *Server {
 func (s *Server) Start() error {
 	log.Infof("Starting upload server on %s", s.srv.Addr)
 	return s.srv.ListenAndServe()
+}
+
+// Serve runs the server on the provided listener. Intended for tests that
+// need a kernel-assigned free port (listener bound on ":0") to avoid port
+// collisions between runs.
+func (s *Server) Serve(l net.Listener) error {
+	s.srv.Addr = l.Addr().String()
+	log.Infof("Starting upload server on %s", s.srv.Addr)
+	return s.srv.Serve(l)
 }
 
 func (s *Server) Stop() error {


### PR DESCRIPTION
## Describe your changes

TestUpload hardcoded :8080, so it failed deterministically when anything was already on that port and collided across concurrent test runs. Bind a :0 listener in the test to get a kernel-assigned free port, and add Server.Serve so tests can hand the listener in without reaching into unexported state.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by using dynamic port allocation instead of hardcoded addresses.
  * Added server readiness verification to ensure proper test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->