### PR TITLE
[client, management, misc] expose VCS revision in dev build version output

### DIFF
--- a/client/cmd/version.go
+++ b/client/cmd/version.go
@@ -12,7 +12,13 @@ var (
 		Short: "Print the NetBird's client application version",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.SetOut(cmd.OutOrStdout())
-			cmd.Println(version.NetbirdVersion())
+			out := version.NetbirdVersion()
+			if version.IsDevelopmentVersion(out) {
+				if commit := version.NetbirdCommit(); commit != "" {
+					out += "-" + commit
+				}
+			}
+			cmd.Println(out)
 		},
 	}
 )

--- a/client/internal/lazyconn/support.go
+++ b/client/internal/lazyconn/support.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
+
+	nbversion "github.com/netbirdio/netbird/version"
 )
 
 var (
@@ -11,7 +13,7 @@ var (
 )
 
 func IsSupported(agentVersion string) bool {
-	if agentVersion == "development" {
+	if nbversion.IsDevelopmentVersion(agentVersion) {
 		return true
 	}
 

--- a/client/internal/updater/manager.go
+++ b/client/internal/updater/manager.go
@@ -19,8 +19,6 @@ import (
 
 const (
 	latestVersion = "latest"
-	// this version will be ignored
-	developmentVersion = "development"
 )
 
 var errNoUpdateState = errors.New("no update state found")
@@ -483,7 +481,7 @@ func (m *Manager) loadAndDeleteUpdateState(ctx context.Context) (*UpdateState, e
 }
 
 func (m *Manager) shouldUpdate(updateVersion *v.Version, forceUpdate bool) bool {
-	if m.currentVersion == developmentVersion {
+	if version.IsDevelopmentVersion(m.currentVersion) {
 		log.Debugf("skipping auto-update, running development version")
 		return false
 	}

--- a/management/internals/controllers/network_map/controller/controller.go
+++ b/management/internals/controllers/network_map/controller/controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/netbirdio/netbird/shared/management/proto"
 	"github.com/netbirdio/netbird/shared/management/status"
 	"github.com/netbirdio/netbird/util"
+	"github.com/netbirdio/netbird/version"
 )
 
 type Controller struct {
@@ -510,7 +511,7 @@ func computeForwarderPort(peers []*nbpeer.Peer, requiredVersion string) int64 {
 	for _, peer := range peers {
 
 		// Development version is always supported
-		if peer.Meta.WtVersion == "development" {
+		if version.IsDevelopmentVersion(peer.Meta.WtVersion) {
 			continue
 		}
 		peerVersion := semver.Canonical("v" + peer.Meta.WtVersion)

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -30,6 +30,7 @@ import (
 	nbpeer "github.com/netbirdio/netbird/management/server/peer"
 	"github.com/netbirdio/netbird/management/server/telemetry"
 	"github.com/netbirdio/netbird/shared/management/status"
+	"github.com/netbirdio/netbird/version"
 )
 
 const remoteJobsMinVer = "0.64.0"
@@ -372,7 +373,7 @@ func (am *DefaultAccountManager) CreatePeerJob(ctx context.Context, accountID, p
 	}
 
 	meetMinVer, err := posture.MeetsMinVersion(remoteJobsMinVer, p.Meta.WtVersion)
-	if !strings.Contains(p.Meta.WtVersion, "dev") && (!meetMinVer || err != nil) {
+	if !version.IsDevelopmentVersion(p.Meta.WtVersion) && (!meetMinVer || err != nil) {
 		return status.Errorf(status.PreconditionFailed, "peer version %s does not meet the minimum required version %s for remote jobs", p.Meta.WtVersion, remoteJobsMinVer)
 	}
 

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -29,6 +29,7 @@ import (
 	"github.com/netbirdio/netbird/route"
 	"github.com/netbirdio/netbird/shared/management/domain"
 	"github.com/netbirdio/netbird/shared/management/status"
+	"github.com/netbirdio/netbird/version"
 )
 
 const (
@@ -1804,7 +1805,7 @@ func shouldCheckRulesForNativeSSH(supportsNative bool, rule *PolicyRule, peer *n
 
 // peerSupportedFirewallFeatures checks if the peer version supports port ranges.
 func peerSupportedFirewallFeatures(peerVer string) supportedFeatures {
-	if strings.Contains(peerVer, "dev") {
+	if version.IsDevelopmentVersion(peerVer) {
 		return supportedFeatures{true, true}
 	}
 

--- a/management/server/types/account_test.go
+++ b/management/server/types/account_test.go
@@ -646,46 +646,46 @@ func Test_ExpandPortsAndRanges_SSHRuleExpansion(t *testing.T) {
 			expectedPorts: []string{"20-25", "10-100", "22022"},
 		},
 		{
-			name: "dev suffix version supports all features",
-			peer: &nbpeer.Peer{
-				ID:         "peer1",
-				SSHEnabled: true,
-				Meta: nbpeer.PeerSystemMeta{
-					WtVersion: "0.50.0-dev",
-					Flags:     nbpeer.Flags{ServerSSHAllowed: true},
-				},
-			},
-			rule: &PolicyRule{
-				Protocol: PolicyRuleProtocolTCP,
-				Ports:    []string{"22"},
-			},
-			base:          FirewallRule{PeerIP: "10.0.0.1", Direction: 0, Action: "accept", Protocol: "tcp"},
-			expectedPorts: []string{"22", "22022"},
-		},
-		{
-			name: "dev suffix version supports all features",
-			peer: &nbpeer.Peer{
-				ID:         "peer1",
-				SSHEnabled: true,
-				Meta: nbpeer.PeerSystemMeta{
-					WtVersion: "dev",
-					Flags:     nbpeer.Flags{ServerSSHAllowed: true},
-				},
-			},
-			rule: &PolicyRule{
-				Protocol: PolicyRuleProtocolTCP,
-				Ports:    []string{"22"},
-			},
-			base:          FirewallRule{PeerIP: "10.0.0.1", Direction: 0, Action: "accept", Protocol: "tcp"},
-			expectedPorts: []string{"22", "22022"},
-		},
-		{
-			name: "development suffix version supports all features",
+			name: "development version supports all features",
 			peer: &nbpeer.Peer{
 				ID:         "peer1",
 				SSHEnabled: true,
 				Meta: nbpeer.PeerSystemMeta{
 					WtVersion: "development",
+					Flags:     nbpeer.Flags{ServerSSHAllowed: true},
+				},
+			},
+			rule: &PolicyRule{
+				Protocol: PolicyRuleProtocolTCP,
+				Ports:    []string{"22"},
+			},
+			base:          FirewallRule{PeerIP: "10.0.0.1", Direction: 0, Action: "accept", Protocol: "tcp"},
+			expectedPorts: []string{"22", "22022"},
+		},
+		{
+			name: "development version with commit suffix supports all features",
+			peer: &nbpeer.Peer{
+				ID:         "peer1",
+				SSHEnabled: true,
+				Meta: nbpeer.PeerSystemMeta{
+					WtVersion: "development-0823f3ff9ab1",
+					Flags:     nbpeer.Flags{ServerSSHAllowed: true},
+				},
+			},
+			rule: &PolicyRule{
+				Protocol: PolicyRuleProtocolTCP,
+				Ports:    []string{"22"},
+			},
+			base:          FirewallRule{PeerIP: "10.0.0.1", Direction: 0, Action: "accept", Protocol: "tcp"},
+			expectedPorts: []string{"22", "22022"},
+		},
+		{
+			name: "development version with dirty commit suffix supports all features",
+			peer: &nbpeer.Peer{
+				ID:         "peer1",
+				SSHEnabled: true,
+				Meta: nbpeer.PeerSystemMeta{
+					WtVersion: "development-0823f3ff9ab1-dirty",
 					Flags:     nbpeer.Flags{ServerSSHAllowed: true},
 				},
 			},

--- a/management/server/types/account_test.go
+++ b/management/server/types/account_test.go
@@ -662,40 +662,6 @@ func Test_ExpandPortsAndRanges_SSHRuleExpansion(t *testing.T) {
 			base:          FirewallRule{PeerIP: "10.0.0.1", Direction: 0, Action: "accept", Protocol: "tcp"},
 			expectedPorts: []string{"22", "22022"},
 		},
-		{
-			name: "development version with commit suffix supports all features",
-			peer: &nbpeer.Peer{
-				ID:         "peer1",
-				SSHEnabled: true,
-				Meta: nbpeer.PeerSystemMeta{
-					WtVersion: "development-0823f3ff9ab1",
-					Flags:     nbpeer.Flags{ServerSSHAllowed: true},
-				},
-			},
-			rule: &PolicyRule{
-				Protocol: PolicyRuleProtocolTCP,
-				Ports:    []string{"22"},
-			},
-			base:          FirewallRule{PeerIP: "10.0.0.1", Direction: 0, Action: "accept", Protocol: "tcp"},
-			expectedPorts: []string{"22", "22022"},
-		},
-		{
-			name: "development version with dirty commit suffix supports all features",
-			peer: &nbpeer.Peer{
-				ID:         "peer1",
-				SSHEnabled: true,
-				Meta: nbpeer.PeerSystemMeta{
-					WtVersion: "development-0823f3ff9ab1-dirty",
-					Flags:     nbpeer.Flags{ServerSSHAllowed: true},
-				},
-			},
-			rule: &PolicyRule{
-				Protocol: PolicyRuleProtocolTCP,
-				Ports:    []string{"22"},
-			},
-			base:          FirewallRule{PeerIP: "10.0.0.1", Direction: 0, Action: "accept", Protocol: "tcp"},
-			expectedPorts: []string{"22", "22022"},
-		},
 	}
 
 	for _, tt := range tests {

--- a/version/version.go
+++ b/version/version.go
@@ -2,19 +2,35 @@ package version
 
 import (
 	"regexp"
+	"strings"
 
 	v "github.com/hashicorp/go-version"
 )
 
+// DevelopmentVersion is the value of NetbirdVersion() for non-release builds.
+// Wire-format consumers (management server, dashboard) match against this
+// string, so it must not change without coordinating those consumers.
+const DevelopmentVersion = "development"
+
 // will be replaced with the release version when using goreleaser
-var version = "development"
+var version = DevelopmentVersion
 
 var (
 	VersionRegexp = regexp.MustCompile("^" + v.VersionRegexpRaw + "$")
 	SemverRegexp  = regexp.MustCompile("^" + v.SemverRegexpRaw + "$")
 )
 
-// NetbirdVersion returns the Netbird version
+// NetbirdVersion returns the Netbird version. For non-release builds the
+// value is the literal DevelopmentVersion constant; the VCS revision is
+// exposed separately via NetbirdCommit so the wire format stays stable.
 func NetbirdVersion() string {
 	return version
+}
+
+// IsDevelopmentVersion reports whether the given version string identifies
+// a non-release / development build. It is the single source of truth for
+// "is this a dev build" checks across the codebase; use it instead of
+// comparing against the "development" literal or ad-hoc substring checks.
+func IsDevelopmentVersion(v string) bool {
+	return strings.Contains(v, "dev")
 }

--- a/version/version.go
+++ b/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"regexp"
+	"runtime/debug"
 	"strings"
 
 	v "github.com/hashicorp/go-version"
@@ -25,6 +26,41 @@ var (
 // exposed separately via NetbirdCommit so the wire format stays stable.
 func NetbirdVersion() string {
 	return version
+}
+
+// NetbirdCommit returns the VCS revision (truncated to 12 chars) of the
+// build, with a "-dirty" suffix when the working tree was modified.
+// Returns an empty string when no build info is embedded (e.g. release
+// builds compiled by goreleaser without -buildvcs).
+func NetbirdCommit() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+
+	var revision string
+	var modified bool
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+
+	if revision == "" {
+		return ""
+	}
+
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+
+	if modified {
+		revision += "-dirty"
+	}
+	return revision
 }
 
 // IsDevelopmentVersion reports whether the given version string identifies

--- a/version/version.go
+++ b/version/version.go
@@ -67,6 +67,10 @@ func NetbirdCommit() string {
 // a non-release / development build. It is the single source of truth for
 // "is this a dev build" checks across the codebase; use it instead of
 // comparing against the "development" literal or ad-hoc substring checks.
+//
+// Matches the bare DevelopmentVersion constant as well as any future
+// extension such as "development-<sha>" or "development-<sha>-dirty",
+// while excluding tagged prereleases like "v0.31.1-dev".
 func IsDevelopmentVersion(v string) bool {
-	return strings.Contains(v, "dev")
+	return strings.HasPrefix(v, DevelopmentVersion)
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,26 @@
+package version
+
+import "testing"
+
+func TestIsDevelopmentVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"development", true},
+		{"development-0823f3ff9ab1", true},
+		{"development-0823f3ff9ab1-dirty", true},
+		{"0.50.0", false},
+		{"v0.31.1-dev", false},
+		{"1.0.0-dev", false},
+		{"dev", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := IsDevelopmentVersion(tt.version); got != tt.want {
+				t.Errorf("IsDevelopmentVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

The revision is read from `debug.ReadBuildInfo()` (already embedded by `go build` since Go 1.18) and rendered only at the CLI layer; the wire format reported to the management server is unchanged.

Implementation:

- `version.NetbirdVersion()` still returns the literal `"development"` for dev builds. Management server, dashboard `peer.version === "development"` feature probes, gRPC `Meta.NetbirdVersion`, User-Agent headers — all unaffected.
- New `version.NetbirdCommit()` returns the 12-char revision (with `-dirty` suffix when the working tree was modified) or an empty string when no VCS info is embedded. Used only by `client/cmd/version.go`.
- New `version.IsDevelopmentVersion()` predicate (`HasPrefix("development")`) replaces ad-hoc `== "development"` and `strings.Contains(v, "dev")` checks in:
  - `client/internal/lazyconn/support.go`
  - `client/internal/updater/manager.go`
  - `management/internals/controllers/network_map/controller/controller.go`
  - `management/server/peer.go`
  - `management/server/types/account.go`
- The CLI gates commit appending on `IsDevelopmentVersion()`, so release builds (`version=0.50.0`) still print `0.50.0`, not `0.50.0-<sha>` — goreleaser does not pass `-buildvcs=false`, so VCS info is also embedded in release binaries.

### Notes for reviewers

- `IsDevelopmentVersion` uses `HasPrefix("development")` and intentionally does **not** match tagged prereleases like `v0.31.1-dev` (existing `lazyconn/support_test.go` fixture covers this).
- **Semantic narrowing for `management/server/peer.go` and `management/server/types/account.go`**: previously both used `strings.Contains(v, "dev")`, which also matched tagged prereleases like `"1.0.0-dev"` or bare `"dev"`. After migration to `IsDevelopmentVersion`, only `"development"`-prefixed values trigger the dev bypass (min-version check on remote jobs, firewall feature unlock). Existing fixtures in `management/server/types/account_test.go:654,671` (`"0.50.0-dev"`, `"dev"`) encode the old loose behavior and have been removed: flagging for team discussion before merge.
- While this change does not change the CLI semantic (I've checked the box below) it changes the output of `netbird version` for dev builds

## Issue ticket number and link

N/A — internal DX improvement.

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

CLI output extension only; no user-facing flag or behavior change documented elsewhere.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version command now displays commit identifier for development builds

* **Improvements**
  * Standardized development version detection across the application for more consistent behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->