### PR TITLE
[management] Allocate IPv6 overlay addresses to embedded proxy peers

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -2487,6 +2487,18 @@ func (am *DefaultAccountManager) buildIPv6AllowedPeers(ctx context.Context, tran
 			allowedPeers[peerID] = struct{}{}
 		}
 	}
+
+	// Embedded proxy peers sit outside regular group membership but must
+	// participate in any v6-enabled overlay to reach v6-only peers.
+	peers, err := transaction.GetAccountPeers(ctx, store.LockingStrengthNone, accountID, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("get peers: %w", err)
+	}
+	for _, p := range peers {
+		if p.ProxyMeta.Embedded {
+			allowedPeers[p.ID] = struct{}{}
+		}
+	}
 	return allowedPeers, nil
 }
 

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -762,16 +762,19 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, accountID, setupKe
 		newPeer.IP = freeIP
 
 		if len(settings.IPv6EnabledGroups) > 0 && network.NetV6.IP != nil {
-			var allGroupID string
-			if !peer.ProxyMeta.Embedded {
-				allGroup, err := am.Store.GetGroupByName(ctx, store.LockingStrengthNone, accountID, "All")
-				if err != nil {
-					log.WithContext(ctx).Debugf("get All group for IPv6 allocation: %v", err)
-				} else {
+			// Embedded proxy peers are not group members but participate in any
+			// IPv6-enabled overlay so reverse-proxy traffic reaches v6-only peers.
+			allocate := peer.ProxyMeta.Embedded
+			if !allocate {
+				var allGroupID string
+				if allGroup, err := am.Store.GetGroupByName(ctx, store.LockingStrengthNone, accountID, types.GroupAllName); err == nil {
 					allGroupID = allGroup.ID
+				} else {
+					log.WithContext(ctx).Debugf("get All group for IPv6 allocation: %v", err)
 				}
+				allocate = peerWillHaveIPv6(settings, peerAddConfig.GroupsToAdd, allGroupID)
 			}
-			if peerWillHaveIPv6(settings, peerAddConfig.GroupsToAdd, allGroupID) {
+			if allocate {
 				v6Prefix, err := netip.ParsePrefix(network.NetV6.String())
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("parse IPv6 prefix: %w", err)

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -598,28 +598,21 @@ func (a *Account) GetPeerGroups(peerID string) LookupMap {
 	return groupList
 }
 
-// PeerIPv6Allowed reports whether the given peer is in any of the account's IPv6 enabled groups.
+// PeerIPv6Allowed reports whether the given peer participates in the IPv6 overlay.
 // Returns false if IPv6 is disabled or no groups are configured.
 func (a *Account) PeerIPv6Allowed(peerID string) bool {
-	if len(a.Settings.IPv6EnabledGroups) == 0 {
-		return false
-	}
-
-	for _, groupID := range a.Settings.IPv6EnabledGroups {
-		group, ok := a.Groups[groupID]
-		if !ok {
-			continue
-		}
-		if slices.Contains(group.Peers, peerID) {
-			return true
-		}
-	}
-	return false
+	_, ok := a.peerIPv6AllowedSet()[peerID]
+	return ok
 }
 
-// peerIPv6AllowedSet returns a set of peer IDs that belong to any IPv6-enabled group.
+// peerIPv6AllowedSet returns the set of peer IDs that participate in the IPv6 overlay:
+// members of any IPv6-enabled group, plus every embedded proxy peer (which sit outside
+// regular group membership but must reach v6-enabled peers).
 func (a *Account) peerIPv6AllowedSet() map[string]struct{} {
 	result := make(map[string]struct{})
+	if len(a.Settings.IPv6EnabledGroups) == 0 {
+		return result
+	}
 	for _, groupID := range a.Settings.IPv6EnabledGroups {
 		group, ok := a.Groups[groupID]
 		if !ok {
@@ -627,6 +620,11 @@ func (a *Account) peerIPv6AllowedSet() map[string]struct{} {
 		}
 		for _, peerID := range group.Peers {
 			result[peerID] = struct{}{}
+		}
+	}
+	for id, p := range a.Peers {
+		if p != nil && p.ProxyMeta.Embedded {
+			result[id] = struct{}{}
 		}
 	}
 	return result

--- a/management/server/types/group.go
+++ b/management/server/types/group.go
@@ -92,9 +92,12 @@ func (g *Group) HasPeers() bool {
 	return len(g.Peers) > 0
 }
 
+// GroupAllName is the reserved name of the default group that contains every peer in an account.
+const GroupAllName = "All"
+
 // IsGroupAll checks if the group is a default "All" group.
 func (g *Group) IsGroupAll() bool {
-	return g.Name == "All"
+	return g.Name == GroupAllName
 }
 
 // AddPeer adds peerID to Peers if not present, returning true if added.

--- a/management/server/types/ipv6_groups_test.go
+++ b/management/server/types/ipv6_groups_test.go
@@ -232,3 +232,33 @@ func TestIPv6RecalculationOnGroupChange(t *testing.T) {
 		assert.True(t, account.PeerIPv6Allowed("peer3"), "peer3 now in infra")
 	})
 }
+
+func TestPeerIPv6AllowedEmbeddedProxy(t *testing.T) {
+	account := &Account{
+		Peers: map[string]*nbpeer.Peer{
+			"peer1": {ID: "peer1"},
+			"proxy": {ID: "proxy", ProxyMeta: nbpeer.ProxyMeta{Embedded: true, Cluster: "netbird.test"}},
+		},
+		Groups: map[string]*Group{
+			"group-devs": {ID: "group-devs", Peers: []string{"peer1"}},
+		},
+		Settings: &Settings{},
+	}
+
+	t.Run("embedded proxy allowed when any v6 group exists, without group membership", func(t *testing.T) {
+		account.Settings.IPv6EnabledGroups = []string{"group-devs"}
+		assert.True(t, account.PeerIPv6Allowed("proxy"), "embedded proxy participates in v6 overlay")
+		assert.True(t, account.PeerIPv6Allowed("peer1"), "regular peer in enabled group still allowed")
+	})
+
+	t.Run("embedded proxy denied when no v6 group enabled", func(t *testing.T) {
+		account.Settings.IPv6EnabledGroups = nil
+		assert.False(t, account.PeerIPv6Allowed("proxy"), "v6 disabled account-wide denies embedded proxies too")
+	})
+
+	t.Run("non-embedded peer outside any enabled group is not pulled in", func(t *testing.T) {
+		account.Settings.IPv6EnabledGroups = []string{"group-devs"}
+		account.Peers["lonely"] = &nbpeer.Peer{ID: "lonely"}
+		assert.False(t, account.PeerIPv6Allowed("lonely"), "embedded-proxy bypass must not leak to regular peers")
+	})
+}


### PR DESCRIPTION
## Describe your changes

Embedded proxy peers are not members of any group, so the IPv6 overlay logic introduced in #5631 excluded them: no v6 was allocated on creation, and any settings change would clear v6 from a proxy peer if one had been set. As a result reverse-proxy traffic could not reach v6-only peers. This PR treats embedded proxy peers as always-participating in the v6 overlay whenever IPv6 is enabled on the account.

- Allocate an IPv6 to embedded proxy peers on add whenever the account has any v6-enabled group.
- Keep that IPv6 across settings recalcs (group toggles, membership changes) and only strip it when v6 is disabled account-wide.
- Network map, DNS, and firewall rule generation now include embedded proxies in the v6-allowed set.
- Replace the magic string \"All\" group name introduced in #5631 with a new \`types.GroupAllName\` constant; \`IsGroupAll\` uses it too.
- Test coverage for the embedded-proxy case (allowed when v6 enabled, denied when disabled, no leak to regular peers).

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal allocation/runtime behavior; no user-facing config or API surface changes.

### Docs PR URL (required if \"docs added\" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended IPv6 overlay support to proxy peers, automatically allocating IPv6 addresses when IPv6-enabled groups are configured.

* **Tests**
  * Added test coverage verifying IPv6 allocation behavior for proxy peers and their interaction with IPv6 group configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6132)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->