### PR TITLE
[client] bootstrap pkg before installing FreeBSD port deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
           copyback: false
           release: "15.0"
           prepare: |
+            # Refresh pkg to handle metadata format changes on FreeBSD 15.0
+            env ASSUME_ALWAYS_YES=yes pkg bootstrap -f
+            pkg update -f
+
             # Install required packages
             pkg install -y git curl portlint go
 


### PR DESCRIPTION
The FreeBSD 15.0 VM image used by vmactions/freebsd-vm@v1 ships a pkg binary that fails to parse the current pkg.freebsd.org metadata, with:
  pkg: truncated reply for signature_fingerprintsoutput, wanted 0 bytes
  pkg: Repository FreeBSD-ports cannot be opened.

This breaks 'pkg install', failing every release run since 2026-04-24. Run 'pkg bootstrap -f' + 'pkg update -f' first to refresh pkg and the catalogue before installing build deps.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated FreeBSD release workflow build preparation steps to ensure package manager state is properly refreshed before package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->