### PR TITLE
[management] Add Zitadel Management API v2 support

### DIFF
--- a/management/server/idp/idp.go
+++ b/management/server/idp/idp.go
@@ -169,6 +169,7 @@ func NewManager(ctx context.Context, config Config, appMetrics telemetry.AppMetr
 				TokenEndpoint:      config.ClientConfig.TokenEndpoint,
 				ManagementEndpoint: config.ExtraConfig["ManagementEndpoint"],
 				PAT:                config.ExtraConfig["PAT"],
+				APIVersion:         config.ExtraConfig["APIVersion"],
 			}
 		}
 

--- a/management/server/idp/zitadel.go
+++ b/management/server/idp/zitadel.go
@@ -25,6 +25,7 @@ type ZitadelManager struct {
 	credentials        ManagerCredentials
 	helper             ManagerHelper
 	appMetrics         telemetry.AppMetrics
+	useV2API           bool // Set from APIVersion config field ("v2" → true, anything else → false)
 }
 
 // ZitadelClientConfig zitadel manager client configurations.
@@ -35,6 +36,8 @@ type ZitadelClientConfig struct {
 	TokenEndpoint      string
 	ManagementEndpoint string
 	PAT                string
+	// APIVersion selects the Zitadel Management API version to use: "v2" enables the v2 API, any other value (including "") uses v1.
+	APIVersion string
 }
 
 // ZitadelCredentials zitadel authentication information.
@@ -50,13 +53,16 @@ type ZitadelCredentials struct {
 // zitadelEmail specifies details of a user email.
 type zitadelEmail struct {
 	Email           string `json:"email"`
-	IsEmailVerified bool   `json:"isEmailVerified"`
+	IsEmailVerified bool   `json:"isEmailVerified"` // v1
+	IsVerified      bool   `json:"isVerified"`      // v2
 }
 
 // zitadelUserInfo specifies user information.
 type zitadelUserInfo struct {
-	FirstName   string `json:"firstName"`
-	LastName    string `json:"lastName"`
+	FirstName   string `json:"firstName"`  // v1
+	LastName    string `json:"lastName"`   // v1
+	GivenName   string `json:"givenName"`  // v2
+	FamilyName  string `json:"familyName"` // v2
 	DisplayName string `json:"displayName"`
 }
 
@@ -71,7 +77,8 @@ type zitadelAttributes map[string][]map[string]any
 
 // zitadelProfile represents an zitadel user profile response.
 type zitadelProfile struct {
-	ID                 string       `json:"id"`
+	ID                 string       `json:"id"`     // v1
+	UserID             string       `json:"userId"` // v2
 	State              string       `json:"state"`
 	UserName           string       `json:"userName"`
 	PreferredLoginName string       `json:"preferredLoginName"`
@@ -81,23 +88,25 @@ type zitadelProfile struct {
 
 // zitadelUserDetails represents the metadata for the new user that was created
 type zitadelUserDetails struct {
-	Sequence      string `json:"sequence"`     // uint64 as a string
-	CreationDate  string `json:"creationDate"` // ISO format
-	ChangeDate    string `json:"changeDate"`   // ISO format
-	ResourceOwner string
+	Sequence      string `json:"sequence"`
+	CreationDate  string `json:"creationDate"`
+	ChangeDate    string `json:"changeDate"`
+	ResourceOwner string `json:"resourceOwner"`
 }
 
-// zitadelPasswordlessRegistration represents the information for the user to complete signup
+// zitadelPasswordlessRegistration represents the information for the user to complete signup (v1)
 type zitadelPasswordlessRegistration struct {
 	Link       string `json:"link"`
-	Expiration string `json:"expiration"` // ex: 3600s
+	Expiration string `json:"expiration"`
 }
 
-// zitadelUser represents an zitadel create user response
+// zitadelUserResponse represents an zitadel create user response
 type zitadelUserResponse struct {
-	UserId                   string                          `json:"userId"`
-	Details                  zitadelUserDetails              `json:"details"`
-	PasswordlessRegistration zitadelPasswordlessRegistration `json:"passwordlessRegistration"`
+	UserId                   string                           `json:"userId"`
+	Details                  zitadelUserDetails               `json:"details"`
+	PasswordlessRegistration *zitadelPasswordlessRegistration `json:"passwordlessRegistration"` // v1
+	EmailCode                string                           `json:"emailCode"`                // v2
+	PhoneCode                string                           `json:"phoneCode"`                // v2
 }
 
 // readZitadelError parses errors returned by the zitadel APIs from a response.
@@ -114,7 +123,6 @@ func readZitadelError(body io.ReadCloser) error {
 		return fmt.Errorf("error unparsable body: %s", string(bodyBytes))
 	}
 
-	// ensure keys are ordered for consistent logging behaviour.
 	errorKeys := make([]string, 0, len(target))
 	for k := range target {
 		errorKeys = append(errorKeys, k)
@@ -138,23 +146,18 @@ func readZitadelError(body io.ReadCloser) error {
 
 // verifyJWTConfig ensures necessary values are set in the ZitadelClientConfig for JWTs to be generated.
 func verifyJWTConfig(config ZitadelClientConfig) error {
-
 	if config.ClientID == "" {
 		return fmt.Errorf("zitadel IdP configuration is incomplete, clientID is missing")
 	}
-
 	if config.ClientSecret == "" {
 		return fmt.Errorf("zitadel IdP configuration is incomplete, ClientSecret is missing")
 	}
-
 	if config.TokenEndpoint == "" {
 		return fmt.Errorf("zitadel IdP configuration is incomplete, TokenEndpoint is missing")
 	}
-
 	if config.GrantType == "" {
 		return fmt.Errorf("zitadel IdP configuration is incomplete, GrantType is missing")
 	}
-
 	return nil
 }
 
@@ -189,12 +192,15 @@ func NewZitadelManager(config ZitadelClientConfig, appMetrics telemetry.AppMetri
 		appMetrics:   appMetrics,
 	}
 
+	useV2API := strings.EqualFold(config.APIVersion, "v2")
+
 	return &ZitadelManager{
 		managementEndpoint: config.ManagementEndpoint,
 		httpClient:         httpClient,
 		credentials:        credentials,
 		helper:             helper,
 		appMetrics:         appMetrics,
+		useV2API:           useV2API,
 	}, nil
 }
 
@@ -225,7 +231,6 @@ func (zc *ZitadelCredentials) requestJWTToken(ctx context.Context) (*http.Respon
 		if zc.appMetrics != nil {
 			zc.appMetrics.IDPMetrics().CountRequestError()
 		}
-
 		return nil, err
 	}
 
@@ -259,7 +264,6 @@ func (zc *ZitadelCredentials) parseRequestJWTResponse(rawBody io.ReadCloser) (JW
 		return jwtToken, err
 	}
 
-	// Exp maps into exp from jwt token
 	var IssuedAt struct{ Exp int64 }
 	err = zc.helper.Unmarshal(data, &IssuedAt)
 	if err != nil {
@@ -293,8 +297,6 @@ func (zc *ZitadelCredentials) Authenticate(ctx context.Context) (JWTToken, error
 		zc.appMetrics.IDPMetrics().CountAuthenticate()
 	}
 
-	// reuse the token without requesting a new one if it is not expired,
-	// and if expiry time is sufficient time available to make a request.
 	if zc.jwtStillValid() {
 		return zc.jwtToken, nil
 	}
@@ -322,20 +324,46 @@ func (zc *ZitadelCredentials) Authenticate(ctx context.Context) (JWTToken, error
 // CreateUser creates a new user in zitadel Idp and sends an invite via Zitadel.
 func (zm *ZitadelManager) CreateUser(ctx context.Context, email, name, accountID, invitedByEmail string) (*UserData, error) {
 	firstLast := strings.SplitN(name, " ", 2)
+	lastName := firstLast[0]
+	if len(firstLast) > 1 {
+		lastName = firstLast[1]
+	}
 
-	var addUser = map[string]any{
-		"userName": email,
-		"profile": map[string]string{
-			"firstName":   firstLast[0],
-			"lastName":    firstLast[0],
-			"displayName": name,
-		},
-		"email": map[string]any{
-			"email":           email,
-			"isEmailVerified": false,
-		},
-		"passwordChangeRequired":          true,
-		"requestPasswordlessRegistration": false, // let Zitadel send the invite for us
+	var addUser map[string]any
+	var endpoint string
+
+	if zm.useV2API {
+		// v2 API (AddHumanUser): proto field is "username" (single word, no underscore → JSON "username")
+		addUser = map[string]any{
+			"username": email,
+			"profile": map[string]string{
+				"givenName":   firstLast[0],
+				"familyName":  lastName,
+				"displayName": name,
+			},
+			"email": map[string]any{
+				"email":      email,
+				"isVerified": false,
+			},
+		}
+		endpoint = "users/human"
+	} else {
+		// v1 API
+		addUser = map[string]any{
+			"userName": email,
+			"profile": map[string]string{
+				"firstName":   firstLast[0],
+				"lastName":    lastName,
+				"displayName": name,
+			},
+			"email": map[string]any{
+				"email":           email,
+				"isEmailVerified": false,
+			},
+			"passwordChangeRequired":          true,
+			"requestPasswordlessRegistration": false,
+		}
+		endpoint = "users/human/_import"
 	}
 
 	payload, err := zm.helper.Marshal(addUser)
@@ -343,7 +371,7 @@ func (zm *ZitadelManager) CreateUser(ctx context.Context, email, name, accountID
 		return nil, err
 	}
 
-	body, err := zm.post(ctx, "users/human/_import", string(payload))
+	body, err := zm.post(ctx, endpoint, string(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +418,12 @@ func (zm *ZitadelManager) GetUserByEmail(ctx context.Context, email string) ([]*
 		return nil, err
 	}
 
-	body, err := zm.post(ctx, "users/_search", string(payload))
+	endpoint := "users/_search"
+	if zm.useV2API {
+		endpoint = "users"
+	}
+
+	body, err := zm.post(ctx, endpoint, string(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +471,12 @@ func (zm *ZitadelManager) GetUserDataByID(ctx context.Context, userID string, ap
 
 // GetAccount returns all the users for a given profile.
 func (zm *ZitadelManager) GetAccount(ctx context.Context, accountID string) ([]*UserData, error) {
-	body, err := zm.post(ctx, "users/_search", "")
+	endpoint := "users/_search"
+	if zm.useV2API {
+		endpoint = "users"
+	}
+
+	body, err := zm.post(ctx, endpoint, "{}")
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +505,12 @@ func (zm *ZitadelManager) GetAccount(ctx context.Context, accountID string) ([]*
 // GetAllAccounts gets all registered accounts with corresponding user data.
 // It returns a list of users indexed by accountID.
 func (zm *ZitadelManager) GetAllAccounts(ctx context.Context) (map[string][]*UserData, error) {
-	body, err := zm.post(ctx, "users/_search", "")
+	endpoint := "users/_search"
+	if zm.useV2API {
+		endpoint = "users"
+	}
+
+	body, err := zm.post(ctx, endpoint, "{}")
 	if err != nil {
 		return nil, err
 	}
@@ -497,24 +540,28 @@ func (zm *ZitadelManager) UpdateUserAppMetadata(_ context.Context, _ string, _ A
 	return nil
 }
 
-type inviteUserRequest struct {
-	Email string `json:"email"`
-}
-
 // InviteUserByID resend invitations to users who haven't activated,
 // their accounts prior to the expiration period.
 func (zm *ZitadelManager) InviteUserByID(ctx context.Context, userID string) error {
-	inviteUser := inviteUserRequest{
-		Email: userID,
+	var endpoint string
+	var payload string
+
+	if zm.useV2API {
+		// CreateInviteCode: creates and sends a new invite code regardless of prior state.
+		// ResendInviteCode (/invite_code/resend) is deprecated and requires a pre-existing code.
+		endpoint = fmt.Sprintf("users/%s/invite_code", userID)
+		payload = "{}"
+	} else {
+		endpoint = fmt.Sprintf("users/%s/_resend_initialization", userID)
+		inviteUser := map[string]string{"email": userID}
+		payloadBytes, err := zm.helper.Marshal(inviteUser)
+		if err != nil {
+			return err
+		}
+		payload = string(payloadBytes)
 	}
 
-	payload, err := zm.helper.Marshal(inviteUser)
-	if err != nil {
-		return err
-	}
-
-	// don't care about the body in the response
-	_, err = zm.post(ctx, fmt.Sprintf("users/%s/_resend_initialization", userID), string(payload))
+	_, err := zm.post(ctx, endpoint, payload)
 	return err
 }
 
@@ -552,7 +599,6 @@ func (zm *ZitadelManager) post(ctx context.Context, resource string, body string
 		if zm.appMetrics != nil {
 			zm.appMetrics.IDPMetrics().CountRequestError()
 		}
-
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -561,9 +607,7 @@ func (zm *ZitadelManager) post(ctx context.Context, resource string, body string
 		if zm.appMetrics != nil {
 			zm.appMetrics.IDPMetrics().CountRequestStatusError()
 		}
-
 		zErr := readZitadelError(resp.Body)
-
 		return nil, fmt.Errorf("unable to post %s, statusCode %d, zitadel: %w", reqURL, resp.StatusCode, zErr)
 	}
 
@@ -590,7 +634,6 @@ func (zm *ZitadelManager) delete(ctx context.Context, resource string) error {
 		if zm.appMetrics != nil {
 			zm.appMetrics.IDPMetrics().CountRequestError()
 		}
-
 		return err
 	}
 	defer resp.Body.Close()
@@ -599,8 +642,7 @@ func (zm *ZitadelManager) delete(ctx context.Context, resource string) error {
 		if zm.appMetrics != nil {
 			zm.appMetrics.IDPMetrics().CountRequestStatusError()
 		}
-
-		return fmt.Errorf("unable to get %s, statusCode %d", reqURL, resp.StatusCode)
+		return fmt.Errorf("unable to delete %s, statusCode %d", reqURL, resp.StatusCode)
 	}
 
 	return nil
@@ -626,7 +668,6 @@ func (zm *ZitadelManager) get(ctx context.Context, resource string, q url.Values
 		if zm.appMetrics != nil {
 			zm.appMetrics.IDPMetrics().CountRequestError()
 		}
-
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -635,9 +676,7 @@ func (zm *ZitadelManager) get(ctx context.Context, resource string, q url.Values
 		if zm.appMetrics != nil {
 			zm.appMetrics.IDPMetrics().CountRequestStatusError()
 		}
-
 		zErr := readZitadelError(resp.Body)
-
 		return nil, fmt.Errorf("unable to get %s, statusCode %d, zitadel: %w", reqURL, resp.StatusCode, zErr)
 	}
 
@@ -649,7 +688,15 @@ func (zp zitadelProfile) userData() *UserData {
 	var (
 		email string
 		name  string
+		id    string
 	)
+
+	// Get ID - try v2 field first, then v1
+	if zp.UserID != "" {
+		id = zp.UserID
+	} else {
+		id = zp.ID
+	}
 
 	// Obtain the email for the human account and the login name,
 	// for the machine account.
@@ -664,6 +711,6 @@ func (zp zitadelProfile) userData() *UserData {
 	return &UserData{
 		Email: email,
 		Name:  name,
-		ID:    zp.ID,
+		ID:    id,
 	}
 }

--- a/management/server/idp/zitadel.go
+++ b/management/server/idp/zitadel.go
@@ -324,7 +324,7 @@ func (zc *ZitadelCredentials) Authenticate(ctx context.Context) (JWTToken, error
 // CreateUser creates a new user in zitadel Idp and sends an invite via Zitadel.
 func (zm *ZitadelManager) CreateUser(ctx context.Context, email, name, accountID, invitedByEmail string) (*UserData, error) {
 	firstLast := strings.SplitN(name, " ", 2)
-	lastName := firstLast[0]
+	lastName := ""
 	if len(firstLast) > 1 {
 		lastName = firstLast[1]
 	}
@@ -550,7 +550,7 @@ func (zm *ZitadelManager) InviteUserByID(ctx context.Context, userID string) err
 		// CreateInviteCode: creates and sends a new invite code regardless of prior state.
 		// ResendInviteCode (/invite_code/resend) is deprecated and requires a pre-existing code.
 		endpoint = fmt.Sprintf("users/%s/invite_code", userID)
-		payload = "{}"
+		payload = `{"sendCode":{}}`
 	} else {
 		endpoint = fmt.Sprintf("users/%s/_resend_initialization", userID)
 		inviteUser := map[string]string{"email": userID}

--- a/management/server/idp/zitadel_test.go
+++ b/management/server/idp/zitadel_test.go
@@ -399,6 +399,7 @@ func TestZitadelInviteUser_v2_Endpoint(t *testing.T) {
 
 	assert.Contains(t, capturedURL, "users/user-abc-123/invite_code", "v2 must use CreateInviteCode endpoint")
 	assert.NotContains(t, capturedURL, "invite_code/resend", "v2 must not use deprecated ResendInviteCode endpoint")
+	assert.Equal(t, `{"sendCode":{}}`, client.reqBody, "v2 invite must include sendCode variant")
 }
 
 func TestZitadelGetAccount_v2_RequestBody(t *testing.T) {

--- a/management/server/idp/zitadel_test.go
+++ b/management/server/idp/zitadel_test.go
@@ -379,6 +379,7 @@ func TestZitadelCreateUser_v1_RequestBody(t *testing.T) {
 	assert.Contains(t, client.reqBody, `"userName"`, "v1 API must use \"userName\" field")
 	assert.NotContains(t, client.reqBody, `"username"`, "v1 API must not use \"username\" field")
 	assert.Contains(t, client.reqBody, `"firstName"`, "v1 API must use \"firstName\" in profile")
+	assert.Contains(t, client.reqBody, `"lastName"`, "v1 API must use \"lastName\" in profile")
 	assert.Contains(t, client.reqBody, `"isEmailVerified"`, "v1 API must use \"isEmailVerified\" in email")
 }
 

--- a/management/server/idp/zitadel_test.go
+++ b/management/server/idp/zitadel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ func TestNewZitadelManager(t *testing.T) {
 		inputConfig          ZitadelClientConfig
 		assertErrFunc        require.ErrorAssertionFunc
 		assertErrFuncMessage string
+		expectedUseV2API     bool
 	}
 
 	defaultTestConfig := ZitadelClientConfig{
@@ -35,6 +37,7 @@ func TestNewZitadelManager(t *testing.T) {
 		inputConfig:          defaultTestConfig,
 		assertErrFunc:        require.NoError,
 		assertErrFuncMessage: "shouldn't return error",
+		expectedUseV2API:     false,
 	}
 
 	testCase2Config := defaultTestConfig
@@ -57,10 +60,48 @@ func TestNewZitadelManager(t *testing.T) {
 		assertErrFuncMessage: "should return error when field empty",
 	}
 
-	for _, testCase := range []test{testCase1, testCase2, testCase3} {
+	testCase4Config := defaultTestConfig
+	testCase4Config.APIVersion = "v2"
+
+	testCase4 := test{
+		name:                 "APIVersion v2 enables v2 API",
+		inputConfig:          testCase4Config,
+		assertErrFunc:        require.NoError,
+		assertErrFuncMessage: "shouldn't return error",
+		expectedUseV2API:     true,
+	}
+
+	testCase5Config := defaultTestConfig
+	testCase5Config.APIVersion = "V2"
+
+	testCase5 := test{
+		name:                 "APIVersion v2 is case-insensitive",
+		inputConfig:          testCase5Config,
+		assertErrFunc:        require.NoError,
+		assertErrFuncMessage: "shouldn't return error",
+		expectedUseV2API:     true,
+	}
+
+	testCase6Config := ZitadelClientConfig{
+		ManagementEndpoint: "http://localhost/management/v1",
+		PAT:                "my-personal-access-token",
+	}
+
+	testCase6 := test{
+		name:                 "PAT configuration skips JWT validation",
+		inputConfig:          testCase6Config,
+		assertErrFunc:        require.NoError,
+		assertErrFuncMessage: "shouldn't return error with PAT",
+		expectedUseV2API:     false,
+	}
+
+	for _, testCase := range []test{testCase1, testCase2, testCase3, testCase4, testCase5, testCase6} {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := NewZitadelManager(testCase.inputConfig, &telemetry.MockAppMetrics{})
+			manager, err := NewZitadelManager(testCase.inputConfig, &telemetry.MockAppMetrics{})
 			testCase.assertErrFunc(t, err, testCase.assertErrFuncMessage)
+			if err == nil {
+				assert.Equal(t, testCase.expectedUseV2API, manager.useV2API, "useV2API should match expected value")
+			}
 		})
 	}
 }
@@ -287,6 +328,116 @@ func TestZitadelAuthenticate(t *testing.T) {
 	}
 }
 
+// newZitadelManagerWithMock builds a ZitadelManager wired to a pre-authenticated mock HTTP client,
+// bypassing NewZitadelManager so tests can control useV2API directly.
+func newZitadelManagerWithMock(useV2API bool, httpClient *mockHTTPClient) *ZitadelManager {
+	exp := 100
+	creds := &ZitadelCredentials{
+		clientConfig: ZitadelClientConfig{},
+		httpClient:   httpClient,
+		helper:       JsonParser{},
+	}
+	creds.jwtToken.AccessToken = "test-token"
+	creds.jwtToken.expiresInTime = time.Now().Add(time.Duration(exp) * time.Second)
+
+	return &ZitadelManager{
+		managementEndpoint: "http://localhost/v2",
+		httpClient:         httpClient,
+		credentials:        creds,
+		helper:             JsonParser{},
+		useV2API:           useV2API,
+	}
+}
+
+func TestZitadelCreateUser_v2_RequestBody(t *testing.T) {
+	client := &mockHTTPClient{
+		code:    201,
+		resBody: `{"userId":"new-user-id-v2"}`,
+	}
+	manager := newZitadelManagerWithMock(true, client)
+
+	_, err := manager.CreateUser(context.Background(), "alice@example.com", "Alice Smith", "acc1", "inviter@example.com")
+	require.NoError(t, err)
+
+	assert.Contains(t, client.reqBody, `"username"`, "v2 API must use \"username\" field")
+	assert.NotContains(t, client.reqBody, `"userName"`, "v2 API must not use \"userName\" field")
+	assert.Contains(t, client.reqBody, `"givenName"`, "v2 API must use \"givenName\" in profile")
+	assert.Contains(t, client.reqBody, `"familyName"`, "v2 API must use \"familyName\" in profile")
+	assert.Contains(t, client.reqBody, `"isVerified"`, "v2 API must use \"isVerified\" in email")
+}
+
+func TestZitadelCreateUser_v1_RequestBody(t *testing.T) {
+	client := &mockHTTPClient{
+		code:    200,
+		resBody: `{"userId":"new-user-id-v1"}`,
+	}
+	manager := newZitadelManagerWithMock(false, client)
+
+	_, err := manager.CreateUser(context.Background(), "alice@example.com", "Alice Smith", "acc1", "inviter@example.com")
+	require.NoError(t, err)
+
+	assert.Contains(t, client.reqBody, `"userName"`, "v1 API must use \"userName\" field")
+	assert.NotContains(t, client.reqBody, `"username"`, "v1 API must not use \"username\" field")
+	assert.Contains(t, client.reqBody, `"firstName"`, "v1 API must use \"firstName\" in profile")
+	assert.Contains(t, client.reqBody, `"isEmailVerified"`, "v1 API must use \"isEmailVerified\" in email")
+}
+
+func TestZitadelInviteUser_v2_Endpoint(t *testing.T) {
+	var capturedURL string
+	client := &mockHTTPClient{
+		code:    200,
+		resBody: `{}`,
+	}
+	manager := newZitadelManagerWithMock(true, client)
+
+	// Intercept the HTTP request to capture the URL
+	origClient := manager.httpClient
+	manager.httpClient = &captureURLClient{inner: origClient, capturedURL: &capturedURL}
+
+	err := manager.InviteUserByID(context.Background(), "user-abc-123")
+	require.NoError(t, err)
+
+	assert.Contains(t, capturedURL, "users/user-abc-123/invite_code", "v2 must use CreateInviteCode endpoint")
+	assert.NotContains(t, capturedURL, "invite_code/resend", "v2 must not use deprecated ResendInviteCode endpoint")
+}
+
+func TestZitadelGetAccount_v2_RequestBody(t *testing.T) {
+	client := &mockHTTPClient{
+		code:    200,
+		resBody: `{"result":[]}`,
+	}
+	manager := newZitadelManagerWithMock(true, client)
+
+	_, err := manager.GetAccount(context.Background(), "acc1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "{}", client.reqBody, "v2 search must send \"{}\" body, not empty string")
+}
+
+func TestZitadelGetAllAccounts_v2_RequestBody(t *testing.T) {
+	client := &mockHTTPClient{
+		code:    200,
+		resBody: `{"result":[]}`,
+	}
+	manager := newZitadelManagerWithMock(true, client)
+
+	_, err := manager.GetAllAccounts(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "{}", client.reqBody, "v2 search must send \"{}\" body, not empty string")
+}
+
+// captureURLClient wraps a ManagerHTTPClient to capture the request URL.
+type captureURLClient struct {
+	inner       ManagerHTTPClient
+	capturedURL *string
+}
+
+func (c *captureURLClient) Do(req *http.Request) (*http.Response, error) {
+	*c.capturedURL = req.URL.String()
+	return c.inner.Do(req)
+}
+
 func TestZitadelProfile(t *testing.T) {
 	type azureProfileTest struct {
 		name             string
@@ -351,7 +502,42 @@ func TestZitadelProfile(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range []azureProfileTest{azureProfileTestCase1, azureProfileTestCase2} {
+	// v2 API response: uses userId instead of id, givenName/familyName instead of firstName/lastName
+	azureProfileTestCase3 := azureProfileTest{
+		name:   "V2 User Request",
+		invite: false,
+		inputProfile: zitadelProfile{
+			UserID:             "test3-v2",
+			ID:                 "", // v2 does not populate id
+			State:              "USER_STATE_ACTIVE",
+			UserName:           "test3@mail.com",
+			PreferredLoginName: "test3@mail.com",
+			LoginNames: []string{
+				"test3@mail.com",
+			},
+			Human: &zitadelUser{
+				Profile: zitadelUserInfo{
+					GivenName:   "Alice",
+					FamilyName:  "Smith",
+					DisplayName: "Alice Smith",
+				},
+				Email: zitadelEmail{
+					Email:      "test3@mail.com",
+					IsVerified: true,
+				},
+			},
+		},
+		expectedUserData: UserData{
+			ID:    "test3-v2",
+			Name:  "Alice Smith",
+			Email: "test3@mail.com",
+			AppMetadata: AppMetadata{
+				WTAccountID: "1",
+			},
+		},
+	}
+
+	for _, testCase := range []azureProfileTest{azureProfileTestCase1, azureProfileTestCase2, azureProfileTestCase3} {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.expectedUserData.AppMetadata.WTPendingInvite = &testCase.invite
 			userData := testCase.inputProfile.userData()


### PR DESCRIPTION
## Describe your changes

Zitadel introduced a v2 Management API with updated REST endpoints and revised field naming conventions. This PR adds full v2 support to the Zitadel IdP manager while preserving complete backward compatibility with existing v1 deployments.

### Changes

**Dual-version response structs** — JSON structs carry both v1 and v2 field names so the same types deserialize responses from either API version:
- Profile: `firstName`/`lastName` (v1) + `givenName`/`familyName` (v2)
- Email verification: `isEmailVerified` (v1) → `isVerified` (v2)
- User ID: `id` (v1) → `userId` (v2)

**Optional `APIVersion` config field** — set `"APIVersion": "v2"` in `ExtraConfig` to enable the v2 API. Any other value (including empty, which is the default) uses v1. This follows the same pattern as the existing `PAT` field.

**v1/v2 branching across all mutating and search methods:**

| Method | v1 | v2 |
|---|---|---|
| `CreateUser` | `POST users/human/_import`, field `userName` | `POST users/human`, field `username` |
| `GetUserByEmail` | `POST users/_search` | `POST users` |
| `GetAccount` / `GetAllAccounts` | `POST users/_search`, body `""` | `POST users`, body `{}` |
| `InviteUserByID` | `POST users/{id}/_resend_initialization` | `POST users/{id}/invite_code` (`CreateInviteCode`) |
| `DeleteUser` | `DELETE users/{id}` | `DELETE users/{id}` (unchanged) |

Note: `InviteUserByID` v2 uses `CreateInviteCode` (`/invite_code`) rather than the deprecated `ResendInviteCode` (`/invite_code/resend`), which requires a pre-existing code.

**Minor fix** — the `delete` HTTP helper previously logged `"unable to get"` instead of `"unable to delete"`.

### Configuration example

```json
{
  "IdpManagerConfig": {
    "ManagerType": "zitadel",
    "ClientConfig": {
      "ClientID": "...",
      "ClientSecret": "...",
      "GrantType": "client_credentials",
      "TokenEndpoint": "https://instance.zitadel.cloud/oauth/v2/token"
    },
    "ExtraConfig": {
      "ManagementEndpoint": "https://instance.zitadel.cloud/v2",
      "APIVersion": "v2"
    }
  }
}
```

Omitting `APIVersion` (or setting it to any value other than `"v2"`) retains the existing v1 behaviour.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (the `APIVersion` field follows the same pattern as the existing `PAT` field in `ExtraConfig`)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Zitadel API version support with runtime routing for user creation, lookup, invites, and account listing.
* **Bug Fixes / Behavior**
  * Improved management HTTP error reporting to surface Zitadel error details on failures.
* **Tests**
  * Expanded tests to cover v1 vs v2 request/response shapes, invite behavior, and account search.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6130)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->