### PR TITLE
[client] wire LogPath into DebugBundle via InitializeLog

### DIFF
--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -68,6 +68,7 @@ type Client struct {
 	cfgFile               string
 	stateFile             string
 	cacheDir              string
+	logFilePath           string
 	recorder              *peer.Status
 	ctxCancel             context.CancelFunc
 	ctxCancelLock         *sync.Mutex
@@ -87,11 +88,12 @@ type Client struct {
 }
 
 // NewClient instantiate a new Client
-func NewClient(cfgFile, stateFile, cacheDir, deviceName string, osVersion string, osName string, networkChangeListener NetworkChangeListener, dnsManager DnsManager) *Client {
+func NewClient(cfgFile, stateFile, cacheDir, logFilePath, deviceName string, osVersion string, osName string, networkChangeListener NetworkChangeListener, dnsManager DnsManager) *Client {
 	return &Client{
 		cfgFile:               cfgFile,
 		stateFile:             stateFile,
 		cacheDir:              cacheDir,
+		logFilePath:           logFilePath,
 		deviceName:            deviceName,
 		osName:                osName,
 		osVersion:             osVersion,
@@ -219,6 +221,7 @@ func (c *Client) DebugBundle(anonymize bool) (string, error) {
 		StatusRecorder: c.recorder,
 		TempDir:        c.cacheDir,
 		StatePath:      c.stateFile,
+		LogPath:        c.logFilePath,
 	}
 
 	if cc != nil {


### PR DESCRIPTION
Store the log file path in a package-level variable when InitializeLog is called, so DebugBundle can pass it to GeneratorDependencies.LogPath without requiring the caller to set it separately.

Also expose SetLogPath() so the Swift side can override the path explicitly when needed (e.g. main app process generating a bundle for the extension's logs).

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
