### PR TITLE
[client] Use fwmark-aware route lookup for raw socket UDP checksum source

### DIFF
--- a/sharedsock/sock_linux.go
+++ b/sharedsock/sock_linux.go
@@ -302,6 +302,9 @@ func (s *SharedSocket) WriteTo(buf []byte, rAddr net.Addr) (n int, err error) {
 	}
 
 	rSockAddr, conn, nwLayer := s.getWriterObjects(src, rUDPAddr.IP)
+	if conn == nil {
+		return 0, fmt.Errorf("no raw socket for %s", rUDPAddr.IP)
+	}
 
 	if err := udp.SetNetworkLayerForChecksum(nwLayer); err != nil {
 		return -1, fmt.Errorf("failed to set network layer for checksum: %w", err)

--- a/sharedsock/sock_linux.go
+++ b/sharedsock/sock_linux.go
@@ -10,15 +10,13 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/google/gopacket/routing"
-	"github.com/libp2p/go-netroute"
 	"github.com/mdlayher/socket"
 	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 
@@ -37,8 +35,6 @@ type SharedSocket struct {
 	conn6       *socket.Conn
 	port        int
 	mtu         uint16
-	routerMux   sync.RWMutex
-	router      routing.Router
 	packetDemux chan rcvdPacket
 	cancel      context.CancelFunc
 }
@@ -82,11 +78,6 @@ func Listen(port int, filter BPFFilter, mtu uint16) (_ net.PacketConn, err error
 		}
 	}()
 
-	rawSock.router, err = netroute.New()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create raw socket router: %w", err)
-	}
-
 	rawSock.conn4, err = socket.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_UDP, "raw_udp4", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ipv4 raw socket: %w", err)
@@ -127,31 +118,26 @@ func Listen(port int, filter BPFFilter, mtu uint16) (_ net.PacketConn, err error
 		go rawSock.read(rawSock.conn6.Recvfrom)
 	}
 
-	go rawSock.updateRouter()
-
 	return rawSock, nil
 }
 
-// updateRouter updates the listener routing table client
-// this is needed to avoid outdated information across different client networks
-func (s *SharedSocket) updateRouter() {
-	ticker := time.NewTicker(15 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-s.ctx.Done():
-			return
-		case <-ticker.C:
-			router, err := netroute.New()
-			if err != nil {
-				log.Errorf("Failed to create and update packet router for stunListener: %s", err)
-				continue
-			}
-			s.routerMux.Lock()
-			s.router = router
-			s.routerMux.Unlock()
+// resolveSrc returns the source IP the kernel will pick for a packet sent to
+// dst by these raw sockets, mirroring the fwmark the kernel will see on send.
+func (s *SharedSocket) resolveSrc(dst net.IP) (net.IP, error) {
+	opts := &netlink.RouteGetOptions{}
+	if nbnet.AdvancedRouting() {
+		opts.Mark = nbnet.ControlPlaneMark
+	}
+	routes, err := netlink.RouteGetWithOptions(dst, opts)
+	if err != nil {
+		return nil, fmt.Errorf("route get %s: %w", dst, err)
+	}
+	for _, r := range routes {
+		if r.Src != nil {
+			return r.Src, nil
 		}
 	}
+	return nil, fmt.Errorf("no source IP for %s", dst)
 }
 
 // LocalAddr returns the local address, preferring IPv4 for backward compatibility.
@@ -310,12 +296,9 @@ func (s *SharedSocket) WriteTo(buf []byte, rAddr net.Addr) (n int, err error) {
 		DstPort: layers.UDPPort(rUDPAddr.Port),
 	}
 
-	s.routerMux.RLock()
-	defer s.routerMux.RUnlock()
-
-	_, _, src, err := s.router.Route(rUDPAddr.IP)
+	src, err := s.resolveSrc(rUDPAddr.IP)
 	if err != nil {
-		return 0, fmt.Errorf("got an error while checking route, err: %w", err)
+		return 0, fmt.Errorf("resolve source for %s: %w", rUDPAddr.IP, err)
 	}
 
 	rSockAddr, conn, nwLayer := s.getWriterObjects(src, rUDPAddr.IP)


### PR DESCRIPTION
## Describe your changes

Fixes #4503 on Linux: enabling an exit node (`0.0.0.0/0` route) caused already-P2P connections to fall back to Relayed.

The Linux raw-socket path that ICE/STUN traffic shares with WireGuard precomputed the UDP checksum from a source IP returned by a fwmark-unaware route lookup. Once an exit-node peer installed `0.0.0.0/0`, that lookup started returning the wt0 source while the kernel (honoring `SO_MARK`) actually sent the packet from the underlay interface, so receivers dropped the packets on checksum mismatch and ICE silently fell back to relay.

- Replace the periodic `libp2p/go-netroute` snapshot in sharedsock with a per-send `netlink.RouteGetWithOptions` call that passes the control-plane fwmark when advanced routing is on, so the precomputed UDP pseudo-header source matches the IP source the kernel will use on the wire.
- Drop the now-unused router cache, mutex, and refresh goroutine.

## Issue ticket number and link

#4503

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal Linux networking detail with no user-facing surface.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic source IP resolution for network routing, enhancing compatibility with advanced routing configurations.

* **Refactor**
  * Optimized socket routing logic by removing periodic cache refresh mechanism, reducing resource overhead while maintaining routing accuracy on a per-destination basis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->