### PR TITLE
[misc] Bump to Go 1.26.4

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm
+FROM golang:1.26-bookworm
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends\

--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -225,7 +225,7 @@ jobs:
             -e GOCACHE=${CONTAINER_GOCACHE} \
             -e GOMODCACHE=${CONTAINER_GOMODCACHE} \
             -e CONTAINER=${CONTAINER} \
-            golang:1.25-alpine \
+            golang:1.26-alpine \
             sh -c ' \
               apk update; apk add --no-cache \
                 ca-certificates iptables ip6tables dbus dbus-dev libpcap-dev build-base; \

--- a/client/internal/metrics/infra/ingest/Dockerfile
+++ b/client/internal/metrics/infra/ingest/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /app
 COPY go.mod main.go ./
 RUN CGO_ENABLED=0 go build -o ingest .

--- a/combined/Dockerfile.multistage
+++ b/combined/Dockerfile.multistage
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 WORKDIR /app
 
 # Install build dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netbirdio/netbird
 
-go 1.25.5
+go 1.26.4
 
 require (
 	cunicu.li/go-rosenpass v0.5.42

--- a/management/Dockerfile.multistage
+++ b/management/Dockerfile.multistage
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 WORKDIR /app
 
 # Install build dependencies

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /app
 
 RUN echo "netbird:x:1000:1000:netbird:/var/lib/netbird:/sbin/nologin" > /tmp/passwd && \

--- a/proxy/Dockerfile.multistage
+++ b/proxy/Dockerfile.multistage
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -289,22 +289,20 @@ func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
 	return nil, errKeyNotFound
 }
 
-func getPublicKeyFromECDSA(jwk JSONWebKey) (publicKey *ecdsa.PublicKey, err error) {
+func getPublicKeyFromECDSA(jwk JSONWebKey) (*ecdsa.PublicKey, error) {
 	if jwk.X == "" || jwk.Y == "" || jwk.Crv == "" {
 		return nil, fmt.Errorf("ecdsa key incomplete")
 	}
 
-	var xCoordinate []byte
-	if xCoordinate, err = base64.RawURLEncoding.DecodeString(jwk.X); err != nil {
+	xCoordinate, err := base64.RawURLEncoding.DecodeString(jwk.X)
+	if err != nil {
 		return nil, err
 	}
 
-	var yCoordinate []byte
-	if yCoordinate, err = base64.RawURLEncoding.DecodeString(jwk.Y); err != nil {
+	yCoordinate, err := base64.RawURLEncoding.DecodeString(jwk.Y)
+	if err != nil {
 		return nil, err
 	}
-
-	publicKey = &ecdsa.PublicKey{}
 
 	var curve elliptic.Curve
 	switch jwk.Crv {
@@ -316,11 +314,13 @@ func getPublicKeyFromECDSA(jwk JSONWebKey) (publicKey *ecdsa.PublicKey, err erro
 		curve = elliptic.P521()
 	}
 
-	publicKey.Curve = curve
-	publicKey.X = big.NewInt(0).SetBytes(xCoordinate)
-	publicKey.Y = big.NewInt(0).SetBytes(yCoordinate)
+	// SEC1 uncompressed point format: 0x04 || X || Y
+	point := make([]byte, 1+len(xCoordinate)+len(yCoordinate))
+	point[0] = 0x04
+	copy(point[1:], xCoordinate)
+	copy(point[1+len(xCoordinate):], yCoordinate)
 
-	return publicKey, nil
+	return ecdsa.ParseUncompressedPublicKey(curve, point)
 }
 
 func getPublicKeyFromRSA(jwk JSONWebKey) (*rsa.PublicKey, error) {


### PR DESCRIPTION
## Describe your changes

Updates the Go version to 1.26.4 to enable importing of Kubernetes dependencies. It also fixes linter warnings due to use of deprecated features.

## Issue ticket number and link

Relates to #6260

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain in build and CI images to 1.26 for improved compatibility and security.
* **Bug Fixes**
  * Improved ECDSA JWT public-key handling to make token validation more robust and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->