### PR TITLE
[client] Match DNS wildcard handlers on label boundaries

### DIFF
--- a/client/internal/dns/handler_chain.go
+++ b/client/internal/dns/handler_chain.go
@@ -339,8 +339,7 @@ func (c *HandlerChain) isHandlerMatch(qname string, entry HandlerEntry) bool {
 	case entry.Pattern == ".":
 		return true
 	case entry.IsWildcard:
-		parts := strings.Split(strings.TrimSuffix(qname, entry.Pattern), ".")
-		return len(parts) >= 2 && strings.HasSuffix(qname, entry.Pattern)
+		return strings.HasSuffix(qname, "."+entry.Pattern)
 	default:
 		// For non-wildcard patterns:
 		// If handler wants subdomain matching, allow suffix match

--- a/client/internal/dns/handler_chain_test.go
+++ b/client/internal/dns/handler_chain_test.go
@@ -164,6 +164,54 @@ func TestHandlerChain_ServeDNS_DomainMatching(t *testing.T) {
 			matchSubdomains: true,
 			shouldMatch:     true,
 		},
+		{
+			name:            "wildcard label-boundary mismatch (suffix overlap)",
+			handlerDomain:   "*.b.test.",
+			queryDomain:     "x.ab.test.",
+			isWildcard:      true,
+			matchSubdomains: false,
+			shouldMatch:     false,
+		},
+		{
+			name:            "wildcard label-boundary match",
+			handlerDomain:   "*.b.test.",
+			queryDomain:     "x.b.test.",
+			isWildcard:      true,
+			matchSubdomains: false,
+			shouldMatch:     true,
+		},
+		{
+			name:            "wildcard multi-label match",
+			handlerDomain:   "*.b.test.",
+			queryDomain:     "x.y.b.test.",
+			isWildcard:      true,
+			matchSubdomains: false,
+			shouldMatch:     true,
+		},
+		{
+			name:            "wildcard no match on multi-label apex",
+			handlerDomain:   "*.b.test.",
+			queryDomain:     "b.test.",
+			isWildcard:      true,
+			matchSubdomains: false,
+			shouldMatch:     false,
+		},
+		{
+			name:            "wildcard no match on unrelated suffix containment",
+			handlerDomain:   "*.example.com.",
+			queryDomain:     "notexample.com.",
+			isWildcard:      true,
+			matchSubdomains: false,
+			shouldMatch:     false,
+		},
+		{
+			name:            "wildcard accepts pattern registered without trailing dot",
+			handlerDomain:   "*.b.test",
+			queryDomain:     "x.b.test.",
+			isWildcard:      true,
+			matchSubdomains: false,
+			shouldMatch:     true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -272,6 +320,19 @@ func TestHandlerChain_ServeDNS_OverlappingDomains(t *testing.T) {
 			queryDomain:     "sub.test.example.com.",
 			expectedCalls:   1,
 			expectedHandler: 2, // highest priority matching handler should be called
+		},
+		{
+			name: "overlapping wildcard suffixes route to correct handler",
+			handlers: []struct {
+				pattern  string
+				priority int
+			}{
+				{pattern: "*.b.test.", priority: nbdns.PriorityDNSRoute},
+				{pattern: "*.ab.test.", priority: nbdns.PriorityDNSRoute},
+			},
+			queryDomain:     "app.ab.test.",
+			expectedCalls:   1,
+			expectedHandler: 1,
 		},
 		{
 			name: "root zone with specific domain",


### PR DESCRIPTION
## Describe your changes

Wildcard DNS handlers were selected via plain string suffix matching, so a handler registered for `*.b.example.com` could intercept queries for `app.ab.example.com` and route them to the wrong peer (REFUSED).

- Match wildcard patterns on a full DNS label boundary so overlapping suffixes route to the correct handler
- Add unit tests covering suffix overlap, multi-label apex, non-suffix containment, and the overlapping-handler dispatch case

## Issue ticket number and link

https://github.com/netbirdio/netbird/discussions/6254

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal DNS handler matching, no user-facing surface.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Modified wildcard DNS pattern matching in handler chains by updating to simplified suffix-based evaluation logic, affecting how subdomains are matched and routed against registered wildcard patterns.

* **Tests**
  * Added extensive test coverage for wildcard DNS domain matching scenarios including multi-label domain names, label-boundary edge cases, unrelated suffix rejection, wildcard registration validation, and correct handler routing with overlapping wildcard patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->