### PR TITLE
[client] add new `--json` / `--yaml` output flags to client commands

### DIFF
--- a/client/cmd/debug.go
+++ b/client/cmd/debug.go
@@ -17,6 +17,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
 	"github.com/netbirdio/netbird/client/server"
+	nbstatus "github.com/netbirdio/netbird/client/status"
 	mgmProto "github.com/netbirdio/netbird/shared/management/proto"
 	"github.com/netbirdio/netbird/upload-server/types"
 )
@@ -108,16 +109,41 @@ func debugBundle(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to bundle debug: %v", status.Convert(err).Message())
 	}
-	cmd.Printf("Local file:\n%s\n", resp.GetPath())
 
 	if resp.GetUploadFailureReason() != "" {
 		return fmt.Errorf("upload failed: %s", resp.GetUploadFailureReason())
 	}
 
-	if uploadBundleFlag {
-		cmd.Printf("Upload file key:\n%s\n", resp.GetUploadedKey())
+	return emitDebugBundle(cmd, resp.GetPath(), resp.GetUploadedKey())
+}
+
+func emitDebugBundle(cmd *cobra.Command, path, uploadedKey string) error {
+	if !jsonFlag && !yamlFlag {
+		cmd.Printf("Local file:\n%s\n", path)
+		if uploadBundleFlag {
+			cmd.Printf("Upload file key:\n%s\n", uploadedKey)
+		}
+		return nil
 	}
 
+	out := &nbstatus.DebugBundleOutput{Path: path}
+	if uploadBundleFlag {
+		out.UploadedKey = uploadedKey
+	}
+
+	if jsonFlag {
+		s, err := out.JSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(s)
+		return nil
+	}
+	s, err := out.YAML()
+	if err != nil {
+		return err
+	}
+	cmd.Print(s)
 	return nil
 }
 
@@ -451,6 +477,9 @@ func init() {
 	debugBundleCmd.Flags().BoolVarP(&systemInfoFlag, "system-info", "S", true, "Adds system information to the debug bundle")
 	debugBundleCmd.Flags().BoolVarP(&uploadBundleFlag, "upload-bundle", "U", false, "Uploads the debug bundle to a server")
 	debugBundleCmd.Flags().StringVar(&uploadBundleURLFlag, "upload-bundle-url", types.DefaultBundleURL, "Service URL to get an URL to upload the debug bundle")
+	debugBundleCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	debugBundleCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	debugBundleCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	forCmd.Flags().Uint32VarP(&logFileCount, "log-file-count", "C", 1, "Number of rotated log files to include in debug bundle")
 	forCmd.Flags().BoolVarP(&systemInfoFlag, "system-info", "S", true, "Adds system information to the debug bundle")

--- a/client/cmd/down.go
+++ b/client/cmd/down.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/netbirdio/netbird/client/proto"
+	nbstatus "github.com/netbirdio/netbird/client/status"
 )
 
 var downCmd = &cobra.Command{
@@ -44,7 +45,29 @@ var downCmd = &cobra.Command{
 			return err
 		}
 
-		cmd.Println("Disconnected")
+		out := &nbstatus.DownOutput{Status: "Disconnected"}
+		switch {
+		case jsonFlag:
+			s, err := out.JSON()
+			if err != nil {
+				return err
+			}
+			cmd.Println(s)
+		case yamlFlag:
+			s, err := out.YAML()
+			if err != nil {
+				return err
+			}
+			cmd.Print(s)
+		default:
+			cmd.Println(out.Status)
+		}
 		return nil
 	},
+}
+
+func init() {
+	downCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	downCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	downCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 }

--- a/client/cmd/forwarding_rules.go
+++ b/client/cmd/forwarding_rules.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/netbirdio/netbird/client/proto"
+	nbstatus "github.com/netbirdio/netbird/client/status"
 )
 
 var forwardingRulesCmd = &cobra.Command{
@@ -25,6 +26,12 @@ var forwardingRulesListCmd = &cobra.Command{
 	RunE:    listForwardingRules,
 }
 
+func init() {
+	forwardingRulesListCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	forwardingRulesListCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	forwardingRulesListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+}
+
 func listForwardingRules(cmd *cobra.Command, _ []string) error {
 	conn, err := getClient(cmd)
 	if err != nil {
@@ -38,19 +45,23 @@ func listForwardingRules(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to list network: %v", status.Convert(err).Message())
 	}
 
-	if len(resp.GetRules()) == 0 {
+	rules := resp.GetRules()
+	sortForwardingRules(rules)
+
+	if jsonFlag || yamlFlag {
+		return emitForwardingList(cmd, rules)
+	}
+
+	if len(rules) == 0 {
 		cmd.Println("No forwarding rules available.")
 		return nil
 	}
 
-	printForwardingRules(cmd, resp.GetRules())
+	printForwardingRules(cmd, rules)
 	return nil
 }
 
-func printForwardingRules(cmd *cobra.Command, rules []*proto.ForwardingRule) {
-	cmd.Println("Available forwarding rules:")
-
-	// Sort rules by translated address
+func sortForwardingRules(rules []*proto.ForwardingRule) {
 	sort.Slice(rules, func(i, j int) bool {
 		if rules[i].GetTranslatedAddress() != rules[j].GetTranslatedAddress() {
 			return rules[i].GetTranslatedAddress() < rules[j].GetTranslatedAddress()
@@ -58,9 +69,40 @@ func printForwardingRules(cmd *cobra.Command, rules []*proto.ForwardingRule) {
 		if rules[i].GetProtocol() != rules[j].GetProtocol() {
 			return rules[i].GetProtocol() < rules[j].GetProtocol()
 		}
-
 		return getFirstPort(rules[i].GetDestinationPort()) < getFirstPort(rules[j].GetDestinationPort())
 	})
+}
+
+func emitForwardingList(cmd *cobra.Command, rules []*proto.ForwardingRule) error {
+	out := &nbstatus.ForwardingListOutput{Rules: make([]nbstatus.ForwardingRuleOutput, 0, len(rules))}
+	for _, rule := range rules {
+		out.Rules = append(out.Rules, nbstatus.ForwardingRuleOutput{
+			TranslatedAddress:  rule.GetTranslatedAddress(),
+			TranslatedHostname: rule.GetTranslatedHostname(),
+			Protocol:           rule.GetProtocol(),
+			DestinationPort:    portToString(rule.GetDestinationPort()),
+			TranslatedPort:     portToString(rule.GetTranslatedPort()),
+		})
+	}
+
+	if jsonFlag {
+		s, err := out.JSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(s)
+		return nil
+	}
+	s, err := out.YAML()
+	if err != nil {
+		return err
+	}
+	cmd.Print(s)
+	return nil
+}
+
+func printForwardingRules(cmd *cobra.Command, rules []*proto.ForwardingRule) {
+	cmd.Println("Available forwarding rules:")
 
 	var lastIP string
 	for _, rule := range rules {

--- a/client/cmd/forwarding_rules.go
+++ b/client/cmd/forwarding_rules.go
@@ -76,13 +76,18 @@ func sortForwardingRules(rules []*proto.ForwardingRule) {
 func emitForwardingList(cmd *cobra.Command, rules []*proto.ForwardingRule) error {
 	out := &nbstatus.ForwardingListOutput{Rules: make([]nbstatus.ForwardingRuleOutput, 0, len(rules))}
 	for _, rule := range rules {
-		out.Rules = append(out.Rules, nbstatus.ForwardingRuleOutput{
+		row := nbstatus.ForwardingRuleOutput{
 			TranslatedAddress:  rule.GetTranslatedAddress(),
 			TranslatedHostname: rule.GetTranslatedHostname(),
 			Protocol:           rule.GetProtocol(),
-			DestinationPort:    portToString(rule.GetDestinationPort()),
-			TranslatedPort:     portToString(rule.GetTranslatedPort()),
-		})
+		}
+		if s, ok := portToStringOpt(rule.GetDestinationPort()); ok {
+			row.DestinationPort = &s
+		}
+		if s, ok := portToStringOpt(rule.GetTranslatedPort()); ok {
+			row.TranslatedPort = &s
+		}
+		out.Rules = append(out.Rules, row)
 	}
 
 	if jsonFlag {
@@ -129,12 +134,22 @@ func getFirstPort(portInfo *proto.PortInfo) int {
 }
 
 func portToString(translatedPort *proto.PortInfo) string {
-	switch v := translatedPort.PortSelection.(type) {
+	if s, ok := portToStringOpt(translatedPort); ok {
+		return s
+	}
+	return "No port specified"
+}
+
+// portToStringOpt returns the formatted port string and whether port info was
+// actually present. Used by the structured (json/yaml) output so the absent
+// case becomes a missing field instead of a sentinel string.
+func portToStringOpt(p *proto.PortInfo) (string, bool) {
+	switch v := p.GetPortSelection().(type) {
 	case *proto.PortInfo_Port:
-		return fmt.Sprintf("%d", v.Port)
+		return fmt.Sprintf("%d", v.Port), true
 	case *proto.PortInfo_Range_:
-		return fmt.Sprintf("%d-%d", v.Range.GetStart(), v.Range.GetEnd())
+		return fmt.Sprintf("%d-%d", v.Range.GetStart(), v.Range.GetEnd()), true
 	default:
-		return "No port specified"
+		return "", false
 	}
 }

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -18,6 +18,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/auth"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
+	nbstatus "github.com/netbirdio/netbird/client/status"
 	"github.com/netbirdio/netbird/client/system"
 	"github.com/netbirdio/netbird/util"
 )
@@ -337,6 +338,11 @@ func foregroundGetTokenInfo(ctx context.Context, cmd *cobra.Command, config *pro
 }
 
 func openURL(cmd *cobra.Command, verificationURIComplete, userCode string, noBrowser, showQR bool) {
+	if jsonFlag || yamlFlag {
+		emitSSOEvent(cmd, verificationURIComplete, userCode)
+		return
+	}
+
 	var codeMsg string
 	if userCode != "" && !strings.Contains(verificationURIComplete, userCode) {
 		codeMsg = fmt.Sprintf("and enter the code %s to authenticate.", userCode)
@@ -364,6 +370,33 @@ func openURL(cmd *cobra.Command, verificationURIComplete, userCode string, noBro
 				"https://docs.netbird.io/how-to/register-machines-using-setup-keys")
 		}
 	}
+}
+
+// emitSSOEvent writes the verification URL/code as a structured event for
+// callers using --json or --yaml. The browser is intentionally not opened in
+// this mode since automation contexts (CI, scripts) typically run headless.
+func emitSSOEvent(cmd *cobra.Command, verificationURIComplete, userCode string) {
+	event := &nbstatus.SSOEvent{
+		Event:                   "sso_required",
+		VerificationURIComplete: verificationURIComplete,
+		UserCode:                userCode,
+	}
+	if jsonFlag {
+		s, err := event.JSON()
+		if err != nil {
+			log.Errorf("marshal sso event: %v", err)
+			return
+		}
+		cmd.Println(s)
+		return
+	}
+	s, err := event.YAML()
+	if err != nil {
+		log.Errorf("marshal sso event: %v", err)
+		return
+	}
+	cmd.Print(s)
+	cmd.Println("---")
 }
 
 // isUnixRunningDesktop checks if a Linux OS is running desktop environment

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -28,6 +28,10 @@ func init() {
 	loginCmd.PersistentFlags().BoolVar(&showQR, showQRFlag, false, showQRDesc)
 	loginCmd.PersistentFlags().StringVar(&profileName, profileNameFlag, "", profileNameDesc)
 	loginCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "(DEPRECATED) Netbird config file location")
+
+	loginCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	loginCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	loginCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 }
 
 var loginCmd = &cobra.Command{
@@ -74,10 +78,34 @@ var loginCmd = &cobra.Command{
 			return fmt.Errorf("daemon login failed: %v", err)
 		}
 
-		cmd.Println("Logging successfully")
-
-		return nil
+		return emitLoginOutput(cmd, activeProf.Name)
 	},
+}
+
+// emitLoginOutput writes the result of a successful login in the format
+// requested by the user (json, yaml, or human-readable text fallback).
+func emitLoginOutput(cmd *cobra.Command, profileName string) error {
+	out := &nbstatus.LoginOutput{
+		Status:      "logged_in",
+		ProfileName: profileName,
+	}
+	switch {
+	case jsonFlag:
+		s, err := out.JSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(s)
+	case yamlFlag:
+		s, err := out.YAML()
+		if err != nil {
+			return err
+		}
+		cmd.Print(s)
+	default:
+		cmd.Println("Logging successfully")
+	}
+	return nil
 }
 
 func doDaemonLogin(ctx context.Context, cmd *cobra.Command, providedSetupKey string, activeProf *profilemanager.Profile, username string, pm *profilemanager.ProfileManager) error {
@@ -254,8 +282,7 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, setupKey string,
 	if err != nil {
 		return fmt.Errorf("foreground login failed: %v", err)
 	}
-	cmd.Println("Logging successfully")
-	return nil
+	return emitLoginOutput(cmd, activeProf.Name)
 }
 
 func handleSSOLogin(ctx context.Context, cmd *cobra.Command, loginResp *proto.LoginResponse, client proto.DaemonServiceClient, pm *profilemanager.ProfileManager) error {

--- a/client/cmd/logout.go
+++ b/client/cmd/logout.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/netbirdio/netbird/client/proto"
+	nbstatus "github.com/netbirdio/netbird/client/status"
 )
 
 var logoutCmd = &cobra.Command{
@@ -49,11 +50,33 @@ var logoutCmd = &cobra.Command{
 			return fmt.Errorf("deregister: %v", err)
 		}
 
-		cmd.Println("Deregistered successfully")
+		out := &nbstatus.DeregisterOutput{
+			Status:      "deregistered",
+			ProfileName: profileName,
+		}
+		switch {
+		case jsonFlag:
+			s, err := out.JSON()
+			if err != nil {
+				return err
+			}
+			cmd.Println(s)
+		case yamlFlag:
+			s, err := out.YAML()
+			if err != nil {
+				return err
+			}
+			cmd.Print(s)
+		default:
+			cmd.Println("Deregistered successfully")
+		}
 		return nil
 	},
 }
 
 func init() {
 	logoutCmd.PersistentFlags().StringVar(&profileName, profileNameFlag, "", profileNameDesc)
+	logoutCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	logoutCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	logoutCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 }

--- a/client/cmd/networks.go
+++ b/client/cmd/networks.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/netbirdio/netbird/client/proto"
+	nbstatus "github.com/netbirdio/netbird/client/status"
 )
 
 var appendFlag bool
@@ -48,6 +49,10 @@ var routesDeselectCmd = &cobra.Command{
 
 func init() {
 	routesSelectCmd.PersistentFlags().BoolVarP(&appendFlag, "append", "a", false, "Append to current network selection instead of replacing")
+
+	routesListCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	routesListCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	routesListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 }
 
 func networksList(cmd *cobra.Command, _ []string) error {
@@ -63,6 +68,10 @@ func networksList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to list network: %v", status.Convert(err).Message())
 	}
 
+	if jsonFlag || yamlFlag {
+		return emitNetworksList(cmd, resp)
+	}
+
 	if len(resp.Routes) == 0 {
 		cmd.Println("No networks available.")
 		return nil
@@ -70,6 +79,40 @@ func networksList(cmd *cobra.Command, _ []string) error {
 
 	printNetworks(cmd, resp)
 
+	return nil
+}
+
+func emitNetworksList(cmd *cobra.Command, resp *proto.ListNetworksResponse) error {
+	out := &nbstatus.NetworksListOutput{Networks: make([]nbstatus.NetworkOutput, 0, len(resp.GetRoutes()))}
+	for _, route := range resp.GetRoutes() {
+		row := nbstatus.NetworkOutput{
+			ID:       route.GetID(),
+			Range:    route.GetRange(),
+			Domains:  route.GetDomains(),
+			Selected: route.GetSelected(),
+		}
+		if resolved := route.GetResolvedIPs(); len(resolved) > 0 {
+			row.ResolvedIPs = make(map[string][]string, len(resolved))
+			for d, ipList := range resolved {
+				row.ResolvedIPs[d] = ipList.GetIps()
+			}
+		}
+		out.Networks = append(out.Networks, row)
+	}
+
+	if jsonFlag {
+		s, err := out.JSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(s)
+		return nil
+	}
+	s, err := out.YAML()
+	if err != nil {
+		return err
+	}
+	cmd.Print(s)
 	return nil
 }
 

--- a/client/cmd/networks.go
+++ b/client/cmd/networks.go
@@ -50,9 +50,11 @@ var routesDeselectCmd = &cobra.Command{
 func init() {
 	routesSelectCmd.PersistentFlags().BoolVarP(&appendFlag, "append", "a", false, "Append to current network selection instead of replacing")
 
-	routesListCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
-	routesListCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
-	routesListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+	for _, c := range []*cobra.Command{routesListCmd, routesSelectCmd, routesDeselectCmd} {
+		c.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+		c.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+		c.MarkFlagsMutuallyExclusive("json", "yaml")
+	}
 }
 
 func networksList(cmd *cobra.Command, _ []string) error {
@@ -185,10 +187,9 @@ func networksSelect(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to select networks: %v", status.Convert(err).Message())
 	}
 
-	cmd.Println("Networks selected successfully.")
-
-	return nil
+	return emitNetworksMutation(cmd, "selected", req, "Networks selected successfully.")
 }
+
 
 func networksDeselect(cmd *cobra.Command, args []string) error {
 	conn, err := getClient(cmd)
@@ -210,7 +211,35 @@ func networksDeselect(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to deselect networks: %v", status.Convert(err).Message())
 	}
 
-	cmd.Println("Networks deselected successfully.")
+	return emitNetworksMutation(cmd, "deselected", req, "Networks deselected successfully.")
+}
 
+func emitNetworksMutation(cmd *cobra.Command, action string, req *proto.SelectNetworksRequest, textFallback string) error {
+	if !jsonFlag && !yamlFlag {
+		cmd.Println(textFallback)
+		return nil
+	}
+
+	out := &nbstatus.NetworksMutationOutput{
+		Status: action,
+		All:    req.GetAll(),
+	}
+	if !req.GetAll() {
+		out.Networks = req.GetNetworkIDs()
+	}
+
+	if jsonFlag {
+		s, err := out.JSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(s)
+		return nil
+	}
+	s, err := out.YAML()
+	if err != nil {
+		return err
+	}
+	cmd.Print(s)
 	return nil
 }

--- a/client/cmd/profile.go
+++ b/client/cmd/profile.go
@@ -11,8 +11,15 @@ import (
 	"github.com/netbirdio/netbird/client/internal"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
+	nbstatus "github.com/netbirdio/netbird/client/status"
 	"github.com/netbirdio/netbird/util"
 )
+
+func init() {
+	profileListCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	profileListCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	profileListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+}
 
 var profileCmd = &cobra.Command{
 	Use:   "profile",
@@ -90,6 +97,10 @@ func listProfilesFunc(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	if jsonFlag || yamlFlag {
+		return emitProfileList(cmd, profiles.GetProfiles())
+	}
+
 	// list profiles, add a tick if the profile is active
 	cmd.Println("Found", len(profiles.Profiles), "profiles:")
 	for _, profile := range profiles.Profiles {
@@ -101,6 +112,31 @@ func listProfilesFunc(cmd *cobra.Command, _ []string) error {
 		cmd.Println(activeMarker, profile.Name)
 	}
 
+	return nil
+}
+
+func emitProfileList(cmd *cobra.Command, profiles []*proto.Profile) error {
+	out := &nbstatus.ProfileListOutput{Profiles: make([]nbstatus.ProfileOutput, 0, len(profiles))}
+	for _, p := range profiles {
+		out.Profiles = append(out.Profiles, nbstatus.ProfileOutput{
+			Name:   p.GetName(),
+			Active: p.GetIsActive(),
+		})
+	}
+
+	if jsonFlag {
+		s, err := out.JSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(s)
+		return nil
+	}
+	s, err := out.YAML()
+	if err != nil {
+		return err
+	}
+	cmd.Print(s)
 	return nil
 }
 

--- a/client/cmd/profile.go
+++ b/client/cmd/profile.go
@@ -16,9 +16,11 @@ import (
 )
 
 func init() {
-	profileListCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
-	profileListCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
-	profileListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+	for _, c := range []*cobra.Command{profileListCmd, profileAddCmd, profileRemoveCmd, profileSelectCmd} {
+		c.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+		c.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+		c.MarkFlagsMutuallyExclusive("json", "yaml")
+	}
 }
 
 var profileCmd = &cobra.Command{
@@ -115,6 +117,33 @@ func listProfilesFunc(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+func emitProfileMutation(cmd *cobra.Command, action, profile, textFallback string) error {
+	if !jsonFlag && !yamlFlag {
+		cmd.Println(textFallback)
+		return nil
+	}
+
+	out := &nbstatus.ProfileMutationOutput{
+		Status:      action,
+		ProfileName: profile,
+	}
+
+	if jsonFlag {
+		s, err := out.JSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(s)
+		return nil
+	}
+	s, err := out.YAML()
+	if err != nil {
+		return err
+	}
+	cmd.Print(s)
+	return nil
+}
+
 func emitProfileList(cmd *cobra.Command, profiles []*proto.Profile) error {
 	out := &nbstatus.ProfileListOutput{Profiles: make([]nbstatus.ProfileOutput, 0, len(profiles))}
 	for _, p := range profiles {
@@ -168,8 +197,7 @@ func addProfileFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cmd.Println("Profile added successfully:", profileName)
-	return nil
+	return emitProfileMutation(cmd, "added", profileName, "Profile added successfully: "+profileName)
 }
 
 func removeProfileFunc(cmd *cobra.Command, args []string) error {
@@ -200,8 +228,7 @@ func removeProfileFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cmd.Println("Profile removed successfully:", profileName)
-	return nil
+	return emitProfileMutation(cmd, "removed", profileName, "Profile removed successfully: "+profileName)
 }
 
 func selectProfileFunc(cmd *cobra.Command, args []string) error {
@@ -267,6 +294,5 @@ func selectProfileFunc(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	cmd.Println("Profile switched successfully to:", profileName)
-	return nil
+	return emitProfileMutation(cmd, "selected", profileName, "Profile switched successfully to: "+profileName)
 }

--- a/client/cmd/state.go
+++ b/client/cmd/state.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/netbirdio/netbird/client/proto"
+	nbstatus "github.com/netbirdio/netbird/client/status"
 )
 
 var (
@@ -75,6 +76,10 @@ func init() {
 
 	stateCleanCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Clean all states")
 	stateDeleteCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Delete all states")
+
+	stateListCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	stateListCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	stateListCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 }
 
 func stateList(cmd *cobra.Command, _ []string) error {
@@ -94,11 +99,37 @@ func stateList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to list states: %v", status.Convert(err).Message())
 	}
 
+	if jsonFlag || yamlFlag {
+		return emitStateList(cmd, resp.GetStates())
+	}
+
 	cmd.Printf("\nStored states:\n\n")
 	for _, state := range resp.States {
 		cmd.Printf("- %s\n", state.Name)
 	}
 
+	return nil
+}
+
+func emitStateList(cmd *cobra.Command, states []*proto.State) error {
+	out := &nbstatus.StateListOutput{States: make([]nbstatus.StateOutput, 0, len(states))}
+	for _, s := range states {
+		out.States = append(out.States, nbstatus.StateOutput{Name: s.GetName()})
+	}
+
+	if jsonFlag {
+		s, err := out.JSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(s)
+		return nil
+	}
+	s, err := out.YAML()
+	if err != nil {
+		return err
+	}
+	cmd.Print(s)
 	return nil
 }
 

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -22,6 +22,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
+	nbstatus "github.com/netbirdio/netbird/client/status"
 	"github.com/netbirdio/netbird/client/system"
 	"github.com/netbirdio/netbird/shared/management/domain"
 	"github.com/netbirdio/netbird/util"
@@ -88,6 +89,9 @@ func init() {
 	upCmd.PersistentFlags().StringVar(&profileName, profileNameFlag, "", profileNameDesc)
 	upCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "(DEPRECATED) NetBird config file location. ")
 
+	upCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	upCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	upCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 }
 
 func upFunc(cmd *cobra.Command, args []string) error {
@@ -95,6 +99,10 @@ func upFunc(cmd *cobra.Command, args []string) error {
 	SetFlagsFromEnvVars(cmd)
 
 	cmd.SetOut(cmd.OutOrStdout())
+
+	if (jsonFlag || yamlFlag) && foregroundMode {
+		return fmt.Errorf("--json/--yaml is not supported with --foreground-mode; use daemon mode")
+	}
 
 	err := util.InitLog(logLevel, util.LogConsole)
 	if err != nil {
@@ -245,8 +253,10 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager
 
 	if status.Status == string(internal.StatusConnected) {
 		if !profileSwitched {
-			cmd.Println("Already connected")
-			return nil
+			return emitUpOutput(cmd, &nbstatus.UpOutput{
+				Status:      "already_connected",
+				ProfileName: activeProf.Name,
+			}, "Already connected")
 		}
 
 		if _, err := client.Down(ctx, &proto.DownRequest{}); err != nil {
@@ -273,7 +283,31 @@ func runInDaemonMode(ctx context.Context, cmd *cobra.Command, pm *profilemanager
 	if err := doDaemonUp(ctx, cmd, client, pm, activeProf, customDNSAddressConverted, username.Username); err != nil {
 		return fmt.Errorf("daemon up failed: %v", err)
 	}
-	cmd.Println("Connected")
+	return emitUpOutput(cmd, &nbstatus.UpOutput{
+		Status:      "connected",
+		ProfileName: activeProf.Name,
+	}, "Connected")
+}
+
+// emitUpOutput writes the result of an up command in the format requested by
+// the user (json, yaml, or human-readable text fallback).
+func emitUpOutput(cmd *cobra.Command, out *nbstatus.UpOutput, textFallback string) error {
+	switch {
+	case jsonFlag:
+		s, err := out.JSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(s)
+	case yamlFlag:
+		s, err := out.YAML()
+		if err != nil {
+			return err
+		}
+		cmd.Print(s)
+	default:
+		cmd.Println(textFallback)
+	}
 	return nil
 }
 

--- a/client/cmd/version.go
+++ b/client/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	nbstatus "github.com/netbirdio/netbird/client/status"
 	"github.com/netbirdio/netbird/version"
 )
 
@@ -10,9 +11,35 @@ var (
 	versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "Print the NetBird's client application version",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SetOut(cmd.OutOrStdout())
-			cmd.Println(version.NetbirdVersion())
+			v := version.NetbirdVersion()
+
+			switch {
+			case jsonFlag:
+				out := &nbstatus.VersionOutput{Version: v}
+				s, err := out.JSON()
+				if err != nil {
+					return err
+				}
+				cmd.Println(s)
+			case yamlFlag:
+				out := &nbstatus.VersionOutput{Version: v}
+				s, err := out.YAML()
+				if err != nil {
+					return err
+				}
+				cmd.Print(s)
+			default:
+				cmd.Println(v)
+			}
+			return nil
 		},
 	}
 )
+
+func init() {
+	versionCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "display command result in json format")
+	versionCmd.PersistentFlags().BoolVarP(&yamlFlag, "yaml", "y", false, "display command result in yaml format")
+	versionCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+}

--- a/client/status/status.go
+++ b/client/status/status.go
@@ -384,6 +384,80 @@ func (o *OutputOverview) YAML() (string, error) {
 	return string(yamlBytes), nil
 }
 
+// DownOutput is the structured result of a `netbird down` command.
+type DownOutput struct {
+	Status string `json:"status" yaml:"status"`
+}
+
+// UpOutput is the final structured result of a `netbird up` command.
+type UpOutput struct {
+	Status      string `json:"status" yaml:"status"` // "connected" | "already_connected"
+	ProfileName string `json:"profileName,omitempty" yaml:"profileName,omitempty"`
+}
+
+// JSON returns the UpOutput as a JSON string.
+func (o *UpOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the UpOutput as a YAML string.
+func (o *UpOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
+// SSOEvent is emitted before the final UpOutput when interactive SSO is required.
+// It carries the verification URL and user code so callers can surface them
+// (e.g. to a Slack channel) without parsing free-form text.
+type SSOEvent struct {
+	Event                   string `json:"event" yaml:"event"` // "sso_required"
+	VerificationURIComplete string `json:"verificationUriComplete" yaml:"verificationUriComplete"`
+	UserCode                string `json:"userCode,omitempty" yaml:"userCode,omitempty"`
+}
+
+// JSON returns the SSOEvent as a JSON string.
+func (e *SSOEvent) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(e)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the SSOEvent as a YAML string.
+func (e *SSOEvent) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(e)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
+// JSON returns the DownOutput as a JSON string.
+func (o *DownOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the DownOutput as a YAML string.
+func (o *DownOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
 // GeneralSummary returns a general summary of the status overview.
 func (o *OutputOverview) GeneralSummary(showURL bool, showRelays bool, showNameServers bool, showSSHSessions bool) string {
 	var managementConnString string

--- a/client/status/status.go
+++ b/client/status/status.go
@@ -473,12 +473,15 @@ func (o *NetworksListOutput) YAML() (string, error) {
 }
 
 // ForwardingRuleOutput is one row of a forwarding-list response.
+// DestinationPort and TranslatedPort are pointers so that absent port info
+// (oneof not set in the protobuf) surfaces as a missing field rather than a
+// human-readable sentinel string.
 type ForwardingRuleOutput struct {
-	TranslatedAddress  string `json:"translatedAddress" yaml:"translatedAddress"`
-	TranslatedHostname string `json:"translatedHostname,omitempty" yaml:"translatedHostname,omitempty"`
-	Protocol           string `json:"protocol" yaml:"protocol"`
-	DestinationPort    string `json:"destinationPort" yaml:"destinationPort"`
-	TranslatedPort     string `json:"translatedPort" yaml:"translatedPort"`
+	TranslatedAddress  string  `json:"translatedAddress" yaml:"translatedAddress"`
+	TranslatedHostname string  `json:"translatedHostname,omitempty" yaml:"translatedHostname,omitempty"`
+	Protocol           string  `json:"protocol" yaml:"protocol"`
+	DestinationPort    *string `json:"destinationPort,omitempty" yaml:"destinationPort,omitempty"`
+	TranslatedPort     *string `json:"translatedPort,omitempty" yaml:"translatedPort,omitempty"`
 }
 
 // ForwardingListOutput is the structured result of `netbird forwarding list`.

--- a/client/status/status.go
+++ b/client/status/status.go
@@ -564,6 +564,104 @@ func (o *StateListOutput) YAML() (string, error) {
 	return string(yamlBytes), nil
 }
 
+// DeregisterOutput is the structured result of `netbird deregister`.
+type DeregisterOutput struct {
+	Status      string `json:"status" yaml:"status"` // "deregistered"
+	ProfileName string `json:"profileName,omitempty" yaml:"profileName,omitempty"`
+}
+
+// JSON returns the DeregisterOutput as a JSON string.
+func (o *DeregisterOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the DeregisterOutput as a YAML string.
+func (o *DeregisterOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
+// LoginOutput is the structured result of `netbird login` after successful auth.
+type LoginOutput struct {
+	Status      string `json:"status" yaml:"status"` // "logged_in"
+	ProfileName string `json:"profileName,omitempty" yaml:"profileName,omitempty"`
+}
+
+// JSON returns the LoginOutput as a JSON string.
+func (o *LoginOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the LoginOutput as a YAML string.
+func (o *LoginOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
+// NetworksMutationOutput is the structured result of `netbird networks select`
+// or `netbird networks deselect`.
+type NetworksMutationOutput struct {
+	Status   string   `json:"status" yaml:"status"` // "selected" | "deselected"
+	Networks []string `json:"networks,omitempty" yaml:"networks,omitempty"`
+	All      bool     `json:"all,omitempty" yaml:"all,omitempty"`
+}
+
+// JSON returns the NetworksMutationOutput as a JSON string.
+func (o *NetworksMutationOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the NetworksMutationOutput as a YAML string.
+func (o *NetworksMutationOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
+// DebugBundleOutput is the structured result of `netbird debug bundle`.
+type DebugBundleOutput struct {
+	Path        string `json:"path" yaml:"path"`
+	UploadedKey string `json:"uploadedKey,omitempty" yaml:"uploadedKey,omitempty"`
+}
+
+// JSON returns the DebugBundleOutput as a JSON string.
+func (o *DebugBundleOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the DebugBundleOutput as a YAML string.
+func (o *DebugBundleOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
 // VersionOutput is the structured result of `netbird version`.
 type VersionOutput struct {
 	Version string `json:"version" yaml:"version"`

--- a/client/status/status.go
+++ b/client/status/status.go
@@ -612,6 +612,31 @@ func (o *LoginOutput) YAML() (string, error) {
 	return string(yamlBytes), nil
 }
 
+// ProfileMutationOutput is the structured result of `netbird profile add`,
+// `remove`, or `select`.
+type ProfileMutationOutput struct {
+	Status      string `json:"status" yaml:"status"` // "added" | "removed" | "selected"
+	ProfileName string `json:"profileName" yaml:"profileName"`
+}
+
+// JSON returns the ProfileMutationOutput as a JSON string.
+func (o *ProfileMutationOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the ProfileMutationOutput as a YAML string.
+func (o *ProfileMutationOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
 // NetworksMutationOutput is the structured result of `netbird networks select`
 // or `netbird networks deselect`.
 type NetworksMutationOutput struct {

--- a/client/status/status.go
+++ b/client/status/status.go
@@ -440,6 +440,150 @@ func (e *SSOEvent) YAML() (string, error) {
 	return string(yamlBytes), nil
 }
 
+// NetworkOutput is one row of a networks-list response.
+type NetworkOutput struct {
+	ID          string              `json:"id" yaml:"id"`
+	Range       string              `json:"range,omitempty" yaml:"range,omitempty"`
+	Domains     []string            `json:"domains,omitempty" yaml:"domains,omitempty"`
+	ResolvedIPs map[string][]string `json:"resolvedIps,omitempty" yaml:"resolvedIps,omitempty"`
+	Selected    bool                `json:"selected" yaml:"selected"`
+}
+
+// NetworksListOutput is the structured result of `netbird networks list`.
+type NetworksListOutput struct {
+	Networks []NetworkOutput `json:"networks" yaml:"networks"`
+}
+
+// JSON returns the NetworksListOutput as a JSON string.
+func (o *NetworksListOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the NetworksListOutput as a YAML string.
+func (o *NetworksListOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
+// ForwardingRuleOutput is one row of a forwarding-list response.
+type ForwardingRuleOutput struct {
+	TranslatedAddress  string `json:"translatedAddress" yaml:"translatedAddress"`
+	TranslatedHostname string `json:"translatedHostname,omitempty" yaml:"translatedHostname,omitempty"`
+	Protocol           string `json:"protocol" yaml:"protocol"`
+	DestinationPort    string `json:"destinationPort" yaml:"destinationPort"`
+	TranslatedPort     string `json:"translatedPort" yaml:"translatedPort"`
+}
+
+// ForwardingListOutput is the structured result of `netbird forwarding list`.
+type ForwardingListOutput struct {
+	Rules []ForwardingRuleOutput `json:"rules" yaml:"rules"`
+}
+
+// JSON returns the ForwardingListOutput as a JSON string.
+func (o *ForwardingListOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the ForwardingListOutput as a YAML string.
+func (o *ForwardingListOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
+// ProfileOutput is one row of a profile-list response.
+type ProfileOutput struct {
+	Name   string `json:"name" yaml:"name"`
+	Active bool   `json:"active" yaml:"active"`
+}
+
+// ProfileListOutput is the structured result of `netbird profile list`.
+type ProfileListOutput struct {
+	Profiles []ProfileOutput `json:"profiles" yaml:"profiles"`
+}
+
+// JSON returns the ProfileListOutput as a JSON string.
+func (o *ProfileListOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the ProfileListOutput as a YAML string.
+func (o *ProfileListOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
+// StateOutput is one row of a state-list response.
+type StateOutput struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+// StateListOutput is the structured result of `netbird state list`.
+type StateListOutput struct {
+	States []StateOutput `json:"states" yaml:"states"`
+}
+
+// JSON returns the StateListOutput as a JSON string.
+func (o *StateListOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the StateListOutput as a YAML string.
+func (o *StateListOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
+// VersionOutput is the structured result of `netbird version`.
+type VersionOutput struct {
+	Version string `json:"version" yaml:"version"`
+}
+
+// JSON returns the VersionOutput as a JSON string.
+func (o *VersionOutput) JSON() (string, error) {
+	jsonBytes, err := json.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed")
+	}
+	return string(jsonBytes), err
+}
+
+// YAML returns the VersionOutput as a YAML string.
+func (o *VersionOutput) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed")
+	}
+	return string(yamlBytes), nil
+}
+
 // JSON returns the DownOutput as a JSON string.
 func (o *DownOutput) JSON() (string, error) {
 	jsonBytes, err := json.Marshal(o)


### PR DESCRIPTION
## Describe your changes

Extends the structured-output pattern already used by `netbird status` (`OutputOverview.JSON()` / `YAML()`) to the rest of the client CLI surface that benefits from machine-readable output. Automation use cases (provisioning scripts, CI runners, OpenWRT-style packaging, NetworkManager integrations) no longer need to scrape free-form text or `grep` for English status messages.

All new flags follow the same pattern: `--json` / `-j` and `--yaml` / `-y` are registered per leaf command, marked mutually exclusive, and the default text path is preserved unchanged. Each command emits a typed struct from `client/status` so the on-the-wire schema is visible in one place.

### New flags

- **`netbird up`** — daemon-mode emits a final `UpOutput` (`status: "connected" | "already_connected"`, `profileName`). When SSO is required, `openURL` emits an NDJSON `SSOEvent` (`event: "sso_required"`, `verificationUriComplete`, `userCode`) before the final result, and skips browser-opening since automation contexts are typically headless. `--json` / `--yaml` combined with `--foreground-mode` is rejected upfront — foreground mode is a long-running logrus stream that doesn't fit a single-object contract.
- **`netbird down`** — emits `DownOutput` (`status: "Disconnected"`).
- **`netbird version`** — emits `VersionOutput` (`version`). `Run:` converted to `RunE:` so marshal errors can propagate.
- **`netbird deregister`** (alias `logout`) — emits `DeregisterOutput` (`status: "deregistered"`, optional `profileName` when `--profile` was used).
- **`netbird login`** — emits `LoginOutput` (`status: "logged_in"`, `profileName`) on both daemon-mode and foreground-mode paths. SSO event flows through the same `openURL` gating as `up`.
- **`netbird networks list`** — emits `NetworksListOutput` (`networks: [{id, range, domains, resolvedIps, selected}]`).
- **`netbird networks select` / `deselect`** — emit `NetworksMutationOutput` (`status: "selected" | "deselected"`, `networks` list, `all: true` when special `all` arg was used).
- **`netbird forwarding list`** — emits `ForwardingListOutput` (`rules: [{translatedAddress, translatedHostname, protocol, destinationPort, translatedPort}]`). Sort moved out of the printer into a shared helper so JSON and text output have the same ordering. Port fields are `*string` with `omitempty` — when the underlying `PortInfo` oneof is unset, the field is omitted entirely rather than emitted as the human-readable sentinel `"No port specified"`.
- **`netbird profile list`** — emits `ProfileListOutput` (`profiles: [{name, active}]`).
- **`netbird profile add` / `remove` / `select`** — emit `ProfileMutationOutput` (`status: "added" | "removed" | "selected"`, `profileName`).
- **`netbird state list`** — emits `StateListOutput` (`states: [{name}]`).
- **`netbird debug bundle`** — emits `DebugBundleOutput` (`path`, optional `uploadedKey` when `--upload-bundle` is set).

### Schema

All output structs live in `client/status/status.go` alongside the existing `OutputOverview`. Each struct exposes `JSON()` and `YAML()` methods that marshal via `encoding/json` and `gopkg.in/yaml.v3` respectively — the same shape as the existing `OutputOverview.JSON()` / `YAML()`. Field tags use camelCase (consistent with `OutputOverview`).

### Behavior preserved

- All text-mode (no flag) output is byte-for-byte identical to before.
- Errors still return through cobra and print plain-text to stderr — same as `status` and the rest of the CLI today. Structured error JSON is a deliberate follow-up, not part of this PR.
- `log.Errorf` / `log.Warnf` writes via logrus continue to land on stderr, so stdout remains clean for JSON consumers.

### Behavior changes worth noting

- **Empty-result list commands emit empty arrays under `--json`** instead of the human-readable "No X available." message. e.g. `netbird networks list --json` with no networks now emits `{"networks":[]}`. This is intentional — zero-length is meaningful to automation — but is a behavior change for any caller that was checking text output.
- **`openURL` now suppresses browser-opening when `--json`/`--yaml` is set.** Automation contexts are typically headless. The SSO event still carries the verification URL so the caller can surface it.
- **`netbird up --json --foreground-mode` returns an error.** Foreground mode is a long-running logrus stream; supporting it would require a logrus JSON formatter swap and an event schema for every log category — out of scope.

## Testing

### Manual

```bash
# Connection lifecycle
netbird up --json
netbird up --yaml
netbird up --json --foreground-mode   # expect: error
netbird status --json                  # unchanged, existing behavior
netbird down --json

# Listing
netbird networks list --json
netbird networks list --json           # with zero networks: expect {"networks":[]}
netbird forwarding list --json
netbird forwarding list --yaml
netbird profile list --json
netbird state list --json
netbird version --json

# Mutations
netbird networks select route1 route2 --json
netbird networks select all --json     # expect "all":true, no "networks" field
netbird networks deselect all --json
netbird profile add work --json
netbird profile select work --json
netbird profile remove work --json
netbird deregister --json
netbird deregister --profile work --json

# Auth
netbird login --json                   # with setup key: one object
netbird login --json                   # SSO flow: NDJSON, sso_required then logged_in

# Debug bundle
netbird debug bundle --json
netbird debug bundle --upload-bundle --json  # expect uploadedKey field
```

### Parser sanity

For each command above, pipe stdout through `jq .` and confirm it parses without error. Confirm stderr stays free of JSON pollution (e.g. logrus warnings going to stderr should not appear in `jq` output).

For NDJSON-shaped output (`up --json` with SSO, `login --json` with SSO), confirm each line parses as standalone JSON:

```bash
netbird login --json | while read -r line; do echo "$line" | jq .; done
```

### Edge cases

- [ ] `--json` and `--yaml` together: confirm cobra rejects via `MarkFlagsMutuallyExclusive`.
- [ ] `forwarding list` with a rule that has no destination/translated port: confirm the field is omitted, not emitted as `"No port specified"`.
- [ ] `networks list --json` when daemon is not running: current behavior is plain-text error from cobra — confirm this matches `status` behavior (it does; addressing it across the CLI is tracked separately under netbirdio/netbird#2780).
- [ ] `up --json` happy path with setup key: single object on stdout.
- [ ] `up --json` SSO path: two objects on stdout (sso_required, then connected).
- [ ] `up --json` "already connected" path: single object, `status: "already_connected"`.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [X] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

Not needed yet, this is mostly for testing.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## Out of scope (deliberate follow-ups)

- Structured JSON errors (would require `cmd.SilenceErrors = true` and threading a JSON error path through every `return fmt.Errorf(...)`).
- `netbird trace` (rich per-rule structured output, larger schema design).
- `netbird expose`, `netbird ssh`, `netbird capture`, `netbird service install/start/stop/...` (interactive or long-running streams that don't fit the single-object contract).
- The smaller debug subcommands (`debug log level`, `debug for`, `debug persistence`).
- The schema-consistency fix for `netbird status` when daemon is unreachable (issue #2780 — separate proposal in progress).
- Test coverage for the new flag paths (no tests added in this PR).
- Documentation / `--help` text consistency pass (the original `status` flag description differs slightly from the new ones).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI commands now support JSON and YAML output formats via `--json/-j` and `--yaml/-y` flags
  * Applicable to: up, down, login, logout, networks, profile, state, version, debug bundle, and forwarding rules commands

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->