### PR TITLE
[client] Server RPC call resolves correct wireguard port

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -2318,6 +2318,11 @@ func (e *Engine) SetCapture(pc device.PacketCapture) error {
 	return nil
 }
 
+// GetWgPort returns the port currently configured for Wireguard.
+func (e *Engine) GetWgPort() int {
+	return e.config.WgPort
+}
+
 // setForwarderCapture propagates capture to the USP filter's forwarder endpoint.
 // This captures outbound response packets that bypass the FilteredDevice in netstack mode.
 func (e *Engine) setForwarderCapture(pc device.PacketCapture) {

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -1446,6 +1446,7 @@ func (s *Server) runProbes(waitForProbeResult bool) {
 // GetConfig of the daemon.
 func (s *Server) GetConfig(ctx context.Context, req *proto.GetConfigRequest) (*proto.GetConfigResponse, error) {
 	s.mutex.Lock()
+	connectClient := s.connectClient
 	defer s.mutex.Unlock()
 
 	if ctx.Err() != nil {
@@ -1522,12 +1523,21 @@ func (s *Server) GetConfig(ctx context.Context, req *proto.GetConfigRequest) (*p
 		sshJWTCacheTTL = int32(*cfg.SSHJWTCacheTTL)
 	}
 
+	wgPort := int64(cfg.WgPort)
+	// Get correct assigned port, could be random if cfg.WgPort is 0.
+	if connectClient != nil && wgPort == 0 {
+		engine := connectClient.Engine()
+		if engine != nil {
+			wgPort = int64(engine.GetWgPort())
+		}
+	}
+
 	return &proto.GetConfigResponse{
 		ManagementUrl:                 managementURL.String(),
 		PreSharedKey:                  preSharedKey,
 		AdminURL:                      adminURL.String(),
 		InterfaceName:                 cfg.WgIface,
-		WireguardPort:                 int64(cfg.WgPort),
+		WireguardPort:                 wgPort,
 		Mtu:                           int64(cfg.MTU),
 		DisableAutoConnect:            cfg.DisableAutoConnect,
 		ServerSSHAllowed:              *cfg.ServerSSHAllowed,


### PR DESCRIPTION
## Describe your changes

When WgPort is configured as 0, the engine picks a random free port at startup ([connect.go:598](https://github.com/netbirdio/netbird/blob/07e5450117dd0451aaeefc18729a822115587e69/client/internal/connect.go#L598)), but `GetConfig` was reading WgPort straight from the on-disk profile config. The UI therefore showed the default WG port instead of the port WG is actually listening on.

This change adds `Engine.GetWgPort()` exposing `e.config.WgPort` (the resolved port), and updates the daemon's GetConfig RPC to fall back to the engine's value when the configured port is 0 and the engine is running. The configured port is still returned when set explicitly or when the engine isn't up.


## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/4557

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WireGuard port reporting to correctly display the actual port being used, including properly handling cases where the port is dynamically assigned at runtime rather than statically configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6151)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->