### PR TITLE
[client] Clean up legacy 32-bit and HKCU registry entries on Windows install

### DIFF
--- a/client/installer.nsis
+++ b/client/installer.nsis
@@ -260,15 +260,23 @@ WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "Publisher" "${COMP_NAME}"
 
 WriteRegStr ${REG_ROOT} "${UI_REG_APP_PATH}" "" "$INSTDIR\${UI_APP_EXE}"
 
-; Create autostart registry entry based on checkbox
+; Drop Run, App Paths and Uninstall entries left in the 32-bit registry view
+; or HKCU by legacy installers.
+DetailPrint "Cleaning legacy 32-bit / HKCU entries..."
+DeleteRegValue HKCU "${AUTOSTART_REG_KEY}" "${APP_NAME}"
+SetRegView 32
+DeleteRegValue HKLM "${AUTOSTART_REG_KEY}" "${APP_NAME}"
+DeleteRegKey HKLM "${REG_APP_PATH}"
+DeleteRegKey HKLM "${UI_REG_APP_PATH}"
+DeleteRegKey HKLM "${UNINSTALL_PATH}"
+SetRegView 64
+
 DetailPrint "Autostart enabled: $AutostartEnabled"
 ${If} $AutostartEnabled == "1"
     WriteRegStr HKLM "${AUTOSTART_REG_KEY}" "${APP_NAME}" '"$INSTDIR\${UI_APP_EXE}.exe"'
     DetailPrint "Added autostart registry entry: $INSTDIR\${UI_APP_EXE}.exe"
 ${Else}
     DeleteRegValue HKLM "${AUTOSTART_REG_KEY}" "${APP_NAME}"
-    ; Legacy: pre-HKLM installs wrote to HKCU; clean that up too.
-    DeleteRegValue HKCU "${AUTOSTART_REG_KEY}" "${APP_NAME}"
     DetailPrint "Autostart not enabled by user"
 ${EndIf}
 
@@ -299,11 +307,16 @@ ExecWait '"$INSTDIR\${MAIN_APP_EXE}" service uninstall'
 DetailPrint "Terminating Netbird UI process..."
 ExecWait `taskkill /im ${UI_APP_EXE}.exe /f`
 
-; Remove autostart registry entry
+; Remove autostart entries from every view a previous installer may have used.
 DetailPrint "Removing autostart registry entry if exists..."
 DeleteRegValue HKLM "${AUTOSTART_REG_KEY}" "${APP_NAME}"
-; Legacy: pre-HKLM installs wrote to HKCU; clean that up too.
 DeleteRegValue HKCU "${AUTOSTART_REG_KEY}" "${APP_NAME}"
+SetRegView 32
+DeleteRegValue HKLM "${AUTOSTART_REG_KEY}" "${APP_NAME}"
+DeleteRegKey HKLM "${REG_APP_PATH}"
+DeleteRegKey HKLM "${UI_REG_APP_PATH}"
+DeleteRegKey HKLM "${UNINSTALL_PATH}"
+SetRegView 64
 
 ; Handle data deletion based on checkbox
 DetailPrint "Checking if user requested data deletion..."

--- a/client/netbird.wxs
+++ b/client/netbird.wxs
@@ -64,6 +64,13 @@
 					<RegistryValue Name="InstalledByMSI" Type="integer" Value="1" KeyPath="yes" />
 				</RegistryKey>
 			</Component>
+			<!-- Drop the HKCU Run\Netbird value written by legacy NSIS installers. -->
+			<Component Id="NetbirdLegacyHKCUCleanup" Guid="*">
+				<RegistryValue Root="HKCU" Key="Software\NetBird GmbH\Installer"
+					Name="LegacyHKCUCleanup" Type="integer" Value="1" KeyPath="yes" />
+				<RemoveRegistryValue Root="HKCU"
+					Key="Software\Microsoft\Windows\CurrentVersion\Run" Name="Netbird" />
+			</Component>
 		</StandardDirectory>
 
 		<StandardDirectory Id="CommonAppDataFolder">
@@ -76,10 +83,28 @@
 			</Directory>
 		</StandardDirectory>
 
+		<!-- Drop Run, App Paths and Uninstall entries written by legacy NSIS
+		     installers into the 32-bit registry view (HKLM\Software\Wow6432Node). -->
+		<Component Id="NetbirdLegacyWow6432Cleanup" Directory="NetbirdInstallDir"
+			Guid="bda5d628-16bd-4086-b2c1-5099d8d51763" Bitness="always32">
+			<RegistryValue Root="HKLM" Key="Software\NetBird GmbH\Installer"
+				Name="LegacyWow6432Cleanup" Type="integer" Value="1" KeyPath="yes" />
+			<RemoveRegistryValue Root="HKLM"
+				Key="Software\Microsoft\Windows\CurrentVersion\Run" Name="Netbird" />
+			<RemoveRegistryKey Action="removeOnInstall" Root="HKLM"
+				Key="Software\Microsoft\Windows\CurrentVersion\App Paths\Netbird" />
+			<RemoveRegistryKey Action="removeOnInstall" Root="HKLM"
+				Key="Software\Microsoft\Windows\CurrentVersion\App Paths\Netbird-ui" />
+			<RemoveRegistryKey Action="removeOnInstall" Root="HKLM"
+				Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\Netbird" />
+		</Component>
+
 		<ComponentGroup Id="NetbirdFilesComponent">
 			<ComponentRef Id="NetbirdFiles" />
 			<ComponentRef Id="NetbirdAumidRegistry" />
 			<ComponentRef Id="NetbirdAutoStart" />
+			<ComponentRef Id="NetbirdLegacyHKCUCleanup" />
+			<ComponentRef Id="NetbirdLegacyWow6432Cleanup" />
 		</ComponentGroup>
 
 		<util:CloseApplication Id="CloseNetBird" CloseMessage="no" Target="netbird.exe" RebootPrompt="no" />


### PR DESCRIPTION
## Describe your changes

Legacy NSIS installers (pre-0.70.1, before `SetRegView 64` was added in `.onInit`) wrote their HKLM registry entries from a 32-bit process, so the writes were WOW64-redirected to `HKLM\Software\Wow6432Node\…`. Even older builds wrote the autostart entry under HKCU. Neither the current NSIS nor the MSI removes those legacy values on upgrade, so a user who installed an older NSIS and later runs a newer installer (NSIS or MSI) ends up with duplicate `Run\Netbird` values across registry views and a stale row in Programs and Features.

- NSIS install and uninstall: also clean `HKCU\…\Run\Netbird` and the 32-bit-view HKLM `Run\Netbird`, `App Paths\Netbird{,-ui}` and `Uninstall\Netbird`.
- MSI: new per-machine `always32` component removes the same Wow6432Node entries on install; new per-user component removes the HKCU `Run\Netbird` value. Both use marker KeyPaths under `Software\NetBird GmbH\Installer`.

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/6049

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal installer behavior, no user-facing surface change.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced installer cleanup procedures to more thoroughly remove legacy registry entries and configuration settings left behind by previous versions. Both installation and uninstallation processes now provide improved cleanup across registry locations, ensuring better system cleanliness and preventing conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
