### PR TITLE
[management] Add public connection ipv4 and ipv6 posture check

### DIFF
--- a/management/server/posture/network.go
+++ b/management/server/posture/network.go
@@ -18,7 +18,18 @@ type PeerNetworkRangeCheck struct {
 var _ Check = (*PeerNetworkRangeCheck)(nil)
 
 func (p *PeerNetworkRangeCheck) Check(ctx context.Context, peer nbpeer.Peer) (bool, error) {
-	if len(peer.Meta.NetworkAddresses) == 0 {
+	peerMaskedPrefixes := make([]netip.Prefix, 0, len(peer.Meta.NetworkAddresses)+1)
+	for _, peerNetAddr := range peer.Meta.NetworkAddresses {
+		peerMaskedPrefixes = append(peerMaskedPrefixes, peerNetAddr.NetIP.Masked())
+	}
+	if connIP := peer.Location.ConnectionIP; len(connIP) > 0 {
+		if addr, ok := netip.AddrFromSlice(connIP); ok {
+			addr = addr.Unmap()
+			peerMaskedPrefixes = append(peerMaskedPrefixes, netip.PrefixFrom(addr, addr.BitLen()))
+		}
+	}
+
+	if len(peerMaskedPrefixes) == 0 {
 		return false, fmt.Errorf("peer's does not contain peer network range addresses")
 	}
 
@@ -27,8 +38,7 @@ func (p *PeerNetworkRangeCheck) Check(ctx context.Context, peer nbpeer.Peer) (bo
 		maskedPrefixes = append(maskedPrefixes, prefix.Masked())
 	}
 
-	for _, peerNetAddr := range peer.Meta.NetworkAddresses {
-		peerMaskedPrefix := peerNetAddr.NetIP.Masked()
+	for _, peerMaskedPrefix := range peerMaskedPrefixes {
 		if slices.Contains(maskedPrefixes, peerMaskedPrefix) {
 			switch p.Action {
 			case CheckActionDeny:

--- a/management/server/posture/network.go
+++ b/management/server/posture/network.go
@@ -17,11 +17,17 @@ type PeerNetworkRangeCheck struct {
 
 var _ Check = (*PeerNetworkRangeCheck)(nil)
 
+// Check evaluates configured ranges against the peer's local network interfaces and its
+// public connection IP (as a /32 or /128). Including the connection IP lets operators
+// match peers by their NAT'd public address — local NICs alone never expose that.
 func (p *PeerNetworkRangeCheck) Check(ctx context.Context, peer nbpeer.Peer) (bool, error) {
 	peerMaskedPrefixes := make([]netip.Prefix, 0, len(peer.Meta.NetworkAddresses)+1)
 	for _, peerNetAddr := range peer.Meta.NetworkAddresses {
 		peerMaskedPrefixes = append(peerMaskedPrefixes, peerNetAddr.NetIP.Masked())
 	}
+	// Include the peer's public connection IP as a host prefix (/32 or /128) so operators
+	// can match on the NAT'd egress IP — peer.Meta.NetworkAddresses only carries local NICs.
+	// Unmap collapses 4-in-6 forms (::ffff:a.b.c.d) so an IPv4 prefix matches.
 	if connIP := peer.Location.ConnectionIP; len(connIP) > 0 {
 		if addr, ok := netip.AddrFromSlice(connIP); ok {
 			addr = addr.Unmap()

--- a/management/server/posture/network.go
+++ b/management/server/posture/network.go
@@ -17,30 +17,46 @@ type PeerNetworkRangeCheck struct {
 
 var _ Check = (*PeerNetworkRangeCheck)(nil)
 
-// Check evaluates configured ranges against the peer's local network interface IPs and
-// its public connection IP. A configured range matches when it contains any of those
-// addresses, so operators can target both NAT'd egress (e.g. 1.0.0.0/24) and exact hosts
-// (e.g. 2.2.2.2/32). Including the connection IP is what lets a public-range posture
-// check work — peer.Meta.NetworkAddresses only carries local NIC addresses.
+// prefixContains reports whether outer fully contains inner (equal counts as contained).
+// Requires the same address family, that outer is no more specific than inner (its
+// netmask is shorter or equal), and that inner's network address falls inside outer.
+// This is stricter than netip.Prefix.Contains(Addr) — a peer's /24 NIC will not match a
+// configured /32 rule, since the rule covers a single host but the NIC describes a whole
+// subnet whose host bits are unknown.
+func prefixContains(outer, inner netip.Prefix) bool {
+	outer = outer.Masked()
+	inner = inner.Masked()
+	return outer.Bits() <= inner.Bits() &&
+		outer.Addr().BitLen() == inner.Addr().BitLen() && // same family
+		outer.Contains(inner.Addr())
+}
+
+// Check evaluates configured ranges against the peer's local network interface prefixes
+// and its public connection IP (as a /32 or /128). A configured range matches when it
+// fully contains one of those prefixes, so operators can target both private subnets
+// and public CIDRs (e.g. 1.0.0.0/24, 2.2.2.2/32). Including the connection IP is what
+// lets a public-range posture check work — peer.Meta.NetworkAddresses only carries
+// local NIC addresses.
 func (p *PeerNetworkRangeCheck) Check(ctx context.Context, peer nbpeer.Peer) (bool, error) {
-	peerAddrs := make([]netip.Addr, 0, len(peer.Meta.NetworkAddresses)+1)
+	peerPrefixes := make([]netip.Prefix, 0, len(peer.Meta.NetworkAddresses)+1)
 	for _, peerNetAddr := range peer.Meta.NetworkAddresses {
-		peerAddrs = append(peerAddrs, peerNetAddr.NetIP.Addr())
+		peerPrefixes = append(peerPrefixes, peerNetAddr.NetIP)
 	}
 	// Unmap collapses 4-in-6 forms (::ffff:a.b.c.d) so an IPv4 range matches.
 	if connIP := peer.Location.ConnectionIP; len(connIP) > 0 {
 		if addr, ok := netip.AddrFromSlice(connIP); ok {
-			peerAddrs = append(peerAddrs, addr.Unmap())
+			addr = addr.Unmap()
+			peerPrefixes = append(peerPrefixes, netip.PrefixFrom(addr, addr.BitLen()))
 		}
 	}
 
-	if len(peerAddrs) == 0 {
+	if len(peerPrefixes) == 0 {
 		return false, fmt.Errorf("peer's does not contain peer network range addresses")
 	}
 
-	for _, peerAddr := range peerAddrs {
-		for _, prefix := range p.Ranges {
-			if !prefix.Contains(peerAddr) {
+	for _, peerPrefix := range peerPrefixes {
+		for _, rangePrefix := range p.Ranges {
+			if !prefixContains(rangePrefix, peerPrefix) {
 				continue
 			}
 			switch p.Action {

--- a/management/server/posture/network.go
+++ b/management/server/posture/network.go
@@ -17,35 +17,32 @@ type PeerNetworkRangeCheck struct {
 
 var _ Check = (*PeerNetworkRangeCheck)(nil)
 
-// Check evaluates configured ranges against the peer's local network interfaces and its
-// public connection IP (as a /32 or /128). Including the connection IP lets operators
-// match peers by their NAT'd public address — local NICs alone never expose that.
+// Check evaluates configured ranges against the peer's local network interface IPs and
+// its public connection IP. A configured range matches when it contains any of those
+// addresses, so operators can target both NAT'd egress (e.g. 1.0.0.0/24) and exact hosts
+// (e.g. 2.2.2.2/32). Including the connection IP is what lets a public-range posture
+// check work — peer.Meta.NetworkAddresses only carries local NIC addresses.
 func (p *PeerNetworkRangeCheck) Check(ctx context.Context, peer nbpeer.Peer) (bool, error) {
-	peerMaskedPrefixes := make([]netip.Prefix, 0, len(peer.Meta.NetworkAddresses)+1)
+	peerAddrs := make([]netip.Addr, 0, len(peer.Meta.NetworkAddresses)+1)
 	for _, peerNetAddr := range peer.Meta.NetworkAddresses {
-		peerMaskedPrefixes = append(peerMaskedPrefixes, peerNetAddr.NetIP.Masked())
+		peerAddrs = append(peerAddrs, peerNetAddr.NetIP.Addr())
 	}
-	// Include the peer's public connection IP as a host prefix (/32 or /128) so operators
-	// can match on the NAT'd egress IP — peer.Meta.NetworkAddresses only carries local NICs.
-	// Unmap collapses 4-in-6 forms (::ffff:a.b.c.d) so an IPv4 prefix matches.
+	// Unmap collapses 4-in-6 forms (::ffff:a.b.c.d) so an IPv4 range matches.
 	if connIP := peer.Location.ConnectionIP; len(connIP) > 0 {
 		if addr, ok := netip.AddrFromSlice(connIP); ok {
-			addr = addr.Unmap()
-			peerMaskedPrefixes = append(peerMaskedPrefixes, netip.PrefixFrom(addr, addr.BitLen()))
+			peerAddrs = append(peerAddrs, addr.Unmap())
 		}
 	}
 
-	if len(peerMaskedPrefixes) == 0 {
+	if len(peerAddrs) == 0 {
 		return false, fmt.Errorf("peer's does not contain peer network range addresses")
 	}
 
-	maskedPrefixes := make([]netip.Prefix, 0, len(p.Ranges))
-	for _, prefix := range p.Ranges {
-		maskedPrefixes = append(maskedPrefixes, prefix.Masked())
-	}
-
-	for _, peerMaskedPrefix := range peerMaskedPrefixes {
-		if slices.Contains(maskedPrefixes, peerMaskedPrefix) {
+	for _, peerAddr := range peerAddrs {
+		for _, prefix := range p.Ranges {
+			if !prefix.Contains(peerAddr) {
+				continue
+			}
 			switch p.Action {
 			case CheckActionDeny:
 				return false, nil

--- a/management/server/posture/network_test.go
+++ b/management/server/posture/network_test.go
@@ -2,6 +2,7 @@ package posture
 
 import (
 	"context"
+	"net"
 	"net/netip"
 	"testing"
 
@@ -128,6 +129,84 @@ func TestPeerNetworkRangeCheck_Check(t *testing.T) {
 				Ranges: []netip.Prefix{
 					netip.MustParsePrefix("192.168.0.0/16"),
 					netip.MustParsePrefix("10.0.0.0/8"),
+				},
+			},
+			peer:    nbpeer.Peer{},
+			wantErr: true,
+			isValid: false,
+		},
+		{
+			name: "Peer connection IP matches the denied /32",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionDeny,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("109.41.115.194/32"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Meta: nbpeer.PeerSystemMeta{
+					NetworkAddresses: []nbpeer.NetworkAddress{
+						{NetIP: netip.MustParsePrefix("192.168.0.123/24")},
+					},
+				},
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("109.41.115.194")},
+			},
+			wantErr: false,
+			isValid: false,
+		},
+		{
+			name: "Peer connection IP does not match the denied /32",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionDeny,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("109.41.115.194/32"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Meta: nbpeer.PeerSystemMeta{
+					NetworkAddresses: []nbpeer.NetworkAddress{
+						{NetIP: netip.MustParsePrefix("192.168.0.123/24")},
+					},
+				},
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("8.8.8.8")},
+			},
+			wantErr: false,
+			isValid: true,
+		},
+		{
+			name: "Peer connection IP matches the allowed /32 with no NetworkAddresses",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionAllow,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("109.41.115.194/32"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("109.41.115.194")},
+			},
+			wantErr: false,
+			isValid: true,
+		},
+		{
+			name: "IPv4-mapped IPv6 connection IP matches IPv4 /32",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionDeny,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("109.41.115.194/32"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("::ffff:109.41.115.194")},
+			},
+			wantErr: false,
+			isValid: false,
+		},
+		{
+			name: "Empty NetworkAddresses and empty ConnectionIP still errors",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionDeny,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("109.41.115.194/32"),
 				},
 			},
 			peer:    nbpeer.Peer{},

--- a/management/server/posture/network_test.go
+++ b/management/server/posture/network_test.go
@@ -287,6 +287,24 @@ func TestPeerNetworkRangeCheck_Check(t *testing.T) {
 			isValid: false,
 		},
 		{
+			name: "Local NIC /24 does not match a /32 rule even if host bit lines up",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionAllow,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("192.168.0.5/32"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Meta: nbpeer.PeerSystemMeta{
+					NetworkAddresses: []nbpeer.NetworkAddress{
+						{NetIP: netip.MustParsePrefix("192.168.0.5/24")},
+					},
+				},
+			},
+			wantErr: false,
+			isValid: false,
+		},
+		{
 			name: "Local NIC address inside an allowed /16 range",
 			check: PeerNetworkRangeCheck{
 				Action: CheckActionAllow,

--- a/management/server/posture/network_test.go
+++ b/management/server/posture/network_test.go
@@ -230,6 +230,81 @@ func TestPeerNetworkRangeCheck_Check(t *testing.T) {
 			isValid: false,
 		},
 		{
+			name: "Connection IP falls inside an allowed /24 range",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionAllow,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("1.0.0.0/24"),
+					netip.MustParsePrefix("2.2.2.2/32"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("1.0.0.55")},
+			},
+			wantErr: false,
+			isValid: true,
+		},
+		{
+			name: "Connection IP falls inside an allowed /23 range",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionAllow,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("3.0.0.0/23"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("3.0.1.200")},
+			},
+			wantErr: false,
+			isValid: true,
+		},
+		{
+			name: "Connection IP outside the allowed /24 range",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionAllow,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("1.0.0.0/24"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("1.0.1.5")},
+			},
+			wantErr: false,
+			isValid: false,
+		},
+		{
+			name: "Connection IP inside a denied /24 range",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionDeny,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("1.0.0.0/24"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("1.0.0.7")},
+			},
+			wantErr: false,
+			isValid: false,
+		},
+		{
+			name: "Local NIC address inside an allowed /16 range",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionAllow,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("192.168.0.0/16"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Meta: nbpeer.PeerSystemMeta{
+					NetworkAddresses: []nbpeer.NetworkAddress{
+						{NetIP: netip.MustParsePrefix("192.168.5.7/24")},
+					},
+				},
+			},
+			wantErr: false,
+			isValid: true,
+		},
+		{
 			name: "Empty NetworkAddresses and empty ConnectionIP still errors",
 			check: PeerNetworkRangeCheck{
 				Action: CheckActionDeny,

--- a/management/server/posture/network_test.go
+++ b/management/server/posture/network_test.go
@@ -188,6 +188,34 @@ func TestPeerNetworkRangeCheck_Check(t *testing.T) {
 			isValid: true,
 		},
 		{
+			name: "IPv6 connection IP matches the denied /128",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionDeny,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("2001:db8::1/128"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("2001:db8::1")},
+			},
+			wantErr: false,
+			isValid: false,
+		},
+		{
+			name: "IPv6 connection IP does not match the denied /128",
+			check: PeerNetworkRangeCheck{
+				Action: CheckActionDeny,
+				Ranges: []netip.Prefix{
+					netip.MustParsePrefix("2001:db8::1/128"),
+				},
+			},
+			peer: nbpeer.Peer{
+				Location: nbpeer.Location{ConnectionIP: net.ParseIP("2001:db8::2")},
+			},
+			wantErr: false,
+			isValid: true,
+		},
+		{
 			name: "IPv4-mapped IPv6 connection IP matches IPv4 /32",
 			check: PeerNetworkRangeCheck{
 				Action: CheckActionDeny,

--- a/shared/management/http/api/openapi.yml
+++ b/shared/management/http/api/openapi.yml
@@ -1687,15 +1687,18 @@ components:
         - locations
         - action
     PeerNetworkRangeCheck:
-      description: Posture check for allow or deny access based on peer local network addresses
+      description: |
+        Posture check for allow or deny access based on the peer's IP addresses. A range matches when it
+        contains any of the peer's local network interface IPs or its public connection (NAT egress) IP,
+        so ranges may target private subnets, public CIDRs, or single hosts via a /32 or /128.
       type: object
       properties:
         ranges:
-          description: List of peer network ranges in CIDR notation
+          description: List of network ranges in CIDR notation, matched against the peer's local interface IPs and its public connection IP
           type: array
           items:
             type: string
-          example: [ "192.168.1.0/24", "10.0.0.0/8", "2001:db8:1234:1a00::/56" ]
+          example: [ "192.168.1.0/24", "10.0.0.0/8", "1.0.0.0/24", "2.2.2.2/32", "2001:db8:1234:1a00::/56" ]
         action:
           description: Action to take upon policy match
           type: string

--- a/shared/management/http/api/types.gen.go
+++ b/shared/management/http/api/types.gen.go
@@ -1626,7 +1626,7 @@ type Checks struct {
 	// OsVersionCheck Posture check for the version of operating system
 	OsVersionCheck *OSVersionCheck `json:"os_version_check,omitempty"`
 
-	// PeerNetworkRangeCheck Posture check for allow or deny access based on peer local network addresses
+	// PeerNetworkRangeCheck Posture check for allow or deny access based on the peer's IP addresses. A range matches when it contains any of the peer's local network interface IPs or its public connection (NAT egress) IP, so ranges may target private subnets, public CIDRs, or single hosts via a /32 or /128.
 	PeerNetworkRangeCheck *PeerNetworkRangeCheck `json:"peer_network_range_check,omitempty"`
 
 	// ProcessCheck Posture Check for binaries exist and are running in the peer’s system
@@ -3312,12 +3312,12 @@ type PeerMinimum struct {
 	Name string `json:"name"`
 }
 
-// PeerNetworkRangeCheck Posture check for allow or deny access based on peer local network addresses
+// PeerNetworkRangeCheck Posture check for allow or deny access based on the peer's IP addresses. A range matches when it contains any of the peer's local network interface IPs or its public connection (NAT egress) IP, so ranges may target private subnets, public CIDRs, or single hosts via a /32 or /128.
 type PeerNetworkRangeCheck struct {
 	// Action Action to take upon policy match
 	Action PeerNetworkRangeCheckAction `json:"action"`
 
-	// Ranges List of peer network ranges in CIDR notation
+	// Ranges List of network ranges in CIDR notation, matched against the peer's local interface IPs and its public connection IP
 	Ranges []string `json:"ranges"`
 }
 


### PR DESCRIPTION
## Describe your changes

PeerNetworkRangeCheck now also evaluates the peer's public connection IP (the source IP the management server observes), in addition to the peer's local network interface ranges. The connection IP is matched as a single-host 
  prefix (/32 for IPv4, /128 for IPv6, with IPv4-in-IPv6 forms normalized via Unmap), enabling rules like "block peers connecting from the office public IP 203.0.113.10/32" — which previously couldn't be expressed because the
  check only saw local NIC addresses.                                                                                                                                                                                              
                  
  Backward compatible: existing rules matching on local network ranges behave identically. The "empty addresses" error path now only triggers when both NetworkAddresses and ConnectionIP are absent. Includes new unit tests for  
  IPv4/IPv6 match and non-match, IPv4-mapped IPv6, and the preserved empty-input error case. Docs updated in the docs repo (posture-checks/index.mdx and connecting-from-the-office.mdx) with IPv4/IPv6 examples and a note on
  reverse-proxy X-Forwarded-For requirements.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
https://github.com/netbirdio/docs/pull/718
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Network range validation now checks any peer IP (local interface addresses plus public connection/NAT egress IP) and uses containment-based matching for IPv4 and IPv6, including /32 and /128 single-host entries.

* **Tests**
  * Expanded coverage for IPv4, IPv6, IPv4-mapped IPv6, subnet and exact-host matches, and the error case when no peer addresses are present.

* **Documentation**
  * Clarified OpenAPI and in-code docs to describe matching behavior and updated example CIDRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->