### PR TITLE
[auth] Add clock-skew leeway to JWT validation

### DIFF
--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -40,6 +40,26 @@ const (
 	p521 = "P-521"
 )
 
+// defaultClockSkewLeeway is the tolerance applied to time-based JWT claims
+// (exp, nbf and iat) when validating a token, to account for clock skew between
+// the IdP that issues the token and the NetBird services that validate it.
+//
+// RFC 7519 §4.1.4 (exp) and §4.1.5 (nbf) explicitly allow this:
+//
+//	"Implementers MAY provide for some small leeway, usually no more than a few
+//	 minutes, to account for clock skew."
+//	https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
+//
+// golang-jwt/v5 defaults to zero leeway, so without this any token whose iat or
+// nbf is even momentarily in the future relative to the validator's wall clock
+// is rejected (e.g. "token used before issued"). This is common right after
+// boot, before NTP has converged, or with steady drift between separately
+// synced hosts. 60s is conservative next to comparable validators:
+// HashiCorp cap/jwt defaults to 150s, Auth0 go-jwt-middleware exposes a
+// configurable WithAllowedClockSkew, and MIT Kerberos clockskew defaults to
+// 300s.
+const defaultClockSkewLeeway = 60 * time.Second
+
 // JSONWebKey is a representation of a Jason Web Key
 type JSONWebKey struct {
 	Kty string   `json:"kty"`
@@ -217,6 +237,7 @@ func (v *Validator) ValidateAndParse(ctx context.Context, token string) (*jwt.To
 		jwt.WithAudience(v.audienceList...),
 		jwt.WithIssuer(v.issuer),
 		jwt.WithIssuedAt(),
+		jwt.WithLeeway(defaultClockSkewLeeway),
 	)
 
 	// Check if there was an error in parsing...

--- a/shared/auth/jwt/validator_test.go
+++ b/shared/auth/jwt/validator_test.go
@@ -1,0 +1,127 @@
+package jwt
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testIssuer = "https://idp.example.com"
+	testKid    = "test-key-1"
+)
+
+var testAudience = []string{"netbird"}
+
+// newTestValidator returns a Validator whose key set contains the public part of
+// the returned RSA key, so tokens signed with that key can be validated without
+// any HTTP round-trip.
+func newTestValidator(t *testing.T) (*Validator, *rsa.PrivateKey) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	jwk := JSONWebKey{
+		Kty: "RSA",
+		Kid: testKid,
+		Use: "sig",
+		N:   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes()),
+	}
+
+	v := &Validator{
+		keys:         &Jwks{Keys: []JSONWebKey{jwk}},
+		issuer:       testIssuer,
+		audienceList: testAudience,
+	}
+	return v, key
+}
+
+// signToken builds and signs a token. iatNbfOffset is applied to the iat/nbf
+// claims (a positive value places them in the future, simulating an IdP whose
+// clock is ahead of the validator); expFromNow sets the exp claim relative to
+// now (a negative value yields an expired token). The token is signed with the
+// provided key, which lets callers sign with a key the validator does not know
+// to exercise signature verification.
+func signToken(t *testing.T, key *rsa.PrivateKey, iatNbfOffset, expFromNow time.Duration) string {
+	t.Helper()
+
+	issued := time.Now().Add(iatNbfOffset)
+	claims := jwt.MapClaims{
+		"iss": testIssuer,
+		"aud": testAudience,
+		"iat": issued.Unix(),
+		"nbf": issued.Unix(),
+		"exp": time.Now().Add(expFromNow).Unix(),
+		"sub": "user-123",
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = testKid
+
+	signed, err := token.SignedString(key)
+	require.NoError(t, err)
+	return signed
+}
+
+func TestValidateAndParse(t *testing.T) {
+	tests := []struct {
+		name         string
+		iatNbfOffset time.Duration
+		expFromNow   time.Duration
+		wrongKey     bool
+		wantErr      bool
+	}{
+		{
+			name:         "issuer ahead, within leeway",
+			iatNbfOffset: defaultClockSkewLeeway / 2,
+			expFromNow:   time.Hour,
+		},
+		{
+			name:         "issuer ahead, beyond leeway",
+			iatNbfOffset: defaultClockSkewLeeway * 3 / 2,
+			expFromNow:   time.Hour,
+			wantErr:      true,
+		},
+		{
+			name:       "expired token",
+			expFromNow: -defaultClockSkewLeeway * 2,
+			wantErr:    true,
+		},
+		{
+			name:       "signed with unknown key",
+			expFromNow: time.Hour,
+			wrongKey:   true,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, key := newTestValidator(t)
+			if tc.wrongKey {
+				other, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+				key = other
+			}
+
+			token := signToken(t, key, tc.iatNbfOffset, tc.expFromNow)
+
+			parsed, err := v.ValidateAndParse(context.Background(), token)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, parsed.Valid)
+		})
+	}
+}

--- a/shared/auth/jwt/validator_test.go
+++ b/shared/auth/jwt/validator_test.go
@@ -48,10 +48,11 @@ func newTestValidator(t *testing.T) (*Validator, *rsa.PrivateKey) {
 // signToken builds and signs a token. iatNbfOffset is applied to the iat/nbf
 // claims (a positive value places them in the future, simulating an IdP whose
 // clock is ahead of the validator); expFromNow sets the exp claim relative to
-// now (a negative value yields an expired token). The token is signed with the
-// provided key, which lets callers sign with a key the validator does not know
-// to exercise signature verification.
-func signToken(t *testing.T, key *rsa.PrivateKey, iatNbfOffset, expFromNow time.Duration) string {
+// now (a negative value yields an expired token). kid is stamped into the token
+// header, and the token is signed with the provided key, so callers can
+// exercise both the unknown-kid path (kid not in the key set) and the
+// wrong-signature path (kid known but signed with a different key).
+func signToken(t *testing.T, key *rsa.PrivateKey, kid string, iatNbfOffset, expFromNow time.Duration) string {
 	t.Helper()
 
 	issued := time.Now().Add(iatNbfOffset)
@@ -65,7 +66,7 @@ func signToken(t *testing.T, key *rsa.PrivateKey, iatNbfOffset, expFromNow time.
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	token.Header["kid"] = testKid
+	token.Header["kid"] = kid
 
 	signed, err := token.SignedString(key)
 	require.NoError(t, err)
@@ -75,6 +76,7 @@ func signToken(t *testing.T, key *rsa.PrivateKey, iatNbfOffset, expFromNow time.
 func TestValidateAndParse(t *testing.T) {
 	tests := []struct {
 		name         string
+		kid          string
 		iatNbfOffset time.Duration
 		expFromNow   time.Duration
 		wrongKey     bool
@@ -82,22 +84,32 @@ func TestValidateAndParse(t *testing.T) {
 	}{
 		{
 			name:         "issuer ahead, within leeway",
+			kid:          testKid,
 			iatNbfOffset: defaultClockSkewLeeway / 2,
 			expFromNow:   time.Hour,
 		},
 		{
 			name:         "issuer ahead, beyond leeway",
+			kid:          testKid,
 			iatNbfOffset: defaultClockSkewLeeway * 3 / 2,
 			expFromNow:   time.Hour,
 			wantErr:      true,
 		},
 		{
-			name:       "expired token",
+			name:       "expired beyond leeway",
+			kid:        testKid,
 			expFromNow: -defaultClockSkewLeeway * 2,
 			wantErr:    true,
 		},
 		{
-			name:       "signed with unknown key",
+			name:       "unknown kid",
+			kid:        "unknown-kid",
+			expFromNow: time.Hour,
+			wantErr:    true,
+		},
+		{
+			name:       "known kid, wrong signature",
+			kid:        testKid,
 			expFromNow: time.Hour,
 			wrongKey:   true,
 			wantErr:    true,
@@ -113,7 +125,7 @@ func TestValidateAndParse(t *testing.T) {
 				key = other
 			}
 
-			token := signToken(t, key, tc.iatNbfOffset, tc.expFromNow)
+			token := signToken(t, key, tc.kid, tc.iatNbfOffset, tc.expFromNow)
 
 			parsed, err := v.ValidateAndParse(context.Background(), token)
 			if tc.wantErr {


### PR DESCRIPTION
## Describe your changes

   `Validator.ValidateAndParse` (`shared/auth/jwt/validator.go`) parses tokens with `golang-jwt/v5`, which defaults to **zero leeway**, and explicitly enables `iat` validation via `jwt.WithIssuedAt()`:

   ```go
   parsedToken, err := jwt.Parse(
       token,
       v.getKeyFunc(ctx),
       jwt.WithAudience(v.audienceList...),
       jwt.WithIssuer(v.issuer),
       jwt.WithIssuedAt(),
   )
   ```

   With zero tolerance, the validator compares `exp`/`nbf`/`iat` against its own wall clock with no slack. If the IdP issuing the token is even slightly ahead of the NetBird service validating it,
   `iat`/`nbf` land in the future from the validator's perspective and the token is rejected — surfacing as `token used before issued` (v5 / `iat`) or the older `Token is not valid yet` (v4 / `nbf`). Same
   root cause: zero clock-skew tolerance.

   This happens routinely without any misconfiguration:
   - right after boot, before NTP has converged;
   - small steady drift between two separately-synced hosts.

   NTP doesn't eliminate it — it's exactly the gap RFC 7519 calls out leeway to cover, rather than relying on perfect clocks.

   ## Fix

   Apply a conservative, non-configurable **60s** leeway via `jwt.WithLeeway(...)` (the library's documented mechanism for "exp, nbf, iat ... to account for clock skew between systems"). Expiry and
   signature verification stay strict — this only widens the time-based comparison window by under a minute.

   ```go
   jwt.WithLeeway(defaultClockSkewLeeway), // 60s
   ```

   The change lives in the shared validator, so it covers both the management auth manager and the client SSH server, which both use it.

   ## Why 60s — RFC and prior art

   **RFC 7519 §4.1.4 (`exp`) / §4.1.5 (`nbf`)** — the normative source:

   > Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew.

   https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5

   Comparable validators ship non-zero defaults, so defaulting to 0 is the outlier:

   | Implementation | Default clock skew |
   | --- | --- |
   | HashiCorp `cap/jwt` | [**150s** (nbf/exp/iat)](https://pkg.go.dev/github.com/hashicorp/cap/jwt#pkg-constants) |
   | MIT Kerberos `clockskew` | [**300s**](https://web.mit.edu/kerberos/krb5-latest/doc/admin/conf_files/krb5_conf.html) |

   60s sits well under the RFC's "few minutes" ceiling while covering the unsynced-NTP startup window.

   ## Tests

   Added `shared/auth/jwt/validator_test.go` (the file had no tests). Table covers: a future-issued token within leeway (accepted), one beyond leeway (rejected), an expired token (rejected), and a token
   signed with an unknown key (rejected) — confirming the leeway widens only the time window and does not weaken expiry or signature checks.

## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/4500

## Stack

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why) -- subtle details of jwt validation not worth documenting

### Docs PR URL (required if "docs added" is checked)

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JWT validation now tolerates a 60-second clock skew when checking token issuance, not-before, and expiration times, reducing false rejections due to minor server clock differences.

* **Tests**
  * Added end-to-end tests covering valid and invalid JWT scenarios (clock skew, expired tokens, unknown or mismatched signing keys) to ensure robust token validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->