### PR TITLE
[client] protect Manager.server access under m.lock

### DIFF
--- a/client/internal/rosenpass/manager.go
+++ b/client/internal/rosenpass/manager.go
@@ -182,24 +182,31 @@ func (m *Manager) Run() error {
 		return err
 	}
 
-	m.server, err = rp.NewUDPServer(conf)
+	server, err := rp.NewUDPServer(conf)
 	if err != nil {
 		return err
 	}
 
+	m.lock.Lock()
+	m.server = server
+	m.lock.Unlock()
+
 	log.Infof("starting rosenpass server on port %d", m.port)
 
-	return m.server.Run()
+	return server.Run()
 }
 
 // Close closes the Rosenpass server
 func (m *Manager) Close() error {
-	if m.server != nil {
-		err := m.server.Close()
-		if err != nil {
-			log.Errorf("failed closing local rosenpass server")
-		}
-		m.server = nil
+	m.lock.Lock()
+	server := m.server
+	m.server = nil
+	m.lock.Unlock()
+	if server == nil {
+		return nil
+	}
+	if err := server.Close(); err != nil {
+		log.Errorf("failed closing local rosenpass server: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Describe your changes

Protect `Manager.server` in `client/internal/rosenpass/manager.go` with the
existing `m.lock`. Reads and writes of `m.server` on the `Run` and `Close`
paths previously ran without the lock, while peer worker callbacks
(`OnConnected` → `addPeer`, `OnDisconnected` → `removePeer`) accessed the
same field under `m.lock`. This left a data race between peer worker
goroutines and engine shutdown:

- `addPeer` nil-checks `m.server` and then calls `m.server.AddPeer(...)`.
  Without locking on the `Close` side, another goroutine running `Close()`
  could zero `m.server` between the check and the call, turning the
  defensive nil-guard into a nil-pointer panic.
- `Run()` publishing `m.server` and a concurrent `Close()` zeroing it
  also raced.

`Run()` now takes `m.lock` only to publish the new `*rp.Server`, then
invokes the lib's `server.Run()` on a local variable so the lock is not
held during it. `Close()` detaches `m.server` under the lock and calls
`server.Close()` on the local variable, so a slow shutdown does not block
other Manager methods waiting on `m.lock`.

Verified with `go test -race ./client/internal/rosenpass/...`.

## Issue ticket number and link

Surfaced during CodeRabbit review of PR
https://github.com/netbirdio/netbird/pull/6136. The race is pre-existing
(present since the original Rosenpass integration in commit `5de4acf2f`,
PR #1153) but worth fixing alongside the other Rosenpass concurrency work
(#4341 nil-guard). No separate public issue.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal concurrency fix. The public NetBird CLI / API surface,
configuration options, and Rosenpass feature behavior are unchanged: the
lock prevents a nil-pointer panic under a shutdown-vs-peer-callback race
without altering any observable flow.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced server lifecycle management for improved reliability and thread safety during startup and shutdown sequences.
  * Improved error logging during server cleanup operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6147)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->