### PR TITLE
[client] Filter scoped/cloned default routes from BSD network monitor

### DIFF
--- a/client/internal/networkmonitor/check_change_common.go
+++ b/client/internal/networkmonitor/check_change_common.go
@@ -50,7 +50,7 @@ func routeCheck(ctx context.Context, fd int, nexthopv4, nexthopv6 systemops.Next
 		switch msg.Type {
 		// handle route changes
 		case unix.RTM_ADD, syscall.RTM_DELETE:
-			route, err := parseRouteMessage(buf[:n])
+			route, flags, err := parseRouteMessage(buf[:n])
 			if err != nil {
 				log.Debugf("Network monitor: error parsing routing message: %v", err)
 				continue
@@ -66,6 +66,10 @@ func routeCheck(ctx context.Context, fd int, nexthopv4, nexthopv6 systemops.Next
 			}
 			switch msg.Type {
 			case unix.RTM_ADD:
+				if systemops.IgnoreAddedDefaultRoute(flags) {
+					log.Debugf("Network monitor: ignoring added default route via %s, interface %s, flags %#x", route.Gw, intf, flags)
+					continue
+				}
 				log.Infof("Network monitor: default route changed: via %s, interface %s", route.Gw, intf)
 				return nil
 			case unix.RTM_DELETE:
@@ -78,22 +82,26 @@ func routeCheck(ctx context.Context, fd int, nexthopv4, nexthopv6 systemops.Next
 	}
 }
 
-func parseRouteMessage(buf []byte) (*systemops.Route, error) {
+func parseRouteMessage(buf []byte) (*systemops.Route, int, error) {
 	msgs, err := route.ParseRIB(route.RIBTypeRoute, buf)
 	if err != nil {
-		return nil, fmt.Errorf("parse RIB: %v", err)
+		return nil, 0, fmt.Errorf("parse RIB: %v", err)
 	}
 
 	if len(msgs) != 1 {
-		return nil, fmt.Errorf("unexpected RIB message msgs: %v", msgs)
+		return nil, 0, fmt.Errorf("unexpected RIB message msgs: %v", msgs)
 	}
 
 	msg, ok := msgs[0].(*route.RouteMessage)
 	if !ok {
-		return nil, fmt.Errorf("unexpected RIB message type: %T", msgs[0])
+		return nil, 0, fmt.Errorf("unexpected RIB message type: %T", msgs[0])
 	}
 
-	return systemops.MsgToRoute(msg)
+	r, err := systemops.MsgToRoute(msg)
+	if err != nil {
+		return nil, 0, err
+	}
+	return r, msg.Flags, nil
 }
 
 // waitReadable blocks until fd has data to read, or ctx is cancelled.

--- a/client/internal/routemanager/systemops/routeflags_addfilter_bsd.go
+++ b/client/internal/routemanager/systemops/routeflags_addfilter_bsd.go
@@ -1,0 +1,9 @@
+//go:build dragonfly || freebsd || netbsd || openbsd
+
+package systemops
+
+// IgnoreAddedDefaultRoute reports whether an RTM_ADD default route with the
+// given flags should be ignored by the network monitor.
+func IgnoreAddedDefaultRoute(flags int) bool {
+	return filterRoutesByFlags(flags)
+}

--- a/client/internal/routemanager/systemops/routeflags_addfilter_darwin.go
+++ b/client/internal/routemanager/systemops/routeflags_addfilter_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package systemops
+
+import "golang.org/x/sys/unix"
+
+// IgnoreAddedDefaultRoute reports whether an RTM_ADD default route with the
+// given flags should be ignored by the network monitor. Scoped routes
+// (RTF_IFSCOPE) are tied to a specific interface index and cannot replace the
+// unscoped default the kernel uses for general egress, so flapping ones (e.g.
+// Wi-Fi calling IMS tunnels on ipsec0, Docker bridges, scoped utun defaults)
+// must not trigger an engine restart.
+func IgnoreAddedDefaultRoute(flags int) bool {
+	if filterRoutesByFlags(flags) {
+		return true
+	}
+	if flags&unix.RTF_IFSCOPE != 0 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Describe your changes

The BSD/darwin network monitor restarts the engine on any RTM_ADD default route, including scoped defaults installed by third-party interfaces alongside the real default. Filter those out so unrelated route churn no longer triggers engine restarts.

- Skip RTM_ADD default routes with `RTF_IFSCOPE` on darwin
- Skip RTM_ADD defaults flagged `!UP / REJECT / BLACKHOLE / WASCLONED` on all BSDs
- Leave RTM_DELETE behavior unchanged (still gated on the monitored nexthop)

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal behavior fix; no user-facing surface changed.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route monitoring to better handle and filter default routes when added to the system, with platform-specific optimizations for BSD and macOS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->