### PR TITLE
fix(peer): keep WG peer entry across lazy-suspend so route-manager AllowedIPs survive

### DIFF
--- a/client/internal/conn_mgr.go
+++ b/client/internal/conn_mgr.go
@@ -210,7 +210,10 @@ func (e *ConnMgr) RemovePeerConn(peerKey string) {
 	if !ok {
 		return
 	}
-	defer conn.Close(false)
+	// Permanent removal: drop the WG peer entry too. The peer is gone for
+	// good and the route-manager's refcounter teardown will release any
+	// AllowedIPs it had appended along the same path.
+	defer conn.Close(false, false)
 
 	if !e.isStartedWithLazyMgr() {
 		return

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1603,7 +1603,11 @@ func (e *Engine) addNewPeer(peerConfig *mgmProto.RemotePeerConfig) error {
 	}
 
 	if exists := e.connMgr.AddPeerConn(e.ctx, peerKey, conn); exists {
-		conn.Close(false)
+		// AddPeerConn race-loser cleanup: a different Conn for this peer is
+		// already in the store and owns the WG peer entry. Pass keepWgPeer=
+		// true so this rejected Conn does not tear down the live one's WG
+		// state (including any AllowedIPs the route-manager has appended).
+		conn.Close(false, true)
 		return fmt.Errorf("peer already exists: %s", peerKey)
 	}
 

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -230,8 +230,24 @@ func (conn *Conn) Open(engineCtx context.Context) error {
 	return nil
 }
 
-// Close closes this peer Conn issuing a close event to the Conn closeCh
-func (conn *Conn) Close(signalToRemote bool) {
+// Close closes this peer Conn issuing a close event to the Conn closeCh.
+//
+// keepWgPeer controls whether the WireGuard peer entry is removed at the
+// iface layer. Pass true on lazy-suspend paths (lazy-mgr deactivate) so
+// that any AllowedIPs the route-manager appended in-place to the peer
+// entry (advertised subnets for a routing peer) survive the wake/sleep
+// cycle. Pass false on permanent-removal paths so the peer is fully
+// dropped from the WG iface.
+//
+// Background: when the peer is also a routing peer, the route-manager's
+// allowedIPsRefCounter calls WgInterface.AddAllowedIP(peerKey, prefix)
+// to extend the peer's AllowedIPs in place. RemovePeer wipes the entire
+// peer entry, so a subsequent lazy-wake re-opens the connection with
+// only the basic peer-IP /32 from the original PeerConfig — the
+// route-manager's refcounter is unaware of the round-trip and does not
+// re-apply the routed prefixes, so traffic to those prefixes is
+// silently dropped by WG until the next mgmt-side reconcile.
+func (conn *Conn) Close(signalToRemote, keepWgPeer bool) {
 	conn.mu.Lock()
 	defer conn.wgWatcherWg.Wait()
 	defer conn.mu.Unlock()
@@ -247,7 +263,7 @@ func (conn *Conn) Close(signalToRemote bool) {
 		}
 	}
 
-	conn.Log.Infof("close peer connection")
+	conn.Log.Infof("close peer connection (keepWgPeer=%v)", keepWgPeer)
 	conn.ctxCancel()
 
 	if conn.wgWatcherCancel != nil {
@@ -274,7 +290,9 @@ func (conn *Conn) Close(signalToRemote bool) {
 		conn.wgProxyICE = nil
 	}
 
-	if err := conn.endpointUpdater.RemoveWgPeer(); err != nil {
+	if keepWgPeer {
+		conn.Log.Debugf("keep WG peer entry across lazy-suspend so route-manager-applied AllowedIPs survive")
+	} else if err := conn.endpointUpdater.RemoveWgPeer(); err != nil {
 		conn.Log.Errorf("failed to remove wg endpoint: %v", err)
 	}
 

--- a/client/internal/peer/conn_close_keepwgpeer_test.go
+++ b/client/internal/peer/conn_close_keepwgpeer_test.go
@@ -1,0 +1,85 @@
+package peer
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestConn_Close_KeepWgPeerSignature pins the second parameter of
+// (*Conn).Close so that the lazy-suspend caller chain (peerstore.PeerConn{Idle,Close}
+// and engine race-loser cleanup) cannot be silently reverted to the
+// single-bool form. Reflection is used so that the check survives any
+// future renaming of the parameter as long as the type stays bool.
+//
+// The underlying bug, if the second parameter is dropped: when a routing
+// peer is also a lazy-managed peer, Conn.Close calls
+// endpointUpdater.RemoveWgPeer unconditionally, removing the WG peer
+// entry and discarding all AllowedIPs the route-manager has appended
+// in-place via WgInterface.AddAllowedIP. The next lazy-wake reopens the
+// peer using only its original PeerConfig AllowedIPs (the peer-IP /32),
+// so traffic to the advertised subnets is silently dropped by WG until
+// the next mgmt-side reconcile re-applies the prefixes.
+func TestConn_Close_KeepWgPeerSignature(t *testing.T) {
+	m, ok := reflect.TypeOf((*Conn)(nil)).MethodByName("Close")
+	if !ok {
+		t.Fatal("(*Conn).Close not found")
+	}
+
+	// Method values include the receiver as the first input.
+	const wantIn = 3 // receiver, signalToRemote bool, keepWgPeer bool
+	if got := m.Type.NumIn(); got != wantIn {
+		t.Fatalf("(*Conn).Close expected %d parameters (receiver + signalToRemote + keepWgPeer); got %d", wantIn, got)
+	}
+
+	boolType := reflect.TypeOf(true)
+	for i := 1; i < wantIn; i++ {
+		if got := m.Type.In(i); got != boolType {
+			t.Errorf("(*Conn).Close parameter %d: want bool, got %s", i, got)
+		}
+	}
+}
+
+// TestConn_Close_KeepWgPeerGate confirms the body of Close routes the
+// RemoveWgPeer call through the keepWgPeer guard. Reflection cannot see
+// inside a method body, so this is a textual landmark test against
+// conn.go. It is intentionally permissive about formatting (either an
+// `if keepWgPeer { ... } else` or an `if !keepWgPeer { ... }` shape is
+// accepted) but strict about the two invariants:
+//
+//  1. The keepWgPeer identifier appears in the same source area as the
+//     RemoveWgPeer call (within ~25 lines).
+//  2. RemoveWgPeer is still reachable for the keepWgPeer=false path —
+//     i.e. the call has not been deleted outright.
+//
+// If either invariant fails, the lazy-suspend AllowedIPs preservation
+// is at risk.
+func TestConn_Close_KeepWgPeerGate(t *testing.T) {
+	src, err := os.ReadFile("conn.go")
+	if err != nil {
+		t.Fatalf("read conn.go: %v", err)
+	}
+	body := string(src)
+
+	const removeCall = "endpointUpdater.RemoveWgPeer()"
+	idx := strings.Index(body, removeCall)
+	if idx < 0 {
+		t.Fatalf("conn.go no longer contains %q — the permanent-removal path is missing or has moved", removeCall)
+	}
+
+	// Look for the keepWgPeer identifier in a 25-line window above the
+	// RemoveWgPeer call. 25 lines comfortably brackets the if/else shape
+	// in the current implementation without becoming a whole-file scan.
+	const window = 25
+	start := idx
+	for i, lines := idx, 0; i > 0 && lines < window; i-- {
+		if body[i] == '\n' {
+			lines++
+			start = i
+		}
+	}
+	if !strings.Contains(body[start:idx], "keepWgPeer") {
+		t.Errorf("conn.go: %q is no longer gated by keepWgPeer within %d lines — every Close call would remove the WG peer entry, dropping route-manager-applied AllowedIPs on lazy-suspend", removeCall, window)
+	}
+}

--- a/client/internal/peerstore/store.go
+++ b/client/internal/peerstore/store.go
@@ -95,6 +95,10 @@ func (s *Store) PeerConnOpen(ctx context.Context, pubKey string) {
 
 }
 
+// PeerConnIdle is invoked by the lazy-manager when a peer's idle timer
+// expires. The data path is suspended but the WG peer entry stays so
+// any AllowedIPs the route-manager has appended (advertised subnets for
+// a routing peer) survive the wake/sleep cycle.
 func (s *Store) PeerConnIdle(pubKey string) {
 	s.peerConnsMu.RLock()
 	defer s.peerConnsMu.RUnlock()
@@ -103,9 +107,12 @@ func (s *Store) PeerConnIdle(pubKey string) {
 	if !ok {
 		return
 	}
-	p.Close(true)
+	p.Close(true, true)
 }
 
+// PeerConnClose is invoked by the lazy-manager when a peer must be
+// closed without notifying the remote side (e.g. excluded from lazy on
+// re-evaluation). Same lazy-suspend semantics: keep the WG peer entry.
 func (s *Store) PeerConnClose(pubKey string) {
 	s.peerConnsMu.RLock()
 	defer s.peerConnsMu.RUnlock()
@@ -114,7 +121,7 @@ func (s *Store) PeerConnClose(pubKey string) {
 	if !ok {
 		return
 	}
-	p.Close(false)
+	p.Close(false, true)
 }
 
 func (s *Store) PeersPubKey() []string {


### PR DESCRIPTION
## Describe your changes

Fixes #6250. Gate `peer.Conn.Close`'s call to `endpointUpdater.RemoveWgPeer` on a new `keepWgPeer bool` parameter so that AllowedIPs the route-manager has appended in place (via `WgInterface.AddAllowedIP` through its `allowedIPsRefCounter`) survive a lazy wake/sleep cycle.

### Caller intent

| Caller | `keepWgPeer` | Why |
|---|---|---|
| `peerstore.PeerConnIdle` | `true` | Lazy-suspend: data path off, WG entry stays |
| `peerstore.PeerConnClose` | `true` | Lazy excluded: same suspend semantics |
| `engine.addNewPeer` race-loser cleanup | `true` | The other `Conn` for this peer owns the WG entry |
| `conn_mgr.RemovePeerConn` | `false` | Permanent removal: drop the WG entry too |

Without this change, the lazy path tears down the entire WG peer entry on every idle cycle, including the route-manager-appended prefixes. The next wake re-opens with only the peer's base /32 from `PeerConfig.AllowedIps`. The route-manager's refcounter is unaware of the round-trip and does not re-apply the prefixes until a management-side reconcile fires, so routed-subnet traffic is silently dropped by WG until then.

The visible symptom is a peer that shows `Status: Connected` with a fresh WireGuard handshake but `Networks: -` in `netbird status -d`, with manual uncheck/re-check of the network in the GUI being the only client-side workaround.

## Issue ticket number and link

#6250

Also related: #4769 (multiple reporters of the same observable symptom requiring `netbird down && netbird up` on the routing peer).

## Stack

This PR is intentionally standalone against `main`. The broader p2p-dynamic rework in #6084 contains a `keepWgPeer` commit that addresses the same code path as part of a 4-PR stack. This PR extracts the equivalent minimum change so the fix can land ahead of that full stack. If #6084 lands first, this PR can be dropped.

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

## Tests

New regression file `client/internal/peer/conn_close_keepwgpeer_test.go`:

- `TestConn_Close_KeepWgPeerSignature` — uses reflection on `(*Conn).Close` to pin the second parameter as `bool`. Survives parameter renaming as long as the shape stays.
- `TestConn_Close_KeepWgPeerGate` — textual landmark check that the `RemoveWgPeer` call remains gated by `keepWgPeer` within the close body. Catches accidental removal of the gate.

Both pass with this change; both fail on `main`. The existing `client/internal/peer/...` and `client/internal/lazyconn/...` suites continue to pass with no other changes.

```
$ go test ./client/internal/peer/
ok  	github.com/netbirdio/netbird/client/internal/peer	6.551s

$ go test ./client/internal/lazyconn/...
ok  	github.com/netbirdio/netbird/client/internal/lazyconn	0.253s
ok  	github.com/netbirdio/netbird/client/internal/lazyconn/activity	1.808s
ok  	github.com/netbirdio/netbird/client/internal/lazyconn/inactivity	1.505s
```

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WireGuard peer state preservation during connection management transitions, ensuring route configuration survives across reconnection cycles and lazy-suspend operations.

* **Tests**
  * Added regression tests for peer connection closure behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->