### PR TITLE
[client] iOS: structured ResolvedIPs collection for domain routes

### DIFF
--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -413,23 +413,40 @@ func (c *Client) GetRoutesSelectionDetails() (*RoutesSelectionDetails, error) {
 func prepareRouteSelectionDetails(routes []*selectRoute, resolvedDomains map[domain.Domain]peer.ResolvedDomainInfo) *RoutesSelectionDetails {
 	var routeSelection []RoutesSelectionInfo
 	for _, r := range routes {
-		domainList := make([]DomainInfo, 0)
+		// resolvedDomains is keyed by the resolved domain (e.g. api.ipify.org),
+		// not the configured pattern (e.g. *.ipify.org). Group entries whose
+		// ParentDomain belongs to this route, mirroring the daemon logic in
+		// client/server/network.go.
+		domainList := make([]DomainInfo, 0, len(r.Domains))
+		domainIndex := make(map[domain.Domain]int, len(r.Domains))
 		for _, d := range r.Domains {
-			domainResp := DomainInfo{
-				Domain: d.SafeString(),
-			}
-
-			if info, exists := resolvedDomains[d]; exists {
-				for _, prefix := range info.Prefixes {
-					domainResp.AddResolvedIP(prefix.Addr().String())
-				}
-			}
-			domainList = append(domainList, domainResp)
+			domainIndex[d] = len(domainList)
+			domainList = append(domainList, DomainInfo{Domain: d.SafeString()})
 		}
+
+		for _, info := range resolvedDomains {
+			idx, ok := domainIndex[info.ParentDomain]
+			if !ok {
+				continue
+			}
+			for _, prefix := range info.Prefixes {
+				domainList[idx].AddResolvedIP(prefix.Addr().String())
+			}
+		}
+
 		domainDetails := DomainDetails{items: domainList}
+
+		// For dynamic (DNS) routes, expose the joined domain pattern as the
+		// Network value so it matches the peer.routes entries on the Swift
+		// side (mirroring the Android bridge in client/android/client.go).
+		netStr := r.Network.String()
+		if len(r.Domains) > 0 {
+			netStr = r.Domains.SafeString()
+		}
+
 		routeSelection = append(routeSelection, RoutesSelectionInfo{
 			ID:       r.NetID,
-			Network:  r.Network.String(),
+			Network:  netStr,
 			Domains:  &domainDetails,
 			Selected: r.Selected,
 		})

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -420,11 +420,9 @@ func prepareRouteSelectionDetails(routes []*selectRoute, resolvedDomains map[dom
 			}
 
 			if info, exists := resolvedDomains[d]; exists {
-				var ipStrings []string
 				for _, prefix := range info.Prefixes {
-					ipStrings = append(ipStrings, prefix.Addr().String())
+					domainResp.AddResolvedIP(prefix.Addr().String())
 				}
-				domainResp.ResolvedIPs = strings.Join(ipStrings, ", ")
 			}
 			domainList = append(domainList, domainResp)
 		}

--- a/client/ios/NetBirdSDK/routes.go
+++ b/client/ios/NetBirdSDK/routes.go
@@ -34,7 +34,34 @@ type DomainDetails struct {
 
 type DomainInfo struct {
 	Domain      string
-	ResolvedIPs string
+	resolvedIPs ResolvedIPs
+}
+
+func (d *DomainInfo) AddResolvedIP(ipAddress string) {
+	d.resolvedIPs.Add(ipAddress)
+}
+
+func (d *DomainInfo) GetResolvedIPs() *ResolvedIPs {
+	return &d.resolvedIPs
+}
+
+type ResolvedIPs struct {
+	items []string
+}
+
+func (r *ResolvedIPs) Add(ipAddress string) {
+	r.items = append(r.items, ipAddress)
+}
+
+func (r *ResolvedIPs) Get(i int) string {
+	if i < 0 || i >= len(r.items) {
+		return ""
+	}
+	return r.items[i]
+}
+
+func (r *ResolvedIPs) Size() int {
+	return len(r.items)
 }
 
 // Add new PeerInfo to the collection


### PR DESCRIPTION
Replace comma-joined ResolvedIPs string with a gomobile-friendly ResolvedIPs collection (Add/Get/Size), mirroring the Android bridge in client/android/network_domains.go.

This allows the iOS app to match domain-route resolved IPs against connected peer routes without parsing CSV strings, fixing the route status indicator for dynamic (DNS) routes.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved domain IP resolution in the iOS NetBirdSDK to aggregate addresses per domain.
  * Enhances reliability and maintainability of domain resolution, reducing edge-case mismatches and improving connection consistency for iOS users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->