### PR TITLE
[client] filter A/AAAA answers pointing at disconnected peers

### DIFF
--- a/client/internal/dns/local/local.go
+++ b/client/internal/dns/local/local.go
@@ -26,6 +26,19 @@ type resolver interface {
 	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
 }
 
+// PeerConnectivity reports whether a tunnel IP belongs to a peer the
+// client knows about and whether that peer is currently connected. The
+// local resolver uses this to suppress A/AAAA answers whose RDATA points
+// at a disconnected peer (typical case: a synthesized private-service
+// record pointing at an embedded proxy peer that just went offline).
+//
+// known=false means the IP isn't in the local peerstore at all — the
+// record is left alone (it points at something outside our mesh, e.g.
+// a non-peer upstream).
+type PeerConnectivity interface {
+	IsConnectedByIP(ip string) (known, connected bool)
+}
+
 type Resolver struct {
 	mu      sync.RWMutex
 	records map[dns.Question][]dns.RR
@@ -33,6 +46,11 @@ type Resolver struct {
 	// zones maps zone domain -> NonAuthoritative (true = non-authoritative, user-created zone)
 	zones    map[domain.Domain]bool
 	resolver resolver
+	// peerConn, when non-nil, is consulted on every A/AAAA answer to
+	// drop records pointing at disconnected peers. nil disables the
+	// filter and preserves the legacy "return whatever is registered"
+	// behaviour for callers that never wire a status source.
+	peerConn PeerConnectivity
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -47,6 +65,15 @@ func NewResolver() *Resolver {
 		ctx:     ctx,
 		cancel:  cancel,
 	}
+}
+
+// SetPeerConnectivity wires the per-IP connectivity check used to filter
+// out A/AAAA answers pointing at disconnected peers. Pass nil to disable.
+// Safe to call multiple times; the latest value wins.
+func (d *Resolver) SetPeerConnectivity(p PeerConnectivity) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.peerConn = p
 }
 
 func (d *Resolver) MatchSubdomains() bool {
@@ -95,6 +122,7 @@ func (d *Resolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	replyMessage.RecursionAvailable = true
 
 	result := d.lookupRecords(logger, question)
+	result.records = d.filterDisconnectedPeerAnswers(logger, question, result.records)
 	replyMessage.Authoritative = !result.hasExternalData
 	replyMessage.Answer = result.records
 	replyMessage.Rcode = d.determineRcode(question, result)
@@ -434,6 +462,78 @@ func (d *Resolver) logDNSError(logger *log.Entry, hostname string, qtype uint16,
 	} else {
 		logger.Debugf("DNS resolution failed for %s type %s: %v", hostname, qtypeName, err)
 	}
+}
+
+// filterDisconnectedPeerAnswers drops A/AAAA records whose RDATA matches
+// a known but disconnected peer. The synthesized private-service zones
+// emit one A record per connected proxy peer in a cluster; when a peer
+// goes offline, the server-side refresh removes the record from the
+// next netmap, but the client may still hold the previous netmap for a
+// short window. This filter is the local belt to that braces — even on
+// the stale netmap, the resolver hides the offline target.
+//
+// Records pointing at unknown IPs (outside the local peerstore, e.g.
+// non-mesh upstreams) are never dropped. Non-A/AAAA records pass
+// through untouched.
+//
+// Escape hatch: if filtering would leave the answer empty AND at least
+// one record was filtered, the original list is returned. Better to
+// hand the client a record that may not respond than NXDOMAIN it
+// completely when every proxy peer is offline (the upstream may still
+// be reachable some other way, or the peerstore may be stale).
+func (d *Resolver) filterDisconnectedPeerAnswers(logger *log.Entry, question dns.Question, records []dns.RR) []dns.RR {
+	if len(records) == 0 {
+		return records
+	}
+	d.mu.RLock()
+	checker := d.peerConn
+	d.mu.RUnlock()
+	if checker == nil {
+		return records
+	}
+
+	kept := make([]dns.RR, 0, len(records))
+	var dropped int
+	for _, rr := range records {
+		ip := extractRecordIP(rr)
+		if ip == "" {
+			kept = append(kept, rr)
+			continue
+		}
+		known, connected := checker.IsConnectedByIP(ip)
+		if known && !connected {
+			dropped++
+			continue
+		}
+		kept = append(kept, rr)
+	}
+	if dropped == 0 {
+		return records
+	}
+	if len(kept) == 0 {
+		logger.Debugf("all %d answers for %s point at disconnected peers; returning the original list", dropped, question.Name)
+		return records
+	}
+	logger.Tracef("dropped %d disconnected-peer answer(s) for %s, returning %d", dropped, question.Name, len(kept))
+	return kept
+}
+
+// extractRecordIP returns the dotted-decimal / colon-hex IP carried by
+// an A or AAAA record, or "" for any other record type.
+func extractRecordIP(rr dns.RR) string {
+	switch r := rr.(type) {
+	case *dns.A:
+		if r.A == nil {
+			return ""
+		}
+		return r.A.String()
+	case *dns.AAAA:
+		if r.AAAA == nil {
+			return ""
+		}
+		return r.AAAA.String()
+	}
+	return ""
 }
 
 // Update replaces all zones and their records

--- a/client/internal/dns/local/local_test.go
+++ b/client/internal/dns/local/local_test.go
@@ -30,6 +30,21 @@ func (m *mockResolver) LookupNetIP(ctx context.Context, network, host string) ([
 	return nil, nil
 }
 
+// mockPeerConnectivity returns canned (known, connected) results per IP.
+// Used by the disconnected-peer filter tests below. IPs not in the map
+// are reported as unknown so the filter leaves them alone.
+type mockPeerConnectivity struct {
+	byIP map[string]struct{ known, connected bool }
+}
+
+func (m mockPeerConnectivity) IsConnectedByIP(ip string) (known, connected bool) {
+	v, ok := m.byIP[ip]
+	if !ok {
+		return false, false
+	}
+	return v.known, v.connected
+}
+
 func TestLocalResolver_ServeDNS(t *testing.T) {
 	recordA := nbdns.SimpleRecord{
 		Name:  "peera.netbird.cloud.",
@@ -2650,5 +2665,116 @@ func BenchmarkIsInManagedZone_ManyZones(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		resolver.isInManagedZone(qname)
+	}
+}
+
+// TestLocalResolver_FilterDisconnectedPeerAnswers verifies the
+// connectivity-aware filtering layered on top of lookupRecords:
+// when an A record's IP belongs to a known peer that's disconnected,
+// the record is dropped from the answer. Records for unknown IPs pass
+// through. If filtering would empty the answer entirely and at least
+// one record was dropped, the original list is restored (escape hatch
+// for the "all proxies offline" case).
+func TestLocalResolver_FilterDisconnectedPeerAnswers(t *testing.T) {
+	zone := "svc.cluster.netbird."
+	connectedRec := nbdns.SimpleRecord{
+		Name:  zone,
+		Type:  int(dns.TypeA),
+		Class: nbdns.DefaultClass,
+		TTL:   5,
+		RData: "100.64.0.10",
+	}
+	disconnectedRec := nbdns.SimpleRecord{
+		Name:  zone,
+		Type:  int(dns.TypeA),
+		Class: nbdns.DefaultClass,
+		TTL:   5,
+		RData: "100.64.0.11",
+	}
+	unknownRec := nbdns.SimpleRecord{
+		Name:  zone,
+		Type:  int(dns.TypeA),
+		Class: nbdns.DefaultClass,
+		TTL:   5,
+		RData: "203.0.113.5",
+	}
+
+	type ipState struct{ known, connected bool }
+	tests := []struct {
+		name        string
+		records     []nbdns.SimpleRecord
+		connByIP    map[string]ipState
+		wantInOrder []string
+	}{
+		{
+			name:    "drops disconnected peer, keeps connected",
+			records: []nbdns.SimpleRecord{connectedRec, disconnectedRec},
+			connByIP: map[string]ipState{
+				"100.64.0.10": {known: true, connected: true},
+				"100.64.0.11": {known: true, connected: false},
+			},
+			wantInOrder: []string{"100.64.0.10"},
+		},
+		{
+			name:    "unknown IPs pass through untouched",
+			records: []nbdns.SimpleRecord{unknownRec, disconnectedRec},
+			connByIP: map[string]ipState{
+				"100.64.0.11": {known: true, connected: false},
+			},
+			wantInOrder: []string{"203.0.113.5"},
+		},
+		{
+			name:    "all disconnected falls back to original list",
+			records: []nbdns.SimpleRecord{disconnectedRec, connectedRec},
+			connByIP: map[string]ipState{
+				"100.64.0.10": {known: true, connected: false},
+				"100.64.0.11": {known: true, connected: false},
+			},
+			wantInOrder: []string{"100.64.0.11", "100.64.0.10"},
+		},
+		{
+			name:        "no checker wired returns all records",
+			records:     []nbdns.SimpleRecord{connectedRec, disconnectedRec},
+			connByIP:    nil,
+			wantInOrder: []string{"100.64.0.10", "100.64.0.11"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resolver := NewResolver()
+			if tc.connByIP != nil {
+				cm := mockPeerConnectivity{byIP: make(map[string]struct{ known, connected bool }, len(tc.connByIP))}
+				for ip, st := range tc.connByIP {
+					cm.byIP[ip] = struct{ known, connected bool }{st.known, st.connected}
+				}
+				resolver.SetPeerConnectivity(cm)
+			}
+			resolver.Update([]nbdns.CustomZone{{
+				Domain:           strings.TrimSuffix(zone, "."),
+				Records:          tc.records,
+				NonAuthoritative: true,
+			}})
+
+			var got *dns.Msg
+			writer := &test.MockResponseWriter{
+				WriteMsgFunc: func(m *dns.Msg) error {
+					got = m
+					return nil
+				},
+			}
+			req := new(dns.Msg).SetQuestion(zone, dns.TypeA)
+			resolver.ServeDNS(writer, req)
+
+			require.NotNil(t, got, "resolver must produce a response")
+			require.Len(t, got.Answer, len(tc.wantInOrder),
+				"answer count must match expected: %v", tc.wantInOrder)
+			for i, want := range tc.wantInOrder {
+				a, ok := got.Answer[i].(*dns.A)
+				require.True(t, ok, "answer[%d] must be an A record", i)
+				assert.Equal(t, want, a.A.String(),
+					"answer[%d] expected %s got %s", i, want, a.A.String())
+			}
+		})
 	}
 }

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -301,6 +301,11 @@ func newDefaultServer(
 		warningDelayBase:  defaultWarningDelayBase,
 		healthRefresh:     make(chan struct{}, 1),
 	}
+	// Wire the local resolver against the peer status recorder so it can
+	// suppress A/AAAA answers that point at disconnected peers (typical
+	// case: synthesised private-service records pointing at an embedded
+	// proxy peer that just went offline).
+	defaultServer.localResolver.SetPeerConnectivity(localPeerConnectivity{statusRecorder})
 
 	// register with root zone, handler chain takes care of the routing
 	dnsService.RegisterMux(".", handlerChain)
@@ -1385,4 +1390,26 @@ func (s *DefaultServer) PopulateManagementDomain(mgmtURL *url.URL) error {
 		return s.mgmtCacheResolver.PopulateFromConfig(s.ctx, mgmtURL)
 	}
 	return nil
+}
+
+// localPeerConnectivity adapts *peer.Status to local.PeerConnectivity so
+// the local resolver can ask "is this IP a known peer and is it
+// connected?" without taking on the peer package as a dependency.
+// A nil status recorder always reports known=false so the resolver
+// short-circuits to the legacy "return everything" path.
+type localPeerConnectivity struct {
+	status *peer.Status
+}
+
+// IsConnectedByIP looks the IP up in the peerstore and surfaces both
+// the known and connected bits. Used by Resolver.filterDisconnectedPeerAnswers.
+func (l localPeerConnectivity) IsConnectedByIP(ip string) (known, connected bool) {
+	if l.status == nil {
+		return false, false
+	}
+	state, ok := l.status.PeerStateByIP(ip)
+	if !ok {
+		return false, false
+	}
+	return true, state.ConnStatus == peer.StatusConnected
 }


### PR DESCRIPTION
## Describe your changes
When the local resolver hands back records for a query, walk the A/AAAA answers and consult a connectivity checker keyed by IP. Records whose RDATA points at a known-but-disconnected peer are dropped from the answer. Records pointing at unknown IPs (anything outside the local peerstore) pass through untouched.

Motivation: synthesised private-service zones emit one A record per connected proxy peer in a cluster. The management side now refreshes the netmap whenever a proxy peer flips state, but the client may still hold a stale netmap for a short window. This is the client-side belt to that braces — even on the stale data, the resolver hides records pointing at peers that the local peerstore reports offline.

Escape hatch: if filtering would empty the answer entirely AND at least one record was dropped, the original list is restored. Better to hand the client a record that may not respond than NXDOMAIN it completely when every proxy in the cluster is offline (the upstream may still be reachable some other way, or the peerstore may be stale).

- local.PeerConnectivity interface: IsConnectedByIP(ip) (known, connected).
- Resolver.SetPeerConnectivity wires the source (nil = disabled, the legacy "return everything" default).
- ServeDNS runs filterDisconnectedPeerAnswers between lookupRecords and the reply assembly; extractRecordIP pulls IP from A/AAAA only, other record types pass through.
- server.go adapter localPeerConnectivity wraps *peer.Status and reports connected when ConnStatus == StatusConnected.
- New tests cover the four cases: drop disconnected, pass unknown, fallback when all disconnected, and no-op when no checker is wired.
## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNS resolver now filters out local A/AAAA answers for peers that are not currently connected, preventing users from resolving IP addresses for unavailable peers.

* **Tests**
  * Added comprehensive test coverage for DNS filtering behavior, including handling of mixed connectivity states and fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->