### PR TITLE
[client] Apply netroute default-gateway workaround on android

### DIFF
--- a/client/internal/portforward/pcp/nat.go
+++ b/client/internal/portforward/pcp/nat.go
@@ -179,8 +179,10 @@ func getDefaultGateway() (gateway net.IP, localIP net.IP, err error) {
 	}
 
 	dst := net.IPv4zero
-	if runtime.GOOS == "linux" {
-		// go-netroute v0.4.0 rejects unspecified destinations client-side on Linux.
+	if runtime.GOOS == "linux" || runtime.GOOS == "android" {
+		// go-netroute v0.4.0 rejects unspecified destinations client-side on Linux/Android.
+		// TODO: on android/ios, use platform APIs (ConnectivityManager.getLinkProperties /
+		// NWPathMonitor) when netlink-based lookup is restricted or unavailable.
 		dst = net.IPv4(0, 0, 0, 1)
 	}
 	_, gateway, localIP, err = router.Route(dst)
@@ -203,7 +205,7 @@ func getDefaultGateway6() (gateway net.IP, localIP net.IP, err error) {
 	}
 
 	dst := net.IPv6zero
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" || runtime.GOOS == "android" {
 		// ::2
 		dst = net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
 	}


### PR DESCRIPTION
## Describe your changes

`netroute_linux.go` in `go-netroute` is gated on the `linux` build tag, which Go also satisfies when `GOOS=android`, so the same `0.0.0.0` rejection that the Linux workaround in PCP discovery already handles also fires on Android (visible as `PCP discovery failed: get default gateway: destination IP must be specified`).

This is a consistency fix only: extending the workaround to android lets the netlink RTM_GETROUTE lookup actually run, but on most Android devices it will still fail (untrusted_app SELinux restrictions, no permission to read the routing table reliably), and PCP/NAT-PMP will keep falling back to UPnP. A follow-up is needed to do the lookup via platform APIs (ConnectivityManager.getLinkProperties on android, NWPathMonitor on ios) for the route resolution to actually succeed on mobile.

- Extend the netroute unspecified-destination workaround to `runtime.GOOS == "android"` for both v4 and v6 default-gateway lookups in PCP discovery.
- Add a TODO for the platform-API-based fallback.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal bug fix with no user-visible API change.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default gateway discovery for port forwarding on Android to behave consistently with other platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->