### PR TITLE
[client] Fix fwmark bit 0x20 conflict with OVH OKS kube-proxy MASQUERADE rules

### DIFF
--- a/client/net/net.go
+++ b/client/net/net.go
@@ -28,13 +28,15 @@ const (
 	DataPlaneMarkOut = 0x1BD11
 
 	// PreroutingFwmarkRedirected is applied to packets that are were redirected (input -> forward, e.g. by Docker or Podman) for special handling.
-	PreroutingFwmarkRedirected = 0x1BD20
+	// Note: values 0x1BD20-0x1BD3F are avoided because their lower byte has bit 0x20 set, which conflicts with OVH OKS
+	// iptables rules that match on that bit in mangle POSTROUTING and strip the kube-proxy MASQUERADE bit (0x4000).
+	PreroutingFwmarkRedirected = 0x1BD40
 
 	// PreroutingFwmarkMasquerade is applied to packets that arrive from the NetBird interface and should be masqueraded.
-	PreroutingFwmarkMasquerade = 0x1BD21
+	PreroutingFwmarkMasquerade = 0x1BD41
 
 	// PreroutingFwmarkMasqueradeReturn is applied to packets that will leave through the NetBird interface and should be masqueraded.
-	PreroutingFwmarkMasqueradeReturn = 0x1BD22
+	PreroutingFwmarkMasqueradeReturn = 0x1BD42
 )
 
 // IsDataPlaneMark determines if a fwmark is in the data plane range (0x1BD10-0x1BDFF)


### PR DESCRIPTION
## Describe your changes

On OVH Managed Kubernetes (OKS) nodes, a pre-installed iptables rule in
`mangle POSTROUTING` matches packets where bit `0x20` is set in the fwmark,
and strips bit `0x4000` — which is kube-proxy's MASQUERADE bit set by
`KUBE-MARK-MASQ`. As a result, `KUBE-POSTROUTING` bails out, MASQUERADE
never happens, and NodePort replies never reach the client.

Since v0.40, the three `PreroutingFwmark*` constants use values `0x1BD20`,
`0x1BD21`, `0x1BD22` — all of which have bit `0x20` set in their lower byte.
This was introduced in #3623 as a sequential grouping choice (after
`0x1BD10`/`0x1BD11`), with no intention of using that specific bit.

**Root cause confirmed with `nft monitor trace`**: `0x4000` is added by
`KUBE-MARK-MASQ` then immediately stripped by the OVH hairpin rule. That
rule's counter shows ~4M packet matches vs ~2.4K for legitimate hairpin
traffic — almost entirely Netbird-marked packets. Manually deleting the rule
fixes NodePort access immediately.

**Fix**: shift the three prerouting marks from `0x1BD2x` to `0x1BD4x`
(`0x40` has bit `0x20` clear). No other code changes are needed as all
consumers reference these constants.

| Constant | Before | After |
|---|---|---|
| `PreroutingFwmarkRedirected` | `0x1BD20` | `0x1BD40` |
| `PreroutingFwmarkMasquerade` | `0x1BD21` | `0x1BD41` |
| `PreroutingFwmarkMasqueradeReturn` | `0x1BD22` | `0x1BD42` |

These marks are managed entirely by the Netbird daemon at start/stop —
no user-visible config or persistent state is affected.

## Issue ticket number and link

No existing issue — bug found in production on OVH OKS.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand.

## Documentation

- [x] Documentation is **not needed** for this change (internal constants, no user-facing behavior change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal firewall mark constants to prevent conflicts with network routing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird/pull/6289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->