### PR TITLE
[client] Fix Darwin DNS parsing for empty scutil values

### DIFF
--- a/client/internal/dns/host_darwin.go
+++ b/client/internal/dns/host_darwin.go
@@ -48,6 +48,15 @@ const (
 	maxDomainBytesPerResolverEntry = 1500
 )
 
+// scutilDNSSection tracks the current DNS array being parsed from scutil output.
+type scutilDNSSection int
+
+const (
+	scutilDNSSectionNone scutilDNSSection = iota
+	scutilDNSSectionSearchDomains
+	scutilDNSSectionServerAddresses
+)
+
 type systemConfigurator struct {
 	createdKeys       map[string]struct{}
 	systemDNSSettings SystemDNSSettings
@@ -267,46 +276,8 @@ func (s *systemConfigurator) getSystemDNSSettings() (SystemDNSSettings, error) {
 		return SystemDNSSettings{}, fmt.Errorf("sending the command: %w", err)
 	}
 
-	var dnsSettings SystemDNSSettings
-	var serverAddresses []netip.Addr
-	inSearchDomainsArray := false
-	inServerAddressesArray := false
-
-	scanner := bufio.NewScanner(bytes.NewReader(b))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		switch {
-		case strings.HasPrefix(line, "DomainName :"):
-			domainName := strings.TrimSpace(strings.Split(line, ":")[1])
-			dnsSettings.Domains = append(dnsSettings.Domains, domainName)
-		case line == "SearchDomains : <array> {":
-			inSearchDomainsArray = true
-			continue
-		case line == "ServerAddresses : <array> {":
-			inServerAddressesArray = true
-			continue
-		case line == "}":
-			inSearchDomainsArray = false
-			inServerAddressesArray = false
-		}
-
-		if inSearchDomainsArray {
-			searchDomain := strings.Split(line, " : ")[1]
-			dnsSettings.Domains = append(dnsSettings.Domains, searchDomain)
-		} else if inServerAddressesArray {
-			address := strings.Split(line, " : ")[1]
-			if ip, err := netip.ParseAddr(address); err == nil && !ip.IsUnspecified() {
-				ip = ip.Unmap()
-				serverAddresses = append(serverAddresses, ip)
-				// Prefer the first IPv4 server as ServerIP since our DNS listener is IPv4.
-				if !dnsSettings.ServerIP.IsValid() && ip.Is4() {
-					dnsSettings.ServerIP = ip
-				}
-			}
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
+	dnsSettings, serverAddresses, err := parseSystemDNSSettings(b)
+	if err != nil {
 		return dnsSettings, err
 	}
 
@@ -318,6 +289,105 @@ func (s *systemConfigurator) getSystemDNSSettings() (SystemDNSSettings, error) {
 	s.mu.Unlock()
 
 	return dnsSettings, nil
+}
+
+// parseSystemDNSSettings extracts DNS domains and nameservers from scutil output.
+func parseSystemDNSSettings(b []byte) (SystemDNSSettings, []netip.Addr, error) {
+	var dnsSettings SystemDNSSettings
+	var serverAddresses []netip.Addr
+	section := scutilDNSSectionNone
+
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if updatedSection, ok := parseScutilDNSSection(line); ok {
+			section = updatedSection
+			continue
+		}
+
+		if parseDomainName(line, &dnsSettings) {
+			continue
+		}
+
+		switch section {
+		case scutilDNSSectionSearchDomains:
+			parseSearchDomain(line, &dnsSettings)
+		case scutilDNSSectionServerAddresses:
+			parseServerAddress(line, &dnsSettings, &serverAddresses)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return dnsSettings, nil, err
+	}
+
+	return dnsSettings, serverAddresses, nil
+}
+
+// parseScutilDNSSection identifies array section boundaries in scutil output.
+func parseScutilDNSSection(line string) (scutilDNSSection, bool) {
+	switch line {
+	case "SearchDomains : <array> {":
+		return scutilDNSSectionSearchDomains, true
+	case "ServerAddresses : <array> {":
+		return scutilDNSSectionServerAddresses, true
+	case "}":
+		return scutilDNSSectionNone, true
+	default:
+		return scutilDNSSectionNone, false
+	}
+}
+
+// parseDomainName appends the primary domain name when present.
+func parseDomainName(line string, dnsSettings *SystemDNSSettings) bool {
+	if !strings.HasPrefix(line, "DomainName :") {
+		return false
+	}
+	return appendScutilDomain(line, dnsSettings)
+}
+
+// parseSearchDomain appends a non-empty search domain array entry.
+func parseSearchDomain(line string, dnsSettings *SystemDNSSettings) bool {
+	return appendScutilDomain(line, dnsSettings)
+}
+
+// appendScutilDomain appends a non-empty scutil value to DNS domains.
+func appendScutilDomain(line string, dnsSettings *SystemDNSSettings) bool {
+	value, ok := parseScutilValue(line)
+	if !ok || value == "" {
+		return false
+	}
+	dnsSettings.Domains = append(dnsSettings.Domains, value)
+	return true
+}
+
+// parseServerAddress appends a valid nameserver and records the first IPv4 server.
+func parseServerAddress(line string, dnsSettings *SystemDNSSettings, serverAddresses *[]netip.Addr) bool {
+	address, ok := parseScutilValue(line)
+	if !ok || address == "" {
+		return false
+	}
+	ip, err := netip.ParseAddr(address)
+	if err != nil || ip.IsUnspecified() {
+		return false
+	}
+
+	ip = ip.Unmap()
+	*serverAddresses = append(*serverAddresses, ip)
+	// Prefer the first IPv4 server as ServerIP since our DNS listener is IPv4.
+	if !dnsSettings.ServerIP.IsValid() && ip.Is4() {
+		dnsSettings.ServerIP = ip
+	}
+	return true
+}
+
+// parseScutilValue returns the trimmed text after the first colon in a scutil line.
+func parseScutilValue(line string) (string, bool) {
+	_, value, ok := strings.Cut(line, ":")
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSpace(value), true
 }
 
 func (s *systemConfigurator) getOriginalNameservers() []netip.Addr {

--- a/client/internal/dns/host_darwin_test.go
+++ b/client/internal/dns/host_darwin_test.go
@@ -125,6 +125,34 @@ func generateLongDomains(count int) []string {
 	return domains
 }
 
+func TestParseSystemDNSSettingsSkipsEmptyValues(t *testing.T) {
+	rawSettings := []byte(`
+<dictionary> {
+  DomainName : dlinkrouter
+  SearchDomains : <array> {
+    0 :
+    1 : corp.example
+  }
+  ServerAddresses : <array> {
+    0 :
+    1 : 0.0.0.0
+    2 : 192.168.100.1
+    3 : ::ffff:9.9.9.9
+    4 : not-an-ip
+  }
+}`)
+
+	settings, servers, err := parseSystemDNSSettings(rawSettings)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"dlinkrouter", "corp.example"}, settings.Domains)
+	assert.Equal(t, netip.MustParseAddr("192.168.100.1"), settings.ServerIP)
+	assert.Equal(t, []netip.Addr{
+		netip.MustParseAddr("192.168.100.1"),
+		netip.MustParseAddr("9.9.9.9"),
+	}, servers)
+}
+
 // readDomainsFromKey reads the SupplementalMatchDomains array back from scutil for a given key.
 func readDomainsFromKey(t *testing.T, key string) []string {
 	t.Helper()


### PR DESCRIPTION
## Describe your changes

Fixes a Darwin DNS parsing panic when `scutil` returns an empty value in an array entry, for example:

```text
SearchDomains : <array> {
  0 :
}
```

The parser previously indexed the result of splitting on `" : "`, which panicked for trimmed empty values such as `0 :`. This change extracts values with `strings.Cut`, skips empty entries, and preserves the existing behavior for valid domain and nameserver entries.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal client parser bug fix with no user-facing configuration or behavior changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## Testing

```text
GOCACHE=/private/tmp/go-build-cache GOMODCACHE=/private/tmp/go-mod-cache go test ./client/internal/dns -run 'Test(ParseSystemDNSSettingsSkipsEmptyValues|SplitDomainsIntoBatches|GetOriginalNameservers)$' -count=1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS detection on macOS by ignoring empty or invalid entries and normalizing server addresses so DNS resolution is more reliable.
* **Tests**
  * Added a unit test to ensure empty/invalid DNS entries are skipped and valid addresses are selected and normalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->