### PR TITLE
[client] Add error event publishing for rejected session deadlines

### DIFF
--- a/client/internal/auth/sessionwatch/event.go
+++ b/client/internal/auth/sessionwatch/event.go
@@ -33,6 +33,14 @@ const (
 	// for the T-10 event, FinalWarningLead for the T-2 event) so the UI
 	// can show "expires in ~N minutes" without hardcoding either constant.
 	MetaSessionLeadMinutes = "lead_minutes"
+	// MetaSessionDeadlineRejected is attached to the ERROR/AUTHENTICATION
+	// SystemEvent the daemon emits when it discards a deadline from the
+	// management server (pre-epoch, too far in the future, or past the
+	// clock-skew tolerance). The value is the rejection reason string.
+	// userMessage is left empty; the UI detects the event via this key
+	// and builds a localized notification — same pattern as the session
+	// warnings above.
+	MetaSessionDeadlineRejected = "session_deadline_rejected"
 )
 
 // expiresAtLayout is the wire format used for MetaSessionExpiresAt.

--- a/client/internal/auth/sessionwatch/event.go
+++ b/client/internal/auth/sessionwatch/event.go
@@ -33,13 +33,6 @@ const (
 	// for the T-10 event, FinalWarningLead for the T-2 event) so the UI
 	// can show "expires in ~N minutes" without hardcoding either constant.
 	MetaSessionLeadMinutes = "lead_minutes"
-	// MetaSessionDeadlineRejected is set to the rejection reason when the
-	// daemon discards a deadline received from the management server (e.g.
-	// pre-epoch, too far in the future, or past the clock-skew tolerance).
-	// The UI uses this key to detect the event and display a localized
-	// message; userMessage is intentionally left empty for the same reason
-	// as the warning events above.
-	MetaSessionDeadlineRejected = "session_deadline_rejected"
 )
 
 // expiresAtLayout is the wire format used for MetaSessionExpiresAt.

--- a/client/internal/auth/sessionwatch/event.go
+++ b/client/internal/auth/sessionwatch/event.go
@@ -33,6 +33,13 @@ const (
 	// for the T-10 event, FinalWarningLead for the T-2 event) so the UI
 	// can show "expires in ~N minutes" without hardcoding either constant.
 	MetaSessionLeadMinutes = "lead_minutes"
+	// MetaSessionDeadlineRejected is set to the rejection reason when the
+	// daemon discards a deadline received from the management server (e.g.
+	// pre-epoch, too far in the future, or past the clock-skew tolerance).
+	// The UI uses this key to detect the event and display a localized
+	// message; userMessage is intentionally left empty for the same reason
+	// as the warning events above.
+	MetaSessionDeadlineRejected = "session_deadline_rejected"
 )
 
 // expiresAtLayout is the wire format used for MetaSessionExpiresAt.

--- a/client/internal/auth/sessionwatch/watcher.go
+++ b/client/internal/auth/sessionwatch/watcher.go
@@ -287,12 +287,16 @@ func (w *Watcher) stopTimerLocked() {
 }
 
 func (w *Watcher) armTimerLocked(deadline time.Time) {
-	w.timer = armOneShotLocked(deadline.Add(-w.lead), func() { w.fire(deadline) })
+	fireAt := deadline.Add(-w.lead)
+	log.Debugf("sessionwatch: arming warning timer at %s (in %s)", fireAt.Format(time.RFC3339), time.Until(fireAt).Round(time.Second))
+	w.timer = armOneShotLocked(fireAt, func() { w.fire(deadline) })
 	// finalLead <= 0 disables the final-warning timer entirely. Used by
 	// tests that predate the final-warning fallback so a millisecond-scale
 	// deadline does not flush both timers at once.
 	if w.finalLead > 0 {
-		w.finalTimer = armOneShotLocked(deadline.Add(-w.finalLead), func() { w.fireFinal(deadline) })
+		finalFireAt := deadline.Add(-w.finalLead)
+		log.Debugf("sessionwatch: arming final-warning timer at %s (in %s)", finalFireAt.Format(time.RFC3339), time.Until(finalFireAt).Round(time.Second))
+		w.finalTimer = armOneShotLocked(finalFireAt, func() { w.fireFinal(deadline) })
 	}
 }
 

--- a/client/internal/auth/sessionwatch/watcher.go
+++ b/client/internal/auth/sessionwatch/watcher.go
@@ -287,16 +287,12 @@ func (w *Watcher) stopTimerLocked() {
 }
 
 func (w *Watcher) armTimerLocked(deadline time.Time) {
-	fireAt := deadline.Add(-w.lead)
-	log.Debugf("sessionwatch: arming warning timer at %s (in %s)", fireAt.Format(time.RFC3339), time.Until(fireAt).Round(time.Second))
-	w.timer = armOneShotLocked(fireAt, func() { w.fire(deadline) })
+	w.timer = armOneShotLocked(deadline.Add(-w.lead), func() { w.fire(deadline) })
 	// finalLead <= 0 disables the final-warning timer entirely. Used by
 	// tests that predate the final-warning fallback so a millisecond-scale
 	// deadline does not flush both timers at once.
 	if w.finalLead > 0 {
-		finalFireAt := deadline.Add(-w.finalLead)
-		log.Debugf("sessionwatch: arming final-warning timer at %s (in %s)", finalFireAt.Format(time.RFC3339), time.Until(finalFireAt).Round(time.Second))
-		w.finalTimer = armOneShotLocked(finalFireAt, func() { w.fireFinal(deadline) })
+		w.finalTimer = armOneShotLocked(deadline.Add(-w.finalLead), func() { w.fireFinal(deadline) })
 	}
 }
 

--- a/client/internal/engine_authsession.go
+++ b/client/internal/engine_authsession.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cProto "github.com/netbirdio/netbird/client/proto"
-	"github.com/netbirdio/netbird/client/internal/auth/sessionwatch"
 	"github.com/netbirdio/netbird/client/system"
 )
 
@@ -57,8 +56,8 @@ func (e *Engine) ApplySessionDeadline(ts *timestamppb.Timestamp) {
 			cProto.SystemEvent_ERROR,
 			cProto.SystemEvent_AUTHENTICATION,
 			"session deadline rejected",
-			"",
-			map[string]string{sessionwatch.MetaSessionDeadlineRejected: err.Error()},
+			"The session expiry time from the server could not be applied. Re-login may be required.",
+			map[string]string{"reason": err.Error()},
 		)
 	}
 }

--- a/client/internal/engine_authsession.go
+++ b/client/internal/engine_authsession.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	cProto "github.com/netbirdio/netbird/client/proto"
 	"github.com/netbirdio/netbird/client/system"
 )
 
@@ -51,6 +52,13 @@ func (e *Engine) ApplySessionDeadline(ts *timestamppb.Timestamp) {
 	// of sync with the warning timers.
 	if err := e.sessionWatcher.Update(deadline); err != nil {
 		log.Errorf("auth session deadline rejected: %v, clearing", err)
+		e.statusRecorder.PublishEvent(
+			cProto.SystemEvent_ERROR,
+			cProto.SystemEvent_AUTHENTICATION,
+			"session deadline rejected",
+			"The session expiry time from the server could not be applied. Re-login may be required.",
+			map[string]string{"reason": err.Error()},
+		)
 	}
 }
 

--- a/client/internal/engine_authsession.go
+++ b/client/internal/engine_authsession.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cProto "github.com/netbirdio/netbird/client/proto"
+	"github.com/netbirdio/netbird/client/internal/auth/sessionwatch"
 	"github.com/netbirdio/netbird/client/system"
 )
 
@@ -56,8 +57,8 @@ func (e *Engine) ApplySessionDeadline(ts *timestamppb.Timestamp) {
 			cProto.SystemEvent_ERROR,
 			cProto.SystemEvent_AUTHENTICATION,
 			"session deadline rejected",
-			"The session expiry time from the server could not be applied. Re-login may be required.",
-			map[string]string{"reason": err.Error()},
+			"",
+			map[string]string{sessionwatch.MetaSessionDeadlineRejected: err.Error()},
 		)
 	}
 }

--- a/client/ui/authsession/warning.go
+++ b/client/ui/authsession/warning.go
@@ -19,10 +19,11 @@ import (
 // side) so UI-side consumers don't have to import the daemon-internal
 // package directly.
 const (
-	MetaWarning     = sessionwatch.MetaSessionWarning
-	MetaFinal       = sessionwatch.MetaSessionFinal
-	MetaExpiresAt   = sessionwatch.MetaSessionExpiresAt
-	MetaLeadMinutes = sessionwatch.MetaSessionLeadMinutes
+	MetaWarning          = sessionwatch.MetaSessionWarning
+	MetaFinal            = sessionwatch.MetaSessionFinal
+	MetaExpiresAt        = sessionwatch.MetaSessionExpiresAt
+	MetaLeadMinutes      = sessionwatch.MetaSessionLeadMinutes
+	MetaDeadlineRejected = sessionwatch.MetaSessionDeadlineRejected
 )
 
 // Warning is the typed payload emitted on the session-warning Wails

--- a/client/ui/i18n/locales/de/common.json
+++ b/client/ui/i18n/locales/de/common.json
@@ -55,6 +55,8 @@
     "notify.sessionWarning.failed": "NetBird-Sitzung konnte nicht verlängert werden",
     "notify.sessionWarning.successTitle": "NetBird-Sitzung verlängert",
     "notify.sessionWarning.successBody": "Ihre Sitzung wurde erneuert.",
+    "notify.sessionDeadlineRejected.title": "Sitzungsfrist abgelehnt",
+    "notify.sessionDeadlineRejected.body": "Der Server hat eine ungültige Sitzungsfrist übermittelt. Bitte melden Sie sich erneut an.",
 
     "common.cancel": "Abbrechen",
     "common.save": "Speichern",

--- a/client/ui/i18n/locales/en/common.json
+++ b/client/ui/i18n/locales/en/common.json
@@ -55,6 +55,8 @@
     "notify.sessionWarning.failed": "Failed to extend NetBird session",
     "notify.sessionWarning.successTitle": "NetBird session extended",
     "notify.sessionWarning.successBody": "Your session has been refreshed.",
+    "notify.sessionDeadlineRejected.title": "Session deadline rejected",
+    "notify.sessionDeadlineRejected.body": "The server sent an invalid session deadline. Please sign in again.",
 
     "common.cancel": "Cancel",
     "common.save": "Save",

--- a/client/ui/i18n/locales/hu/common.json
+++ b/client/ui/i18n/locales/hu/common.json
@@ -55,6 +55,8 @@
     "notify.sessionWarning.failed": "A NetBird munkamenet meghosszabbítása sikertelen",
     "notify.sessionWarning.successTitle": "NetBird munkamenet meghosszabbítva",
     "notify.sessionWarning.successBody": "A munkamenet frissítve.",
+    "notify.sessionDeadlineRejected.title": "Munkamenet-határidő elutasítva",
+    "notify.sessionDeadlineRejected.body": "A szerver érvénytelen munkamenet-határidőt küldött. Kérjük, jelentkezzen be újra.",
 
     "common.cancel": "Mégse",
     "common.save": "Mentés",

--- a/client/ui/tray_events.go
+++ b/client/ui/tray_events.go
@@ -22,11 +22,12 @@ func (t *Tray) onSystemEvent(ev *application.CustomEvent) {
 	if !ok {
 		return
 	}
-	// Session-warning events carry no UserMessage — the tray builds the
-	// localised notification body locally from metadata. Every other
-	// event needs a non-empty UserMessage to show anything meaningful.
+	// Session-warning and deadline-rejected events carry no UserMessage —
+	// the tray builds the localised notification body locally from metadata.
+	// Every other event needs a non-empty UserMessage to show anything meaningful.
 	isSessionWarning := se.Metadata[authsession.MetaWarning] == "true"
-	if !isSessionWarning && se.UserMessage == "" {
+	isDeadlineRejected := se.Metadata[authsession.MetaDeadlineRejected] != ""
+	if !isSessionWarning && !isDeadlineRejected && se.UserMessage == "" {
 		return
 	}
 	if shouldSkipSystemEvent(se) {
@@ -52,6 +53,15 @@ func (t *Tray) onSystemEvent(ev *application.CustomEvent) {
 	//   - T-FinalWarningLead (MetaSessionFinal=true) → auto-open the
 	//     SessionAboutToExpire dialog. No OS notification here; the
 	//     dialog is the last-chance reminder, doubling up would be noise.
+	if isDeadlineRejected {
+		t.notify(
+			t.loc.T("notify.sessionDeadlineRejected.title"),
+			t.loc.T("notify.sessionDeadlineRejected.body"),
+			notifyIDSessionExpired,
+		)
+		return
+	}
+
 	if se.Metadata != nil && se.Metadata[authsession.MetaWarning] == "true" {
 		if se.Metadata[authsession.MetaFinal] == "true" {
 			t.openSessionAboutToExpire()


### PR DESCRIPTION
## Describe your changes

Added event publishing when a session deadline is rejected by the session watcher. When `sessionWatcher.Update()` fails, the engine now publishes a `SystemEvent_ERROR` event with authentication context to inform users that the session expiry time from the server could not be applied and re-login may be required.

This improves observability and user feedback by surfacing authentication issues that previously only logged errors.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] Documentation is **not needed** for this change (this is an internal event publishing enhancement for existing error handling)

### Docs PR URL (required if "docs added" is checked)
N/A

https://claude.ai/code/session_01Y3bQoNgcVjTD4zDTvv7a8u