### PR TITLE
[client] Set 0644 perms on SSH client config after os.CreateTemp

### DIFF
--- a/client/ssh/config/manager.go
+++ b/client/ssh/config/manager.go
@@ -252,6 +252,10 @@ func (m *Manager) writeSSHConfig(sshConfig string) error {
 		return fmt.Errorf("write SSH config file %s: %w", tmpPath, err)
 	}
 
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		return fmt.Errorf("chmod SSH config file %s: %w", tmpPath, err)
+	}
+
 	if err := os.Rename(tmpPath, sshConfigPath); err != nil {
 		return fmt.Errorf("rename SSH config %s -> %s: %w", tmpPath, sshConfigPath, err)
 	}


### PR DESCRIPTION
## Describe your changes

After #6064 switched to `os.CreateTemp` for writing the SSH client config, the temp file is created with mode 0600 and the subsequent `os.WriteFile` does not change the existing file's mode. The renamed `99-netbird.conf` ends up unreadable by non-root users, so `ssh` fails with "Can't open user config file ... Permission denied".

- Explicitly chmod the temp file to 0644 before rename

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal bug fix, no user-facing behavior change.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH config file handling to ensure correct file permissions are properly applied.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6126)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->