### PR TITLE
[client] Fix nil channel panic in external chain monitor stop

### DIFF
--- a/client/firewall/nftables/external_chain_monitor_linux.go
+++ b/client/firewall/nftables/external_chain_monitor_linux.go
@@ -52,9 +52,10 @@ func (m *externalChainMonitor) start() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
-	m.done = make(chan struct{})
+	done := make(chan struct{})
+	m.done = done
 
-	go m.run(ctx)
+	go m.run(ctx, done)
 }
 
 func (m *externalChainMonitor) stop() {
@@ -72,8 +73,8 @@ func (m *externalChainMonitor) stop() {
 	<-done
 }
 
-func (m *externalChainMonitor) run(ctx context.Context) {
-	defer close(m.done)
+func (m *externalChainMonitor) run(ctx context.Context, done chan struct{}) {
+	defer close(done)
 
 	bo := &backoff.ExponentialBackOff{
 		InitialInterval:     externalMonitorInitInterval,


### PR DESCRIPTION
## Describe your changes

`externalChainMonitor.stop()` nilled `m.done` before the monitor goroutine's `defer close(m.done)` ran, causing `panic: close of nil channel` when the engine shut down while the monitor was still active (e.g. after a failed wireguard interface bring-up).

- Pass the done channel as a goroutine parameter so the run goroutine holds its own reference and can't race with `stop()` nilling the field

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal bug fix, no user-facing surface.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal lifecycle management for the firewall chain monitor to enhance code reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->