### PR TITLE
[client] Drop signaling-side ICE filter, gate overlay STUN at mux read-side instead

### DIFF
--- a/client/iface/bind/ice_bind.go
+++ b/client/iface/bind/ice_bind.go
@@ -41,7 +41,6 @@ type ICEBind struct {
 	*wgConn.StdNetBind
 
 	transportNet transport.Net
-	filterFn     udpmux.FilterFn
 	address      wgaddr.Address
 	mtu          uint16
 
@@ -61,12 +60,11 @@ type ICEBind struct {
 	ipv6Conn *net.UDPConn
 }
 
-func NewICEBind(transportNet transport.Net, filterFn udpmux.FilterFn, address wgaddr.Address, mtu uint16) *ICEBind {
+func NewICEBind(transportNet transport.Net, address wgaddr.Address, mtu uint16) *ICEBind {
 	b, _ := wgConn.NewStdNetBind().(*wgConn.StdNetBind)
 	ib := &ICEBind{
 		StdNetBind:       b,
 		transportNet:     transportNet,
-		filterFn:         filterFn,
 		address:          address,
 		mtu:              mtu,
 		endpoints:        make(map[netip.Addr]net.Conn),
@@ -265,7 +263,6 @@ func (s *ICEBind) createOrUpdateMux() {
 		udpmux.UniversalUDPMuxParams{
 			UDPConn:   muxConn,
 			Net:       s.transportNet,
-			FilterFn:  s.filterFn,
 			WGAddress: s.address,
 			MTU:       s.mtu,
 		},

--- a/client/iface/bind/ice_bind_test.go
+++ b/client/iface/bind/ice_bind_test.go
@@ -289,7 +289,7 @@ func setupICEBind(t *testing.T) *ICEBind {
 		IP:      netip.MustParseAddr("100.64.0.1"),
 		Network: netip.MustParsePrefix("100.64.0.0/10"),
 	}
-	return NewICEBind(transportNet, nil, address, 1280)
+	return NewICEBind(transportNet, address, 1280)
 }
 
 func createDualStackConns(t *testing.T) (*net.UDPConn, *net.UDPConn) {

--- a/client/iface/device/device_kernel_unix.go
+++ b/client/iface/device/device_kernel_unix.go
@@ -32,8 +32,6 @@ type TunKernelDevice struct {
 	link       *wgLink
 	udpMuxConn net.PacketConn
 	udpMux     *udpmux.UniversalUDPMuxDefault
-
-	filterFn udpmux.FilterFn
 }
 
 func NewKernelDevice(name string, address wgaddr.Address, wgPort int, key string, mtu uint16, transportNet transport.Net) *TunKernelDevice {
@@ -104,7 +102,6 @@ func (t *TunKernelDevice) Up() (*udpmux.UniversalUDPMuxDefault, error) {
 	bindParams := udpmux.UniversalUDPMuxParams{
 		UDPConn:   nbnet.WrapPacketConn(rawSock),
 		Net:       t.transportNet,
-		FilterFn:  t.filterFn,
 		WGAddress: t.address,
 		MTU:       t.mtu,
 	}

--- a/client/iface/iface.go
+++ b/client/iface/iface.go
@@ -63,7 +63,6 @@ type WGIFaceOpts struct {
 	MTU          uint16
 	MobileArgs   *device.MobileIFaceArguments
 	TransportNet transport.Net
-	FilterFn     udpmux.FilterFn
 	DisableDNS   bool
 }
 

--- a/client/iface/iface_new.go
+++ b/client/iface/iface_new.go
@@ -11,7 +11,7 @@ import (
 
 // NewWGIFace Creates a new WireGuard interface instance
 func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
-	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, opts.Address, opts.MTU)
+	iceBind := bind.NewICEBind(opts.TransportNet, opts.Address, opts.MTU)
 
 	var tun WGTunDevice
 	if netstack.IsEnabled() {

--- a/client/iface/iface_new_android.go
+++ b/client/iface/iface_new_android.go
@@ -9,7 +9,7 @@ import (
 
 // NewWGIFace Creates a new WireGuard interface instance
 func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
-	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, opts.Address, opts.MTU)
+	iceBind := bind.NewICEBind(opts.TransportNet, opts.Address, opts.MTU)
 
 	if netstack.IsEnabled() {
 		wgIFace := &WGIface{

--- a/client/iface/iface_new_ios.go
+++ b/client/iface/iface_new_ios.go
@@ -10,7 +10,7 @@ import (
 
 // NewWGIFace Creates a new WireGuard interface instance
 func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
-	iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, opts.Address, opts.MTU)
+	iceBind := bind.NewICEBind(opts.TransportNet, opts.Address, opts.MTU)
 
 	wgIFace := &WGIface{
 		tun:            device.NewTunDevice(opts.IFaceName, opts.Address, opts.WGPort, opts.WGPrivKey, opts.MTU, iceBind, opts.MobileArgs.TunFd),

--- a/client/iface/iface_new_linux.go
+++ b/client/iface/iface_new_linux.go
@@ -14,7 +14,7 @@ import (
 // NewWGIFace Creates a new WireGuard interface instance
 func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
 	if netstack.IsEnabled() {
-		iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, opts.Address, opts.MTU)
+		iceBind := bind.NewICEBind(opts.TransportNet, opts.Address, opts.MTU)
 		return &WGIface{
 			tun:            device.NewNetstackDevice(opts.IFaceName, opts.Address, opts.WGPort, opts.WGPrivKey, opts.MTU, iceBind, netstack.ListenAddr()),
 			userspaceBind:  true,
@@ -30,7 +30,7 @@ func NewWGIFace(opts WGIFaceOpts) (*WGIface, error) {
 	}
 
 	if device.ModuleTunIsLoaded() {
-		iceBind := bind.NewICEBind(opts.TransportNet, opts.FilterFn, opts.Address, opts.MTU)
+		iceBind := bind.NewICEBind(opts.TransportNet, opts.Address, opts.MTU)
 		return &WGIface{
 			tun:            device.NewTunDevice(opts.IFaceName, opts.Address, opts.WGPort, opts.WGPrivKey, opts.MTU, iceBind),
 			userspaceBind:  true,

--- a/client/iface/udpmux/universal.go
+++ b/client/iface/udpmux/universal.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/netip"
-	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -21,10 +19,6 @@ import (
 	"github.com/netbirdio/netbird/client/iface/bufsize"
 	"github.com/netbirdio/netbird/client/iface/wgaddr"
 )
-
-// FilterFn is a function that filters out candidates based on the address.
-// If it returns true, the address is to be filtered. It also returns the prefix of matching route.
-type FilterFn func(address netip.Addr) (bool, netip.Prefix, error)
 
 // UniversalUDPMuxDefault handles STUN and TURN servers packets by wrapping the original UDPConn
 // It then passes packets to the UDPMux that does the actual connection muxing.
@@ -43,7 +37,6 @@ type UniversalUDPMuxParams struct {
 	UDPConn               net.PacketConn
 	XORMappedAddrCacheTTL time.Duration
 	Net                   transport.Net
-	FilterFn              FilterFn
 	WGAddress             wgaddr.Address
 	MTU                   uint16
 }
@@ -68,7 +61,6 @@ func NewUniversalUDPMuxDefault(params UniversalUDPMuxParams) *UniversalUDPMuxDef
 		PacketConn: params.UDPConn,
 		mux:        m,
 		logger:     params.Logger,
-		filterFn:   params.FilterFn,
 		address:    params.WGAddress,
 	}
 
@@ -115,15 +107,12 @@ func (m *UniversalUDPMuxDefault) ReadFromConn(ctx context.Context) {
 	}
 }
 
-// UDPConn is a wrapper around UDPMux conn that overrides ReadFrom and handles STUN/TURN packets
+// UDPConn is a wrapper around UDPMux conn that overrides WriteTo to drop packets destined for the overlay subnet.
 type UDPConn struct {
 	net.PacketConn
-	mux      *UniversalUDPMuxDefault
-	logger   logging.LeveledLogger
-	filterFn FilterFn
-	// TODO: reset cache on route changes
-	addrCache sync.Map
-	address   wgaddr.Address
+	mux     *UniversalUDPMuxDefault
+	logger  logging.LeveledLogger
+	address wgaddr.Address
 }
 
 // GetPacketConn returns the underlying PacketConn
@@ -132,65 +121,16 @@ func (u *UDPConn) GetPacketConn() net.PacketConn {
 }
 
 func (u *UDPConn) WriteTo(b []byte, addr net.Addr) (int, error) {
-	if u.filterFn == nil {
+	udpAddr, ok := addr.(*net.UDPAddr)
+	if !ok {
 		return u.PacketConn.WriteTo(b, addr)
 	}
-
-	if isRouted, found := u.addrCache.Load(addr.String()); found {
-		return u.handleCachedAddress(isRouted.(bool), b, addr)
-	}
-
-	return u.handleUncachedAddress(b, addr)
-}
-
-func (u *UDPConn) handleCachedAddress(isRouted bool, b []byte, addr net.Addr) (int, error) {
-	if isRouted {
-		return 0, fmt.Errorf("address %s is part of a routed network, refusing to write", addr)
-	}
-	return u.PacketConn.WriteTo(b, addr)
-}
-
-func (u *UDPConn) handleUncachedAddress(b []byte, addr net.Addr) (int, error) {
-	if err := u.performFilterCheck(addr); err != nil {
-		return 0, err
-	}
-	return u.PacketConn.WriteTo(b, addr)
-}
-
-func (u *UDPConn) performFilterCheck(addr net.Addr) error {
-	host, err := getHostFromAddr(addr)
-	if err != nil {
-		log.Errorf("Failed to get host from address %s: %v", addr, err)
-		return nil
-	}
-
-	a, err := netip.ParseAddr(host)
-	if err != nil {
-		log.Errorf("Failed to parse address %s: %v", addr, err)
-		return nil
-	}
-
-	if u.address.Network.Contains(a) {
+	dst := udpAddr.AddrPort().Addr().Unmap()
+	if (u.address.Network.IsValid() && u.address.Network.Contains(dst)) || (u.address.IPv6Net.IsValid() && u.address.IPv6Net.Contains(dst)) {
 		log.Warnf("address %s is part of the NetBird network %s, refusing to write", addr, u.address)
-		return fmt.Errorf("address %s is part of the NetBird network %s, refusing to write", addr, u.address)
+		return 0, fmt.Errorf("address %s is part of the NetBird network %s, refusing to write", addr, u.address)
 	}
-
-	if isRouted, prefix, err := u.filterFn(a); err != nil {
-		log.Errorf("Failed to check if address %s is routed: %v", addr, err)
-	} else {
-		u.addrCache.Store(addr.String(), isRouted)
-		if isRouted {
-			// Extra log, as the error only shows up with ICE logging enabled
-			log.Infof("address %s is part of routed network %s, refusing to write", addr, prefix)
-			return fmt.Errorf("address %s is part of routed network %s, refusing to write", addr, prefix)
-		}
-	}
-	return nil
-}
-
-func getHostFromAddr(addr net.Addr) (string, error) {
-	host, _, err := net.SplitHostPort(addr.String())
-	return host, err
+	return u.PacketConn.WriteTo(b, addr)
 }
 
 // GetSharedConn returns the shared udp conn
@@ -222,6 +162,13 @@ func (m *UniversalUDPMuxDefault) HandleSTUNMessage(msg *stun.Message, addr net.A
 	udpAddr, ok := addr.(*net.UDPAddr)
 	if !ok {
 		// message about this err will be logged in the UDPMux
+		return nil
+	}
+
+	src := udpAddr.AddrPort().Addr().Unmap()
+	wg := m.params.WGAddress
+	if (wg.Network.IsValid() && wg.Network.Contains(src)) || (wg.IPv6Net.IsValid() && wg.IPv6Net.Contains(src)) {
+		log.Debugf("dropping STUN message from overlay source %s", udpAddr)
 		return nil
 	}
 

--- a/client/iface/wgproxy/proxy_linux_test.go
+++ b/client/iface/wgproxy/proxy_linux_test.go
@@ -66,7 +66,7 @@ func seedProxyForProxyCloseByRemoteConn() ([]proxyInstance, error) {
 	if err != nil {
 		return nil, err
 	}
-	iceBind := bind.NewICEBind(nil, nil, wgAddress, 1280)
+	iceBind := bind.NewICEBind(nil, wgAddress, 1280)
 	endpointAddress := &net.UDPAddr{
 		IP:   net.IPv4(10, 0, 0, 1),
 		Port: 1234,

--- a/client/iface/wgproxy/proxy_seed_test.go
+++ b/client/iface/wgproxy/proxy_seed_test.go
@@ -22,7 +22,7 @@ func seedProxyForProxyCloseByRemoteConn() ([]proxyInstance, error) {
 	if err != nil {
 		return nil, err
 	}
-	iceBind := bind.NewICEBind(nil, nil, wgAddress, 1280)
+	iceBind := bind.NewICEBind(nil, wgAddress, 1280)
 	endpointAddress := &net.UDPAddr{
 		IP:   net.IPv4(10, 0, 0, 1),
 		Port: 1234,

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -54,7 +54,6 @@ import (
 	"github.com/netbirdio/netbird/client/internal/relay"
 	"github.com/netbirdio/netbird/client/internal/rosenpass"
 	"github.com/netbirdio/netbird/client/internal/routemanager"
-	"github.com/netbirdio/netbird/client/internal/routemanager/systemops"
 	"github.com/netbirdio/netbird/client/internal/statemanager"
 	"github.com/netbirdio/netbird/client/internal/updater"
 	"github.com/netbirdio/netbird/client/jobexec"
@@ -1876,7 +1875,6 @@ func (e *Engine) newWgIface() (*iface.WGIface, error) {
 		WGPrivKey:    e.config.WgPrivateKey.String(),
 		MTU:          e.config.MTU,
 		TransportNet: transportNet,
-		FilterFn:     e.addrViaRoutes,
 		DisableDNS:   e.config.DisableDNS,
 	}
 
@@ -2099,21 +2097,6 @@ func (e *Engine) startNetworkMonitor() {
 		log.Infof("Network monitor: detected network change, triggering client restart")
 		e.triggerClientRestart()
 	}()
-}
-
-func (e *Engine) addrViaRoutes(addr netip.Addr) (bool, netip.Prefix, error) {
-	var vpnRoutes []netip.Prefix
-	for _, routes := range e.routeManager.GetClientRoutes() {
-		if len(routes) > 0 && routes[0] != nil {
-			vpnRoutes = append(vpnRoutes, routes[0].Network)
-		}
-	}
-
-	if isVpn, prefix := systemops.IsAddrRouted(addr, vpnRoutes); isVpn {
-		return true, prefix, nil
-	}
-
-	return false, netip.Prefix{}, nil
 }
 
 func (e *Engine) stopDNSServer() {

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/netip"
 	"strconv"
 	"sync"
 	"time"
@@ -162,10 +161,6 @@ func (w *WorkerICE) OnRemoteCandidate(candidate ice.Candidate, haRoutes route.HA
 	w.log.Debugf("OnRemoteCandidate from peer %s -> %s", w.config.Key, candidate.String())
 	if w.agent == nil {
 		w.log.Warnf("ICE Agent is not initialized yet")
-		return
-	}
-
-	if candidateViaRoutes(candidate, haRoutes) {
 		return
 	}
 
@@ -587,34 +582,6 @@ func extraSrflxCandidate(candidate ice.Candidate) (*ice.CandidateServerReflexive
 	}
 
 	return ec, nil
-}
-
-func candidateViaRoutes(candidate ice.Candidate, clientRoutes route.HAMap) bool {
-	addr, err := netip.ParseAddr(candidate.Address())
-	if err != nil {
-		log.Errorf("Failed to parse IP address %s: %v", candidate.Address(), err)
-		return false
-	}
-
-	var routePrefixes []netip.Prefix
-	for _, routes := range clientRoutes {
-		if len(routes) > 0 && routes[0] != nil {
-			routePrefixes = append(routePrefixes, routes[0].Network)
-		}
-	}
-
-	for _, prefix := range routePrefixes {
-		// default route is handled by route exclusion / ip rules
-		if prefix.Bits() == 0 {
-			continue
-		}
-
-		if prefix.Contains(addr) {
-			log.Debugf("Ignoring candidate [%s], its address is part of routed network %s", candidate.String(), prefix)
-			return true
-		}
-	}
-	return false
 }
 
 func isRelayCandidate(candidate ice.Candidate) bool {

--- a/client/internal/routemanager/systemops/systemops_generic.go
+++ b/client/internal/routemanager/systemops/systemops_generic.go
@@ -121,9 +121,12 @@ func (r *SysOps) addRouteToNonVPNIntf(prefix netip.Prefix, vpnIntf wgIface, init
 		return Nexthop{}, vars.ErrRouteNotAllowed
 	}
 
-	// Check if the prefix is part of any local subnets
-	if isLocal, subnet := r.isPrefixInLocalSubnets(prefix); isLocal {
-		return Nexthop{}, fmt.Errorf("prefix %s is part of local subnet %s: %w", prefix, subnet, vars.ErrRouteNotAllowed)
+	// BSDs blackhole a /32 added inside a directly-connected subnet; Linux/Windows need it to beat the wt0 route.
+	switch runtime.GOOS {
+	case "darwin", "freebsd", "netbsd", "openbsd", "dragonfly":
+		if isLocal, subnet := r.isPrefixInLocalSubnets(prefix); isLocal {
+			return Nexthop{}, fmt.Errorf("prefix %s is part of local subnet %s: %w", prefix, subnet, vars.ErrRouteNotAllowed)
+		}
 	}
 
 	// Determine the exit interface and next hop for the prefix, so we can add a specific route


### PR DESCRIPTION
## Describe your changes

Replace the signaling-side ICE candidate filter with a smaller, more targeted drop on inbound STUN messages whose source falls inside the WireGuard overlay subnet. The old filter rejected any remote candidate whose address fell within an advertised route prefix, which dropped valid same-LAN host candidates whenever an overlapping route was distributed (e.g. an admin advertises 192.168.100.0/24 to make a remote subnet reachable, but two peers already share that LAN). The new filter only blocks the case it needs to: peer-reflexive ICE candidates synthesized from packets that arrived through the tunnel itself, which would otherwise cause the WG endpoint to be set to the peer's overlay IP and loop traffic back through the tunnel.

- Remove `candidateViaRoutes` from the ICE worker so signaled host/srflx candidates inside routed prefixes are accepted normally
- Drop inbound STUN whose source IP belongs to the local overlay subnet (v4 or v6) inside `UniversalUDPMuxDefault.HandleSTUNMessage` so pion never creates a peer-reflexive candidate for it
- Simplify the mux's write-side filter to only refuse writes to the local overlay subnet; remove the `FilterFn` plumbing and the `addrViaRoutes` engine hook that used to feed routed-prefix info into it
- Gate the `addRouteToNonVPNIntf` "is part of local subnet" rejection to BSDs only, so Linux and Windows can install per-host exclusion routes for LAN-overlapping peers under legacy routing (where the broader wt0 route would otherwise win by metric)

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal client-side ICE/routing behavior; no user-facing surface area changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal network configuration mechanisms and removed unused filtering infrastructure.
  * Adjusted route handling behavior on BSD-based systems for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6142)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->