### PR TITLE
[relay, client] Fall back to WebSocket relay transport on oversized QUIC datagrams

### DIFF
--- a/.github/workflows/wasm-build-validation.yml
+++ b/.github/workflows/wasm-build-validation.yml
@@ -65,7 +65,7 @@ jobs:
 
           echo "Size: ${SIZE} bytes (${SIZE_MB} MB)"
 
-          if [ ${SIZE} -gt 58720256 ]; then
-            echo "Wasm binary size (${SIZE_MB}MB) exceeds 56MB limit!"
+          if [ ${SIZE} -gt 62914560 ]; then
+            echo "Wasm binary size (${SIZE_MB}MB) exceeds 60MB limit!"
             exit 1
           fi

--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -175,15 +175,16 @@ type Client struct {
 
 	mtu uint16
 
-	// transportFallback, when set, records QUIC datagram failures so the relay
-	// is dialed over WebSocket on subsequent connects. Shared via the manager.
+	// transportFallback, when set, records datagram-too-large failures so a
+	// datagram-sized transport is avoided on subsequent connects. Shared via
+	// the manager.
 	transportFallback *transportFallback
 	// datagramFallbackTriggered guards a single fallback per connection so a
 	// burst of oversized datagrams triggers one reconnect, not many.
 	datagramFallbackTriggered atomic.Bool
 }
 
-// SetTransportFallback wires the shared QUIC-to-WebSocket fallback tracker.
+// SetTransportFallback wires the shared datagram-transport fallback tracker.
 func (c *Client) SetTransportFallback(tf *transportFallback) {
 	c.transportFallback = tf
 }
@@ -665,21 +666,24 @@ func (c *Client) writeTo(containerRef *connContainer, dstID messages.PeerID, pay
 	return len(payload), err
 }
 
-// onDatagramTooLarge reacts to a QUIC datagram rejected as too large for the
-// path. Unless the transport is pinned to QUIC, it records a WebSocket fallback
-// for this server and closes the connection so the reconnect dials WebSocket.
-// A single fallback is triggered per connection regardless of how many
-// oversized datagrams arrive. cause carries the datagram size and path budget.
+// onDatagramTooLarge reacts to a datagram rejected as too large for the path.
+// When a non-datagram transport is available, it records a fallback for this
+// server and closes the connection so the reconnect avoids datagram-sized
+// transports. A single fallback is triggered per connection regardless of how
+// many oversized datagrams arrive. cause carries the datagram size and budget.
 func (c *Client) onDatagramTooLarge(conn net.Conn, cause error) {
-	if transportModeFromEnv() == TransportModeQUIC {
+	// If the selected mode offers no non-datagram transport (e.g. pinned to a
+	// datagram-sized transport), reconnecting would just re-fail, so leave the
+	// connection up rather than loop.
+	if len(nonDatagramSized(c.baseDialers(transportModeFromEnv()))) == 0 {
 		if c.datagramFallbackTriggered.CompareAndSwap(false, true) {
-			c.log.Warnf("%s, but %s=quic pins QUIC, not falling back", cause, EnvRelayTransport)
+			c.log.Warnf("%s, but no non-datagram transport is available, not falling back", cause)
 		}
 		return
 	}
 
-	// Without the shared tracker a reconnect would just race QUIC again and
-	// re-fail, so leave the connection up rather than loop.
+	// Without the shared tracker a reconnect would just select the same
+	// transport again and re-fail, so leave the connection up rather than loop.
 	if c.transportFallback == nil {
 		if c.datagramFallbackTriggered.CompareAndSwap(false, true) {
 			c.log.Debugf("%s, but no transport fallback configured, leaving connection up", cause)
@@ -692,7 +696,7 @@ func (c *Client) onDatagramTooLarge(conn net.Conn, cause error) {
 	}
 
 	window := c.transportFallback.recordFailure(c.connectionURL)
-	c.log.Warnf("%s, falling back to WebSocket for %s", cause, window)
+	c.log.Warnf("%s, avoiding datagram-sized transport for %s", cause, window)
 
 	if err := conn.Close(); err != nil {
 		c.log.Debugf("close relay connection for transport fallback: %s", err)

--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -672,26 +672,24 @@ func (c *Client) writeTo(containerRef *connContainer, dstID messages.PeerID, pay
 // transports. A single fallback is triggered per connection regardless of how
 // many oversized datagrams arrive. cause carries the datagram size and budget.
 func (c *Client) onDatagramTooLarge(conn net.Conn, cause error) {
+	// Handle one oversized datagram per connection; a burst triggers a single
+	// fallback (and a single log line), not many.
+	if !c.datagramFallbackTriggered.CompareAndSwap(false, true) {
+		return
+	}
+
 	// If the selected mode offers no non-datagram transport (e.g. pinned to a
 	// datagram-sized transport), reconnecting would just re-fail, so leave the
 	// connection up rather than loop.
 	if len(nonDatagramSized(c.baseDialers(transportModeFromEnv()))) == 0 {
-		if c.datagramFallbackTriggered.CompareAndSwap(false, true) {
-			c.log.Warnf("%s, but no non-datagram transport is available, not falling back", cause)
-		}
+		c.log.Warnf("%s, but no non-datagram transport is available, not falling back", cause)
 		return
 	}
 
 	// Without the shared tracker a reconnect would just select the same
 	// transport again and re-fail, so leave the connection up rather than loop.
 	if c.transportFallback == nil {
-		if c.datagramFallbackTriggered.CompareAndSwap(false, true) {
-			c.log.Debugf("%s, but no transport fallback configured, leaving connection up", cause)
-		}
-		return
-	}
-
-	if !c.datagramFallbackTriggered.CompareAndSwap(false, true) {
+		c.log.Debugf("%s, but no transport fallback configured, leaving connection up", cause)
 		return
 	}
 

--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -9,12 +9,14 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	auth "github.com/netbirdio/netbird/shared/relay/auth/hmac"
 	"github.com/netbirdio/netbird/shared/relay/client/dialer"
+	netErr "github.com/netbirdio/netbird/shared/relay/client/dialer/net"
 	"github.com/netbirdio/netbird/shared/relay/healthcheck"
 	"github.com/netbirdio/netbird/shared/relay/messages"
 )
@@ -172,6 +174,18 @@ type Client struct {
 	stateSubscription *PeersStateSubscription
 
 	mtu uint16
+
+	// transportFallback, when set, records QUIC datagram failures so the relay
+	// is dialed over WebSocket on subsequent connects. Shared via the manager.
+	transportFallback *transportFallback
+	// datagramFallbackTriggered guards a single fallback per connection so a
+	// burst of oversized datagrams triggers one reconnect, not many.
+	datagramFallbackTriggered atomic.Bool
+}
+
+// SetTransportFallback wires the shared QUIC-to-WebSocket fallback tracker.
+func (c *Client) SetTransportFallback(tf *transportFallback) {
+	c.transportFallback = tf
 }
 
 // NewClient creates a new client for the relay server. The client is not connected to the server until the Connect
@@ -361,12 +375,13 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) connect(ctx context.Context) (*RelayAddr, error) {
-	dialers := c.getDialers()
+	mode := transportModeFromEnv()
+	dialers := c.getDialers(mode)
 
 	var conn net.Conn
 	if c.serverIP.IsValid() {
 		var err error
-		conn, err = c.dialRaceDirect(ctx, dialers)
+		conn, err = c.dialRaceDirect(ctx, mode, dialers)
 		if err != nil {
 			c.log.Infof("dial via server IP %s failed, falling back to FQDN: %v", c.serverIP, err)
 			conn = nil
@@ -375,6 +390,9 @@ func (c *Client) connect(ctx context.Context) (*RelayAddr, error) {
 
 	if conn == nil {
 		rd := dialer.NewRaceDial(c.log, dialer.DefaultConnectionTimeout, c.connectionURL, dialers...)
+		if mode.sequential() {
+			rd.WithSequential()
+		}
 		var err error
 		conn, err = rd.Dial(ctx)
 		if err != nil {
@@ -382,6 +400,7 @@ func (c *Client) connect(ctx context.Context) (*RelayAddr, error) {
 		}
 	}
 	c.relayConn = conn
+	c.datagramFallbackTriggered.Store(false)
 
 	instanceURL, err := c.handShake(ctx)
 	if err != nil {
@@ -396,7 +415,7 @@ func (c *Client) connect(ctx context.Context) (*RelayAddr, error) {
 }
 
 // dialRaceDirect dials c.serverIP, preserving the original FQDN as the TLS ServerName for SNI.
-func (c *Client) dialRaceDirect(ctx context.Context, dialers []dialer.DialeFn) (net.Conn, error) {
+func (c *Client) dialRaceDirect(ctx context.Context, mode TransportMode, dialers []dialer.DialeFn) (net.Conn, error) {
 	directURL, serverName, err := substituteHost(c.connectionURL, c.serverIP)
 	if err != nil {
 		return nil, fmt.Errorf("substitute host: %w", err)
@@ -406,6 +425,9 @@ func (c *Client) dialRaceDirect(ctx context.Context, dialers []dialer.DialeFn) (
 
 	rd := dialer.NewRaceDial(c.log, dialer.DefaultConnectionTimeout, directURL, dialers...).
 		WithServerName(serverName)
+	if mode.sequential() {
+		rd.WithSequential()
+	}
 	return rd.Dial(ctx)
 }
 
@@ -631,11 +653,47 @@ func (c *Client) writeTo(containerRef *connContainer, dstID messages.PeerID, pay
 	}
 
 	// the write always return with 0 length because the underling does not support the size feedback.
-	_, err = c.relayConn.Write(msg)
+	conn := c.relayConn
+	_, err = conn.Write(msg)
 	if err != nil {
-		c.log.Errorf("failed to write transport message: %s", err)
+		if errors.Is(err, netErr.ErrDatagramTooLarge) {
+			c.onDatagramTooLarge(conn, err)
+		} else {
+			c.log.Errorf("failed to write transport message: %s", err)
+		}
 	}
 	return len(payload), err
+}
+
+// onDatagramTooLarge reacts to a QUIC datagram rejected as too large for the
+// path. Unless the transport is pinned to QUIC, it records a WebSocket fallback
+// for this server and closes the connection so the reconnect dials WebSocket.
+// A single fallback is triggered per connection regardless of how many
+// oversized datagrams arrive. cause carries the datagram size and path budget.
+func (c *Client) onDatagramTooLarge(conn net.Conn, cause error) {
+	if transportModeFromEnv() == TransportModeQUIC {
+		if c.datagramFallbackTriggered.CompareAndSwap(false, true) {
+			c.log.Warnf("%s, but %s=quic pins QUIC, not falling back", cause, EnvRelayTransport)
+		}
+		return
+	}
+
+	// Without the shared tracker a reconnect would just race QUIC again and
+	// re-fail, so leave the connection up rather than loop.
+	if c.transportFallback == nil {
+		return
+	}
+
+	if !c.datagramFallbackTriggered.CompareAndSwap(false, true) {
+		return
+	}
+
+	window := c.transportFallback.recordFailure(c.connectionURL)
+	c.log.Warnf("%s, falling back to WebSocket for %s", cause, window)
+
+	if err := conn.Close(); err != nil {
+		c.log.Debugf("close relay connection for transport fallback: %s", err)
+	}
 }
 
 func (c *Client) listenForStopEvents(ctx context.Context, hc *healthcheck.Receiver, conn net.Conn, internalStopFlag *internalStopFlag) {

--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -681,6 +681,9 @@ func (c *Client) onDatagramTooLarge(conn net.Conn, cause error) {
 	// Without the shared tracker a reconnect would just race QUIC again and
 	// re-fail, so leave the connection up rather than loop.
 	if c.transportFallback == nil {
+		if c.datagramFallbackTriggered.CompareAndSwap(false, true) {
+			c.log.Debugf("%s, but no transport fallback configured, leaving connection up", cause)
+		}
 		return
 	}
 

--- a/shared/relay/client/dialer/capability.go
+++ b/shared/relay/client/dialer/capability.go
@@ -1,0 +1,18 @@
+package dialer
+
+// DatagramSized is implemented by dialers whose connections carry each write in
+// a single datagram, so a write can be rejected when it exceeds the path's
+// datagram budget (e.g. QUIC). Transports without this capability (e.g.
+// WebSocket over TCP) impose no per-write size limit, so the relay client can
+// fall back to them when a datagram-sized transport rejects a write as too
+// large. The capability is advertised per dialer rather than hardcoded, so a
+// new transport only needs to declare whether it is datagram-sized.
+type DatagramSized interface {
+	DatagramSized()
+}
+
+// IsDatagramSized reports whether d produces datagram-sized connections.
+func IsDatagramSized(d DialeFn) bool {
+	_, ok := d.(DatagramSized)
+	return ok
+}

--- a/shared/relay/client/dialer/net/err.go
+++ b/shared/relay/client/dialer/net/err.go
@@ -4,4 +4,9 @@ import "errors"
 
 var (
 	ErrClosedByServer = errors.New("closed by server")
+
+	// ErrDatagramTooLarge is returned when a transport message exceeds the
+	// QUIC datagram size the path to the relay can carry. The relay client
+	// treats it as a signal to fall back to a non-datagram transport.
+	ErrDatagramTooLarge = errors.New("datagram frame too large")
 )

--- a/shared/relay/client/dialer/quic/conn.go
+++ b/shared/relay/client/dialer/quic/conn.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go"
-	log "github.com/sirupsen/logrus"
 
 	netErr "github.com/netbirdio/netbird/shared/relay/client/dialer/net"
 )
@@ -52,11 +51,8 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 }
 
 func (c *Conn) Write(b []byte) (int, error) {
-	err := c.session.SendDatagram(b)
-	if err != nil {
-		err = c.remoteCloseErrHandling(err)
-		log.Errorf("failed to write to QUIC stream: %v", err)
-		return 0, err
+	if err := c.session.SendDatagram(b); err != nil {
+		return 0, c.writeErrHandling(err, len(b))
 	}
 	return len(b), nil
 }
@@ -94,4 +90,16 @@ func (c *Conn) remoteCloseErrHandling(err error) error {
 		return netErr.ErrClosedByServer
 	}
 	return err
+}
+
+// writeErrHandling normalizes SendDatagram errors. A datagram that exceeds the
+// path's QUIC packet budget is mapped to ErrDatagramTooLarge (annotated with the
+// datagram size and path budget) so the relay client can fall back to a
+// non-datagram transport.
+func (c *Conn) writeErrHandling(err error, size int) error {
+	var tooLarge *quic.DatagramTooLargeError
+	if errors.As(err, &tooLarge) {
+		return fmt.Errorf("%w: %d byte datagram over path budget %d", netErr.ErrDatagramTooLarge, size, tooLarge.MaxDatagramPayloadSize)
+	}
+	return c.remoteCloseErrHandling(err)
 }

--- a/shared/relay/client/dialer/quic/quic.go
+++ b/shared/relay/client/dialer/quic/quic.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/logging"
 	log "github.com/sirupsen/logrus"
 
 	nbnet "github.com/netbirdio/netbird/client/net"
@@ -47,6 +48,7 @@ func (d Dialer) Dial(ctx context.Context, address, serverName string) (net.Conn,
 		MaxIdleTimeout:    4 * time.Minute,
 		EnableDatagrams:   true,
 		InitialPacketSize: nbRelay.QUICInitialPacketSize,
+		Tracer:            connectionTracer(quicURL),
 	}
 
 	udpConn, err := nbnet.ListenUDP("udp", &net.UDPAddr{Port: 0})
@@ -72,6 +74,28 @@ func (d Dialer) Dial(ctx context.Context, address, serverName string) (net.Conn,
 
 	conn := NewConn(session)
 	return conn, nil
+}
+
+// connectionTracer returns a QUIC tracer that logs the DPLPMTUD result and the
+// reason a relay connection closed, so the path MTU settled on and teardown
+// cause are visible in logs. Lines carry the relay address as a structured
+// field, matching the rest of the relay client logging.
+func connectionTracer(addr string) func(context.Context, logging.Perspective, quic.ConnectionID) *logging.ConnectionTracer {
+	relayLog := log.WithField("relay", addr)
+	return func(context.Context, logging.Perspective, quic.ConnectionID) *logging.ConnectionTracer {
+		return &logging.ConnectionTracer{
+			UpdatedMTU: func(mtu logging.ByteCount, done bool) {
+				if done {
+					relayLog.Infof("QUIC path MTU settled at %d", mtu)
+					return
+				}
+				relayLog.Debugf("QUIC path MTU probing at %d", mtu)
+			},
+			ClosedConnection: func(err error) {
+				relayLog.Debugf("QUIC connection closed: %v", err)
+			},
+		}
+	}
 }
 
 func prepareURL(address string) (string, error) {

--- a/shared/relay/client/dialer/quic/quic.go
+++ b/shared/relay/client/dialer/quic/quic.go
@@ -24,6 +24,10 @@ func (d Dialer) Protocol() string {
 	return Network
 }
 
+// DatagramSized marks QUIC as a datagram-sized transport: relay traffic is
+// carried in QUIC DATAGRAM frames, which must fit a single packet.
+func (d Dialer) DatagramSized() {}
+
 func (d Dialer) Dial(ctx context.Context, address, serverName string) (net.Conn, error) {
 	quicURL, err := prepareURL(address)
 	if err != nil {

--- a/shared/relay/client/dialer/quic/quic.go
+++ b/shared/relay/client/dialer/quic/quic.go
@@ -26,7 +26,9 @@ func (d Dialer) Protocol() string {
 
 // DatagramSized marks QUIC as a datagram-sized transport: relay traffic is
 // carried in QUIC DATAGRAM frames, which must fit a single packet.
-func (d Dialer) DatagramSized() {}
+func (d Dialer) DatagramSized() {
+	// Intentional marker method; presence is the capability signal.
+}
 
 func (d Dialer) Dial(ctx context.Context, address, serverName string) (net.Conn, error) {
 	quicURL, err := prepareURL(address)

--- a/shared/relay/client/dialer/race_dialer.go
+++ b/shared/relay/client/dialer/race_dialer.go
@@ -32,6 +32,7 @@ type RaceDial struct {
 	serverName        string
 	dialerFns         []DialeFn
 	connectionTimeout time.Duration
+	sequential        bool
 }
 
 func NewRaceDial(log *log.Entry, connectionTimeout time.Duration, serverURL string, dialerFns ...DialeFn) *RaceDial {
@@ -53,7 +54,21 @@ func (r *RaceDial) WithServerName(serverName string) *RaceDial {
 	return r
 }
 
+// WithSequential makes Dial try the dialers in order, falling back to the next
+// only when one fails to connect, instead of racing them concurrently.
+//
+// Mutates the receiver and is not safe for concurrent reconfiguration; a
+// RaceDial is intended to be constructed per dial and discarded.
+func (r *RaceDial) WithSequential() *RaceDial {
+	r.sequential = true
+	return r
+}
+
 func (r *RaceDial) Dial(ctx context.Context) (net.Conn, error) {
+	if r.sequential {
+		return r.dialSequential(ctx)
+	}
+
 	connChan := make(chan dialResult, len(r.dialerFns))
 	winnerConn := make(chan net.Conn, 1)
 	abortCtx, abort := context.WithCancel(ctx)
@@ -70,6 +85,27 @@ func (r *RaceDial) Dial(ctx context.Context) (net.Conn, error) {
 		return nil, errors.New("failed to dial to Relay server on any protocol")
 	}
 	return conn, nil
+}
+
+// dialSequential tries each dialer in order, returning the first connection and
+// falling back to the next on failure.
+func (r *RaceDial) dialSequential(ctx context.Context) (net.Conn, error) {
+	for _, dfn := range r.dialerFns {
+		attemptCtx, cancel := context.WithTimeout(ctx, r.connectionTimeout)
+		r.log.Infof("dialing Relay server via %s", dfn.Protocol())
+		conn, err := dfn.Dial(attemptCtx, r.serverURL, r.serverName)
+		cancel()
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil, err
+			}
+			r.log.Errorf("failed to dial via %s: %s", dfn.Protocol(), err)
+			continue
+		}
+		r.log.Infof("successfully dialed via: %s", dfn.Protocol())
+		return conn, nil
+	}
+	return nil, errors.New("failed to dial to Relay server on any protocol")
 }
 
 func (r *RaceDial) dial(dfn DialeFn, abortCtx context.Context, connChan chan dialResult) {

--- a/shared/relay/client/dialer/race_dialer.go
+++ b/shared/relay/client/dialer/race_dialer.go
@@ -91,6 +91,9 @@ func (r *RaceDial) Dial(ctx context.Context) (net.Conn, error) {
 // falling back to the next on failure.
 func (r *RaceDial) dialSequential(ctx context.Context) (net.Conn, error) {
 	for _, dfn := range r.dialerFns {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		attemptCtx, cancel := context.WithTimeout(ctx, r.connectionTimeout)
 		r.log.Infof("dialing Relay server via %s", dfn.Protocol())
 		conn, err := dfn.Dial(attemptCtx, r.serverURL, r.serverName)

--- a/shared/relay/client/dialer/race_dialer_test.go
+++ b/shared/relay/client/dialer/race_dialer_test.go
@@ -250,3 +250,66 @@ func TestRaceDialFirstSuccessfulDialerWins(t *testing.T) {
 		}
 	}
 }
+
+func TestRaceDialSequentialFallback(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
+	serverURL := "test.server.com"
+
+	var firstDialed, secondDialed bool
+	preferred := &MockDialer{
+		protocolStr: "quic",
+		dialFunc: func(ctx context.Context, address string) (net.Conn, error) {
+			firstDialed = true
+			return nil, errors.New("quic unreachable")
+		},
+	}
+	fallbackConn := &MockConn{remoteAddr: &MockAddr{network: "ws"}}
+	fallback := &MockDialer{
+		protocolStr: "ws",
+		dialFunc: func(ctx context.Context, address string) (net.Conn, error) {
+			secondDialed = true
+			return fallbackConn, nil
+		},
+	}
+
+	rd := NewRaceDial(logger, DefaultConnectionTimeout, serverURL, preferred, fallback).WithSequential()
+	conn, err := rd.Dial(context.Background())
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got %v", err)
+	}
+	if conn != fallbackConn {
+		t.Errorf("expected fallback connection, got %v", conn)
+	}
+	if !firstDialed || !secondDialed {
+		t.Errorf("expected both dialers attempted in order, first=%v second=%v", firstDialed, secondDialed)
+	}
+}
+
+func TestRaceDialSequentialPreferredWins(t *testing.T) {
+	logger := logrus.NewEntry(logrus.New())
+	serverURL := "test.server.com"
+
+	preferredConn := &MockConn{remoteAddr: &MockAddr{network: "quic"}}
+	preferred := &MockDialer{
+		protocolStr: "quic",
+		dialFunc: func(ctx context.Context, address string) (net.Conn, error) {
+			return preferredConn, nil
+		},
+	}
+	fallback := &MockDialer{
+		protocolStr: "ws",
+		dialFunc: func(ctx context.Context, address string) (net.Conn, error) {
+			t.Errorf("fallback dialer must not be tried when preferred succeeds")
+			return nil, errors.New("should not happen")
+		},
+	}
+
+	rd := NewRaceDial(logger, DefaultConnectionTimeout, serverURL, preferred, fallback).WithSequential()
+	conn, err := rd.Dial(context.Background())
+	if err != nil {
+		t.Fatalf("expected preferred to succeed, got %v", err)
+	}
+	if conn != preferredConn {
+		t.Errorf("expected preferred connection, got %v", conn)
+	}
+}

--- a/shared/relay/client/dialers_generic.go
+++ b/shared/relay/client/dialers_generic.go
@@ -9,10 +9,25 @@ import (
 	"github.com/netbirdio/netbird/shared/relay/client/dialer/ws"
 )
 
-// getDialers returns the ordered list of dialers for connecting to the relay
-// server. For racing modes (auto) the order is irrelevant; for prefer modes the
-// first entry is tried before falling back to the second.
+// getDialers returns the ordered dialers for connecting to the relay server. It
+// applies the datagram fallback generically: if this server recently rejected a
+// datagram-sized transport, those dialers are dropped, leaving the rest.
 func (c *Client) getDialers(mode TransportMode) []dialer.DialeFn {
+	dialers := c.baseDialers(mode)
+
+	if c.transportFallback != nil && c.transportFallback.avoidDatagramSized(c.connectionURL) {
+		if filtered := nonDatagramSized(dialers); len(filtered) > 0 {
+			c.log.Infof("relay recently rejected a datagram-sized transport, avoiding it")
+			return filtered
+		}
+	}
+	return dialers
+}
+
+// baseDialers returns the ordered dialers for the mode, before any datagram
+// fallback filtering. For racing modes (auto) the order is irrelevant; for
+// prefer modes the first entry is tried before falling back to the second.
+func (c *Client) baseDialers(mode TransportMode) []dialer.DialeFn {
 	switch mode {
 	case TransportModeWS:
 		c.log.Infof("%s=ws, using WebSocket transport", EnvRelayTransport)
@@ -22,18 +37,14 @@ func (c *Client) getDialers(mode TransportMode) []dialer.DialeFn {
 		return []dialer.DialeFn{quic.Dialer{}}
 	}
 
-	if c.mtu > 0 && c.mtu > iface.DefaultMTU {
-		c.log.Infof("MTU %d exceeds default (%d), forcing WebSocket transport to avoid DATAGRAM frame size issues", c.mtu, iface.DefaultMTU)
-		return []dialer.DialeFn{ws.Dialer{}}
-	}
-
-	if c.transportFallback != nil && c.transportFallback.preferWS(c.connectionURL) {
-		c.log.Infof("relay recently rejected QUIC datagrams, using WebSocket transport")
-		return []dialer.DialeFn{ws.Dialer{}}
-	}
-
+	all := []dialer.DialeFn{quic.Dialer{}, ws.Dialer{}}
 	if mode == TransportModePreferWS {
-		return []dialer.DialeFn{ws.Dialer{}, quic.Dialer{}}
+		all = []dialer.DialeFn{ws.Dialer{}, quic.Dialer{}}
 	}
-	return []dialer.DialeFn{quic.Dialer{}, ws.Dialer{}}
+
+	if c.mtu > 0 && c.mtu > iface.DefaultMTU {
+		c.log.Infof("MTU %d exceeds default (%d), avoiding datagram-sized transports", c.mtu, iface.DefaultMTU)
+		return nonDatagramSized(all)
+	}
+	return all
 }

--- a/shared/relay/client/dialers_generic.go
+++ b/shared/relay/client/dialers_generic.go
@@ -9,11 +9,31 @@ import (
 	"github.com/netbirdio/netbird/shared/relay/client/dialer/ws"
 )
 
-// getDialers returns the list of dialers to use for connecting to the relay server.
-func (c *Client) getDialers() []dialer.DialeFn {
+// getDialers returns the ordered list of dialers for connecting to the relay
+// server. For racing modes (auto) the order is irrelevant; for prefer modes the
+// first entry is tried before falling back to the second.
+func (c *Client) getDialers(mode TransportMode) []dialer.DialeFn {
+	switch mode {
+	case TransportModeWS:
+		c.log.Infof("%s=ws, using WebSocket transport", EnvRelayTransport)
+		return []dialer.DialeFn{ws.Dialer{}}
+	case TransportModeQUIC:
+		c.log.Infof("%s=quic, using QUIC transport", EnvRelayTransport)
+		return []dialer.DialeFn{quic.Dialer{}}
+	}
+
 	if c.mtu > 0 && c.mtu > iface.DefaultMTU {
 		c.log.Infof("MTU %d exceeds default (%d), forcing WebSocket transport to avoid DATAGRAM frame size issues", c.mtu, iface.DefaultMTU)
 		return []dialer.DialeFn{ws.Dialer{}}
+	}
+
+	if c.transportFallback != nil && c.transportFallback.preferWS(c.connectionURL) {
+		c.log.Infof("relay recently rejected QUIC datagrams, using WebSocket transport")
+		return []dialer.DialeFn{ws.Dialer{}}
+	}
+
+	if mode == TransportModePreferWS {
+		return []dialer.DialeFn{ws.Dialer{}, quic.Dialer{}}
 	}
 	return []dialer.DialeFn{quic.Dialer{}, ws.Dialer{}}
 }

--- a/shared/relay/client/dialers_generic_test.go
+++ b/shared/relay/client/dialers_generic_test.go
@@ -1,0 +1,92 @@
+//go:build !js
+
+package client
+
+import (
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/shared/relay/client/dialer"
+	netErr "github.com/netbirdio/netbird/shared/relay/client/dialer/net"
+)
+
+func protocols(dialers []dialer.DialeFn) []string {
+	out := make([]string, len(dialers))
+	for i, d := range dialers {
+		out[i] = d.Protocol()
+	}
+	return out
+}
+
+func TestGetDialers(t *testing.T) {
+	const url = "rels://relay.example:443"
+
+	tests := []struct {
+		name     string
+		mode     string
+		mtu      uint16
+		preferWS bool
+		want     []string
+	}{
+		{name: "auto races quic and ws", mode: "auto", mtu: iface.DefaultMTU, want: []string{"quic", "WS"}},
+		{name: "ws pinned", mode: "ws", mtu: iface.DefaultMTU, want: []string{"WS"}},
+		{name: "quic pinned", mode: "quic", mtu: iface.DefaultMTU, want: []string{"quic"}},
+		{name: "prefer-quic orders quic first", mode: "prefer-quic", mtu: iface.DefaultMTU, want: []string{"quic", "WS"}},
+		{name: "prefer-ws orders ws first", mode: "prefer-ws", mtu: iface.DefaultMTU, want: []string{"WS", "quic"}},
+		{name: "mtu above default forces ws", mode: "auto", mtu: iface.DefaultMTU + 100, want: []string{"WS"}},
+		{name: "sticky fallback forces ws in auto", mode: "auto", mtu: iface.DefaultMTU, preferWS: true, want: []string{"WS"}},
+		{name: "sticky fallback forces ws in prefer-quic", mode: "prefer-quic", mtu: iface.DefaultMTU, preferWS: true, want: []string{"WS"}},
+		{name: "quic pin overrides sticky fallback", mode: "quic", mtu: iface.DefaultMTU, preferWS: true, want: []string{"quic"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvRelayTransport, tc.mode)
+			if tc.mode == "" {
+				os.Unsetenv(EnvRelayTransport)
+			}
+
+			tf := newTransportFallback()
+			if tc.preferWS {
+				tf.recordFailure(url)
+			}
+
+			c := &Client{
+				log:               log.WithField("test", t.Name()),
+				connectionURL:     url,
+				mtu:               tc.mtu,
+				transportFallback: tf,
+			}
+
+			assert.Equal(t, tc.want, protocols(c.getDialers(transportModeFromEnv())))
+		})
+	}
+}
+
+// TestStickyFallbackAfterDatagramTooLarge verifies the full chain: an oversized
+// datagram records a fallback that makes the next dial pick WebSocket, the way a
+// reconnect would after the connection is closed.
+func TestStickyFallbackAfterDatagramTooLarge(t *testing.T) {
+	const url = "rels://relay.example:443"
+	t.Setenv(EnvRelayTransport, string(TransportModeAuto))
+
+	c := &Client{
+		log:               log.WithField("test", t.Name()),
+		connectionURL:     url,
+		mtu:               iface.DefaultMTU,
+		transportFallback: newTransportFallback(),
+	}
+
+	// First dial races both transports.
+	assert.Equal(t, []string{"quic", "WS"}, protocols(c.getDialers(transportModeFromEnv())))
+
+	// An oversized datagram records the fallback for this server.
+	c.onDatagramTooLarge(&closeTrackingConn{}, netErr.ErrDatagramTooLarge)
+
+	// The reconnect now sticks to WebSocket.
+	assert.Equal(t, []string{"WS"}, protocols(c.getDialers(transportModeFromEnv())))
+}

--- a/shared/relay/client/dialers_generic_test.go
+++ b/shared/relay/client/dialers_generic_test.go
@@ -12,7 +12,16 @@ import (
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/shared/relay/client/dialer"
 	netErr "github.com/netbirdio/netbird/shared/relay/client/dialer/net"
+	"github.com/netbirdio/netbird/shared/relay/client/dialer/quic"
+	"github.com/netbirdio/netbird/shared/relay/client/dialer/ws"
 )
+
+// TestDatagramSizedCapability locks the capability the generic fallback relies
+// on: QUIC is datagram-sized, WebSocket is not.
+func TestDatagramSizedCapability(t *testing.T) {
+	assert.True(t, dialer.IsDatagramSized(quic.Dialer{}), "QUIC must advertise datagram-sized")
+	assert.False(t, dialer.IsDatagramSized(ws.Dialer{}), "WebSocket must not advertise datagram-sized")
+}
 
 func protocols(dialers []dialer.DialeFn) []string {
 	out := make([]string, len(dialers))

--- a/shared/relay/client/dialers_js.go
+++ b/shared/relay/client/dialers_js.go
@@ -11,3 +11,7 @@ func (c *Client) getDialers(_ TransportMode) []dialer.DialeFn {
 	// JS/WASM build only uses WebSocket transport
 	return []dialer.DialeFn{ws.Dialer{}}
 }
+
+func (c *Client) baseDialers(_ TransportMode) []dialer.DialeFn {
+	return []dialer.DialeFn{ws.Dialer{}}
+}

--- a/shared/relay/client/dialers_js.go
+++ b/shared/relay/client/dialers_js.go
@@ -7,7 +7,7 @@ import (
 	"github.com/netbirdio/netbird/shared/relay/client/dialer/ws"
 )
 
-func (c *Client) getDialers() []dialer.DialeFn {
+func (c *Client) getDialers(_ TransportMode) []dialer.DialeFn {
 	// JS/WASM build only uses WebSocket transport
 	return []dialer.DialeFn{ws.Dialer{}}
 }

--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -79,23 +79,30 @@ type Manager struct {
 
 	cleanupInterval      time.Duration
 	keepUnusedServerTime time.Duration
+
+	// transportFallback is shared across home and foreign relay clients so a
+	// QUIC datagram failure pins WebSocket for that server across reconnects.
+	transportFallback *transportFallback
 }
 
 // NewManager creates a new manager instance.
 // The serverURL address can be empty. In this case, the manager will not serve.
 func NewManager(ctx context.Context, serverURLs []string, peerID string, mtu uint16, opts ...ManagerOption) *Manager {
 	tokenStore := &relayAuth.TokenStore{}
+	tf := newTransportFallback()
 
 	m := &Manager{
-		ctx:        ctx,
-		peerID:     peerID,
-		tokenStore: tokenStore,
-		mtu:        mtu,
+		ctx:               ctx,
+		peerID:            peerID,
+		tokenStore:        tokenStore,
+		mtu:               mtu,
+		transportFallback: tf,
 		serverPicker: &ServerPicker{
 			TokenStore:        tokenStore,
 			PeerID:            peerID,
 			MTU:               mtu,
 			ConnectionTimeout: defaultConnectionTimeout,
+			TransportFallback: tf,
 		},
 		relayClients:            make(map[string]*RelayTrack),
 		onDisconnectedListeners: make(map[string]*list.List),
@@ -287,6 +294,7 @@ func (m *Manager) openConnVia(ctx context.Context, serverAddress, peerKey string
 	m.relayClientsMutex.Unlock()
 
 	relayClient := NewClientWithServerIP(serverAddress, serverIP, m.tokenStore, m.peerID, m.mtu)
+	relayClient.SetTransportFallback(m.transportFallback)
 	err := relayClient.Connect(m.ctx)
 	if err != nil {
 		rt.err = err

--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -81,7 +81,7 @@ type Manager struct {
 	keepUnusedServerTime time.Duration
 
 	// transportFallback is shared across home and foreign relay clients so a
-	// QUIC datagram failure pins WebSocket for that server across reconnects.
+	// datagram-too-large failure makes that server avoid datagram-sized transports across reconnects.
 	transportFallback *transportFallback
 }
 

--- a/shared/relay/client/picker.go
+++ b/shared/relay/client/picker.go
@@ -29,6 +29,7 @@ type ServerPicker struct {
 	PeerID            string
 	MTU               uint16
 	ConnectionTimeout time.Duration
+	TransportFallback *transportFallback
 }
 
 func (sp *ServerPicker) PickServer(parentCtx context.Context) (*Client, error) {
@@ -70,6 +71,7 @@ func (sp *ServerPicker) PickServer(parentCtx context.Context) (*Client, error) {
 func (sp *ServerPicker) startConnection(ctx context.Context, resultChan chan connResult, url string) {
 	log.Infof("try to connecting to relay server: %s", url)
 	relayClient := NewClient(url, sp.TokenStore, sp.PeerID, sp.MTU)
+	relayClient.SetTransportFallback(sp.TransportFallback)
 	err := relayClient.Connect(ctx)
 	resultChan <- connResult{
 		RelayClient: relayClient,

--- a/shared/relay/client/transport.go
+++ b/shared/relay/client/transport.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/shared/relay/client/dialer"
 )
 
 // EnvRelayTransport pins the relay transport. Valid values: "auto" (default,
@@ -18,8 +20,8 @@ import (
 const EnvRelayTransport = "NB_RELAY_TRANSPORT"
 
 const (
-	// transportFallbackBase is the initial window a relay server is pinned to
-	// WebSocket after a QUIC datagram is rejected as too large.
+	// transportFallbackBase is the initial window a relay server avoids
+	// datagram-sized transports after a datagram is rejected as too large.
 	transportFallbackBase = 10 * time.Minute
 	// transportFallbackMax caps the pinned window when failures repeat.
 	transportFallbackMax = 60 * time.Minute
@@ -62,11 +64,12 @@ func (m TransportMode) sequential() bool {
 	return m == TransportModePreferQUIC || m == TransportModePreferWS
 }
 
-// transportFallback tracks relay servers that have failed to carry QUIC
-// datagrams and should temporarily use WebSocket instead. It is shared across
-// the relay manager so the preference survives client recreation (foreign relay
-// clients are evicted and rebuilt on disconnect). Entries are keyed by server
-// URL and expire after a window that grows on repeated failures.
+// transportFallback tracks relay servers that have rejected a datagram-sized
+// transport (a write too large for the path) and should temporarily avoid such
+// transports. It is shared across the relay manager so the preference survives
+// client recreation (foreign relay clients are evicted and rebuilt on
+// disconnect). Entries are keyed by server URL and expire after a window that
+// grows on repeated failures.
 type transportFallback struct {
 	mu      sync.Mutex
 	entries map[string]*fallbackEntry
@@ -81,18 +84,31 @@ func newTransportFallback() *transportFallback {
 	return &transportFallback{entries: make(map[string]*fallbackEntry)}
 }
 
-// preferWS reports whether serverURL is currently within a WebSocket fallback
-// window.
-func (f *transportFallback) preferWS(serverURL string) bool {
+// nonDatagramSized returns the dialers from in that are not datagram-sized,
+// preserving order.
+func nonDatagramSized(in []dialer.DialeFn) []dialer.DialeFn {
+	out := make([]dialer.DialeFn, 0, len(in))
+	for _, d := range in {
+		if !dialer.IsDatagramSized(d) {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// avoidDatagramSized reports whether serverURL is currently within a window
+// where datagram-sized transports should be avoided.
+func (f *transportFallback) avoidDatagramSized(serverURL string) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	e := f.entries[serverURL]
 	return e != nil && time.Now().Before(e.until)
 }
 
-// recordFailure pins serverURL to WebSocket for a window: transportFallbackBase
-// on the first failure, doubling up to transportFallbackMax when QUIC fails
-// again after a previous window expired. It returns the active window duration.
+// recordFailure makes serverURL avoid datagram-sized transports for a window:
+// transportFallbackBase on the first failure, doubling up to transportFallbackMax
+// when a datagram transport fails again after a previous window expired. It
+// returns the active window duration.
 func (f *transportFallback) recordFailure(serverURL string) time.Duration {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/shared/relay/client/transport.go
+++ b/shared/relay/client/transport.go
@@ -84,18 +84,6 @@ func newTransportFallback() *transportFallback {
 	return &transportFallback{entries: make(map[string]*fallbackEntry)}
 }
 
-// nonDatagramSized returns the dialers from in that are not datagram-sized,
-// preserving order.
-func nonDatagramSized(in []dialer.DialeFn) []dialer.DialeFn {
-	out := make([]dialer.DialeFn, 0, len(in))
-	for _, d := range in {
-		if !dialer.IsDatagramSized(d) {
-			out = append(out, d)
-		}
-	}
-	return out
-}
-
 // avoidDatagramSized reports whether serverURL is currently within a window
 // where datagram-sized transports should be avoided.
 func (f *transportFallback) avoidDatagramSized(serverURL string) bool {
@@ -126,4 +114,16 @@ func (f *transportFallback) recordFailure(serverURL string) time.Duration {
 	}
 	e.until = now.Add(e.duration)
 	return e.duration
+}
+
+// nonDatagramSized returns the dialers from in that are not datagram-sized,
+// preserving order.
+func nonDatagramSized(in []dialer.DialeFn) []dialer.DialeFn {
+	out := make([]dialer.DialeFn, 0, len(in))
+	for _, d := range in {
+		if !dialer.IsDatagramSized(d) {
+			out = append(out, d)
+		}
+	}
+	return out
 }

--- a/shared/relay/client/transport.go
+++ b/shared/relay/client/transport.go
@@ -1,0 +1,113 @@
+package client
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// EnvRelayTransport pins the relay transport. Valid values: "auto" (default,
+// race QUIC and WebSocket), "quic" (QUIC only), "ws" (WebSocket only),
+// "prefer-quic" / "prefer-ws" (try the preferred transport first, fall back to
+// the other only if it fails to connect; no race). The prefer modes trade a
+// slower connect when the preferred transport is blackholed for deterministic
+// transport selection.
+const EnvRelayTransport = "NB_RELAY_TRANSPORT"
+
+const (
+	// transportFallbackBase is the initial window a relay server is pinned to
+	// WebSocket after a QUIC datagram is rejected as too large.
+	transportFallbackBase = 10 * time.Minute
+	// transportFallbackMax caps the pinned window when failures repeat.
+	transportFallbackMax = 60 * time.Minute
+)
+
+// TransportMode selects which relay dialers are used.
+type TransportMode string
+
+const (
+	TransportModeAuto       TransportMode = "auto"
+	TransportModeQUIC       TransportMode = "quic"
+	TransportModeWS         TransportMode = "ws"
+	TransportModePreferQUIC TransportMode = "prefer-quic"
+	TransportModePreferWS   TransportMode = "prefer-ws"
+)
+
+// transportModeFromEnv reads EnvRelayTransport, defaulting to auto for an empty
+// or unrecognized value.
+func transportModeFromEnv() TransportMode {
+	switch TransportMode(strings.ToLower(strings.TrimSpace(os.Getenv(EnvRelayTransport)))) {
+	case "", TransportModeAuto:
+		return TransportModeAuto
+	case TransportModeQUIC:
+		return TransportModeQUIC
+	case TransportModeWS:
+		return TransportModeWS
+	case TransportModePreferQUIC:
+		return TransportModePreferQUIC
+	case TransportModePreferWS:
+		return TransportModePreferWS
+	default:
+		log.Warnf("invalid %s value %q, using %q", EnvRelayTransport, os.Getenv(EnvRelayTransport), TransportModeAuto)
+		return TransportModeAuto
+	}
+}
+
+// sequential reports whether the mode tries dialers in order with fallback
+// instead of racing them concurrently.
+func (m TransportMode) sequential() bool {
+	return m == TransportModePreferQUIC || m == TransportModePreferWS
+}
+
+// transportFallback tracks relay servers that have failed to carry QUIC
+// datagrams and should temporarily use WebSocket instead. It is shared across
+// the relay manager so the preference survives client recreation (foreign relay
+// clients are evicted and rebuilt on disconnect). Entries are keyed by server
+// URL and expire after a window that grows on repeated failures.
+type transportFallback struct {
+	mu      sync.Mutex
+	entries map[string]*fallbackEntry
+}
+
+type fallbackEntry struct {
+	until    time.Time
+	duration time.Duration
+}
+
+func newTransportFallback() *transportFallback {
+	return &transportFallback{entries: make(map[string]*fallbackEntry)}
+}
+
+// preferWS reports whether serverURL is currently within a WebSocket fallback
+// window.
+func (f *transportFallback) preferWS(serverURL string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	e := f.entries[serverURL]
+	return e != nil && time.Now().Before(e.until)
+}
+
+// recordFailure pins serverURL to WebSocket for a window: transportFallbackBase
+// on the first failure, doubling up to transportFallbackMax when QUIC fails
+// again after a previous window expired. It returns the active window duration.
+func (f *transportFallback) recordFailure(serverURL string) time.Duration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	now := time.Now()
+	e := f.entries[serverURL]
+	switch {
+	case e == nil:
+		e = &fallbackEntry{duration: transportFallbackBase}
+		f.entries[serverURL] = e
+	case now.Before(e.until):
+		return time.Until(e.until)
+	default:
+		e.duration = min(e.duration*2, transportFallbackMax)
+	}
+	e.until = now.Add(e.duration)
+	return e.duration
+}

--- a/shared/relay/client/transport_test.go
+++ b/shared/relay/client/transport_test.go
@@ -55,11 +55,11 @@ func TestTransportFallbackRecordAndExpiry(t *testing.T) {
 	const url = "rels://relay.example:443"
 	f := newTransportFallback()
 
-	assert.False(t, f.preferWS(url), "no fallback recorded yet")
+	assert.False(t, f.avoidDatagramSized(url), "no fallback recorded yet")
 
 	d := f.recordFailure(url)
 	assert.Equal(t, transportFallbackBase, d, "first failure pins for the base window")
-	assert.True(t, f.preferWS(url), "WebSocket preferred within the window")
+	assert.True(t, f.avoidDatagramSized(url), "datagram-sized transport avoided within the window")
 
 	// A second failure while still inside the window must not grow the window.
 	d = f.recordFailure(url)
@@ -67,9 +67,9 @@ func TestTransportFallbackRecordAndExpiry(t *testing.T) {
 	require.NotNil(t, f.entries[url])
 	assert.Equal(t, transportFallbackBase, f.entries[url].duration, "duration unchanged inside window")
 
-	// Expire the window: WebSocket no longer preferred.
+	// Expire the window: datagram-sized transport allowed again.
 	f.entries[url].until = time.Now().Add(-time.Second)
-	assert.False(t, f.preferWS(url), "window expired")
+	assert.False(t, f.avoidDatagramSized(url), "window expired, datagram-sized transport allowed")
 }
 
 func TestTransportFallbackGrowsOnRepeat(t *testing.T) {
@@ -105,7 +105,7 @@ func TestOnDatagramTooLargeAuto(t *testing.T) {
 	c.onDatagramTooLarge(conn, netErr.ErrDatagramTooLarge)
 
 	assert.True(t, conn.closed, "connection closed to force reconnect")
-	assert.True(t, tf.preferWS(url), "fallback recorded for the server")
+	assert.True(t, tf.avoidDatagramSized(url), "fallback recorded for the server")
 
 	// A second oversized datagram on the same connection must not re-close.
 	conn.closed = false
@@ -128,13 +128,13 @@ func TestOnDatagramTooLargeQUICPinned(t *testing.T) {
 	c.onDatagramTooLarge(conn, netErr.ErrDatagramTooLarge)
 
 	assert.False(t, conn.closed, "QUIC pin keeps the connection, no fallback redial")
-	assert.False(t, tf.preferWS(url), "QUIC pin records no fallback")
+	assert.False(t, tf.avoidDatagramSized(url), "QUIC pin records no fallback")
 }
 
 func TestTransportFallbackPerServer(t *testing.T) {
 	f := newTransportFallback()
 	f.recordFailure("rels://a.example:443")
 
-	assert.True(t, f.preferWS("rels://a.example:443"))
-	assert.False(t, f.preferWS("rels://b.example:443"), "fallback is scoped to one server")
+	assert.True(t, f.avoidDatagramSized("rels://a.example:443"))
+	assert.False(t, f.avoidDatagramSized("rels://b.example:443"), "fallback is scoped to one server")
 }

--- a/shared/relay/client/transport_test.go
+++ b/shared/relay/client/transport_test.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	netErr "github.com/netbirdio/netbird/shared/relay/client/dialer/net"
+)
+
+// closeTrackingConn records whether Close was called; only Close is exercised.
+type closeTrackingConn struct {
+	net.Conn
+	closed bool
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.closed = true
+	return nil
+}
+
+func TestTransportModeFromEnv(t *testing.T) {
+	tests := []struct {
+		value string
+		want  TransportMode
+	}{
+		{"", TransportModeAuto},
+		{"auto", TransportModeAuto},
+		{"quic", TransportModeQUIC},
+		{"QUIC", TransportModeQUIC},
+		{"ws", TransportModeWS},
+		{" Ws ", TransportModeWS},
+		{"prefer-quic", TransportModePreferQUIC},
+		{"prefer-ws", TransportModePreferWS},
+		{"garbage", TransportModeAuto},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			t.Setenv(EnvRelayTransport, tc.value)
+			if tc.value == "" {
+				os.Unsetenv(EnvRelayTransport)
+			}
+			assert.Equal(t, tc.want, transportModeFromEnv())
+		})
+	}
+}
+
+func TestTransportFallbackRecordAndExpiry(t *testing.T) {
+	const url = "rels://relay.example:443"
+	f := newTransportFallback()
+
+	assert.False(t, f.preferWS(url), "no fallback recorded yet")
+
+	d := f.recordFailure(url)
+	assert.Equal(t, transportFallbackBase, d, "first failure pins for the base window")
+	assert.True(t, f.preferWS(url), "WebSocket preferred within the window")
+
+	// A second failure while still inside the window must not grow the window.
+	d = f.recordFailure(url)
+	assert.LessOrEqual(t, d, transportFallbackBase, "still within the active window")
+	require.NotNil(t, f.entries[url])
+	assert.Equal(t, transportFallbackBase, f.entries[url].duration, "duration unchanged inside window")
+
+	// Expire the window: WebSocket no longer preferred.
+	f.entries[url].until = time.Now().Add(-time.Second)
+	assert.False(t, f.preferWS(url), "window expired")
+}
+
+func TestTransportFallbackGrowsOnRepeat(t *testing.T) {
+	const url = "rels://relay.example:443"
+	f := newTransportFallback()
+
+	want := transportFallbackBase
+	for i := range 6 {
+		d := f.recordFailure(url)
+		assert.Equal(t, want, d, "window after %d expiries", i)
+
+		// expire the window so the next failure is treated as a repeat
+		f.entries[url].until = time.Now().Add(-time.Second)
+
+		want = min(want*2, transportFallbackMax)
+	}
+
+	assert.Equal(t, transportFallbackMax, f.entries[url].duration, "window caps at the max")
+}
+
+func TestOnDatagramTooLargeAuto(t *testing.T) {
+	const url = "rels://relay.example:443"
+	t.Setenv(EnvRelayTransport, string(TransportModeAuto))
+
+	tf := newTransportFallback()
+	c := &Client{
+		log:               log.WithField("test", t.Name()),
+		connectionURL:     url,
+		transportFallback: tf,
+	}
+	conn := &closeTrackingConn{}
+
+	c.onDatagramTooLarge(conn, netErr.ErrDatagramTooLarge)
+
+	assert.True(t, conn.closed, "connection closed to force reconnect")
+	assert.True(t, tf.preferWS(url), "fallback recorded for the server")
+
+	// A second oversized datagram on the same connection must not re-close.
+	conn.closed = false
+	c.onDatagramTooLarge(conn, netErr.ErrDatagramTooLarge)
+	assert.False(t, conn.closed, "single fallback per connection")
+}
+
+func TestOnDatagramTooLargeQUICPinned(t *testing.T) {
+	const url = "rels://relay.example:443"
+	t.Setenv(EnvRelayTransport, string(TransportModeQUIC))
+
+	tf := newTransportFallback()
+	c := &Client{
+		log:               log.WithField("test", t.Name()),
+		connectionURL:     url,
+		transportFallback: tf,
+	}
+	conn := &closeTrackingConn{}
+
+	c.onDatagramTooLarge(conn, netErr.ErrDatagramTooLarge)
+
+	assert.False(t, conn.closed, "QUIC pin keeps the connection, no fallback redial")
+	assert.False(t, tf.preferWS(url), "QUIC pin records no fallback")
+}
+
+func TestTransportFallbackPerServer(t *testing.T) {
+	f := newTransportFallback()
+	f.recordFailure("rels://a.example:443")
+
+	assert.True(t, f.preferWS("rels://a.example:443"))
+	assert.False(t, f.preferWS("rels://b.example:443"), "fallback is scoped to one server")
+}


### PR DESCRIPTION
## Describe your changes

Relayed traffic over QUIC is carried in DATAGRAM frames, which must fit a single QUIC packet. When the path MTU between a client and a relay is too small to carry a full-size overlay packet (overlay packet + WireGuard overhead + relay framing), the relay write fails with "DATAGRAM frame too large" and every full-size packet to that relayed peer is silently dropped, so bulk transfers stall while the tunnel still looks up. The race dialer made this intermittent: the same relay would sometimes connect over QUIC (broken) and sometimes over WebSocket (fine).

- Add `NB_RELAY_TRANSPORT` to select the relay transport: `auto` (default, race QUIC and WebSocket), `quic`, `ws`, and `prefer-quic` / `prefer-ws` which try one transport first and fall back to the other on connect failure instead of racing.
- On the first oversized QUIC datagram, record a WebSocket fallback for that relay and reconnect over WebSocket. The preference is shared across the relay manager so it survives reconnects of both the home relay and foreign relays, with a window that grows on repeated failures. When the transport is pinned to `quic`, the fallback is skipped.
- Map the QUIC datagram-too-large error to a single warning that includes the datagram size and the path budget, instead of logging it twice per packet.
- Log the QUIC path MTU discovery result and connection close reason, scoped to the relay address, to make relay path issues diagnosable.

## Issue ticket number and link


## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

A new opt-in env var for an edge transport behavior; default behavior is unchanged.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Env var to control relay transport mode (QUIC, WebSocket, auto, prefer).
  * Automatic fallback from QUIC datagrams to WebSocket with per-server sticky backoff (backoff grows, caps) and safer reconnects after oversized-datagram events.
  * Optional sequential dialing so transports can be tried in order instead of raced.
  * Improved QUIC connection tracing and detection of datagram-capable transports.

* **Tests**
  * Added tests for sequential dialing, transport-mode parsing, sticky fallback, and datagram-too-large handling.

* **Chores**
  * Raised Wasm build size check threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->