### PR TITLE
[client] Tolerate EEXIST when adding macOS scoped default routes

### DIFF
--- a/client/internal/routemanager/systemops/systemops_darwin.go
+++ b/client/internal/routemanager/systemops/systemops_darwin.go
@@ -89,8 +89,16 @@ func (r *SysOps) installScopedDefaultFor(unspec netip.Addr) (bool, error) {
 		return false, fmt.Errorf("unusable default nexthop for %s (no interface)", unspec)
 	}
 
+	reused := false
 	if err := r.addScopedDefault(unspec, nexthop); err != nil {
-		return false, fmt.Errorf("add scoped default on %s: %w", nexthop.Intf.Name, err)
+		if !errors.Is(err, unix.EEXIST) {
+			return false, fmt.Errorf("add scoped default on %s: %w", nexthop.Intf.Name, err)
+		}
+		// macOS installs its own RTF_IFSCOPE defaults for primary service
+		// selection on multi-NIC setups, so a route on this ifindex can
+		// already exist before we try. Binding to it via IP[V6]_BOUND_IF
+		// still produces the scoped lookup we need.
+		reused = true
 	}
 
 	af := unix.AF_INET
@@ -102,7 +110,11 @@ func (r *SysOps) installScopedDefaultFor(unspec netip.Addr) (bool, error) {
 	if nexthop.IP.IsValid() {
 		via = nexthop.IP.String()
 	}
-	log.Infof("installed scoped default route via %s on %s for %s", via, nexthop.Intf.Name, afOf(unspec))
+	verb := "installed"
+	if reused {
+		verb = "reused existing"
+	}
+	log.Infof("%s scoped default route via %s on %s for %s", verb, via, nexthop.Intf.Name, afOf(unspec))
 	return true, nil
 }
 


### PR DESCRIPTION
## Describe your changes

On macOS, `setupAdvancedRouting` failed to start when the kernel already had an `RTF_IFSCOPE` default route on the chosen physical interface. macOS installs its own service-scoped defaults on multi-NIC setups, so the `RTM_ADD` returned `EEXIST` and our route manager init aborted, preventing peer connectivity.

- Treat `EEXIST` from the scoped-default add as success and proceed to bind the cached interface
- Log line distinguishes "installed" vs "reused existing" for visibility

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal route-manager behavior, no user-visible API change.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS network configuration to gracefully handle existing scoped default routes, preventing errors during system setup and improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->