### PR TITLE
[management] Add Microsoft AD FS support for embedded Dex identity providers

### DIFF
--- a/idp/dex/config.go
+++ b/idp/dex/config.go
@@ -193,7 +193,7 @@ func (c *Connector) ToStorageConnector() (storage.Connector, error) {
 // are stored with types that Dex can open.
 func mapConnectorToDex(connType string, config map[string]interface{}) (string, map[string]interface{}) {
 	switch connType {
-	case "oidc", "zitadel", "entra", "okta", "pocketid", "authentik", "keycloak":
+	case "oidc", "zitadel", "entra", "okta", "pocketid", "authentik", "keycloak", "adfs":
 		return "oidc", applyOIDCDefaults(connType, config)
 	default:
 		return connType, config
@@ -218,6 +218,8 @@ func applyOIDCDefaults(connType string, config map[string]interface{}) map[strin
 		setDefault(augmented, "claimMapping", map[string]string{"email": "preferred_username"})
 	case "okta", "pocketid":
 		augmented["scopes"] = []string{"openid", "profile", "email", "groups"}
+	case "adfs":
+		augmented["scopes"] = []string{"openid", "profile", "email", "allatclaims"}
 	}
 
 	return augmented

--- a/idp/dex/connector.go
+++ b/idp/dex/connector.go
@@ -168,7 +168,7 @@ func (p *Provider) buildStorageConnector(cfg *ConnectorConfig) (storage.Connecto
 	var err error
 
 	switch cfg.Type {
-	case "oidc", "zitadel", "entra", "okta", "pocketid", "authentik", "keycloak":
+	case "oidc", "zitadel", "entra", "okta", "pocketid", "authentik", "keycloak", "adfs":
 		dexType = "oidc"
 		configData, err = buildOIDCConnectorConfig(cfg, redirectURI)
 	case "google":
@@ -220,6 +220,8 @@ func buildOIDCConnectorConfig(cfg *ConnectorConfig, redirectURI string) ([]byte,
 		oidcConfig["scopes"] = []string{"openid", "profile", "email", "groups"}
 	case "pocketid":
 		oidcConfig["scopes"] = []string{"openid", "profile", "email", "groups"}
+	case "adfs":
+		oidcConfig["scopes"] = []string{"openid", "profile", "email", "allatclaims"}
 	}
 	return encodeConnectorConfig(oidcConfig)
 }
@@ -283,7 +285,7 @@ func inferIdentityProviderType(dexType, connectorID string, _ map[string]interfa
 // inferOIDCProviderType infers the specific OIDC provider from connector ID
 func inferOIDCProviderType(connectorID string) string {
 	connectorIDLower := strings.ToLower(connectorID)
-	for _, provider := range []string{"pocketid", "zitadel", "entra", "okta", "authentik", "keycloak"} {
+	for _, provider := range []string{"pocketid", "zitadel", "entra", "okta", "authentik", "keycloak", "adfs"} {
 		if strings.Contains(connectorIDLower, provider) {
 			return provider
 		}

--- a/management/server/identity_provider.go
+++ b/management/server/identity_provider.go
@@ -274,7 +274,7 @@ func identityProviderToConnectorConfig(idpConfig *types.IdentityProvider) *dex.C
 }
 
 // generateIdentityProviderID generates a unique ID for an identity provider.
-// For specific provider types (okta, zitadel, entra, google, pocketid, microsoft),
+// For specific provider types (okta, zitadel, entra, google, pocketid, microsoft, adfs),
 // the ID is prefixed with the type name. Generic OIDC providers get no prefix.
 func generateIdentityProviderID(idpType types.IdentityProviderType) string {
 	id := xid.New().String()
@@ -296,6 +296,8 @@ func generateIdentityProviderID(idpType types.IdentityProviderType) string {
 		return "authentik-" + id
 	case types.IdentityProviderTypeKeycloak:
 		return "keycloak-" + id
+	case types.IdentityProviderTypeADFS:
+		return "adfs-" + id
 	default:
 		// Generic OIDC - no prefix
 		return id

--- a/management/server/types/identity_provider.go
+++ b/management/server/types/identity_provider.go
@@ -39,6 +39,8 @@ const (
 	IdentityProviderTypeAuthentik IdentityProviderType = "authentik"
 	// IdentityProviderTypeKeycloak is the Keycloak identity provider
 	IdentityProviderTypeKeycloak IdentityProviderType = "keycloak"
+	// IdentityProviderTypeADFS is the Microsoft AD FS identity provider
+	IdentityProviderTypeADFS IdentityProviderType = "adfs"
 )
 
 // IdentityProvider represents an identity provider configuration
@@ -112,7 +114,8 @@ func (t IdentityProviderType) IsValid() bool {
 	switch t {
 	case IdentityProviderTypeOIDC, IdentityProviderTypeZitadel, IdentityProviderTypeEntra,
 		IdentityProviderTypeGoogle, IdentityProviderTypeOkta, IdentityProviderTypePocketID,
-		IdentityProviderTypeMicrosoft, IdentityProviderTypeAuthentik, IdentityProviderTypeKeycloak:
+		IdentityProviderTypeMicrosoft, IdentityProviderTypeAuthentik, IdentityProviderTypeKeycloak,
+		IdentityProviderTypeADFS:
 		return true
 	}
 	return false

--- a/shared/management/http/api/openapi.yml
+++ b/shared/management/http/api/openapi.yml
@@ -2917,6 +2917,7 @@ components:
         - okta
         - pocketid
         - microsoft
+        - adfs
       example: oidc
     IdentityProvider:
       type: object

--- a/shared/management/http/api/types.gen.go
+++ b/shared/management/http/api/types.gen.go
@@ -518,6 +518,7 @@ const (
 	IdentityProviderTypeOkta      IdentityProviderType = "okta"
 	IdentityProviderTypePocketid  IdentityProviderType = "pocketid"
 	IdentityProviderTypeZitadel   IdentityProviderType = "zitadel"
+	IdentityProviderTypeAdfs      IdentityProviderType = "adfs"
 )
 
 // Valid indicates whether the value is a known member of the IdentityProviderType enum.
@@ -536,6 +537,8 @@ func (e IdentityProviderType) Valid() bool {
 	case IdentityProviderTypePocketid:
 		return true
 	case IdentityProviderTypeZitadel:
+		return true
+	case IdentityProviderTypeAdfs:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ADFS is now available as a supported identity provider type, offering OIDC-compatible authentication with automatic claim scope configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->