### PR TITLE
[management] reject negative usage_limit on setup key creation

### DIFF
--- a/management/server/http/handlers/setup_keys/setupkeys_handler.go
+++ b/management/server/http/handlers/setup_keys/setupkeys_handler.go
@@ -71,6 +71,11 @@ func (h *handler) createSetupKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req.UsageLimit < 0 {
+		util.WriteError(r.Context(), status.Errorf(status.InvalidArgument, "usage_limit can not be negative"), w)
+		return
+	}
+
 	if req.AutoGroups == nil {
 		req.AutoGroups = []string{}
 	}

--- a/management/server/http/handlers/setup_keys/setupkeys_handler_test.go
+++ b/management/server/http/handlers/setup_keys/setupkeys_handler_test.go
@@ -135,6 +135,15 @@ func TestSetupKeysHandlers(t *testing.T) {
 			expectedSetupKey: expectedNewKey,
 		},
 		{
+			name:        "Create Setup Key With Negative Usage Limit",
+			requestType: http.MethodPost,
+			requestPath: "/api/setup-keys",
+			requestBody: bytes.NewBuffer(
+				[]byte(fmt.Sprintf("{\"name\":\"%s\",\"type\":\"%s\",\"expires_in\":86400,\"usage_limit\":-1}", newSetupKey.Name, newSetupKey.Type))),
+			expectedStatus: http.StatusUnprocessableEntity,
+			expectedBody:   false,
+		},
+		{
 			name:        "Update Setup Key",
 			requestType: http.MethodPut,
 			requestPath: "/api/setup-keys/" + defaultSetupKey.Id,

--- a/shared/management/http/api/openapi.yml
+++ b/shared/management/http/api/openapi.yml
@@ -1241,6 +1241,7 @@ components:
         usage_limit:
           description: A number of times this key can be used. The value of 0 indicates the unlimited usage.
           type: integer
+          minimum: 0
           example: 0
         ephemeral:
           description: Indicate that the peer will be ephemeral or not


### PR DESCRIPTION
## Summary
- The `POST /api/setup-keys` endpoint accepted negative values for `usage_limit`. Semantically only `0` (unlimited) or a positive integer (a cap) is meaningful — a negative cap would either produce a key flagged as immediately overused by `IsOverUsed()`, or silently behave like unlimited depending on downstream code paths.
- Added a handler-side guard in `management/server/http/handlers/setup_keys/setupkeys_handler.go` that returns `422 Unprocessable Entity` with `usage_limit can not be negative`, mirroring the existing `expires_in` check just above it.
- Documented the constraint in the OpenAPI schema (`minimum: 0` on `CreateSetupKeyRequest.usage_limit`).
- Added a handler test case (`Create Setup Key With Negative Usage Limit`) covering the rejection path.

## Test plan
- [x] `go build ./...`
- [x] `go test ./management/server/http/handlers/setup_keys/... -count=1`
- [ ] Manual: `POST /api/setup-keys` with `"usage_limit": -1` returns 422 and a non-negative value still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Setup key creation now validates the usage limit parameter to prevent negative values, returning a validation error when invalid.
  * Updated API documentation to clarify that usage limits must be zero or greater.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->