### PR TITLE
[client] Answer NODATA instead of SERVFAIL when a host has no addresses of the requested family

### DIFF
--- a/client/internal/dns/resutil/resolve.go
+++ b/client/internal/dns/resutil/resolve.go
@@ -14,6 +14,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// errNoSuitableAddress mirrors the unexported error string the net package
+// uses when a resolved host has no addresses of the requested family.
+const errNoSuitableAddress = "no suitable address found"
+
 // GenerateRequestID creates a random 8-character hex string for request tracing.
 func GenerateRequestID() string {
 	bytes := make([]byte, 4)
@@ -126,6 +130,14 @@ func LookupIP(ctx context.Context, r resolver, network, host string, qtype uint1
 }
 
 func getRcodeForError(ctx context.Context, r resolver, host string, qtype uint16, err error) int {
+	// The net package returns this AddrError when the host resolves but has
+	// no addresses of the requested family. The domain exists, so answer
+	// NODATA instead of SERVFAIL.
+	var addrErr *net.AddrError
+	if errors.As(err, &addrErr) && addrErr.Err == errNoSuitableAddress {
+		return dns.RcodeSuccess
+	}
+
 	var dnsErr *net.DNSError
 	if !errors.As(err, &dnsErr) {
 		return dns.RcodeServerFailure

--- a/client/internal/dns/resutil/resolve_test.go
+++ b/client/internal/dns/resutil/resolve_test.go
@@ -1,0 +1,122 @@
+package resutil
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockResolver struct {
+	// results maps network ("ip4"/"ip6") to the lookup outcome.
+	results map[string]mockLookup
+}
+
+type mockLookup struct {
+	ips []netip.Addr
+	err error
+}
+
+func (m *mockResolver) LookupNetIP(_ context.Context, network, _ string) ([]netip.Addr, error) {
+	res, ok := m.results[network]
+	if !ok {
+		return nil, errors.New("unexpected network: " + network)
+	}
+	return res.ips, res.err
+}
+
+func TestLookupIP_Success(t *testing.T) {
+	r := &mockResolver{results: map[string]mockLookup{
+		"ip4": {ips: []netip.Addr{netip.MustParseAddr("::ffff:192.0.2.1")}},
+	}}
+
+	result := LookupIP(context.Background(), r, "ip4", "example.com.", dns.TypeA)
+
+	assert.Equal(t, dns.RcodeSuccess, result.Rcode, "successful lookup should return NOERROR")
+	require.Len(t, result.IPs, 1, "should return the resolved address")
+	assert.Equal(t, netip.MustParseAddr("192.0.2.1"), result.IPs[0], "v4-mapped address should be unmapped")
+}
+
+func TestLookupIP_NoSuitableAddress(t *testing.T) {
+	// The net package returns this AddrError when the host resolves but has
+	// no addresses of the requested family (e.g. AAAA query for a v4-only
+	// hosts file entry). The domain exists, so this is NODATA, not SERVFAIL.
+	r := &mockResolver{results: map[string]mockLookup{
+		"ip6": {err: &net.AddrError{Err: "no suitable address found", Addr: "example.com."}},
+	}}
+
+	result := LookupIP(context.Background(), r, "ip6", "example.com.", dns.TypeAAAA)
+
+	assert.Equal(t, dns.RcodeSuccess, result.Rcode, "no suitable address should map to NODATA")
+	assert.Empty(t, result.IPs, "NODATA response should carry no addresses")
+}
+
+// TestErrNoSuitableAddressMatchesNetPackage pins our copy of the error string
+// to what the net package actually emits. A literal IP of the wrong family
+// takes the same filterAddrList path as a resolved hostname, without network
+// access.
+func TestErrNoSuitableAddressMatchesNetPackage(t *testing.T) {
+	_, err := (&net.Resolver{}).LookupNetIP(context.Background(), "ip6", "192.0.2.1")
+	require.Error(t, err)
+
+	var addrErr *net.AddrError
+	require.ErrorAs(t, err, &addrErr, "wrong-family lookup should return AddrError")
+	assert.Equal(t, errNoSuitableAddress, addrErr.Err, "net package error string should match our constant")
+}
+
+func TestLookupIP_OtherAddrError(t *testing.T) {
+	r := &mockResolver{results: map[string]mockLookup{
+		"ip4": {err: &net.AddrError{Err: "some other address problem", Addr: "example.com."}},
+	}}
+
+	result := LookupIP(context.Background(), r, "ip4", "example.com.", dns.TypeA)
+
+	assert.Equal(t, dns.RcodeServerFailure, result.Rcode, "unrecognized AddrError should map to SERVFAIL")
+}
+
+func TestLookupIP_NotFoundNXDomain(t *testing.T) {
+	r := &mockResolver{results: map[string]mockLookup{
+		"ip4": {err: &net.DNSError{Err: "no such host", Name: "example.com.", IsNotFound: true}},
+		"ip6": {err: &net.DNSError{Err: "no such host", Name: "example.com.", IsNotFound: true}},
+	}}
+
+	result := LookupIP(context.Background(), r, "ip4", "example.com.", dns.TypeA)
+
+	assert.Equal(t, dns.RcodeNameError, result.Rcode, "not found for both families should map to NXDOMAIN")
+}
+
+func TestLookupIP_NotFoundNoData(t *testing.T) {
+	r := &mockResolver{results: map[string]mockLookup{
+		"ip6": {err: &net.DNSError{Err: "no such host", Name: "example.com.", IsNotFound: true}},
+		"ip4": {ips: []netip.Addr{netip.MustParseAddr("192.0.2.1")}},
+	}}
+
+	result := LookupIP(context.Background(), r, "ip6", "example.com.", dns.TypeAAAA)
+
+	assert.Equal(t, dns.RcodeSuccess, result.Rcode, "not found with the other family present should map to NODATA")
+}
+
+func TestLookupIP_GenericError(t *testing.T) {
+	r := &mockResolver{results: map[string]mockLookup{
+		"ip4": {err: errors.New("connection refused")},
+	}}
+
+	result := LookupIP(context.Background(), r, "ip4", "example.com.", dns.TypeA)
+
+	assert.Equal(t, dns.RcodeServerFailure, result.Rcode, "generic error should map to SERVFAIL")
+}
+
+func TestLookupIP_DNSErrorNotIsNotFound(t *testing.T) {
+	r := &mockResolver{results: map[string]mockLookup{
+		"ip4": {err: &net.DNSError{Err: "server misbehaving", Name: "example.com.", IsTemporary: true}},
+	}}
+
+	result := LookupIP(context.Background(), r, "ip4", "example.com.", dns.TypeA)
+
+	assert.Equal(t, dns.RcodeServerFailure, result.Rcode, "upstream failure should map to SERVFAIL")
+}


### PR DESCRIPTION
## Describe your changes

The DNS forwarder and upstream resolver answered SERVFAIL when a name resolved but had no addresses of the requested family (e.g. an AAAA query for a name with only an IPv4 hosts-file entry), logging a `failed to resolve query` warning on every such query.

- Map the net package's "no suitable address found" error to NODATA instead of SERVFAIL, since the domain exists
- Add tests for the rcode mapping in resutil, including one that pins the error string against the real net resolver

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal bug fix, no user-facing behavior to document)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced DNS resolver to more accurately handle network address lookup failures, improving error reporting reliability.

* **Tests**
  * Added comprehensive test coverage for DNS address lookup functionality across multiple error scenarios and network conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->