### PR TITLE
[client] Handle management and admin url in profile add command

### DIFF
--- a/client/cmd/profile.go
+++ b/client/cmd/profile.go
@@ -132,6 +132,17 @@ func addProfileFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if managementURL != "" || adminURL != "" {
+		if _, err = daemonClient.SetConfig(cmd.Context(), &proto.SetConfigRequest{
+			ProfileName:   profileName,
+			Username:      currUser.Username,
+			ManagementUrl: managementURL,
+			AdminURL:      adminURL,
+		}); err != nil {
+			return fmt.Errorf("profile created but failed to set URLs: %w", err)
+		}
+	}
+
 	cmd.Println("Profile added successfully:", profileName)
 	return nil
 }


### PR DESCRIPTION
## Describe your changes
I called SetConfig after profile add if there is custom management or/and admin url.

## Issue ticket number and link
#5983

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:
- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

I used global flags that should be respected by subcommands. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional management and admin URL configuration during profile creation. Users can now specify these URLs when setting up a new profile, and the system will automatically apply these configurations with improved error handling. Descriptive error messages are provided to assist users with troubleshooting and verifying their configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->