### PR TITLE
[client] Add commands to discover and write Kubernetes configuration

### DIFF
--- a/client/cmd/kubernetes.go
+++ b/client/cmd/kubernetes.go
@@ -1,0 +1,301 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/netbirdio/netbird/client/proto"
+)
+
+const (
+	KubernetesDNSSuffix = "netbird-kubeapi-proxy"
+)
+
+var kubernetesCmd = &cobra.Command{
+	Use:   "kubernetes",
+	Short: "Kubernetes cluster commands.",
+	Long:  "Kubernetes cluster commands.",
+}
+
+var kubernetesListCmd = &cobra.Command{
+	Use:   "list",
+	RunE:  kubernetesList,
+	Short: "List Kubernetes clusters.",
+	Long:  "List Kubernetes clusters by discovering NetBird peers running netbird-kubeapi-proxy.",
+}
+
+var kubernetesWriteKubeconfigCmd = &cobra.Command{
+	Use:   "write-kubeconfig",
+	RunE:  kubernetesWriteKubeconfig,
+	Args:  cobra.ExactArgs(1),
+	Short: "Write kubeconfig for a Kubernetes cluster.",
+	Long:  "Updates kubeconfig in place to allow token-less access to the Kubernetes cluster through NetBird.",
+}
+
+func init() {
+	kubernetesWriteKubeconfigCmd.Flags().String("kubeconfig", "", "path to kubeconfig file")
+}
+
+func kubernetesList(cmd *cobra.Command, _ []string) error {
+	conn, err := getClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	client := proto.NewDaemonServiceClient(conn)
+	statusResp, err := client.Status(cmd.Context(), &proto.StatusRequest{GetFullPeerStatus: true})
+	if err != nil {
+		return err
+	}
+
+	kcs, err := getKubernetesClusters(cmd.Context(), statusResp.FullStatus.Peers, "")
+	if err != nil {
+		return err
+	}
+	if len(kcs) == 0 {
+		cmd.Println("No Kubernetes clusters available.")
+		return nil
+	}
+	cmd.Println("Available Kubernetes clusters:")
+	for _, k := range kcs {
+		cmd.Printf("\n  - Name: %s\n    FQDN: %s\n    Version: %s\n", k.name, k.url.Host, k.version)
+	}
+	return nil
+}
+
+func kubernetesWriteKubeconfig(cmd *cobra.Command, args []string) error {
+	kubeconfigPath, err := resolveKubeconfigPath(cmd)
+	if err != nil {
+		return err
+	}
+
+	conn, err := getClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	client := proto.NewDaemonServiceClient(conn)
+	statusResp, err := client.Status(cmd.Context(), &proto.StatusRequest{GetFullPeerStatus: true})
+	if err != nil {
+		return err
+	}
+
+	clusterName := args[0]
+	kcs, err := getKubernetesClusters(cmd.Context(), statusResp.FullStatus.Peers, clusterName)
+	if err != nil {
+		return err
+	}
+	if len(kcs) == 0 {
+		return fmt.Errorf("kubernetes cluster named %s not found", clusterName)
+	}
+	if len(kcs) > 1 {
+		return fmt.Errorf("too many Kubernetes clusters returned")
+	}
+	err = writeKubeconfig(kubeconfigPath, kcs[0])
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type kubernetesCluster struct {
+	name    string
+	url     *url.URL
+	version string
+}
+
+func getKubernetesClusters(ctx context.Context, peers []*proto.PeerState, nameFilter string) ([]kubernetesCluster, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	httpClient := &http.Client{
+		Transport: transport,
+	}
+	resolver := net.Resolver{
+		// Required so both DNS records are returned.
+		// https://github.com/golang/go/issues/17093
+		PreferGo: true,
+	}
+
+	kcs := []kubernetesCluster{}
+	attempted := map[string]struct{}{}
+	for _, peer := range peers {
+		fqdns, err := resolver.LookupAddr(ctx, peer.IP)
+		if err != nil {
+			return nil, err
+		}
+		for _, fqdn := range fqdns {
+			if _, ok := attempted[fqdn]; ok {
+				continue
+			}
+			attempted[fqdn] = struct{}{}
+			comps := strings.Split(fqdn, ".")
+			if len(comps) < 2 {
+				continue
+			}
+			if comps[1] != KubernetesDNSSuffix {
+				continue
+			}
+			if nameFilter != "" && nameFilter != comps[0] {
+				continue
+			}
+			clusterURL, clusterVersion, err := fingerprintClusters(ctx, httpClient, fqdn)
+			if err != nil {
+				log.Debugf("could not fingerprint Kubernetes cluster %s %q", fqdn, err)
+				continue
+			}
+			kc := kubernetesCluster{
+				name:    comps[0],
+				url:     clusterURL,
+				version: clusterVersion,
+			}
+			if nameFilter != "" {
+				return []kubernetesCluster{kc}, nil
+			}
+			kcs = append(kcs, kc)
+		}
+	}
+	return kcs, nil
+}
+
+func fingerprintClusters(ctx context.Context, httpClient *http.Client, fqdn string) (*url.URL, string, error) {
+	clusterURL, err := url.Parse("https://" + fqdn)
+	if err != nil {
+		return nil, "", err
+	}
+	versionURL, err := clusterURL.Parse("/version")
+	if err != nil {
+		return nil, "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, versionURL.String(), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("expected %d response but got %s", http.StatusOK, resp.Status)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	versionData := map[string]string{}
+	err = json.Unmarshal(b, &versionData)
+	if err != nil {
+		return nil, "", err
+	}
+	version, ok := versionData["gitVersion"]
+	if !ok {
+		return nil, "", errors.New("no version found in response")
+	}
+	return clusterURL, version, nil
+}
+
+func resolveKubeconfigPath(cmd *cobra.Command) (string, error) {
+	if cmd.Flags().Changed("kubeconfig") {
+		path, err := cmd.Flags().GetString("kubeconfig")
+		if err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+	if env := os.Getenv("KUBECONFIG"); env != "" {
+		return env, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".kube", "config"), nil
+}
+
+func writeKubeconfig(kubeconfigPath string, kc kubernetesCluster) error {
+	b, err := os.ReadFile(kubeconfigPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	var cfg map[string]any
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return err
+	}
+	if cfg == nil {
+		cfg = map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Config",
+		}
+	}
+
+	cfg["clusters"] = appendWithName(cfg["clusters"], map[string]any{
+		"name": kc.name,
+		"cluster": map[string]any{
+			"server":                   kc.url.String(),
+			"insecure-skip-tls-verify": true,
+		},
+	})
+	cfg["users"] = appendWithName(cfg["users"], map[string]any{
+		"name": "netbird",
+		"user": map[string]any{
+			"token": "none",
+		},
+	})
+	cfg["contexts"] = appendWithName(cfg["contexts"], map[string]any{
+		"name": kc.name,
+		"context": map[string]any{
+			"cluster":   kc.name,
+			"user":      "netbird",
+			"namespace": "default",
+		},
+	})
+	cfg["current-context"] = kc.name
+
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(kubeconfigPath, out, 0o600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func appendWithName(data any, add map[string]any) any {
+	if data == nil {
+		return []any{add}
+	}
+	v, ok := data.([]any)
+	if !ok {
+		return []any{add}
+	}
+	i := slices.IndexFunc(v, func(item any) bool {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return false
+		}
+		return m["name"] == add["name"]
+	})
+	if i == -1 {
+		return append(v, add)
+	}
+	v[i] = add
+	return v
+}

--- a/client/cmd/kubernetes_test.go
+++ b/client/cmd/kubernetes_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFingerprintClusters(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//nolint: errcheck
+		w.Write([]byte(`{"gitVersion": "foobar"}`))
+	}))
+	defer srv.Close()
+
+	clusterURL, clusterVersion, err := fingerprintClusters(t.Context(), srv.Client(), srv.Listener.Addr().String())
+	require.NoError(t, err)
+	require.Equal(t, srv.URL, clusterURL.String())
+	require.Equal(t, "foobar", clusterVersion)
+}
+
+func TestResolveKubeconfigPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("could not determine home directory: %v", err)
+	}
+	defaultPath := filepath.Join(home, ".kube", "config")
+	path, err := resolveKubeconfigPath(&cobra.Command{})
+	require.NoError(t, err)
+	require.Equal(t, defaultPath, path)
+
+	flagPath := "flag-path"
+	cmd := &cobra.Command{}
+	cmd.Flags().String("kubeconfig", "", "")
+	err = cmd.Flags().Set("kubeconfig", flagPath)
+	require.NoError(t, err)
+	path, err = resolveKubeconfigPath(cmd)
+	require.NoError(t, err)
+	require.Equal(t, flagPath, path)
+
+	envPath := "env-path"
+	t.Setenv("KUBECONFIG", envPath)
+	path, err = resolveKubeconfigPath(&cobra.Command{})
+	require.NoError(t, err)
+	require.Equal(t, envPath, path)
+}
+
+func TestWriteKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		existing string
+	}{
+		{
+			name: "empty file",
+		},
+		{
+			name: "existing content",
+			existing: `apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://foobar.com
+  name: foo
+current-context: test
+kind: Config
+users: []
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			kubeconfigPath := filepath.Join(t.TempDir(), "config")
+			err := os.WriteFile(kubeconfigPath, []byte(tt.existing), 0o644)
+			require.NoError(t, err)
+
+			kc := kubernetesCluster{
+				name: "foo",
+				url:  &url.URL{Scheme: "https", Host: "example.com"},
+			}
+			err = writeKubeconfig(kubeconfigPath, kc)
+			require.NoError(t, err)
+
+			b, err := os.ReadFile(kubeconfigPath)
+			require.NoError(t, err)
+			expected := `apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://example.com
+  name: foo
+contexts:
+- context:
+    cluster: foo
+    namespace: default
+    user: netbird
+  name: foo
+current-context: foo
+kind: Config
+users:
+- name: netbird
+  user:
+    token: none
+`
+			require.Equal(t, expected, string(b))
+		})
+	}
+
+}

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -169,6 +169,11 @@ func init() {
 	debugCmd.AddCommand(forCmd)
 	debugCmd.AddCommand(persistenceCmd)
 
+	// kubernetes commands
+	rootCmd.AddCommand(kubernetesCmd)
+	kubernetesCmd.AddCommand(kubernetesListCmd)
+	kubernetesCmd.AddCommand(kubernetesWriteKubeconfigCmd)
+
 	// profile commands
 	profileCmd.AddCommand(profileListCmd)
 	profileCmd.AddCommand(profileAddCmd)

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-jose/go-jose/v4 v4.1.4
+	github.com/goccy/go-yaml v1.18.0
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang/mock v1.6.0
@@ -211,10 +212,9 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-webauthn/webauthn v0.16.4 // indirect
 	github.com/go-webauthn/x v0.2.3 // indirect
-	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
-	github.com/google/btree v1.1.2 // indirect
+	github.com/google/btree v1.1.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
-github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=


### PR DESCRIPTION
## Describe your changes

This change adds a new Kubernetes subcommand. It allows listing of Kubernetes clusters that are exposed through the api proxy peers. It allows has a command that will write to the local kubeconfig so that the cluster can be accessed.

## Issue ticket number and link

https://github.com/netbirdio/kubernetes-operator/issues/274

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)

https://github.com/netbirdio/docs/pull/776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `kubernetes` CLI to discover reachable Kubernetes clusters and show cluster name, FQDN and Kubernetes version; prints “No Kubernetes clusters available.” when none found.
  * `write-kubeconfig` creates/updates kubeconfig entries (server URL, user `netbird` token placeholder, context), sets current-context, and supports cluster-name filtering.

* **Tests**
  * Added tests for cluster fingerprinting, kubeconfig path resolution, and kubeconfig writing.

* **Chores**
  * Updated project module dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->