### PR TITLE
[client] fix goroutine leak in TestReceive_ProtocolErrorStreamReconnect

### DIFF
--- a/flow/client/client_test.go
+++ b/flow/client/client_test.go
@@ -457,6 +457,18 @@ func TestReceive_ProtocolErrorStreamReconnect(t *testing.T) {
 
 	client, err := flow.NewClient("http://"+server.addr, "test-payload", "test-signature", 1*time.Second)
 	require.NoError(t, err)
+
+	// Cleanups run LIFO: the goroutine-drain registered here runs after Close below,
+	// which is when Receive has actually returned. Without this, the Receive goroutine
+	// can outlive the test and call t.Logf after teardown, panicking.
+	receiveDone := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-receiveDone:
+		case <-time.After(2 * time.Second):
+			t.Error("Receive goroutine did not exit after Close")
+		}
+	})
 	t.Cleanup(func() {
 		err := client.Close()
 		assert.NoError(t, err, "failed to close flow")
@@ -468,6 +480,7 @@ func TestReceive_ProtocolErrorStreamReconnect(t *testing.T) {
 	receivedAfterReconnect := make(chan struct{})
 
 	go func() {
+		defer close(receiveDone)
 		err := client.Receive(ctx, 1*time.Second, func(msg *proto.FlowEventAck) error {
 			if msg.IsInitiator || len(msg.EventId) == 0 {
 				return nil


### PR DESCRIPTION
## Describe your changes

The Receive goroutine could outlive the test and call t.Logf after teardown, panicking with "Log in goroutine after ... has completed". Register a cleanup that waits for the goroutine to exit; ordering is LIFO so it runs after client.Close, which is what unblocks Receive.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring proper synchronization and cleanup of goroutines in protocol error handling tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->