### PR TITLE
[proxy] notify certificate ready for domains covered by the static certificate

### DIFF
--- a/proxy/server.go
+++ b/proxy/server.go
@@ -75,29 +75,30 @@ type portRouter struct {
 }
 
 type Server struct {
-	ctx           context.Context
-	mgmtClient    proto.ProxyServiceClient
-	proxy         *proxy.ReverseProxy
-	netbird       *roundtrip.NetBird
-	acme          *acme.Manager
-	auth          *auth.Middleware
-	http          *http.Server
-	https         *http.Server
-	debug         *http.Server
-	healthServer  *health.Server
-	healthChecker *health.Checker
-	meter         *proxymetrics.Metrics
-	accessLog     *accesslog.Logger
-	mainRouter    *nbtcp.Router
-	mainPort      uint16
-	udpMu         sync.Mutex
-	udpRelays     map[types.ServiceID]*udprelay.Relay
-	udpRelayWg    sync.WaitGroup
-	portMu        sync.RWMutex
-	portRouters   map[uint16]*portRouter
-	svcPorts      map[types.ServiceID][]uint16
-	lastMappings  map[types.ServiceID]*proto.ProxyMapping
-	portRouterWg  sync.WaitGroup
+	ctx               context.Context
+	mgmtClient        proto.ProxyServiceClient
+	proxy             *proxy.ReverseProxy
+	netbird           *roundtrip.NetBird
+	acme              *acme.Manager
+	staticCertWatcher *certwatch.Watcher
+	auth              *auth.Middleware
+	http              *http.Server
+	https             *http.Server
+	debug             *http.Server
+	healthServer      *health.Server
+	healthChecker     *health.Checker
+	meter             *proxymetrics.Metrics
+	accessLog         *accesslog.Logger
+	mainRouter        *nbtcp.Router
+	mainPort          uint16
+	udpMu             sync.Mutex
+	udpRelays         map[types.ServiceID]*udprelay.Relay
+	udpRelayWg        sync.WaitGroup
+	portMu            sync.RWMutex
+	portRouters       map[uint16]*portRouter
+	svcPorts          map[types.ServiceID][]uint16
+	lastMappings      map[types.ServiceID]*proto.ProxyMapping
+	portRouterWg      sync.WaitGroup
 
 	// hijackTracker tracks hijacked connections (e.g. WebSocket upgrades)
 	// so they can be closed during graceful shutdown, since http.Server.Shutdown
@@ -792,6 +793,7 @@ func (s *Server) configureTLS(ctx context.Context) (*tls.Config, error) {
 			return nil, fmt.Errorf("initialize certificate watcher: %w", err)
 		}
 		go certWatcher.Watch(ctx)
+		s.staticCertWatcher = certWatcher
 		tlsConfig.GetCertificate = certWatcher.GetCertificate
 		return tlsConfig, nil
 	}
@@ -1623,6 +1625,8 @@ func (s *Server) setupHTTPMapping(ctx context.Context, mapping *proto.ProxyMappi
 	var wildcardHit bool
 	if s.acme != nil {
 		wildcardHit = s.acme.AddDomain(d, accountID, svcID)
+	} else {
+		wildcardHit = s.staticCertCovers(d)
 	}
 	httpRoute := nbtcp.Route{
 		Type:      nbtcp.RouteHTTP,
@@ -1645,6 +1649,26 @@ func (s *Server) setupHTTPMapping(ctx context.Context, mapping *proto.ProxyMappi
 	}
 
 	return nil
+}
+
+// staticCertCovers reports whether the static certificate loaded when ACME is
+// disabled covers the given domain, making it certificate-ready immediately —
+// the equivalent of a wildcard hit in the ACME path. Domains the certificate
+// does not cover are logged: clients connecting to them will get TLS errors.
+func (s *Server) staticCertCovers(d domain.Domain) bool {
+	if s.staticCertWatcher == nil {
+		return false
+	}
+	leaf := s.staticCertWatcher.Leaf()
+	if leaf == nil {
+		return false
+	}
+	name := d.PunycodeString()
+	if err := leaf.VerifyHostname(name); err != nil {
+		s.Logger.Warnf("static certificate (SANs %v) does not cover domain %q: %v", leaf.DNSNames, name, err)
+		return false
+	}
+	return true
 }
 
 // setupTCPMapping sets up a TCP port-forwarding fallback route on the listen port.

--- a/proxy/static_cert_test.go
+++ b/proxy/static_cert_test.go
@@ -1,0 +1,89 @@
+package proxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/proxy/internal/certwatch"
+	"github.com/netbirdio/netbird/shared/management/domain"
+)
+
+func generateCertWithSANs(t *testing.T, dnsNames []string) (certPEM, keyPEM []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: dnsNames[0]},
+		DNSNames:     dnsNames,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM
+}
+
+func newStaticWatcher(t *testing.T, dnsNames []string) *certwatch.Watcher {
+	t.Helper()
+
+	dir := t.TempDir()
+	certPEM, keyPEM := generateCertWithSANs(t, dnsNames)
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+
+	w, err := certwatch.NewWatcher(certPath, keyPath, quietLifecycleLogger())
+	require.NoError(t, err)
+	return w
+}
+
+func TestStaticCertCovers(t *testing.T) {
+	s := &Server{
+		Logger:            quietLifecycleLogger(),
+		staticCertWatcher: newStaticWatcher(t, []string{"*.p.example.com", "exact.example.com"}),
+	}
+
+	cases := []struct {
+		domain  string
+		covered bool
+	}{
+		{"svc.p.example.com", true},
+		{"exact.example.com", true},
+		{"a.b.p.example.com", false}, // wildcard does not span labels
+		{"p.example.com", false},
+		{"other.example.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.domain, func(t *testing.T) {
+			assert.Equal(t, tc.covered, s.staticCertCovers(domain.Domain(tc.domain)))
+		})
+	}
+}
+
+func TestStaticCertCoversNoWatcher(t *testing.T) {
+	s := &Server{Logger: quietLifecycleLogger()}
+	assert.False(t, s.staticCertCovers(domain.Domain("svc.p.example.com")))
+}


### PR DESCRIPTION
## Describe your changes

When ACME is disabled (`NB_PROXY_ACME_CERTIFICATES=false`) the proxy serves a static certificate via the `certwatch` watcher, but `setupHTTPMapping` only sent `NotifyCertificateIssued` through the ACME manager's wildcard-hit path. With `s.acme` nil the notification never fired, so management never set the service's `certificate_issued_at` and the dashboard showed the domain stuck on "Issuing certificate..." forever, even though TLS worked fine (`meta_status` was correctly `active`, observed live on a 0.72.2 self-hosted deployment).

This change:
- keeps a reference to the static certificate watcher on `Server` (previously a discarded local in `configureTLS`),
- treats a domain covered by the loaded static certificate as a wildcard hit in `setupHTTPMapping`, mirroring the ACME path's behavior for `WildcardDir` hits, so the existing `NotifyCertificateIssued` call fires and the dashboard clears,
- logs a warning when the static certificate does **not** cover a mapped domain — previously silent, and clients connecting to such a domain get TLS errors.

Coverage is checked with `x509.Certificate.VerifyHostname` on the watcher's leaf, so SAN wildcard semantics (no label spanning) match standard TLS validation.

Unit tests cover the new coverage-check helper (wildcard match, exact SAN, no label spanning, nil watcher); the notification wiring itself reuses the existing wildcard-hit path and is not separately tested.

## Issue ticket number and link

Fixes #5384 (also reported as #5517)

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): fixes the existing documented behavior of `NB_PROXY_ACME_CERTIFICATES=false`; no new flags or behavior to document.

### Docs PR URL (required if "docs added" is checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Static certificates are now properly recognized as covering their configured domains, ensuring consistent certificate readiness handling across both static and ACME-based deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->