### PR TITLE
[management] Ensure SessionStartedAt has a default value

### DIFF
--- a/management/server/migration/migration_test.go
+++ b/management/server/migration/migration_test.go
@@ -198,7 +198,11 @@ func TestMigrateNetIPFieldFromBlobToJSON_WithJSONData(t *testing.T) {
 	require.NoError(t, err, "Failed to insert account")
 
 	account.PeersG = []nbpeer.Peer{
-		{AccountID: "1234", Location: nbpeer.Location{ConnectionIP: net.IP{10, 0, 0, 1}}},
+		{
+			AccountID: "1234",
+			Location:  nbpeer.Location{ConnectionIP: net.IP{10, 0, 0, 1}},
+			Status:    &nbpeer.PeerStatus{LastSeen: time.Now()},
+		},
 	}
 
 	err = db.Save(account).Error

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -86,7 +86,7 @@ type PeerStatus struct { //nolint:revive
 	// active session". Integer nanoseconds are used so equality is
 	// precision-safe across drivers, and so the predicates compose to a
 	// single bigint comparison.
-	SessionStartedAt int64
+	SessionStartedAt int64 `gorm:"not null;default:0"`
 	// Connected indicates whether peer is connected to the management service or not
 	Connected bool
 	// LoginExpired

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -2218,6 +2218,9 @@ func Test_IsUniqueConstraintError(t *testing.T) {
 		ID:        "test-peer-id",
 		AccountID: "bf1c8084-ba50-4ce7-9439-34653001fc3b",
 		DNSLabel:  "test-peer-dns-label",
+		Status: &nbpeer.PeerStatus{
+			LastSeen: time.Now(),
+		},
 	}
 
 	for _, tt := range tests {

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -472,6 +472,9 @@ func getMigrationsPreAuto(ctx context.Context) []migrationFunc {
 			return migration.MigrateNewField[types.User](ctx, db, "email", "")
 		},
 		func(db *gorm.DB) error {
+			return migration.MigrateNewField[nbpeer.Peer](ctx, db, "peer_status_session_started_at", int64(0))
+		},
+		func(db *gorm.DB) error {
 			return migration.RemoveDuplicatePeerKeys(ctx, db)
 		},
 		func(db *gorm.DB) error {


### PR DESCRIPTION

## Describe your changes
Chores
Enforced non-null/default behavior for peer session-start tracking and added a migration to apply this to existing records, improving data consistency.
Tests
Updated uniqueness-related tests to include peer session status data so tests align with the new constraint.
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced non-null/default behavior for peer session-start tracking and added a migration to apply this to existing records, improving data consistency.
* **Tests**
  * Updated uniqueness-related tests to include peer session status data so tests align with the new constraint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->