### PR TITLE
[client] Recognize NetBird DNS forwarder port in capture text format

### DIFF
--- a/util/capture/text.go
+++ b/util/capture/text.go
@@ -13,6 +13,8 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/miekg/dns"
+
+	nbdns "github.com/netbirdio/netbird/dns"
 )
 
 // TextWriter writes human-readable one-line-per-packet summaries.
@@ -150,7 +152,7 @@ func (tw *TextWriter) writeUDP(timeStr string, dir Direction, info *packetInfo, 
 	plen := len(udp.Payload)
 
 	// DNS replaces the entire line format
-	if plen > 0 && isDNSPort(info.srcPort, info.dstPort) {
+	if plen > 0 && (isDNSPort(info.srcPort) || isDNSPort(info.dstPort)) {
 		if s := formatDNSPayload(udp.Payload); s != "" {
 			var verbose string
 			if tw.verbose {
@@ -561,8 +563,12 @@ func findSNIExtension(body []byte, pos int) string {
 	return ""
 }
 
-func isDNSPort(src, dst uint16) bool {
-	return src == 53 || dst == 53 || src == 5353 || dst == 5353
+func isDNSPort(p uint16) bool {
+	switch p {
+	case nbdns.DefaultDNSPort, nbdns.ForwarderClientPort, nbdns.ForwarderServerPort:
+		return true
+	}
+	return false
 }
 
 // formatDNSPayload parses DNS and returns a tcpdump-style summary.


### PR DESCRIPTION
## Describe your changes

Recognize NetBird's DNS forwarder port (22054) alongside 53 and 5353 in the packet capture text format, so UDP packets to/from the forwarder are parsed and summarized as DNS rather than shown as opaque UDP.

- Use the `nbdns` constants (`DefaultDNSPort`, `ForwarderClientPort`, `ForwarderServerPort`) instead of magic numbers

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal diagnostic output format; not a user-facing API.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved DNS packet detection logic to use configuration constants instead of hardcoded port numbers, enhancing code maintainability and consistency with NetBird's DNS configuration standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->