### PR TITLE
[management] reject negative usage_limit on setup key creation

### DIFF
--- a/management/server/http/handlers/setup_keys/setupkeys_handler.go
+++ b/management/server/http/handlers/setup_keys/setupkeys_handler.go
@@ -71,6 +71,11 @@ func (h *handler) createSetupKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req.UsageLimit < 0 {
+		util.WriteError(r.Context(), status.Errorf(status.InvalidArgument, "usage_limit can not be negative"), w)
+		return
+	}
+
 	if req.AutoGroups == nil {
 		req.AutoGroups = []string{}
 	}

--- a/management/server/http/handlers/setup_keys/setupkeys_handler_test.go
+++ b/management/server/http/handlers/setup_keys/setupkeys_handler_test.go
@@ -135,6 +135,15 @@ func TestSetupKeysHandlers(t *testing.T) {
 			expectedSetupKey: expectedNewKey,
 		},
 		{
+			name:        "Create Setup Key With Negative Usage Limit",
+			requestType: http.MethodPost,
+			requestPath: "/api/setup-keys",
+			requestBody: bytes.NewBuffer(
+				[]byte(fmt.Sprintf("{\"name\":\"%s\",\"type\":\"%s\",\"expires_in\":86400,\"usage_limit\":-1}", newSetupKey.Name, newSetupKey.Type))),
+			expectedStatus: http.StatusUnprocessableEntity,
+			expectedBody:   false,
+		},
+		{
 			name:        "Update Setup Key",
 			requestType: http.MethodPut,
 			requestPath: "/api/setup-keys/" + defaultSetupKey.Id,

--- a/shared/management/http/api/openapi.yml
+++ b/shared/management/http/api/openapi.yml
@@ -1241,6 +1241,7 @@ components:
         usage_limit:
           description: A number of times this key can be used. The value of 0 indicates the unlimited usage.
           type: integer
+          minimum: 0
           example: 0
         ephemeral:
           description: Indicate that the peer will be ephemeral or not


### PR DESCRIPTION
## Describe your changes
The `POST /api/setup-keys` endpoint accepted negative values for `usage_limit`. Semantically only `0` (unlimited) or a positive integer (a cap) is meaningful — a negative cap would either produce a key flagged as immediately overused by `IsOverUsed()`, or silently behave like unlimited depending on the downstream code path.

This PR:
- Adds a handler-side guard in `management/server/http/handlers/setup_keys/setupkeys_handler.go` that returns `422 Unprocessable Entity` with `usage_limit can not be negative`, mirroring the existing `expires_in` check.
- Documents the constraint in the OpenAPI schema (`minimum: 0` on `CreateSetupKeyRequest.usage_limit`).
- Adds a handler test case (`Create Setup Key With Negative Usage Limit`) covering the rejection path.

## Issue ticket number and link
N/A — found while exploring the API.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This is a server-side input validation fix that brings the API in line with its documented semantics (the OpenAPI description already says `0` means unlimited, implying non-negative). The OpenAPI schema is updated in-repo (`minimum: 0`), so the public API contract is self-documenting. No user-facing docs in `netbirdio/docs` describe the prior behavior, so there is nothing to update there.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A