### PR TITLE
[client] Mask sensitive data in debug bundle creation

### DIFF
--- a/client/internal/debug/debug.go
+++ b/client/internal/debug/debug.go
@@ -806,6 +806,8 @@ func (g *BundleGenerator) addSyncResponse() error {
 		AllowPartial:    true,
 	}
 
+	g.maskSecrets()
+
 	jsonBytes, err := options.Marshal(g.syncResponse)
 	if err != nil {
 		return fmt.Errorf("generate json: %w", err)
@@ -816,6 +818,25 @@ func (g *BundleGenerator) addSyncResponse() error {
 	}
 
 	return nil
+}
+
+func (g *BundleGenerator) maskSecrets() {
+	if g.syncResponse == nil || g.syncResponse.NetbirdConfig == nil {
+		return
+	}
+
+	if g.syncResponse.NetbirdConfig.Flow != nil {
+		g.syncResponse.NetbirdConfig.Flow.TokenPayload = "xxxx"
+
+	}
+
+	if g.syncResponse.NetbirdConfig.Relay != nil {
+		g.syncResponse.NetbirdConfig.Relay.TokenPayload = "xxxx"
+	}
+
+	for i := range g.syncResponse.NetbirdConfig.Turns {
+		g.syncResponse.NetbirdConfig.Turns[i].Password = "xxxx"
+	}
 }
 
 func (g *BundleGenerator) addStateFile() error {

--- a/client/internal/debug/debug.go
+++ b/client/internal/debug/debug.go
@@ -826,16 +826,18 @@ func (g *BundleGenerator) maskSecrets() {
 	}
 
 	if g.syncResponse.NetbirdConfig.Flow != nil {
-		g.syncResponse.NetbirdConfig.Flow.TokenPayload = "xxxx"
+		g.syncResponse.NetbirdConfig.Flow.TokenPayload = maskedValue
 
 	}
 
 	if g.syncResponse.NetbirdConfig.Relay != nil {
-		g.syncResponse.NetbirdConfig.Relay.TokenPayload = "xxxx"
+		g.syncResponse.NetbirdConfig.Relay.TokenPayload = maskedValue
 	}
 
 	for i := range g.syncResponse.NetbirdConfig.Turns {
-		g.syncResponse.NetbirdConfig.Turns[i].Password = "xxxx"
+		if g.syncResponse.NetbirdConfig.Turns[i] != nil {
+			g.syncResponse.NetbirdConfig.Turns[i].Password = maskedValue
+		}
 	}
 }
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive credential fields in generated debug output are now consistently replaced with placeholder values before files are written, preventing unintended exposure of tokens, relay/flow secrets, and turn passwords. This masking is applied regardless of anonymization settings to ensure debug bundles do not contain raw credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->