### PR TITLE
[client] Bump macOS sleep callback timeout to 20s

### DIFF
--- a/client/internal/sleep/detector_darwin.go
+++ b/client/internal/sleep/detector_darwin.go
@@ -188,7 +188,9 @@ func (d *Detector) triggerCallback(event EventType, cb func(event EventType), do
 	}
 
 	doneChan := make(chan struct{})
-	timeout := time.NewTimer(500 * time.Millisecond)
+	// macOS forces sleep ~30s after kIOMessageSystemWillSleep, so block long
+	// enough for teardown to finish while staying under that deadline.
+	timeout := time.NewTimer(20 * time.Second)
 	defer timeout.Stop()
 
 	go func() {


### PR DESCRIPTION
## Describe your changes

Increase the macOS sleep callback timeout from 500ms to 20s so the daemon can finish `runDown` (engine stop, DNS/route cleanup) before we ack `IOAllowPowerChange`. The previous 500ms bound meant the kernel was free to suspend mid-teardown, which could leave system DNS in a broken state on wake. macOS forces sleep ~30s after `kIOMessageSystemWillSleep`, so 20s leaves headroom.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal timeout change, no user-visible API.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of system sleep handling on macOS to ensure proper cleanup and shutdown procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->