### PR TITLE
[client-ui] Add non default socket file discovery

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -39,6 +39,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
+	daddr "github.com/netbirdio/netbird/client/internal/daemonaddr"
 	"github.com/netbirdio/netbird/client/ui/desktop"
 	"github.com/netbirdio/netbird/client/ui/event"
 	"github.com/netbirdio/netbird/client/ui/notifier"
@@ -162,6 +163,9 @@ func parseFlags() *cliFlags {
 	flag.BoolVar(&flags.showUpdate, "update", false, "show update progress window")
 	flag.StringVar(&flags.showUpdateVersion, "update-version", "", "version to update to")
 	flag.Parse()
+
+
+	flags.daemonAddr = daddr.ResolveUnixDaemonAddr(flags.daemonAddr)
 	return &flags
 }
 


### PR DESCRIPTION
## Describe your changes
Applies the logic from #5425 to the client ui. Without it the ui just looks at `/var/run/netbird.sock` which doesn't exist with the systemd service.

## Issue ticket number and link
https://github.com/netbirdio/netbird/issues/4269

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the `--daemon-addr` CLI flag by normalizing and resolving the provided daemon service address before establishing the connection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->