### PR TITLE
[client] Improve rosenpass support

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -23,6 +23,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/peer/id"
 	"github.com/netbirdio/netbird/client/internal/peer/worker"
 	"github.com/netbirdio/netbird/client/internal/portforward"
+	"github.com/netbirdio/netbird/client/internal/rosenpass"
 	"github.com/netbirdio/netbird/client/internal/stdnet"
 	"github.com/netbirdio/netbird/route"
 	relayClient "github.com/netbirdio/netbird/shared/relay/client"
@@ -899,33 +900,13 @@ func (conn *Conn) presharedKey(remoteRosenpassKey []byte) *wgtypes.Key {
 	}
 
 	// Fallback to deterministic key if no NetBird PSK is configured
-	determKey, err := conn.rosenpassDetermKey()
+	determKey, err := rosenpass.DeterministicSeedKey(conn.config.LocalKey, conn.config.Key)
 	if err != nil {
 		conn.Log.Errorf("failed to generate Rosenpass initial key: %v", err)
 		return nil
 	}
 
 	return determKey
-}
-
-// todo: move this logic into Rosenpass package
-func (conn *Conn) rosenpassDetermKey() (*wgtypes.Key, error) {
-	lk := []byte(conn.config.LocalKey)
-	rk := []byte(conn.config.Key) // remote key
-	var keyInput []byte
-	if string(lk) > string(rk) {
-		//nolint:gocritic
-		keyInput = append(lk[:16], rk[:16]...)
-	} else {
-		//nolint:gocritic
-		keyInput = append(rk[:16], lk[:16]...)
-	}
-
-	key, err := wgtypes.NewKey(keyInput)
-	if err != nil {
-		return nil, err
-	}
-	return &key, nil
 }
 
 func isController(config ConnConfig) bool {

--- a/client/internal/rosenpass/manager.go
+++ b/client/internal/rosenpass/manager.go
@@ -28,6 +28,15 @@ func hashRosenpassKey(key []byte) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
+// rpServer is the subset of rp.Server used by Manager. Defined as an interface
+// so tests can substitute a mock without spinning up a real UDP server.
+type rpServer interface {
+	AddPeer(rp.PeerConfig) (rp.PeerID, error)
+	RemovePeer(rp.PeerID) error
+	Run() error
+	Close() error
+}
+
 type Manager struct {
 	ifaceName    string
 	spk          []byte
@@ -36,7 +45,7 @@ type Manager struct {
 	preSharedKey *[32]byte
 	rpPeerIDs    map[string]*rp.PeerID
 	rpWgHandler  *NetbirdHandler
-	server       *rp.Server
+	server       rpServer
 	lock         sync.Mutex
 	port         int
 	wgIface      PresharedKeySetter

--- a/client/internal/rosenpass/manager.go
+++ b/client/internal/rosenpass/manager.go
@@ -79,6 +79,15 @@ func (m *Manager) addPeer(rosenpassPubKey []byte, rosenpassAddr string, wireGuar
 		if pcfg.Endpoint, err = net.ResolveUDPAddr("udp", peerAddr); err != nil {
 			return fmt.Errorf("failed to resolve peer endpoint address: %w", err)
 		}
+		// Our local Rosenpass UDP server binds on the IPv6 wildcard ([::]) — see
+		// GetAddress(). The remote peer's endpoint (pcfg.Endpoint) is the destination
+		// our server will sendto when initiating handshakes. ResolveUDPAddr returns a
+		// 4-byte IPv4 for IPv4 hosts, which the kernel rejects (EDESTADDRREQ) when
+		// sent from an AF_INET6 socket. Normalize the remote endpoint to IPv4-mapped
+		// IPv6 so its address family matches our listening socket.
+		if v4 := pcfg.Endpoint.IP.To4(); v4 != nil {
+			pcfg.Endpoint.IP = v4.To16()
+		}
 	}
 	peerID, err := m.server.AddPeer(pcfg)
 	if err != nil {

--- a/client/internal/rosenpass/manager.go
+++ b/client/internal/rosenpass/manager.go
@@ -60,7 +60,22 @@ func NewManager(preSharedKey *wgtypes.Key, wgIfaceName string) (*Manager, error)
 
 	rpKeyHash := hashRosenpassKey(public)
 	log.Tracef("generated new rosenpass key pair with public key %s", rpKeyHash)
-	return &Manager{ifaceName: wgIfaceName, rpKeyHash: rpKeyHash, spk: public, ssk: secret, preSharedKey: (*[32]byte)(preSharedKey), rpPeerIDs: make(map[string]*rp.PeerID), lock: sync.Mutex{}}, nil
+	return &Manager{
+		ifaceName:    wgIfaceName,
+		rpKeyHash:    rpKeyHash,
+		spk:          public,
+		ssk:          secret,
+		preSharedKey: (*[32]byte)(preSharedKey),
+		rpPeerIDs:    make(map[string]*rp.PeerID),
+		// rpWgHandler is created here (instead of only in generateConfig) so it
+		// is never nil between NewManager and Run(). Otherwise an early
+		// OnConnected call (race observed on Android, issue #4341) panics on
+		// nil receiver in addPeer -> m.rpWgHandler.AddPeer. generateConfig will
+		// replace it with a fresh handler on each Run() to clear stale peer
+		// state from previous engine sessions.
+		rpWgHandler: NewNetbirdHandler(),
+		lock:        sync.Mutex{},
+	}, nil
 }
 
 func (m *Manager) GetPubKey() []byte {
@@ -74,6 +89,16 @@ func (m *Manager) GetAddress() *net.UDPAddr {
 
 // addPeer adds a new peer to the Rosenpass server
 func (m *Manager) addPeer(rosenpassPubKey []byte, rosenpassAddr string, wireGuardIP string, wireGuardPubKey string) error {
+	// Defense in depth against issue #4341 (Android crash): if Run() has not
+	// completed yet, m.server / m.rpWgHandler may be nil. Return an explicit
+	// error instead of panicking on nil-receiver dereference.
+	if m.server == nil {
+		return fmt.Errorf("rosenpass server not initialized")
+	}
+	if m.rpWgHandler == nil {
+		return fmt.Errorf("rosenpass wg handler not initialized")
+	}
+
 	var err error
 	pcfg := rp.PeerConfig{PublicKey: rosenpassPubKey}
 	if m.preSharedKey != nil {

--- a/client/internal/rosenpass/manager.go
+++ b/client/internal/rosenpass/manager.go
@@ -226,24 +226,31 @@ func (m *Manager) Run() error {
 		return err
 	}
 
-	m.server, err = rp.NewUDPServer(conf)
+	server, err := rp.NewUDPServer(conf)
 	if err != nil {
 		return err
 	}
 
+	m.lock.Lock()
+	m.server = server
+	m.lock.Unlock()
+
 	log.Infof("starting rosenpass server on port %d", m.port)
 
-	return m.server.Run()
+	return server.Run()
 }
 
 // Close closes the Rosenpass server
 func (m *Manager) Close() error {
-	if m.server != nil {
-		err := m.server.Close()
-		if err != nil {
-			log.Errorf("failed closing local rosenpass server")
-		}
-		m.server = nil
+	m.lock.Lock()
+	server := m.server
+	m.server = nil
+	m.lock.Unlock()
+	if server == nil {
+		return nil
+	}
+	if err := server.Close(); err != nil {
+		log.Errorf("failed closing local rosenpass server: %v", err)
 	}
 	return nil
 }

--- a/client/internal/rosenpass/manager.go
+++ b/client/internal/rosenpass/manager.go
@@ -119,6 +119,7 @@ func (m *Manager) addPeer(rosenpassPubKey []byte, rosenpassAddr string, wireGuar
 		// 4-byte IPv4 for IPv4 hosts, which the kernel rejects (EDESTADDRREQ) when
 		// sent from an AF_INET6 socket. Normalize the remote endpoint to IPv4-mapped
 		// IPv6 so its address family matches our listening socket.
+		// TODO: maybe bind the Rosenpass UDP server to the peer wg IP addr
 		if v4 := pcfg.Endpoint.IP.To4(); v4 != nil {
 			pcfg.Endpoint.IP = v4.To16()
 		}

--- a/client/internal/rosenpass/manager_test.go
+++ b/client/internal/rosenpass/manager_test.go
@@ -1,14 +1,381 @@
 package rosenpass
 
 import (
+	"errors"
+	"os"
+	"sync"
 	"testing"
 
+	rp "cunicu.li/go-rosenpass"
 	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
+
+// --- test doubles -----------------------------------------------------------
+
+type addPeerCall struct {
+	cfg rp.PeerConfig
+}
+
+type removePeerCall struct {
+	id rp.PeerID
+}
+
+type mockServer struct {
+	mu         sync.Mutex
+	addCalls   []addPeerCall
+	removed    []removePeerCall
+	nextID     rp.PeerID
+	addErr     error
+	removeErr  error
+	closed     bool
+	ran        bool
+}
+
+func (m *mockServer) AddPeer(cfg rp.PeerConfig) (rp.PeerID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.addCalls = append(m.addCalls, addPeerCall{cfg: cfg})
+	if m.addErr != nil {
+		return rp.PeerID{}, m.addErr
+	}
+	// Increment a byte in nextID so distinct peers get distinct IDs.
+	m.nextID[0]++
+	return m.nextID, nil
+}
+
+func (m *mockServer) RemovePeer(id rp.PeerID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removed = append(m.removed, removePeerCall{id: id})
+	return m.removeErr
+}
+
+func (m *mockServer) Run() error  { m.ran = true; return nil }
+func (m *mockServer) Close() error { m.closed = true; return nil }
+
+type setPSKCall struct {
+	peerKey    string
+	psk        wgtypes.Key
+	updateOnly bool
+}
+
+type mockIface struct {
+	mu    sync.Mutex
+	calls []setPSKCall
+	err   error
+}
+
+func (m *mockIface) SetPresharedKey(peerKey string, psk wgtypes.Key, updateOnly bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, setPSKCall{peerKey: peerKey, psk: psk, updateOnly: updateOnly})
+	return m.err
+}
+
+// newTestManager builds a Manager with deterministic spk so tie-break
+// against a peer pubkey is controllable from tests. The provided spk byte
+// becomes the first byte; remaining bytes are zero.
+func newTestManager(spkFirstByte byte, mock *mockServer) *Manager {
+	spk := make([]byte, 32)
+	spk[0] = spkFirstByte
+	return &Manager{
+		ifaceName:   "wt0",
+		spk:         spk,
+		ssk:         make([]byte, 32),
+		rpKeyHash:   "test-hash",
+		rpPeerIDs:   make(map[string]*rp.PeerID),
+		rpWgHandler: NewNetbirdHandler(),
+		server:      mock,
+	}
+}
+
+// validWGKey returns a deterministic 32-byte wireguard public key (base64).
+func validWGKey(t *testing.T, lastByte byte) string {
+	t.Helper()
+	var k wgtypes.Key
+	k[31] = lastByte
+	return k.String()
+}
+
+// --- pure helpers ----------------------------------------------------------
+
+func TestHashRosenpassKey_Deterministic(t *testing.T) {
+	key := []byte("hello-rosenpass")
+	require.Equal(t, hashRosenpassKey(key), hashRosenpassKey(key))
+	require.Len(t, hashRosenpassKey(key), 64) // sha256 hex
+}
+
+func TestHashRosenpassKey_DifferentInputsDifferOutputs(t *testing.T) {
+	require.NotEqual(t, hashRosenpassKey([]byte("a")), hashRosenpassKey([]byte("b")))
+}
+
+func TestGetLogLevel_DefaultWhenUnset(t *testing.T) {
+	// Snapshot + unset to exercise the LookupEnv ok=false branch. t.Setenv
+	// can only set, not delete, so do it manually with restore via t.Cleanup.
+	prev, hadPrev := os.LookupEnv(defaultLogLevelVar)
+	require.NoError(t, os.Unsetenv(defaultLogLevelVar))
+	t.Cleanup(func() {
+		if hadPrev {
+			_ = os.Setenv(defaultLogLevelVar, prev)
+		} else {
+			_ = os.Unsetenv(defaultLogLevelVar)
+		}
+	})
+	require.Equal(t, defaultLog.String(), getLogLevel().String())
+}
+
+func TestGetLogLevel_Cases(t *testing.T) {
+	cases := map[string]string{
+		"debug":   "DEBUG",
+		"info":    "INFO",
+		"warn":    "WARN",
+		"error":   "ERROR",
+		"unknown": "INFO", // default fallback
+	}
+	for input, wantStr := range cases {
+		input, wantStr := input, wantStr
+		t.Run(input, func(t *testing.T) {
+			t.Setenv(defaultLogLevelVar, input)
+			require.Equal(t, wantStr, getLogLevel().String())
+		})
+	}
+}
 
 func TestFindRandomAvailableUDPPort(t *testing.T) {
 	port, err := findRandomAvailableUDPPort()
 	require.NoError(t, err)
 	require.Greater(t, port, 0)
 	require.LessOrEqual(t, port, 65535)
+}
+
+// --- addPeer ---------------------------------------------------------------
+
+func TestAddPeer_HigherLocalPubkey_SetsEndpoint(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv) // local spk lexicographically larger
+
+	remotePubKey := make([]byte, 32) // remote spk = all zeros (smaller)
+	err := m.addPeer(remotePubKey, "rosenpass-host:7000", "100.1.1.1", validWGKey(t, 1))
+	require.NoError(t, err)
+	require.Len(t, srv.addCalls, 1)
+
+	ep := srv.addCalls[0].cfg.Endpoint
+	require.NotNil(t, ep, "initiator side must set Endpoint")
+	require.Equal(t, 7000, ep.Port)
+	require.Equal(t, "100.1.1.1", ep.IP.String())
+}
+
+func TestAddPeer_HigherLocalPubkey_EndpointIPIsIPv4Mapped(t *testing.T) {
+	// Regression guard for the EDESTADDRREQ fix: Endpoint.IP must be 16-byte
+	// (IPv4-mapped IPv6) so it matches the AF_INET6 listening socket family.
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+
+	err := m.addPeer(make([]byte, 32), "rp:5000", "100.1.1.1", validWGKey(t, 1))
+	require.NoError(t, err)
+
+	ep := srv.addCalls[0].cfg.Endpoint
+	require.NotNil(t, ep)
+	require.Len(t, ep.IP, 16, "IPv4 endpoint must be normalized to 16-byte v4-mapped form")
+	require.True(t, ep.IP.To4() != nil, "Endpoint must still be detected as IPv4")
+}
+
+func TestAddPeer_LowerLocalPubkey_LeavesEndpointNil(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0x00, srv) // local spk smaller
+
+	remotePubKey := make([]byte, 32)
+	remotePubKey[0] = 0xFF
+	err := m.addPeer(remotePubKey, "rp:5000", "100.1.1.1", validWGKey(t, 2))
+	require.NoError(t, err)
+
+	require.Nil(t, srv.addCalls[0].cfg.Endpoint, "responder side must NOT set Endpoint")
+}
+
+func TestAddPeer_PresharedKeyPropagated(t *testing.T) {
+	srv := &mockServer{}
+	psk := &wgtypes.Key{0x42}
+	m := newTestManager(0xFF, srv)
+	m.preSharedKey = (*[32]byte)(psk)
+
+	err := m.addPeer(make([]byte, 32), "rp:5000", "100.1.1.1", validWGKey(t, 3))
+	require.NoError(t, err)
+	require.Equal(t, [32]byte(*psk), [32]byte(srv.addCalls[0].cfg.PresharedKey))
+}
+
+func TestAddPeer_InvalidRosenpassAddr_ReturnsError(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv) // initiator path → parses rosenpassAddr
+
+	err := m.addPeer(make([]byte, 32), "not-a-host-port", "100.1.1.1", validWGKey(t, 1))
+	require.Error(t, err)
+	require.Empty(t, srv.addCalls, "server.AddPeer must not run when address parse fails")
+}
+
+func TestAddPeer_InvalidWireGuardPubKey_ReturnsError(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+
+	err := m.addPeer(make([]byte, 32), "rp:5000", "100.1.1.1", "not-a-valid-key")
+	require.Error(t, err)
+}
+
+func TestAddPeer_ServerError_Propagates(t *testing.T) {
+	srv := &mockServer{addErr: errors.New("boom")}
+	m := newTestManager(0xFF, srv)
+
+	err := m.addPeer(make([]byte, 32), "rp:5000", "100.1.1.1", validWGKey(t, 1))
+	require.Error(t, err)
+}
+
+func TestAddPeer_RecordsPeerID(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+
+	wgKey := validWGKey(t, 5)
+	err := m.addPeer(make([]byte, 32), "rp:5000", "100.1.1.1", wgKey)
+	require.NoError(t, err)
+	require.Contains(t, m.rpPeerIDs, wgKey)
+}
+
+// --- OnConnected / OnDisconnected ------------------------------------------
+
+func TestOnConnected_NilRemotePubKey_NoAddPeer(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+
+	m.OnConnected(validWGKey(t, 1), nil, "100.1.1.1", "rp:5000")
+	require.Empty(t, srv.addCalls, "nil remote rosenpass pubkey must skip AddPeer")
+	require.Empty(t, m.rpPeerIDs)
+}
+
+func TestOnConnected_ValidPubKey_CallsAddPeer(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+
+	wgKey := validWGKey(t, 1)
+	m.OnConnected(wgKey, make([]byte, 32), "100.1.1.1", "rp:5000")
+	require.Len(t, srv.addCalls, 1)
+	require.Contains(t, m.rpPeerIDs, wgKey)
+}
+
+func TestOnDisconnected_UnknownPeer_NoOp(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+
+	m.OnDisconnected(validWGKey(t, 99))
+	require.Empty(t, srv.removed, "unknown peer key must not call RemovePeer")
+}
+
+func TestOnDisconnected_KnownPeer_CallsRemoveAndForgets(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+
+	wgKey := validWGKey(t, 1)
+	require.NoError(t, m.addPeer(make([]byte, 32), "rp:5000", "100.1.1.1", wgKey))
+	require.Contains(t, m.rpPeerIDs, wgKey)
+
+	m.OnDisconnected(wgKey)
+	require.Len(t, srv.removed, 1)
+	require.NotContains(t, m.rpPeerIDs, wgKey, "peer must be forgotten after disconnect")
+}
+
+// --- IsPresharedKeyInitialized ---------------------------------------------
+
+func TestIsPresharedKeyInitialized_UnknownPeer_ReturnsFalse(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+	require.False(t, m.IsPresharedKeyInitialized(validWGKey(t, 1)))
+}
+
+func TestIsPresharedKeyInitialized_AddedButNotHandshaken_ReturnsFalse(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+
+	wgKey := validWGKey(t, 2)
+	require.NoError(t, m.addPeer(make([]byte, 32), "rp:5000", "100.1.1.1", wgKey))
+	require.False(t, m.IsPresharedKeyInitialized(wgKey))
+}
+
+// --- NetbirdHandler.outputKey ----------------------------------------------
+
+func TestHandler_OutputKey_FirstCallUsesUpdateOnlyFalse(t *testing.T) {
+	h := NewNetbirdHandler()
+	iface := &mockIface{}
+	h.SetInterface(iface)
+
+	pid := rp.PeerID{0x01}
+	wgKey := wgtypes.Key{0xAA}
+	h.AddPeer(pid, "wt0", rp.Key(wgKey))
+
+	psk := rp.Key{0xBB}
+	h.HandshakeCompleted(pid, psk)
+
+	require.Len(t, iface.calls, 1)
+	require.False(t, iface.calls[0].updateOnly, "first PSK rotation must use updateOnly=false")
+	require.Equal(t, wgKey.String(), iface.calls[0].peerKey)
+}
+
+func TestHandler_OutputKey_SubsequentCallsUseUpdateOnlyTrue(t *testing.T) {
+	h := NewNetbirdHandler()
+	iface := &mockIface{}
+	h.SetInterface(iface)
+
+	pid := rp.PeerID{0x02}
+	h.AddPeer(pid, "wt0", rp.Key(wgtypes.Key{0xCC}))
+
+	h.HandshakeCompleted(pid, rp.Key{0x01}) // first
+	h.HandshakeCompleted(pid, rp.Key{0x02}) // second
+
+	require.Len(t, iface.calls, 2)
+	require.False(t, iface.calls[0].updateOnly)
+	require.True(t, iface.calls[1].updateOnly, "subsequent rotations must use updateOnly=true")
+}
+
+func TestHandler_OutputKey_NilInterface_NoCrashNoCall(t *testing.T) {
+	h := NewNetbirdHandler()
+	// no SetInterface — iface remains nil
+	pid := rp.PeerID{0x03}
+	h.AddPeer(pid, "wt0", rp.Key(wgtypes.Key{}))
+
+	// Must not panic.
+	h.HandshakeCompleted(pid, rp.Key{})
+}
+
+func TestHandler_OutputKey_UnknownPeer_NoCall(t *testing.T) {
+	h := NewNetbirdHandler()
+	iface := &mockIface{}
+	h.SetInterface(iface)
+
+	h.HandshakeCompleted(rp.PeerID{0xFF}, rp.Key{})
+	require.Empty(t, iface.calls, "unknown peer id must not trigger SetPresharedKey")
+}
+
+func TestHandler_RemovePeer_ClearsInitializedState(t *testing.T) {
+	h := NewNetbirdHandler()
+	iface := &mockIface{}
+	h.SetInterface(iface)
+
+	pid := rp.PeerID{0x04}
+	h.AddPeer(pid, "wt0", rp.Key(wgtypes.Key{0xDD}))
+	h.HandshakeCompleted(pid, rp.Key{0x01})
+	require.True(t, h.IsPeerInitialized(pid))
+
+	h.RemovePeer(pid)
+	require.False(t, h.IsPeerInitialized(pid), "RemovePeer must clear initialized flag")
+}
+
+func TestHandler_SetInterfaceAfterAddPeer_StillReceivesKey(t *testing.T) {
+	h := NewNetbirdHandler()
+	pid := rp.PeerID{0x05}
+	wgKey := wgtypes.Key{0xEE}
+	h.AddPeer(pid, "wt0", rp.Key(wgKey))
+
+	iface := &mockIface{}
+	h.SetInterface(iface) // set after AddPeer
+
+	h.HandshakeCompleted(pid, rp.Key{0x42})
+	require.Len(t, iface.calls, 1)
+	require.Equal(t, wgKey.String(), iface.calls[0].peerKey)
 }

--- a/client/internal/rosenpass/manager_test.go
+++ b/client/internal/rosenpass/manager_test.go
@@ -229,6 +229,37 @@ func TestAddPeer_ServerError_Propagates(t *testing.T) {
 	require.Error(t, err)
 }
 
+// Regression guard for issue #4341 (Android crash). If Run() has not completed
+// before OnConnected fires, m.rpWgHandler or m.server may be nil. Without the
+// nil guards, m.rpWgHandler.AddPeer panics on nil receiver.
+func TestAddPeer_NilHandler_ReturnsErrorNoCrash(t *testing.T) {
+	srv := &mockServer{}
+	m := newTestManager(0xFF, srv)
+	m.rpWgHandler = nil // simulate Run() not yet completed
+
+	err := m.addPeer(make([]byte, 32), "rp:5000", "100.1.1.1", validWGKey(t, 1))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wg handler not initialized")
+}
+
+func TestAddPeer_NilServer_ReturnsErrorNoCrash(t *testing.T) {
+	m := newTestManager(0xFF, nil)
+	m.server = nil // simulate Run() not yet completed
+
+	err := m.addPeer(make([]byte, 32), "rp:5000", "100.1.1.1", validWGKey(t, 1))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "server not initialized")
+}
+
+// NewManager must pre-initialize rpWgHandler so the nil-receiver crash from
+// issue #4341 cannot occur in the window between NewManager and Run().
+func TestNewManager_PreInitializesHandler(t *testing.T) {
+	psk := wgtypes.Key{}
+	m, err := NewManager(&psk, "wt0")
+	require.NoError(t, err)
+	require.NotNil(t, m.rpWgHandler, "rpWgHandler must be initialized in NewManager")
+}
+
 func TestAddPeer_RecordsPeerID(t *testing.T) {
 	srv := &mockServer{}
 	m := newTestManager(0xFF, srv)

--- a/client/internal/rosenpass/seed.go
+++ b/client/internal/rosenpass/seed.go
@@ -1,0 +1,42 @@
+package rosenpass
+
+import (
+	"fmt"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// DeterministicSeedKey derives a 32-byte WireGuard preshared key from a pair
+// of peer public keys. Both peers, given the same key pair, produce the same
+// output regardless of which side runs the function: the inputs are ordered
+// lexicographically before concatenation.
+//
+// NetBird uses this value as the initial Rosenpass-side preshared key when no
+// explicit account-level PSK is configured, so both peers converge on the same
+// PSK before the first post-quantum handshake completes.
+//
+// The resulting key MUST NOT be treated as quantum-safe: it is deterministic
+// from public keys and exists only to seed WireGuard until Rosenpass rotates
+// in a real post-quantum PSK.
+func DeterministicSeedKey(localKey, remoteKey string) (*wgtypes.Key, error) {
+	lk := []byte(localKey)
+	rk := []byte(remoteKey)
+	if len(lk) < 16 || len(rk) < 16 {
+		return nil, fmt.Errorf("rosenpass: peer keys must be at least 16 bytes (got local=%d, remote=%d)", len(lk), len(rk))
+	}
+
+	var keyInput []byte
+	if localKey > remoteKey {
+		keyInput = append(keyInput, lk[:16]...)
+		keyInput = append(keyInput, rk[:16]...)
+	} else {
+		keyInput = append(keyInput, rk[:16]...)
+		keyInput = append(keyInput, lk[:16]...)
+	}
+
+	key, err := wgtypes.NewKey(keyInput)
+	if err != nil {
+		return nil, fmt.Errorf("rosenpass: deterministic seed key: %w", err)
+	}
+	return &key, nil
+}

--- a/client/internal/rosenpass/seed_test.go
+++ b/client/internal/rosenpass/seed_test.go
@@ -1,0 +1,44 @@
+package rosenpass
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeterministicSeedKey_SameForBothSides(t *testing.T) {
+	// Peer A and peer B must derive the same PSK regardless of which side
+	// computes it: the function orders inputs internally.
+	a := strings.Repeat("a", 32)
+	b := strings.Repeat("b", 32)
+
+	keyAB, err := DeterministicSeedKey(a, b)
+	require.NoError(t, err)
+	keyBA, err := DeterministicSeedKey(b, a)
+	require.NoError(t, err)
+	require.Equal(t, keyAB.String(), keyBA.String(), "swapping arguments must yield identical key")
+}
+
+func TestDeterministicSeedKey_ChangesWithKeys(t *testing.T) {
+	a := strings.Repeat("a", 32)
+	b := strings.Repeat("b", 32)
+	c := strings.Repeat("c", 32)
+
+	keyAB, err := DeterministicSeedKey(a, b)
+	require.NoError(t, err)
+	keyAC, err := DeterministicSeedKey(a, c)
+	require.NoError(t, err)
+	require.NotEqual(t, keyAB.String(), keyAC.String(), "different peer pair must yield different key")
+}
+
+func TestDeterministicSeedKey_TooShortKey_ReturnsError(t *testing.T) {
+	short := "short" // < 16 bytes
+	long := strings.Repeat("x", 32)
+
+	_, err := DeterministicSeedKey(short, long)
+	require.Error(t, err)
+	_, err = DeterministicSeedKey(long, short)
+	require.Error(t, err)
+}
+

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/netbirdio/netbird
 go 1.25.5
 
 require (
-	cunicu.li/go-rosenpass v0.4.0
+	cunicu.li/go-rosenpass v0.5.42
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/golang/protobuf v1.5.4
@@ -19,8 +19,8 @@ require (
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sys v0.43.0
-	golang.zx2c4.com/wireguard v0.0.0-20230704135630-469159ecf7d1
-	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
+	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
+	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
 	golang.zx2c4.com/wireguard/windows v0.5.3
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
@@ -38,7 +38,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.3
 	github.com/c-robinson/iplib v1.0.3
 	github.com/caddyserver/certmagic v0.21.3
-	github.com/cilium/ebpf v0.15.0
+	github.com/cilium/ebpf v0.19.0
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-iptables v0.7.0
 	github.com/coreos/go-oidc/v3 v3.18.0
@@ -60,7 +60,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/gopacket v1.1.19
 	github.com/google/nftables v0.3.0
-	github.com/gopacket/gopacket v1.1.1
+	github.com/gopacket/gopacket v1.4.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.2-0.20240212192251-757544f21357
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 codeberg.org/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6 h1:b8xUw3004wk+3ipBhu0VU4RtUJsegMIiqjxSK4++lzA=
 codeberg.org/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6/go.mod h1:+CauBF6R70Jqcyl8N2hC8pAXYbWkGIezuSbuGLtRhnw=
-cunicu.li/go-rosenpass v0.4.0 h1:LtPtBgFWY/9emfgC4glKLEqS0MJTylzV6+ChRhiZERw=
-cunicu.li/go-rosenpass v0.4.0/go.mod h1:MPbjH9nxV4l3vEagKVdFNwHOketqgS5/To1VYJplf/M=
 cunicu.li/go-rosenpass v0.5.42 h1:fRDsGwCxd7DhDgZI1Pxeo8GtNyq8BESZJ7w2/BGGJtU=
 cunicu.li/go-rosenpass v0.5.42/go.mod h1:YRBeyKOe/gWpSX2kpDUec5p9t0XOLsshTguId5gTGVg=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
@@ -113,8 +111,6 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cilium/ebpf v0.15.0 h1:7NxJhNiBT3NG8pZJ3c+yfrVdHY8ScgKD27sScgjLMMk=
-github.com/cilium/ebpf v0.15.0/go.mod h1:DHp1WyrLeiBh19Cf/tfiSMhqheEiK8fXFZ4No0P1Hso=
 github.com/cilium/ebpf v0.19.0 h1:Ro/rE64RmFBeA9FGjcTc+KmCeY6jXmryu6FfnzPRIao=
 github.com/cilium/ebpf v0.19.0/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
@@ -229,9 +225,8 @@ github.com/go-openapi/validate v0.24.0 h1:LdfDKwNbpB6Vn40xhTdNZAnfLECL81w+VX3Bum
 github.com/go-openapi/validate v0.24.0/go.mod h1:iyeX1sEufmv3nPbBdX3ieNviWnOZaJ1+zquzJEf2BAQ=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
-github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
-github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
@@ -312,8 +307,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.14 h1:yh8ncqsbUY4shRD5dA
 github.com/googleapis/enterprise-certificate-proxy v0.3.14/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
 github.com/googleapis/gax-go/v2 v2.21.0 h1:h45NjjzEO3faG9Lg/cFrBh2PgegVVgzqKzuZl/wMbiI=
 github.com/googleapis/gax-go/v2 v2.21.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fHZJt/hsCz3Fih4=
-github.com/gopacket/gopacket v1.1.1 h1:zbx9F9d6A7sWNkFKrvMBZTfGgxFoY4NgUudFVVHMfcw=
-github.com/gopacket/gopacket v1.1.1/go.mod h1:HavMeONEl7W9036of9LbSWoonqhH7HA1+ZRO+rMIvFs=
 github.com/gopacket/gopacket v1.4.0 h1:cr1OlFpzksCkZHNO0eLjaSSOrMQnpPXg0j6qHIY3y2U=
 github.com/gopacket/gopacket v1.4.0/go.mod h1:EpvsxINeehp5qj4YMKMLf2/dekdhKn2IIAO/ZOifS7o=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
@@ -397,6 +390,8 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jsimonetti/rtnetlink/v2 v2.0.1 h1:xda7qaHDSVOsADNouv7ukSuicKZO7GgVUCXxpaIEIlM=
+github.com/jsimonetti/rtnetlink/v2 v2.0.1/go.mod h1:7MoNYNbb3UaDHtF8udiJo/RH6VsTKP1pqKLUTVCvToE=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25 h1:YLvr1eE6cdCqjOe972w/cYF+FjW34v27+9Vo5106B4M=
 github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25/go.mod h1:kLgvv7o6UM+0QSf0QjAse3wReFDsb9qbZJdfexWlrQw=
@@ -907,8 +902,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
-golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6 h1:CawjfCvYQH2OU3/TnxLx97WDSUDRABfT18pCOYwc2GE=
-golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6/go.mod h1:3rxYc4HtVcSG9gVaTs2GEBdehh+sYPOwKtyUWEOTb80=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10 h1:3GDAcqdIg1ozBNLgPy4SLT84nfcBjr6rhGtXYtrkWLU=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10/go.mod h1:T97yPqesLiNrOYxkwmhMI0ZIlJDm+p0PMR8eRVeR5tQ=
 golang.zx2c4.com/wireguard/windows v0.5.3 h1:On6j2Rpn3OEMXqBq00QEDC7bWSZrPIHKIus8eIuExIE=

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ codeberg.org/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6 h1:b8xUw3004wk+3ipB
 codeberg.org/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6/go.mod h1:+CauBF6R70Jqcyl8N2hC8pAXYbWkGIezuSbuGLtRhnw=
 cunicu.li/go-rosenpass v0.4.0 h1:LtPtBgFWY/9emfgC4glKLEqS0MJTylzV6+ChRhiZERw=
 cunicu.li/go-rosenpass v0.4.0/go.mod h1:MPbjH9nxV4l3vEagKVdFNwHOketqgS5/To1VYJplf/M=
+cunicu.li/go-rosenpass v0.5.42 h1:fRDsGwCxd7DhDgZI1Pxeo8GtNyq8BESZJ7w2/BGGJtU=
+cunicu.li/go-rosenpass v0.5.42/go.mod h1:YRBeyKOe/gWpSX2kpDUec5p9t0XOLsshTguId5gTGVg=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
@@ -113,6 +115,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cilium/ebpf v0.15.0 h1:7NxJhNiBT3NG8pZJ3c+yfrVdHY8ScgKD27sScgjLMMk=
 github.com/cilium/ebpf v0.15.0/go.mod h1:DHp1WyrLeiBh19Cf/tfiSMhqheEiK8fXFZ4No0P1Hso=
+github.com/cilium/ebpf v0.19.0 h1:Ro/rE64RmFBeA9FGjcTc+KmCeY6jXmryu6FfnzPRIao=
+github.com/cilium/ebpf v0.19.0/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
@@ -227,6 +231,7 @@ github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3yg
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
@@ -309,6 +314,8 @@ github.com/googleapis/gax-go/v2 v2.21.0 h1:h45NjjzEO3faG9Lg/cFrBh2PgegVVgzqKzuZl
 github.com/googleapis/gax-go/v2 v2.21.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fHZJt/hsCz3Fih4=
 github.com/gopacket/gopacket v1.1.1 h1:zbx9F9d6A7sWNkFKrvMBZTfGgxFoY4NgUudFVVHMfcw=
 github.com/gopacket/gopacket v1.1.1/go.mod h1:HavMeONEl7W9036of9LbSWoonqhH7HA1+ZRO+rMIvFs=
+github.com/gopacket/gopacket v1.4.0 h1:cr1OlFpzksCkZHNO0eLjaSSOrMQnpPXg0j6qHIY3y2U=
+github.com/gopacket/gopacket v1.4.0/go.mod h1:EpvsxINeehp5qj4YMKMLf2/dekdhKn2IIAO/ZOifS7o=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
@@ -902,6 +909,8 @@ golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeu
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6 h1:CawjfCvYQH2OU3/TnxLx97WDSUDRABfT18pCOYwc2GE=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6/go.mod h1:3rxYc4HtVcSG9gVaTs2GEBdehh+sYPOwKtyUWEOTb80=
+golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10 h1:3GDAcqdIg1ozBNLgPy4SLT84nfcBjr6rhGtXYtrkWLU=
+golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10/go.mod h1:T97yPqesLiNrOYxkwmhMI0ZIlJDm+p0PMR8eRVeR5tQ=
 golang.zx2c4.com/wireguard/windows v0.5.3 h1:On6j2Rpn3OEMXqBq00QEDC7bWSZrPIHKIus8eIuExIE=
 golang.zx2c4.com/wireguard/windows v0.5.3/go.mod h1:9TEe8TJmtwyQebdFwAkEWOPr3prrtqm+REGFifP60hI=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=


### PR DESCRIPTION
## Describe your changes

This PR bundles several related changes to the Rosenpass support in the
client agent:

1. **Bump `cunicu.li/go-rosenpass` from v0.4.0 to v0.5.42.** The upstream
   library was pinned at a release from September 2023, ~40 releases behind
   the current upstream. The bump pulls in protocol fixes from upstream
   (resolves the recurring `failed to load biscuit (ICR1): detected
   replay` slog errors observed in production). Transitive bumps:
   - `cilium/ebpf` 0.15 → 0.19, 
   - `gopacket/gopacket` 1.1.1 → 1.4.0, 
   - `wireguard/wgctrl` updated. Wire-protocol interop between v0.4.0 and
   v0.5.42 verified end-to-end (cross-version handshake works), so no
   flag-day rollout is required.

2. **Fix nil-receiver crash on Android (#4341).** When `Engine.Run()` had
   not completed before `OnConnected` fired, `m.rpWgHandler` was nil and
   `m.rpWgHandler.AddPeer(...)` in `addPeer` panicked. `NewManager` now
   pre-initializes `rpWgHandler`, and `addPeer` has explicit nil guards
   for both `m.server` and `m.rpWgHandler` as defense in depth.
   `generateConfig` keeps replacing the handler on each `Run()` so peer
   state from previous engine sessions is not retained.

3. **Normalize peer endpoint to IPv4-mapped IPv6.** The Rosenpass UDP
   server binds on the IPv6 wildcard `[::]` and `net.ResolveUDPAddr` returns
   a 4-byte IPv4 for IPv4 hosts, which the kernel rejected with `EDESTADDRREQ`
   on Linux when the lib called `sendto` from the AF_INET6 socket. The
   initiator path in `addPeer` now converts the remote endpoint to
   IPv4-mapped IPv6 so its family matches the listening socket.

4. **Move `rosenpassDetermKey` into the `rosenpass` package** as the
   exported `DeterministicSeedKey`, closing the `// todo: move this logic
   into Rosenpass package` left at `conn.go:911`. While moving:
   - Replace `append(lk[:16], rk[:16]...)` with `append` onto an empty
     slice so the `//nolint:gocritic` suppression is no longer needed.
   - Validate input length (`>= 16` bytes) so the function returns an
     error instead of panicking on out-of-range slicing.
   - Wrap returned errors with package-scoped context.
   - Doc comment makes explicit that the seed is deterministic and **not**
     post-quantum safe; Rosenpass replaces it with a real PQ PSK on
     first rotation.

5. **Decouple `rp.Server` behind an `rpServer` interface** so the manager
   can be exercised without spinning up a real UDP server, and add unit
   tests covering the initiator/responder tie-break, peer lifecycle,
   PSK rotation `updateOnly` semantics, error propagation, and the new
   nil-guard branches.

## Issue ticket number and link

GitHub: <https://github.com/netbirdio/netbird/issues/4341>

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal change only. The public NetBird CLI/API surface and the Rosenpass
feature behavior are unchanged: the dependency bump is transparent to users
(wire-compatible with v0.4.0), the nil-guard prevents a crash without
altering normal flow, the endpoint normalization restores the intended send
behavior on Linux, and the function move/refactor preserves inputs, outputs,
and call semantics.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic preshared-key generation added for peer handshakes.

* **Bug Fixes**
  * Prevented panics by initializing internal handlers earlier and returning explicit errors when components are unready.
  * Normalized IPv4 endpoints to IPv6-mapped form for consistent connectivity.

* **Tests**
  * Expanded test suite covering key derivation, manager/handler behaviors, endpoint selection, and edge cases.

* **Chores**
  * Updated several dependencies (Rosenpass, WireGuard, eBPF, packet libraries).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6136)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->