### PR TITLE
[client] Refactor Linux system info to use syscalls

### DIFF
--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -3,14 +3,13 @@
 package system
 
 import (
-	"bytes"
 	"context"
 	"os"
-	"os/exec"
 	"regexp"
 	"runtime"
-	"strings"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zcalusic/sysinfo"
@@ -29,19 +28,11 @@ func UpdateStaticInfoAsync() {
 
 // GetInfo retrieves and parses the system information
 func GetInfo(ctx context.Context) *Info {
-	info := _getInfo()
-	for strings.Contains(info, "broken pipe") {
-		info = _getInfo()
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	osStr := strings.ReplaceAll(info, "\n", "")
-	osStr = strings.ReplaceAll(osStr, "\r\n", "")
-	osInfo := strings.Split(osStr, " ")
+	kernelName, kernelVersion, kernelPlatform := kernelInfo()
 
 	osName, osVersion := readOsReleaseFile()
 	if osName == "" {
-		osName = osInfo[3]
+		osName = kernelName
 	}
 
 	systemHostname, _ := os.Hostname()
@@ -58,8 +49,8 @@ func GetInfo(ctx context.Context) *Info {
 	}
 
 	gio := &Info{
-		Kernel:             osInfo[0],
-		Platform:           osInfo[2],
+		Kernel:             kernelName,
+		Platform:           kernelPlatform,
 		OS:                 osName,
 		OSVersion:          osVersion,
 		Hostname:           extractDeviceName(ctx, systemHostname),
@@ -67,7 +58,7 @@ func GetInfo(ctx context.Context) *Info {
 		CPUs:               runtime.NumCPU(),
 		NetbirdVersion:     version.NetbirdVersion(),
 		UIVersion:          extractUserAgent(ctx),
-		KernelVersion:      osInfo[1],
+		KernelVersion:      kernelVersion,
 		NetworkAddresses:   addrs,
 		SystemSerialNumber: si.SystemSerialNumber,
 		SystemProductName:  si.SystemProductName,
@@ -78,18 +69,12 @@ func GetInfo(ctx context.Context) *Info {
 	return gio
 }
 
-func _getInfo() string {
-	cmd := exec.Command("uname", "-srio")
-	cmd.Stdin = strings.NewReader("some")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil {
-		log.Warnf("getInfo: %s", err)
+func kernelInfo() (string, string, string) {
+	var uts unix.Utsname
+	if err := unix.Uname(&uts); err != nil {
+		return "", "", ""
 	}
-	return out.String()
+	return unix.ByteSliceToString(uts.Sysname[:]), unix.ByteSliceToString(uts.Release[:]), unix.ByteSliceToString(uts.Machine[:])
 }
 
 func sysInfo() (string, string, string) {


### PR DESCRIPTION
## Describe your changes

This refactors the linux system info to not shell out to `uname` instead it uses a similar syscall to get the same information.

## Issue ticket number and link

#6225 

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Linux system information detection for more accurate kernel, kernel version, and platform reporting; OS-name fallback now uses kernel identity when release data is missing, and legacy uname parsing was replaced for more reliable results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->