### PR TITLE
dns: prefer loopback over WireGuard IP when binding DNS listener

### DIFF
--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -188,11 +188,10 @@ func (s *serviceViaListener) RuntimeIP() netip.Addr {
 	return s.listenIP
 }
 
-
-// evalListenAddress figure out the listen address for the DNS server
-// first check the 53 port availability on lo or WG interface, if not success
-// pick a random port on WG interface for eBPF, if not success
-// check the 5053 port availability on lo or WG interface without eBPF usage,
+// evalListenAddress figure out the listen address for the DNS server.
+// First tries port 53 on loopback (127.0.0.1, then 127.0.0.153), then the WireGuard IP.
+// If port 53 is unavailable everywhere, tries eBPF on a random port bound to the WireGuard IP.
+// As a final fallback, retries port 5053 in the same loopback-first order.
 func (s *serviceViaListener) evalListenAddress() (netip.Addr, uint16, error) {
 	if s.customAddr != nil {
 		return s.customAddr.Addr(), s.customAddr.Port(), nil

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -190,9 +190,9 @@ func (s *serviceViaListener) RuntimeIP() netip.Addr {
 
 
 // evalListenAddress figure out the listen address for the DNS server
-// first check the 53 port availability on WG interface or lo, if not success
+// first check the 53 port availability on lo or WG interface, if not success
 // pick a random port on WG interface for eBPF, if not success
-// check the 5053 port availability on WG interface or lo without eBPF usage,
+// check the 5053 port availability on lo or WG interface without eBPF usage,
 func (s *serviceViaListener) evalListenAddress() (netip.Addr, uint16, error) {
 	if s.customAddr != nil {
 		return s.customAddr.Addr(), s.customAddr.Port(), nil

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -220,7 +220,7 @@ func (s *serviceViaListener) evalListenAddress() (netip.Addr, uint16, error) {
 func (s *serviceViaListener) testFreePort(port int) (netip.Addr, bool) {
 	var ips []netip.Addr
 	if runtime.GOOS != "darwin" {
-		ips = []netip.Addr{s.wgInterface.Address().IP, defaultIP, customIP}
+		ips = []netip.Addr{defaultIP, customIP, s.wgInterface.Address().IP}
 	} else {
 		ips = []netip.Addr{defaultIP, customIP}
 	}

--- a/client/internal/dns/service_listener_test.go
+++ b/client/internal/dns/service_listener_test.go
@@ -12,6 +12,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestTestFreePort_PrefersLoopback verifies that testFreePort returns a loopback
+// address rather than the WireGuard interface IP when both are available.
+// Before the fix, the WireGuard IP was tried first; binding there caused DNS
+// queries to be silently dropped by the WireGuard kernel module.
+func TestTestFreePort_PrefersLoopback(t *testing.T) {
+	// Find a free port by letting the OS pick one, then releasing it.
+	udpLn, err := net.ListenUDP("udp", net.UDPAddrFromAddrPort(netip.MustParseAddrPort("0.0.0.0:0")))
+	require.NoError(t, err)
+	port := uint16(udpLn.LocalAddr().(*net.UDPAddr).Port)
+	require.NoError(t, udpLn.Close())
+
+	svc := newServiceViaListener(&mocWGIface{}, nil, nil)
+	ip, ok := svc.testFreePort(int(port))
+	require.True(t, ok, "expected to find a free port on loopback")
+	assert.True(t, ip.IsLoopback(), "expected loopback address, got %s — WireGuard IP must not be preferred", ip)
+}
+
 func TestServiceViaListener_TCPAndUDP(t *testing.T) {
 	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
 		m := new(dns.Msg)


### PR DESCRIPTION
## Describe your changes

\`testFreePort\` in \`client/internal/dns/service_listener.go\` tries the WireGuard interface IP first when scanning for a free port. If the DNS server binds to that IP (e.g. \`100.71.x.x:53\`), queries routed to it are silently dropped by the WireGuard kernel module — the host's own WireGuard IP is not in any peer's \`AllowedIPs\`, so packets never reach the listener. DNS resolution breaks entirely.

This fix reorders the candidate IP list so loopback (\`127.0.0.1\`) is tried first, then \`127.0.0.153\`, with the WireGuard IP as a last resort. The DNS proxy then binds to a loopback address where packets are always delivered locally.

\`\`\`go
// Before
ips = []netip.Addr{s.wgInterface.Address().IP, defaultIP, customIP}

// After
ips = []netip.Addr{defaultIP, customIP, s.wgInterface.Address().IP}
\`\`\`

Verified on Ubuntu 25.10 with systemd-resolved: after the fix \`netbird\` binds to \`127.0.0.1:53\` and DNS resolves correctly. Before the fix it bound to the WireGuard IP and all DNS queries timed out.

## Issue ticket number and link

Fixes #4110 (timeout towards netbird domain DNS forwarder on arch linux)
Related to #3258 (client does not set DNS server in systemd-resolved on Linux)

Both issues stem from the DNS listener binding to the WireGuard interface IP, which the WireGuard kernel module drops packets for since the local IP is not in any peer's AllowedIPs.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] Documentation is **not needed** for this change (internal bind address selection, no user-facing behavior change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted DNS port probing order on non-Darwin systems to prefer loopback addresses when determining a free port.
* **Tests**
  * Added a test ensuring loopback addresses are preferred over other interfaces when selecting a free DNS port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->