### PR TITLE
[management] Handle single-string JWT group claim from IdPs

### DIFF
--- a/shared/auth/jwt/extractor.go
+++ b/shared/auth/jwt/extractor.go
@@ -146,7 +146,10 @@ func (c *ClaimsExtractor) ToGroups(token *jwt.Token, claimName string) []string 
 	userJWTGroups := make([]string, 0)
 
 	if claim, ok := claims[claimName]; ok {
-		if claimGroups, ok := claim.([]interface{}); ok {
+		if group, ok := claim.(string); ok {
+			// Some IdPs emit a single group claim as a string instead of an array.
+			userJWTGroups = append(userJWTGroups, group)
+		} else if claimGroups, ok := claim.([]interface{}); ok {
 			for _, g := range claimGroups {
 				if group, ok := g.(string); ok {
 					userJWTGroups = append(userJWTGroups, group)
@@ -154,9 +157,11 @@ func (c *ClaimsExtractor) ToGroups(token *jwt.Token, claimName string) []string 
 					log.Debugf("JWT claim %q contains a non-string group (type: %T): %v", claimName, g, g)
 				}
 			}
+		} else {
+			log.Debugf("JWT claim %q is not a string or string array (type: %T): %v", claimName, claim, claim)
 		}
 	} else {
-		log.Debugf("JWT claim %q is not a string array", claimName)
+		log.Debugf("JWT claim %q is missing", claimName)
 	}
 
 	return userJWTGroups

--- a/shared/auth/jwt/extractor.go
+++ b/shared/auth/jwt/extractor.go
@@ -146,10 +146,11 @@ func (c *ClaimsExtractor) ToGroups(token *jwt.Token, claimName string) []string 
 	userJWTGroups := make([]string, 0)
 
 	if claim, ok := claims[claimName]; ok {
-		if group, ok := claim.(string); ok {
+		switch claimGroups := claim.(type) {
+		case string:
 			// Some IdPs emit a single group claim as a string instead of an array.
-			userJWTGroups = append(userJWTGroups, group)
-		} else if claimGroups, ok := claim.([]interface{}); ok {
+			userJWTGroups = append(userJWTGroups, claimGroups)
+		case []any:
 			for _, g := range claimGroups {
 				if group, ok := g.(string); ok {
 					userJWTGroups = append(userJWTGroups, group)
@@ -157,7 +158,7 @@ func (c *ClaimsExtractor) ToGroups(token *jwt.Token, claimName string) []string 
 					log.Debugf("JWT claim %q contains a non-string group (type: %T): %v", claimName, g, g)
 				}
 			}
-		} else {
+		default:
 			log.Debugf("JWT claim %q is not a string or string array (type: %T): %v", claimName, claim, claim)
 		}
 	} else {

--- a/shared/auth/jwt/extractor_test.go
+++ b/shared/auth/jwt/extractor_test.go
@@ -250,6 +250,15 @@ func TestClaimsExtractor_ToGroups(t *testing.T) {
 			expectedGroups: []string{},
 		},
 		{
+			name: "extracts single group string from claim",
+			claims: jwt.MapClaims{
+				"sub":    "user-123",
+				"groups": "admin",
+			},
+			groupClaimName: "groups",
+			expectedGroups: []string{"admin"},
+		},
+		{
 			name: "handles custom claim name",
 			claims: jwt.MapClaims{
 				"sub":        "user-123",


### PR DESCRIPTION
## Describe your changes

This change adds support for JWT group claims where an IdP emits a single group as a string instead of an array. In that case, management now normalizes the value internally as a one item group slice.

This is only for compatibility with IdPs that format single group claims this way. The expected format for multiple groups remains an array. Sending multiple groups as one string is not supported and will be treated as a single group value.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JWT group claim extraction now accepts both single-string and array formats, improving compatibility with varied token formats.
  * Improved debug messages to clearly indicate when a group claim is missing or in an unexpected format.

* **Tests**
  * Added test coverage for single-string group claims and for filtering non-string claim values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->