### PR TITLE
[client] Flush macOS DNS cache when nameserver group recovers

### DIFF
--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -1117,7 +1117,11 @@ func (s *DefaultServer) projectNSGroupHealth(snap nsHealthSnapshot) {
 // Enabled flag to record in NSGroupState.
 func (s *DefaultServer) projectHealthy(p *nsGroupProj, servers []netip.AddrPort) bool {
 	p.everHealthy = true
+	wasUnhealthy := !p.unhealthySince.IsZero() || p.warningActive
 	p.unhealthySince = time.Time{}
+	if wasUnhealthy {
+		s.flushHostDNSCache()
+	}
 	if !p.warningActive {
 		return true
 	}
@@ -1131,6 +1135,25 @@ func (s *DefaultServer) projectHealthy(p *nsGroupProj, servers []netip.AddrPort)
 	)
 	p.warningActive = false
 	return true
+}
+
+// flushHostDNSCache asks the host manager to drop the OS-level DNS cache,
+// when the platform supports it (currently macOS). While the overlay
+// upstreams for a match domain are unreachable (e.g. right after wake from
+// sleep, before tunnels re-establish), queries can be answered by the
+// public resolvers and the OS caches those answers for their full TTL.
+// Flushing on the unhealthy->healthy transition makes clients pick up the
+// overlay answers again immediately instead of serving stale public ones.
+func (s *DefaultServer) flushHostDNSCache() {
+	flusher, ok := s.hostManager.(interface{ flushDNSCache() error })
+	if !ok {
+		return
+	}
+	go func() {
+		if err := flusher.flushDNSCache(); err != nil {
+			log.Warnf("failed to flush host DNS cache after upstream recovery: %v", err)
+		}
+	}()
 }
 
 // projectUnhealthy records an unhealthy tick on p, publishes the

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -48,6 +48,9 @@ const (
 	// envWarningDelay overrides defaultWarningDelayBase with a Go duration
 	// string (e.g. "90s", "2m"). Invalid or non-positive values are ignored.
 	envWarningDelay = "NB_DNS_HEALTH_WARNING_DELAY"
+	// hostCacheFlushCoalesce is the window within which repeated host DNS
+	// cache flush requests collapse into a single flush.
+	hostCacheFlushCoalesce = 5 * time.Second
 )
 
 // errNoUsableNameservers signals that a merged-domain group has no usable
@@ -186,6 +189,12 @@ type DefaultServer struct {
 	// healthRefresh is buffered=1; writers coalesce, senders never block.
 	// See refreshHealth for the lock-order rationale.
 	healthRefresh chan struct{}
+
+	// cacheFlushMu guards lastCacheFlush.
+	cacheFlushMu sync.Mutex
+	// lastCacheFlush is when the host DNS cache was last flushed by the
+	// health projection; used to coalesce bursts of recoveries.
+	lastCacheFlush time.Time
 }
 
 type handlerWithStop interface {
@@ -1144,11 +1153,32 @@ func (s *DefaultServer) projectHealthy(p *nsGroupProj, servers []netip.AddrPort)
 // public resolvers and the OS caches those answers for their full TTL.
 // Flushing on the unhealthy->healthy transition makes clients pick up the
 // overlay answers again immediately instead of serving stale public ones.
+//
+// Flushes triggered within hostCacheFlushCoalesce of each other coalesce
+// into one, so several groups recovering on the same projection tick cause
+// a single flush.
 func (s *DefaultServer) flushHostDNSCache() {
-	flusher, ok := s.hostManager.(interface{ flushDNSCache() error })
+	s.mux.Lock()
+	hm := s.hostManager
+	s.mux.Unlock()
+
+	// The assertion targets an unexported method on purpose: every
+	// hostManager implementation lives in this package (host_darwin.go
+	// implements flushDNSCache), so this matches on darwin and is a
+	// no-op everywhere else.
+	flusher, ok := hm.(interface{ flushDNSCache() error })
 	if !ok {
 		return
 	}
+
+	s.cacheFlushMu.Lock()
+	if !s.lastCacheFlush.IsZero() && time.Since(s.lastCacheFlush) < hostCacheFlushCoalesce {
+		s.cacheFlushMu.Unlock()
+		return
+	}
+	s.lastCacheFlush = time.Now()
+	s.cacheFlushMu.Unlock()
+
 	go func() {
 		if err := flusher.flushDNSCache(); err != nil {
 			log.Warnf("failed to flush host DNS cache after upstream recovery: %v", err)


### PR DESCRIPTION
## Describe your changes

Fixes #6387.

On macOS, queries for match domains issued while their overlay upstream is briefly unreachable (typically right after wake from sleep, before tunnels re-establish) get answered by the public resolvers, and mDNSResponder caches the public answer for its full TTL. `flushDNSCache` currently only runs when the host DNS config is (re)applied, which doesn't happen on a wake without a network change — so clients keep serving the stale public answer for minutes.

This change flushes the OS-level DNS cache when the health projection records an unhealthy → healthy transition for a nameserver group (`projectHealthy`). The flush is invoked through a type assertion on the host manager, so it's a no-op on every platform except darwin (the only one implementing `flushDNSCache`), and runs in a goroutine to keep the projection loop non-blocking.

## Issue ticket number and link

#6387

## Stack

- OS: macOS (code change is platform-neutral, effective only on darwin)
- NetBird version: main
- NetBird flags: match-domain nameserver groups with overlay-routed upstreams

## Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible) — covered by existing health-projection tests still passing; the flush itself shells out to `dscacheutil`/`mDNSResponder` and isn't unit-testable without a darwin host


## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

No user-facing behavior, flags, or APIs change: this is a darwin-only internal bug fix (flush the OS DNS cache on nameserver-group recovery, which macOS users previously worked around manually). Nothing to document beyond the fix itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DNS cache is now automatically flushed when a target transitions from unhealthy to healthy, improving DNS resolution immediately after recovery.
  * Cache flushes are coalesced to prevent redundant flush work during rapid or repeated recoveries.
  * Cache flush runs asynchronously; any flush errors are captured as warnings and do not block recovery event emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
