### PR TITLE
[client] Trigger mobile submodule bump PRs on release tags

### DIFF
--- a/.github/workflows/sync-tag.yml
+++ b/.github/workflows/sync-tag.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
   cancel-in-progress: true
 
+# Receiving workflows (cloud sync-tag, mobile bump-netbird) expect the short
+# tag form (e.g. v0.30.0), not refs/tags/v0.30.0 — github.ref_name, not github.ref.
 jobs:
   trigger_sync_tag:
     runs-on: ubuntu-latest
@@ -24,10 +26,10 @@ jobs:
 
   trigger_android_bump:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    if: github.event.created && !github.event.deleted && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     steps:
       - name: Trigger android-client submodule bump
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: bump-netbird.yml
           ref: main
@@ -37,10 +39,10 @@ jobs:
 
   trigger_ios_bump:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    if: github.event.created && !github.event.deleted && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     steps:
       - name: Trigger ios-client submodule bump
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: bump-netbird.yml
           ref: main

--- a/.github/workflows/sync-tag.yml
+++ b/.github/workflows/sync-tag.yml
@@ -21,3 +21,29 @@ jobs:
           repo: ${{ secrets.UPSTREAM_REPO }}
           token: ${{ secrets.NC_GITHUB_TOKEN }}
           inputs: '{ "tag": "${{ github.ref_name }}" }'
+
+  trigger_android_bump:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    steps:
+      - name: Trigger android-client submodule bump
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: bump-netbird.yml
+          ref: main
+          repo: netbirdio/android-client
+          token: ${{ secrets.NC_GITHUB_TOKEN }}
+          inputs: '{ "tag": "${{ github.ref_name }}" }'
+
+  trigger_ios_bump:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    steps:
+      - name: Trigger ios-client submodule bump
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: bump-netbird.yml
+          ref: main
+          repo: netbirdio/ios-client
+          token: ${{ secrets.NC_GITHUB_TOKEN }}
+          inputs: '{ "tag": "${{ github.ref_name }}" }'


### PR DESCRIPTION
## Describe your changes

Trigger mobile submodule bump PRs on release tags

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD automation improved: tag values are now forwarded through the release pipeline.
  * New automation triggers automatically bump mobile Android and iOS client builds when a new v* release tag is created, streamlining release propagation and reducing manual steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->