### PR TITLE
[client] Don't mark management disconnected on transient job stream errors

### DIFF
--- a/shared/management/client/grpc.go
+++ b/shared/management/client/grpc.go
@@ -252,21 +252,19 @@ func (c *GrpcClient) handleJobStream(
 					c.notifyDisconnected(err)
 					return backoff.Permanent(err) // unrecoverable error, propagate to the upper layer
 				case codes.Canceled:
-					log.Debugf("management connection context has been canceled, this usually indicates shutdown")
+					log.Debugf("job stream context has been canceled, this usually indicates shutdown")
 					return err
 				case codes.Unimplemented:
 					log.Warn("Job feature is not supported by the current management server version. " +
 						"Please update the management service to use this feature.")
 					return nil
 				default:
-					c.notifyDisconnected(err)
-					log.Warnf("disconnected from the Management service but will retry silently. Reason: %v", err)
+					log.Warnf("job stream disconnected, will retry silently. Reason: %v", err)
 					return err
 				}
 			} else {
 				// non-gRPC error
-				c.notifyDisconnected(err)
-				log.Warnf("disconnected from the Management service but will retry silently. Reason: %v", err)
+				log.Warnf("job stream disconnected, will retry silently. Reason: %v", err)
 				return err
 			}
 		}


### PR DESCRIPTION
## Describe your changes

The JOB stream is a separate channel from the SYNC stream. Server-side EOF or other transient errors on the JOB stream do not indicate that the management connection is unhealthy — the SYNC stream remains the authoritative state signal.

Previously, a JOB stream EOF would call notifyDisconnected and the client would emit OnConnecting to the UI. The backoff retry would reconnect the JOB stream, but handleJobStream never calls notifyConnected on success, so the UI was stuck on "Connecting" until the next SYNC event or health check (i.e. from netbird status).

Keep notifyDisconnected for codes.PermissionDenied since IsLoginRequired relies on managementError to detect expired auth.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging messages for better diagnostic clarity during job stream operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->