### PR TITLE
[client] Fix possible deadlock in statemanager Stop

### DIFF
--- a/client/internal/statemanager/manager.go
+++ b/client/internal/statemanager/manager.go
@@ -96,17 +96,19 @@ func (m *Manager) Stop(ctx context.Context) error {
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	cancel := m.cancel
+	done := m.done
+	m.mu.Unlock()
 
-	if m.cancel == nil {
+	if cancel == nil {
 		return nil
 	}
-	m.cancel()
+	cancel()
 
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-m.done:
+	case <-done:
 	}
 
 	return nil


### PR DESCRIPTION
## Describe your changes

`statemanager.Manager.Stop()` held `m.mu` for its entire duration, including the `<-m.done` wait. 
`periodicStateSave` calls `PersistState()` which also acquires `m.mu`. If a tick fired around the same time as `Stop()`, the goroutine would block in `PersistState`'s `Lock()` while `Stop()` waited on `m.done` under the lock — neither side could make progress, and the wait only unblocked if the caller's context had a deadline.

Release the lock after capturing `cancel` and `done` locally, then `cancel()` and wait on `done` outside the lock. Double `Stop()` remains idempotent: the second call re-invokes `cancel()` on an already-cancelled context (no-op) and reads `done` which is already closed (immediate return).

Same pattern as the [external chain monitor fix](https://github.com/netbirdio/netbird/pull/6224): capture the channel reference under the lock, do the wait outside.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal bug fix, no user-facing surface.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the reliability and efficiency of the system shutdown mechanism to ensure proper resource cleanup and prevent potential contention during the shutdown process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->