### PR TITLE
[client] Use BindListener for all userspace bind in lazyconn activity

### DIFF
--- a/client/internal/lazyconn/activity/listener_bind_test.go
+++ b/client/internal/lazyconn/activity/listener_bind_test.go
@@ -3,7 +3,6 @@ package activity
 import (
 	"net"
 	"net/netip"
-	"runtime"
 	"testing"
 	"time"
 
@@ -17,10 +16,6 @@ import (
 	"github.com/netbirdio/netbird/client/internal/lazyconn"
 	peerid "github.com/netbirdio/netbird/client/internal/peer/id"
 )
-
-func isBindListenerPlatform() bool {
-	return runtime.GOOS == "windows" || runtime.GOOS == "js"
-}
 
 // mockEndpointManager implements device.EndpointManager for testing
 type mockEndpointManager struct {
@@ -181,10 +176,6 @@ func TestBindListener_Close(t *testing.T) {
 }
 
 func TestManager_BindMode(t *testing.T) {
-	if !isBindListenerPlatform() {
-		t.Skip("BindListener only used on Windows/JS platforms")
-	}
-
 	mockEndpointMgr := newMockEndpointManager()
 	mockIface := &MockWGIfaceBind{endpointMgr: mockEndpointMgr}
 
@@ -226,10 +217,6 @@ func TestManager_BindMode(t *testing.T) {
 }
 
 func TestManager_BindMode_MultiplePeers(t *testing.T) {
-	if !isBindListenerPlatform() {
-		t.Skip("BindListener only used on Windows/JS platforms")
-	}
-
 	mockEndpointMgr := newMockEndpointManager()
 	mockIface := &MockWGIfaceBind{endpointMgr: mockEndpointMgr}
 

--- a/client/internal/lazyconn/activity/manager.go
+++ b/client/internal/lazyconn/activity/manager.go
@@ -4,14 +4,12 @@ import (
 	"errors"
 	"net"
 	"net/netip"
-	"runtime"
 	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
-	"github.com/netbirdio/netbird/client/iface/netstack"
 	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/internal/lazyconn"
 	peerid "github.com/netbirdio/netbird/client/internal/peer/id"
@@ -72,16 +70,6 @@ func (m *Manager) MonitorPeerActivity(peerCfg lazyconn.PeerConfig) error {
 
 func (m *Manager) createListener(peerCfg lazyconn.PeerConfig) (listener, error) {
 	if !m.wgIface.IsUserspaceBind() {
-		return NewUDPListener(m.wgIface, peerCfg)
-	}
-
-	// BindListener is used on Windows, JS, and netstack platforms:
-	// - JS: Cannot listen to UDP sockets
-	// - Windows: IP_UNICAST_IF socket option forces packets out the interface the default
-	//   gateway points to, preventing them from reaching the loopback interface.
-	// - Netstack: Allows multiple instances on the same host without port conflicts.
-	// BindListener bypasses these issues by passing data directly through the bind.
-	if runtime.GOOS != "windows" && runtime.GOOS != "js" && !netstack.IsEnabled() {
 		return NewUDPListener(m.wgIface, peerCfg)
 	}
 


### PR DESCRIPTION
## Describe your changes

Selects `BindListener` for any userspace WireGuard bind in the lazy-connection activity manager, not just Windows / JS / netstack. On darwin, nbnet sets `IP_BOUND_IF` on its UDP sockets, which forces packets off the loopback path the same way `IP_UNICAST_IF` does on Windows, so the prior `UDPListener` fallback would silently miss activity.

- Drop the OS gate in `createListener`; userspace bind always uses `BindListener`
- Remove the matching Windows/JS skip from the bind listener tests

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal behavioral fix, no user-facing surface change.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed platform-specific conditional logic to ensure consistent bind listener behavior across all supported platforms.
  * Expanded test execution to all platforms by removing conditional skipping, improving cross-platform test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->