### PR TITLE
[client] Fix Windows installer upgrade detection for pre-0.70.1 installs

### DIFF
--- a/client/installer.nsis
+++ b/client/installer.nsis
@@ -200,9 +200,17 @@ Pop $0
 !macroend
 
 Function .onInit
-SetRegView 64
 StrCpy $INSTDIR "${INSTALL_DIR}"
+
+; Pre-0.70.1 installers ran without SetRegView, so their uninstall keys live
+; in the 32-bit view. Fall back to it so upgrades still find them.
+SetRegView 64
 ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\$(^NAME)" "UninstallString"
+${If} $R0 == ""
+    SetRegView 32
+    ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\$(^NAME)" "UninstallString"
+    SetRegView 64
+${EndIf}
 ${If} $R0 != ""
     # if silent install jump to uninstall step
     IfSilent uninstall


### PR DESCRIPTION
## Describe your changes

The 0.70.1 installer added `SetRegView 64` in `.onInit`, which broke upgrade detection for installs from earlier versions: their uninstall registry keys live in the 32-bit (WOW6432Node) view because previous installers ran without `SetRegView`. With detection failing, `UninstallPreviousNSIS` was skipped, the running daemon was never stopped, and `File /r` failed to overwrite the locked `netbird.exe` ("error opening file for writing" in interactive mode), leaving the binary at the old version even though new uninstall metadata was written.

- Fall back to the 32-bit registry view when the 64-bit lookup finds no existing install, so legacy installs are detected and uninstalled before file extraction

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal installer logic, no user-visible behavior change beyond fixing the upgrade path.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a critical installer compatibility issue that prevented proper detection of older installations during the upgrade process. Users upgrading from previous versions will now experience smooth, conflict-free transitions with complete preservation of existing settings and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->