### PR TITLE
[client] pass entrypoint args to "netbird up"

### DIFF
--- a/client/netbird-entrypoint.sh
+++ b/client/netbird-entrypoint.sh
@@ -51,8 +51,8 @@ wait_for_daemon_startup() {
 }
 
 connect() {
-  info "running 'netbird up'..."
-  "${NETBIRD_BIN}" up
+  info "running: netbird up $*"
+  "${NETBIRD_BIN}" up "$@"
   return $?
 }
 
@@ -63,7 +63,7 @@ main() {
   info "registered new service process 'netbird service run', currently running: ${service_pids[@]@Q}"
 
   wait_for_daemon_startup "${NB_ENTRYPOINT_SERVICE_TIMEOUT}"
-  connect
+  connect "$@"
 
   wait "${service_pids[@]}"
 }


### PR DESCRIPTION
## Describe your changes

this makes passing arguments, such as --extra-iface-blacklist, work as expected.

## Issue ticket number and link

none

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [X] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [X] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

I think it's reasonable for end users to expect that passing args to the docker container passes them to netbird.

### Docs PR URL (required if "docs added" is checked)

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command-line arguments are now forwarded into the daemon startup flow so options passed at launch are honored during initialization.
  * Ensures CLI-provided configuration consistently affects the initial daemon bootstrap.
  * No changes to public interfaces; this only improves startup behavior and predictable configuration from launch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->