### PR TITLE
[management] migration: convert SQLite-imported bool columns to native Postgres boolean (fixes #4326)

### DIFF
--- a/management/server/migration/migration.go
+++ b/management/server/migration/migration.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"unicode/utf8"
 
@@ -630,6 +631,115 @@ func RemoveDuplicatePeerKeys(ctx context.Context, db *gorm.DB) error {
 
 		if err := db.Table("peers").Where("id IN ?", idsToDelete).Delete(nil).Error; err != nil {
 			return fmt.Errorf("delete duplicate peers: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// FixPostgresBoolColumns walks the gorm-mapped fields of T and ensures every
+// bool-typed field has the corresponding Postgres column declared as type
+// `boolean`. This addresses the failure mode reported in
+// https://github.com/netbirdio/netbird/issues/4326 where a SQLite -> Postgres
+// data migration done with external tooling (e.g. pgloader) preserves the
+// SQLite INTEGER 0/1 representation as Postgres `numeric`. The Go struct
+// fields are bool, so any subsequent attempt to write `true` from the
+// management server fails with:
+//
+//	failed to encode args[N]: unable to encode true into binary format for
+//	numeric (OID 1700): cannot find encode plan
+//
+// On non-Postgres engines the function is a no-op. On Postgres it queries
+// information_schema.columns for each gorm-mapped bool field and runs an
+// idempotent ALTER TABLE ... ALTER COLUMN ... TYPE boolean USING ... when
+// the current type is anything other than `boolean`. Default values are
+// re-applied so the migrated schema matches what gorm.AutoMigrate would
+// have produced on a fresh install.
+//
+// The migration must run in the pre-AutoMigrate phase so AutoMigrate's own
+// type-mismatch check does not trip on the still-numeric columns.
+func FixPostgresBoolColumns[T any](ctx context.Context, db *gorm.DB) error {
+	if db.Name() != "postgres" {
+		return nil
+	}
+
+	var model T
+
+	if !db.Migrator().HasTable(&model) {
+		log.WithContext(ctx).Debugf("table for %T does not exist, no postgres bool migration needed", model)
+		return nil
+	}
+
+	stmt := &gorm.Statement{DB: db}
+	if err := stmt.Parse(&model); err != nil {
+		return fmt.Errorf("parse model: %w", err)
+	}
+	tableName := stmt.Schema.Table
+
+	for _, field := range stmt.Schema.Fields {
+		if field.IgnoreMigration || field.DBName == "" {
+			continue
+		}
+		if field.FieldType.Kind() != reflect.Bool {
+			continue
+		}
+
+		columnName := field.DBName
+		var dataType string
+		row := db.Raw(`
+			SELECT data_type
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = ?
+			  AND column_name = ?
+		`, tableName, columnName).Row()
+		if err := row.Scan(&dataType); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				// column not in DB yet — AutoMigrate will create it as boolean
+				continue
+			}
+			return fmt.Errorf("inspect %s.%s: %w", tableName, columnName, err)
+		}
+		if dataType == "" || dataType == "boolean" {
+			continue
+		}
+
+		log.WithContext(ctx).Infof(
+			"converting Postgres column %s.%s from %s to boolean (issue #4326)",
+			tableName, columnName, dataType,
+		)
+
+		// USING expression: cast to numeric (covers numeric/integer/bigint/
+		// smallint) and compare to 0; NULL -> false via COALESCE. text-typed
+		// columns containing "0"/"1" also work; "true"/"false" text values
+		// would error but are not produced by the SQLite-import path that
+		// motivates this migration.
+		usingExpr := fmt.Sprintf(`COALESCE(%q::numeric, 0) <> 0`, columnName)
+
+		alters := []string{
+			// drop any existing default first — the cast may be incompatible
+			// with the current default expression.
+			fmt.Sprintf(`ALTER TABLE %q ALTER COLUMN %q DROP DEFAULT`, tableName, columnName),
+			fmt.Sprintf(
+				`ALTER TABLE %q ALTER COLUMN %q TYPE boolean USING (%s)`,
+				tableName, columnName, usingExpr,
+			),
+			// re-establish the default and the NOT NULL constraint that
+			// gorm.AutoMigrate would have applied on a fresh install.
+			fmt.Sprintf(`UPDATE %q SET %q = false WHERE %q IS NULL`, tableName, columnName, columnName),
+			fmt.Sprintf(`ALTER TABLE %q ALTER COLUMN %q SET NOT NULL`, tableName, columnName),
+			fmt.Sprintf(`ALTER TABLE %q ALTER COLUMN %q SET DEFAULT false`, tableName, columnName),
+		}
+
+		if err := db.Transaction(func(tx *gorm.DB) error {
+			for _, sqlStmt := range alters {
+				if err := tx.Exec(sqlStmt).Error; err != nil {
+					return fmt.Errorf("apply %s: %w", sqlStmt, err)
+				}
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("convert %s.%s: %w", tableName, columnName, err)
 		}
 	}
 

--- a/management/server/migration/migration_test.go
+++ b/management/server/migration/migration_test.go
@@ -635,3 +635,209 @@ func TestCleanupOrphanedResources_SkipsWhenForeignKeyExists(t *testing.T) {
 	db.Model(&testChildWithFK{}).Count(&count)
 	assert.Equal(t, int64(2), count, "Both rows should survive — migration must skip when FK constraint exists")
 }
+
+// --- FixPostgresBoolColumns (issue #4326) -----------------------------------
+
+// boolColTestModel is the synthetic model used by the FixPostgresBoolColumns
+// tests. Mirrors the shape of a settings-bearing entity (top-level bool +
+// embedded Settings-style bool) so the test exercises both direct columns and
+// columns produced via gorm `embedded;embeddedPrefix:`.
+type boolColTestSettings struct {
+	LazyConnectionEnabled bool `gorm:"default:false"`
+	JWTGroupsEnabled      bool `gorm:"default:false"`
+}
+
+type boolColTestModel struct {
+	ID                 string `gorm:"primaryKey"`
+	TopLevelBool       bool   `gorm:"default:false"`
+	NonBool            string
+	Settings           *boolColTestSettings `gorm:"embedded;embeddedPrefix:settings_"`
+}
+
+func (boolColTestModel) TableName() string { return "bool_col_test_models" }
+
+func TestFixPostgresBoolColumns_NoOpOnSqlite(t *testing.T) {
+	t.Setenv("NETBIRD_STORE_ENGINE", "sqlite")
+	db := setupDatabase(t)
+	require.NoError(t, db.AutoMigrate(&boolColTestModel{}))
+
+	// Function returns nil and changes nothing on SQLite.
+	err := migration.FixPostgresBoolColumns[boolColTestModel](context.Background(), db)
+	require.NoError(t, err)
+
+	// Sanity: AutoMigrate-created columns are usable (insert + read bool).
+	require.NoError(t, db.Create(&boolColTestModel{ID: "a", TopLevelBool: true,
+		Settings: &boolColTestSettings{LazyConnectionEnabled: true}}).Error)
+	var got boolColTestModel
+	require.NoError(t, db.First(&got, "id = ?", "a").Error)
+	assert.True(t, got.TopLevelBool)
+	assert.True(t, got.Settings.LazyConnectionEnabled)
+}
+
+func TestFixPostgresBoolColumns_TableMissingIsNoOp(t *testing.T) {
+	if os.Getenv("NETBIRD_STORE_ENGINE") != "postgres" {
+		t.Skip("NETBIRD_STORE_ENGINE != postgres — skipping postgres-only test")
+	}
+	db := setupDatabase(t)
+
+	// Table not created.
+	err := migration.FixPostgresBoolColumns[boolColTestModel](context.Background(), db)
+	require.NoError(t, err, "missing table must be a no-op, not an error")
+}
+
+func TestFixPostgresBoolColumns_AlreadyBooleanIsNoOp(t *testing.T) {
+	if os.Getenv("NETBIRD_STORE_ENGINE") != "postgres" {
+		t.Skip("NETBIRD_STORE_ENGINE != postgres — skipping postgres-only test")
+	}
+	db := setupDatabase(t)
+	require.NoError(t, db.AutoMigrate(&boolColTestModel{}))
+
+	err := migration.FixPostgresBoolColumns[boolColTestModel](context.Background(), db)
+	require.NoError(t, err)
+
+	// Bool inserts must still work afterwards.
+	require.NoError(t, db.Create(&boolColTestModel{ID: "a", TopLevelBool: true,
+		Settings: &boolColTestSettings{LazyConnectionEnabled: true}}).Error)
+
+	// Verify column type stayed `boolean`.
+	for _, col := range []string{"top_level_bool", "settings_lazy_connection_enabled", "settings_jwt_groups_enabled"} {
+		var dt string
+		require.NoError(t, db.Raw(
+			`SELECT data_type FROM information_schema.columns WHERE table_name = ? AND column_name = ?`,
+			"bool_col_test_models", col,
+		).Row().Scan(&dt))
+		assert.Equal(t, "boolean", dt, "column %s should be boolean", col)
+	}
+}
+
+// TestFixPostgresBoolColumns_ConvertsNumericColumnsAndPreservesData is the
+// core regression test for issue #4326. It synthesises the broken-schema
+// state produced by a SQLite -> Postgres data migration done with external
+// tooling (numeric columns where the Go struct expects bool), seeds rows
+// with NULL/0/1 values, runs the migration, and asserts that:
+//
+//  1. each affected column is now declared as `boolean`
+//  2. existing rows have correctly-converted boolean values
+//  3. management-server-style writes (Go bool true) succeed afterwards
+//     (this is the actual user-reported failure mode).
+func TestFixPostgresBoolColumns_ConvertsNumericColumnsAndPreservesData(t *testing.T) {
+	if os.Getenv("NETBIRD_STORE_ENGINE") != "postgres" {
+		t.Skip("NETBIRD_STORE_ENGINE != postgres — skipping postgres-only test")
+	}
+	db := setupDatabase(t)
+
+	// Build the broken schema by hand: integer/numeric columns where the
+	// gorm-mapped Go field is bool. This reproduces the post-pgloader state
+	// reported in #4326.
+	require.NoError(t, db.Exec(`DROP TABLE IF EXISTS bool_col_test_models`).Error)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE bool_col_test_models (
+			id text PRIMARY KEY,
+			top_level_bool numeric DEFAULT 0,
+			non_bool text,
+			settings_lazy_connection_enabled numeric DEFAULT 0,
+			settings_jwt_groups_enabled numeric DEFAULT 0
+		)
+	`).Error)
+
+	// Seed rows representing the three input states the migration must handle:
+	// NULL, 0 (false), 1 (true).
+	require.NoError(t, db.Exec(`
+		INSERT INTO bool_col_test_models
+			(id, top_level_bool, non_bool, settings_lazy_connection_enabled, settings_jwt_groups_enabled)
+		VALUES
+			('null',  NULL, 'a', NULL, NULL),
+			('false', 0,    'b', 0,    0),
+			('true',  1,    'c', 1,    1)
+	`).Error)
+
+	// Run the migration.
+	err := migration.FixPostgresBoolColumns[boolColTestModel](context.Background(), db)
+	require.NoError(t, err)
+
+	// 1. Column types are now boolean.
+	for _, col := range []string{"top_level_bool", "settings_lazy_connection_enabled", "settings_jwt_groups_enabled"} {
+		var dt string
+		require.NoError(t, db.Raw(
+			`SELECT data_type FROM information_schema.columns WHERE table_name = ? AND column_name = ?`,
+			"bool_col_test_models", col,
+		).Row().Scan(&dt))
+		assert.Equal(t, "boolean", dt, "column %s should be boolean after migration", col)
+	}
+
+	// non_bool column must NOT have been touched.
+	var nonBoolType string
+	require.NoError(t, db.Raw(
+		`SELECT data_type FROM information_schema.columns WHERE table_name = ? AND column_name = ?`,
+		"bool_col_test_models", "non_bool",
+	).Row().Scan(&nonBoolType))
+	assert.Equal(t, "text", nonBoolType, "non-bool columns must be left untouched")
+
+	// 2. Existing rows have correctly-converted values; NULL became false.
+	var rows []struct {
+		ID                            string
+		TopLevelBool                  bool `gorm:"column:top_level_bool"`
+		SettingsLazyConnectionEnabled bool `gorm:"column:settings_lazy_connection_enabled"`
+		SettingsJwtGroupsEnabled      bool `gorm:"column:settings_jwt_groups_enabled"`
+	}
+	require.NoError(t, db.Table("bool_col_test_models").Order("id").Find(&rows).Error)
+	require.Len(t, rows, 3)
+	// rows are: false (id=false), null->false (id=null), true (id=true) by id-sort
+	byID := map[string]bool{}
+	for _, r := range rows {
+		byID[r.ID+"|top"] = r.TopLevelBool
+		byID[r.ID+"|lazy"] = r.SettingsLazyConnectionEnabled
+		byID[r.ID+"|jwt"] = r.SettingsJwtGroupsEnabled
+	}
+	for _, suffix := range []string{"top", "lazy", "jwt"} {
+		assert.False(t, byID["null|"+suffix], "NULL must have become false (col=%s)", suffix)
+		assert.False(t, byID["false|"+suffix], "0 must have stayed false (col=%s)", suffix)
+		assert.True(t, byID["true|"+suffix], "1 must have become true (col=%s)", suffix)
+	}
+
+	// 3. The user-reported failure mode: writing Go bool true via gorm now works.
+	require.NoError(t, db.Create(&boolColTestModel{
+		ID:           "post",
+		TopLevelBool: true,
+		Settings:     &boolColTestSettings{LazyConnectionEnabled: true, JWTGroupsEnabled: true},
+	}).Error, "writing Go bool=true after migration must succeed")
+
+	var roundTripped boolColTestModel
+	require.NoError(t, db.First(&roundTripped, "id = ?", "post").Error)
+	assert.True(t, roundTripped.TopLevelBool)
+	require.NotNil(t, roundTripped.Settings)
+	assert.True(t, roundTripped.Settings.LazyConnectionEnabled)
+	assert.True(t, roundTripped.Settings.JWTGroupsEnabled)
+}
+
+// TestFixPostgresBoolColumns_IsIdempotent verifies that running the migration
+// twice in a row is safe — the second run is a no-op because all columns are
+// already boolean. This matters for the management-server startup path, which
+// runs the migration unconditionally.
+func TestFixPostgresBoolColumns_IsIdempotent(t *testing.T) {
+	if os.Getenv("NETBIRD_STORE_ENGINE") != "postgres" {
+		t.Skip("NETBIRD_STORE_ENGINE != postgres — skipping postgres-only test")
+	}
+	db := setupDatabase(t)
+
+	require.NoError(t, db.Exec(`DROP TABLE IF EXISTS bool_col_test_models`).Error)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE bool_col_test_models (
+			id text PRIMARY KEY,
+			top_level_bool numeric DEFAULT 0,
+			non_bool text,
+			settings_lazy_connection_enabled numeric DEFAULT 0,
+			settings_jwt_groups_enabled numeric DEFAULT 0
+		)
+	`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO bool_col_test_models (id, top_level_bool) VALUES ('x', 1)`).Error)
+
+	require.NoError(t, migration.FixPostgresBoolColumns[boolColTestModel](context.Background(), db))
+	require.NoError(t, migration.FixPostgresBoolColumns[boolColTestModel](context.Background(), db),
+		"second run must be a no-op")
+
+	// Existing data must still be correct.
+	var topLevel bool
+	require.NoError(t, db.Raw(`SELECT top_level_bool FROM bool_col_test_models WHERE id = 'x'`).Row().Scan(&topLevel))
+	assert.True(t, topLevel)
+}

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -457,6 +457,15 @@ func getMigrationsPreAuto(ctx context.Context) []migrationFunc {
 		func(db *gorm.DB) error {
 			return migration.CleanupOrphanedResources[domain.Domain, types.Account](ctx, db, "account_id")
 		},
+		// Issue #4326: SQLite -> Postgres migrations done with external
+		// tooling (e.g. pgloader) preserve SQLite's INTEGER 0/1 bool
+		// representation as Postgres `numeric`, which then breaks any
+		// settings update with "cannot find encode plan". Convert all
+		// gorm-mapped bool columns on `accounts` to native `boolean`
+		// before AutoMigrate runs (no-op on non-Postgres engines).
+		func(db *gorm.DB) error {
+			return migration.FixPostgresBoolColumns[types.Account](ctx, db)
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #4326.

When a self-hosted NetBird management server is migrated from SQLite to Postgres with external tooling (e.g. `pgloader`), SQLite's INTEGER 0/1 representation of `bool` fields lands in Postgres as `numeric` rather than `boolean`. The Go struct fields are typed `bool`, so the very first attempt to update any account setting from the dashboard fails with:

```
failed to encode args[N]: unable to encode true into binary format for numeric (OID 1700): cannot find encode plan
```

Multiple operators have hit this on different bool settings fields ([reporter's original report](https://github.com/netbirdio/netbird/issues/4326), [confirmation](https://github.com/netbirdio/netbird/issues/4326#issuecomment-3611776843) that *"this behavior occurs on basically every setting related to the account settings"*). Until now the only fix was running manual `ALTER TABLE` statements per affected column.

## Change

New migration helper [`FixPostgresBoolColumns[T]`](management/server/migration/migration.go) that walks every gorm-mapped bool field on a model, inspects `information_schema.columns` for the actual SQL type, and runs an idempotent `ALTER COLUMN ... TYPE boolean USING ...` when the column is anything other than `boolean`. Conversion semantics:

- `NULL` → `false` (matches Go bool zero value)
- `0` → `false`
- non-zero numeric → `true`
- `NOT NULL` + `DEFAULT false` are re-applied so the post-migration schema matches what `gorm.AutoMigrate` would produce on a fresh install

The migration is registered for `types.Account` in `getMigrationsPreAuto`. Pre-AutoMigrate placement is required so `AutoMigrate`'s own type-mismatch check does not trip on the still-numeric columns. It is a strict no-op on non-Postgres engines (SQLite stores bools natively as INTEGER, MySQL as TINYINT(1) — neither needs conversion).

## Tests

All tests run against a real `postgres:16-alpine` test container via the existing `testcontainers-go` scaffolding:

| Test | Coverage |
|---|---|
| `TestFixPostgresBoolColumns_NoOpOnSqlite` | SQLite path is unchanged |
| `TestFixPostgresBoolColumns_TableMissingIsNoOp` | absent table → return nil, no error |
| `TestFixPostgresBoolColumns_AlreadyBooleanIsNoOp` | already-boolean columns are skipped (fresh-install idempotency) |
| `TestFixPostgresBoolColumns_ConvertsNumericColumnsAndPreservesData` | **core regression test for #4326**: synthesises the broken-schema state (numeric columns where bool is expected), seeds NULL/0/1 rows, runs the migration, asserts data_type is now `boolean`, NULL→false, 0→false, 1→true, and the user-reported failure mode (writing Go `bool=true` via gorm) succeeds afterwards |
| `TestFixPostgresBoolColumns_IsIdempotent` | running the migration twice in a row is safe |

```
$ NETBIRD_STORE_ENGINE=postgres go test ./management/server/migration/ -run TestFixPostgresBoolColumns -v -count=1
=== RUN   TestFixPostgresBoolColumns_NoOpOnSqlite
--- PASS: TestFixPostgresBoolColumns_NoOpOnSqlite (0.00s)
=== RUN   TestFixPostgresBoolColumns_TableMissingIsNoOp
--- PASS: TestFixPostgresBoolColumns_TableMissingIsNoOp (1.66s)
=== RUN   TestFixPostgresBoolColumns_AlreadyBooleanIsNoOp
--- PASS: TestFixPostgresBoolColumns_AlreadyBooleanIsNoOp (1.66s)
=== RUN   TestFixPostgresBoolColumns_ConvertsNumericColumnsAndPreservesData
time="2026-05-08T09:47:27Z" level=info msg="converting Postgres column bool_col_test_models.top_level_bool from numeric to boolean (issue #4326)"
time="2026-05-08T09:47:27Z" level=info msg="converting Postgres column bool_col_test_models.settings_lazy_connection_enabled from numeric to boolean (issue #4326)"
time="2026-05-08T09:47:27Z" level=info msg="converting Postgres column bool_col_test_models.settings_jwt_groups_enabled from numeric to boolean (issue #4326)"
--- PASS: TestFixPostgresBoolColumns_ConvertsNumericColumnsAndPreservesData (1.68s)
=== RUN   TestFixPostgresBoolColumns_IsIdempotent
--- PASS: TestFixPostgresBoolColumns_IsIdempotent (1.62s)
PASS
ok      github.com/netbirdio/netbird/management/server/migration        7.065s
```

## Test plan

- [x] Unit + integration tests cover SQLite no-op, missing-table no-op, already-boolean no-op, the actual conversion + data preservation, and idempotency
- [x] Existing migration test suite still green (no regression)
- [x] `go build ./management/...` clean

## Affected columns (concrete)

For `types.Account` the migration covers the gorm-embedded Settings + ExtraSettings bool fields. At time of writing those are:

```
settings_peer_login_expiration_enabled
settings_peer_inactivity_expiration_enabled
settings_regular_users_view_blocked
settings_groups_propagation_enabled
settings_jwt_groups_enabled
settings_routing_peer_dns_resolution_enabled
settings_peer_expose_enabled
settings_lazy_connection_enabled
settings_auto_update_always
settings_extra_peer_approval_enabled
settings_extra_user_approval_required
```

The list is derived automatically from gorm metadata, so any future bool field added to `Settings`/`ExtraSettings` is covered without code changes.

## Use case

Real-world: any operator who migrated their self-hosted NetBird from SQLite to Postgres using a tool that maps SQLite's `INTEGER` to Postgres `numeric` rather than `boolean`. That includes `pgloader` with default settings (the most common path), but also other custom dump/restore scripts. With this PR the management server self-heals on first start instead of returning HTTP 500 on every settings update.

<!-- Docs acknowledgement -->
- [ ] I added/updated documentation
- [x] Documentation is **not needed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed PostgreSQL database schema issues where boolean columns were not using the proper native type. The correction automatically applies during database migration and is safe to run multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->