### PR TITLE
[client] Enable UI autostart for silent and MSI installs

### DIFF
--- a/client/installer.nsis
+++ b/client/installer.nsis
@@ -201,6 +201,8 @@ Pop $0
 
 Function .onInit
 StrCpy $INSTDIR "${INSTALL_DIR}"
+; Default autostart to enabled so silent installs (/S) match the interactive default
+StrCpy $AutostartEnabled "1"
 
 ; Pre-0.70.1 installers ran without SetRegView, so their uninstall keys live
 ; in the 32-bit view. Fall back to it so upgrades still find them.

--- a/client/netbird.wxs
+++ b/client/netbird.wxs
@@ -13,6 +13,9 @@
 
 		<MajorUpgrade AllowSameVersionUpgrades='yes' DowngradeErrorMessage="A newer version of [ProductName] is already installed. Setup will now exit."/>
 
+		<!-- Autostart: enabled by default, disable with AUTOSTART=0 on the msiexec command line -->
+		<Property Id="AUTOSTART" Value="1" />
+
 		<StandardDirectory Id="ProgramFiles64Folder">
 			<Directory Id="NetbirdInstallDir" Name="Netbird">
 				<Component Id="NetbirdFiles" Guid="db3165de-cc6e-4922-8396-9d892950e23e" Bitness="always64">
@@ -63,9 +66,21 @@
 			</Component>
 		</StandardDirectory>
 
+		<StandardDirectory Id="CommonAppDataFolder">
+			<Directory Id="NetbirdAutoStartDir" Name="Netbird">
+				<Component Id="NetbirdAutoStart" Guid="a1b2c3d4-e5f6-7890-abcd-ef1234567890" Bitness="always64">
+					<Condition>AUTOSTART = "1"</Condition>
+					<RegistryValue Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Run"
+						Name="Netbird" Value="&quot;[NetbirdInstallDir]netbird-ui.exe&quot;"
+						Type="string" KeyPath="yes" />
+				</Component>
+			</Directory>
+		</StandardDirectory>
+
 		<ComponentGroup Id="NetbirdFilesComponent">
 			<ComponentRef Id="NetbirdFiles" />
 			<ComponentRef Id="NetbirdAumidRegistry" />
+			<ComponentRef Id="NetbirdAutoStart" />
 		</ComponentGroup>
 
 		<util:CloseApplication Id="CloseNetBird" CloseMessage="no" Target="netbird.exe" RebootPrompt="no" />

--- a/client/netbird.wxs
+++ b/client/netbird.wxs
@@ -68,7 +68,7 @@
 
 		<StandardDirectory Id="CommonAppDataFolder">
 			<Directory Id="NetbirdAutoStartDir" Name="Netbird">
-				<Component Id="NetbirdAutoStart" Guid="a1b2c3d4-e5f6-7890-abcd-ef1234567890" Bitness="always64">
+				<Component Id="NetbirdAutoStart" Guid="b199eaca-b0dd-4032-af19-679cfad48eb3" Bitness="always64">
 					<Condition>AUTOSTART = "1"</Condition>
 					<RegistryValue Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Run"
 						Name="Netbird" Value="&quot;[NetbirdInstallDir]netbird-ui.exe&quot;"


### PR DESCRIPTION
## Describe your changes

When NetBird is deployed silently via RMM tools (e.g., NinjaOne), the UI tray does not start at login because:
1. The MSI had no autostart logic at all
2. The EXE silent mode skipped the custom autostart GUI page, so the registry entry was never written

The background service runs fine, but users have no tray icon until they manually launch `netbird-ui.exe`.

- **MSI installer**: Add `AUTOSTART` property (default `1`) that writes `HKLM\Software\Microsoft\Windows\CurrentVersion\Run` registry key pointing to `netbird-ui.exe`. IT admins can opt out with `msiexec /i netbird.msi AUTOSTART=0 /quiet`.
- **EXE installer**: Initialize `$AutostartEnabled` to `"1"` in `.onInit` so silent installs (`/S`) match the interactive default (checkbox pre-checked).

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [] Documentation is **not needed** for this change (explain why)

Internal route-manager behavior, no user-visible API change.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here: https://github.com/netbirdio/docs/pull/715


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Autostart functionality is now available on Windows, allowing the application to automatically launch on system startup.
  * Silent installations now enable autostart by default, ensuring consistent default behavior across all installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->