### PR TITLE
Add explicit peer kind support to Management API

### DIFF
--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1631,7 +1631,8 @@ func TestAccount_Copy(t *testing.T) {
 		},
 		Peers: map[string]*nbpeer.Peer{
 			"peer1": {
-				Key: "key1",
+				Key:  "key1",
+				Kind: nbpeer.KindAuto,
 				Status: &nbpeer.PeerStatus{
 					LastSeen:     time.Now(),
 					Connected:    true,

--- a/management/server/http/handlers/peers/peers_handler.go
+++ b/management/server/http/handlers/peers/peers_handler.go
@@ -200,6 +200,15 @@ func (h *Handler) updatePeer(ctx context.Context, accountID, userID, peerID stri
 		InactivityExpirationEnabled: req.InactivityExpirationEnabled,
 	}
 
+	if req.Kind != nil {
+		kind := nbpeer.Kind(*req.Kind)
+		if !kind.IsValid() {
+			util.WriteError(ctx, status.Errorf(status.InvalidArgument, "invalid peer kind %q", kind), w)
+			return
+		}
+		update.Kind = kind
+	}
+
 	if req.ApprovalRequired != nil {
 		// todo: looks like that we reset all status property, is it right?
 		update.Status = &nbpeer.PeerStatus{
@@ -587,6 +596,7 @@ func toSinglePeerResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dnsD
 		SshEnabled:                  peer.SSHEnabled,
 		Hostname:                    peer.Meta.Hostname,
 		UserId:                      peer.UserID,
+		Kind:                        api.PeerKind(peer.Kind.Normalize()),
 		UiVersion:                   peer.Meta.UIVersion,
 		DnsLabel:                    fqdn(peer, dnsDomain),
 		ExtraDnsLabels:              fqdnList(peer.ExtraDNSLabels, dnsDomain),
@@ -642,6 +652,7 @@ func toPeerListItemResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dn
 		SshEnabled:                  peer.SSHEnabled,
 		Hostname:                    peer.Meta.Hostname,
 		UserId:                      peer.UserID,
+		Kind:                        api.PeerKind(peer.Kind.Normalize()),
 		UiVersion:                   peer.Meta.UIVersion,
 		DnsLabel:                    fqdn(peer, dnsDomain),
 		ExtraDnsLabels:              fqdnList(peer.ExtraDNSLabels, dnsDomain),

--- a/management/server/http/handlers/peers/peers_handler_test.go
+++ b/management/server/http/handlers/peers/peers_handler_test.go
@@ -141,6 +141,9 @@ func initTestMetaData(t *testing.T, peers ...*nbpeer.Peer) *Handler {
 				p.SSHEnabled = update.SSHEnabled
 				p.LoginExpirationEnabled = update.LoginExpirationEnabled
 				p.Name = update.Name
+				if update.Kind != "" {
+					p.Kind = update.Kind
+				}
 				return p, nil
 			},
 			UpdatePeerIPFunc: func(_ context.Context, accountID, userID, peerID string, newIP netip.Addr) error {
@@ -252,6 +255,7 @@ func TestGetPeers(t *testing.T) {
 	expectedUpdatedPeer.LoginExpirationEnabled = true
 	expectedUpdatedPeer.SSHEnabled = true
 	expectedUpdatedPeer.Name = "New Name"
+	expectedUpdatedPeer.Kind = nbpeer.KindServer
 
 	expectedPeer1 := peer1.Copy()
 	expectedPeer1.Status.Connected = false
@@ -287,7 +291,7 @@ func TestGetPeers(t *testing.T) {
 			requestPath:    "/api/peers/" + testPeerID,
 			expectedStatus: http.StatusOK,
 			expectedArray:  false,
-			requestBody:    bytes.NewBufferString("{\"login_expiration_enabled\":true,\"name\":\"New Name\",\"ssh_enabled\":true}"),
+			requestBody:    bytes.NewBufferString("{\"login_expiration_enabled\":true,\"name\":\"New Name\",\"ssh_enabled\":true,\"kind\":\"server\"}"),
 			expectedPeer:   expectedUpdatedPeer,
 		},
 	}
@@ -361,8 +365,37 @@ func TestGetPeers(t *testing.T) {
 			assert.Equal(t, tc.expectedPeer.SSHEnabled, got.SshEnabled)
 			assert.Equal(t, tc.expectedPeer.Status.Connected, got.Connected)
 			assert.Equal(t, tc.expectedPeer.Meta.SystemSerialNumber, got.SerialNumber)
+			assert.Equal(t, api.PeerKind(tc.expectedPeer.Kind.Normalize()), got.Kind)
 		})
 	}
+}
+
+func TestPeersHandlerUpdatePeerKindRejectsInvalidValue(t *testing.T) {
+	testPeer := &nbpeer.Peer{
+		ID:     testPeerID,
+		Key:    "key",
+		IP:     netip.MustParseAddr("100.64.0.1"),
+		Status: &nbpeer.PeerStatus{Connected: false, LastSeen: time.Now()},
+		Name:   "test-host",
+	}
+
+	p := initTestMetaData(t, testPeer)
+
+	req := httptest.NewRequest(http.MethodPut, "/peers/"+testPeerID, bytes.NewBufferString(`{"kind":"workstation"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = nbcontext.SetUserAuthInRequest(req, auth.UserAuth{
+		UserId:    adminUser,
+		Domain:    "hotmail.com",
+		AccountId: "test_id",
+	})
+
+	rr := httptest.NewRecorder()
+	router := mux.NewRouter()
+	router.HandleFunc("/peers/{peerId}", p.HandlePeer).Methods("PUT")
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rr.Code)
 }
 
 func TestGetAccessiblePeers(t *testing.T) {

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -208,7 +208,7 @@ func (am *DefaultAccountManager) updatePeerLocationIfChanged(ctx context.Context
 	}
 }
 
-// UpdatePeer updates peer. Only Peer.Name, Peer.SSHEnabled, Peer.LoginExpirationEnabled and Peer.InactivityExpirationEnabled can be updated.
+// UpdatePeer updates peer. Only Peer.Name, Peer.Kind, Peer.SSHEnabled, Peer.LoginExpirationEnabled and Peer.InactivityExpirationEnabled can be updated.
 func (am *DefaultAccountManager) UpdatePeer(ctx context.Context, accountID, userID string, update *nbpeer.Peer) (*nbpeer.Peer, error) {
 	allowed, ctx, err := am.permissionsManager.ValidateUserPermissions(ctx, accountID, userID, modules.Peers, operations.Update)
 	if err != nil {
@@ -281,6 +281,13 @@ func (am *DefaultAccountManager) UpdatePeer(ctx context.Context, accountID, user
 		if peer.SSHEnabled != update.SSHEnabled {
 			peer.SSHEnabled = update.SSHEnabled
 			sshChanged = true
+		}
+
+		if update.Kind != "" {
+			if !update.Kind.IsValid() {
+				return status.Errorf(status.InvalidArgument, "invalid peer kind %q", update.Kind)
+			}
+			peer.Kind = update.Kind.Normalize()
 		}
 
 		if peer.LoginExpirationEnabled != update.LoginExpirationEnabled {

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -17,6 +17,30 @@ const (
 	PeerCapabilityIPv6Overlay    int32 = 2
 )
 
+type Kind string
+
+const (
+	KindAuto   Kind = "auto"
+	KindDevice Kind = "device"
+	KindServer Kind = "server"
+)
+
+func (k Kind) IsValid() bool {
+	switch k {
+	case KindAuto, KindDevice, KindServer:
+		return true
+	default:
+		return false
+	}
+}
+
+func (k Kind) Normalize() Kind {
+	if k.IsValid() {
+		return k
+	}
+	return KindAuto
+}
+
 // Peer represents a machine connected to the network.
 // The Peer is a WireGuard peer identified by a public key
 type Peer struct {
@@ -43,6 +67,8 @@ type Peer struct {
 	Status *PeerStatus `gorm:"embedded;embeddedPrefix:peer_status_"`
 	// The user ID that registered the peer
 	UserID string
+	// Kind is the dashboard classification override for this peer.
+	Kind Kind `gorm:"type:varchar(16);default:auto"`
 	// SSHKey is a public SSH key of the peer
 	SSHKey string
 	// SSHEnabled indicates whether SSH server is enabled on the peer
@@ -280,6 +306,7 @@ func (p *Peer) Copy() *Peer {
 		DNSLabel:                    p.DNSLabel,
 		Status:                      peerStatus,
 		UserID:                      p.UserID,
+		Kind:                        p.Kind.Normalize(),
 		SSHKey:                      p.SSHKey,
 		SSHEnabled:                  p.SSHEnabled,
 		LoginExpirationEnabled:      p.LoginExpirationEnabled,

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -2890,3 +2890,42 @@ func TestUpdatePeer_DnsLabelUniqueName(t *testing.T) {
 	require.NoError(t, err, "renaming to unique FQDN should succeed")
 	assert.Equal(t, "api-server", updated.DNSLabel, "DNS label should be first label of FQDN")
 }
+
+func TestUpdatePeer_Kind(t *testing.T) {
+	manager, _, err := createManager(t)
+	require.NoError(t, err, "unable to create account manager")
+
+	accountID, err := manager.GetAccountIDByUserID(context.Background(), auth.UserAuth{UserId: userID})
+	require.NoError(t, err, "unable to create an account")
+
+	key, err := wgtypes.GenerateKey()
+	require.NoError(t, err)
+	peer, _, _, err := manager.AddPeer(context.Background(), "", "", userID, &nbpeer.Peer{
+		Key:  key.PublicKey().String(),
+		Meta: nbpeer.PeerSystemMeta{Hostname: "kind-test-peer"},
+	}, false)
+	require.NoError(t, err)
+
+	update := peer.Copy()
+	update.Kind = nbpeer.KindDevice
+
+	updated, err := manager.UpdatePeer(context.Background(), accountID, userID, update)
+	require.NoError(t, err)
+	assert.Equal(t, nbpeer.KindDevice, updated.Kind)
+
+	stored, err := manager.GetPeer(context.Background(), accountID, updated.ID, userID)
+	require.NoError(t, err)
+	assert.Equal(t, nbpeer.KindDevice, stored.Kind)
+
+	updateWithoutKind := &nbpeer.Peer{
+		ID:                          updated.ID,
+		Name:                        updated.Name,
+		SSHEnabled:                  updated.SSHEnabled,
+		LoginExpirationEnabled:      updated.LoginExpirationEnabled,
+		InactivityExpirationEnabled: updated.InactivityExpirationEnabled,
+	}
+
+	preserved, err := manager.UpdatePeer(context.Background(), accountID, userID, updateWithoutKind)
+	require.NoError(t, err)
+	assert.Equal(t, nbpeer.KindDevice, preserved.Kind)
+}

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -1827,7 +1827,7 @@ func (s *SqlStore) getSetupKeys(ctx context.Context, accountID string) ([]types.
 }
 
 func (s *SqlStore) getPeers(ctx context.Context, accountID string) ([]nbpeer.Peer, error) {
-	const query = `SELECT id, account_id, key, ip, name, dns_label, user_id, ssh_key, ssh_enabled, login_expiration_enabled,
+	const query = `SELECT id, account_id, key, ip, name, dns_label, user_id, kind, ssh_key, ssh_enabled, login_expiration_enabled,
 	inactivity_expiration_enabled, last_login, created_at, ephemeral, extra_dns_labels, allow_extra_dns_labels, meta_hostname,
 	meta_go_os, meta_kernel, meta_core, meta_platform, meta_os, meta_os_version, meta_wt_version, meta_ui_version,
 	meta_kernel_version, meta_network_addresses, meta_system_serial_number, meta_system_product_name, meta_system_manufacturer,
@@ -1853,11 +1853,11 @@ func (s *SqlStore) getPeers(ctx context.Context, accountID string) ([]nbpeer.Pee
 			metaHostname, metaGoOS, metaKernel, metaCore, metaPlatform                                      sql.NullString
 			metaOS, metaOSVersion, metaWtVersion, metaUIVersion, metaKernelVersion                          sql.NullString
 			metaSystemSerialNumber, metaSystemProductName, metaSystemManufacturer                           sql.NullString
-			locationCountryCode, locationCityName, proxyCluster                                             sql.NullString
+			locationCountryCode, locationCityName, proxyCluster, peerKind                                   sql.NullString
 			locationGeoNameID                                                                               sql.NullInt64
 		)
 
-		err := row.Scan(&p.ID, &p.AccountID, &p.Key, &ip, &p.Name, &p.DNSLabel, &p.UserID, &p.SSHKey, &sshEnabled,
+		err := row.Scan(&p.ID, &p.AccountID, &p.Key, &ip, &p.Name, &p.DNSLabel, &p.UserID, &peerKind, &p.SSHKey, &sshEnabled,
 			&loginExpirationEnabled, &inactivityExpirationEnabled, &lastLogin, &createdAt, &ephemeral, &extraDNS,
 			&allowExtraDNSLabels, &metaHostname, &metaGoOS, &metaKernel, &metaCore, &metaPlatform,
 			&metaOS, &metaOSVersion, &metaWtVersion, &metaUIVersion, &metaKernelVersion, &netAddr,
@@ -1867,6 +1867,7 @@ func (s *SqlStore) getPeers(ctx context.Context, accountID string) ([]nbpeer.Pee
 			&proxyEmbedded, &proxyCluster, &ipv6)
 
 		if err == nil {
+			p.Kind = nbpeer.Kind(peerKind.String).Normalize()
 			if lastLogin.Valid {
 				p.LastLogin = &lastLogin.Time
 			}

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -506,6 +506,9 @@ func getMigrationsPreAuto(ctx context.Context) []migrationFunc {
 			return migration.MigrateNewField[nbpeer.Peer](ctx, db, "peer_status_session_started_at", int64(0))
 		},
 		func(db *gorm.DB) error {
+			return migration.MigrateNewField[nbpeer.Peer](ctx, db, "kind", string(nbpeer.KindAuto))
+		},
+		func(db *gorm.DB) error {
 			return migration.RemoveDuplicatePeerKeys(ctx, db)
 		},
 		func(db *gorm.DB) error {

--- a/shared/management/http/api/openapi.yml
+++ b/shared/management/http/api/openapi.yml
@@ -795,11 +795,21 @@ components:
           type: string
           format: ipv6
           example: "fd00:4e42:ab12::1"
+        kind:
+          $ref: '#/components/schemas/PeerKind'
       required:
         - name
         - ssh_enabled
         - login_expiration_enabled
         - inactivity_expiration_enabled
+    PeerKind:
+      type: string
+      description: Peer classification. Automatic uses the default server-side inference.
+      enum:
+        - auto
+        - device
+        - server
+      example: auto
     Peer:
       allOf:
         - $ref: '#/components/schemas/PeerMinimum'
@@ -861,6 +871,8 @@ components:
               description: User ID of the user that enrolled this peer
               type: string
               example: google-oauth2|277474792786460067937
+            kind:
+              $ref: '#/components/schemas/PeerKind'
             hostname:
               description: Hostname of the machine
               type: string
@@ -937,6 +949,7 @@ components:
             - os
             - ssh_enabled
             - user_id
+            - kind
             - version
             - ui_version
             - approval_required

--- a/shared/management/http/api/types.gen.go
+++ b/shared/management/http/api/types.gen.go
@@ -725,6 +725,27 @@ func (e NotificationChannelType) Valid() bool {
 	}
 }
 
+// Defines values for PeerKind.
+const (
+	PeerKindAuto   PeerKind = "auto"
+	PeerKindDevice PeerKind = "device"
+	PeerKindServer PeerKind = "server"
+)
+
+// Valid indicates whether the value is a known member of the PeerKind enum.
+func (e PeerKind) Valid() bool {
+	switch e {
+	case PeerKindAuto:
+		return true
+	case PeerKindDevice:
+		return true
+	case PeerKindServer:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PeerNetworkRangeCheckAction.
 const (
 	PeerNetworkRangeCheckActionAllow PeerNetworkRangeCheckAction = "allow"
@@ -3182,6 +3203,9 @@ type Peer struct {
 	// KernelVersion Peer's operating system kernel version
 	KernelVersion string `json:"kernel_version"`
 
+	// Kind Peer classification. Automatic uses the default server-side inference.
+	Kind PeerKind `json:"kind"`
+
 	// LastLogin Last time this peer performed log in (authentication). E.g., user authenticated.
 	LastLogin time.Time `json:"last_login"`
 
@@ -3276,6 +3300,9 @@ type PeerBatch struct {
 	// KernelVersion Peer's operating system kernel version
 	KernelVersion string `json:"kernel_version"`
 
+	// Kind Peer classification. Automatic uses the default server-side inference.
+	Kind PeerKind `json:"kind"`
+
 	// LastLogin Last time this peer performed log in (authentication). E.g., user authenticated.
 	LastLogin time.Time `json:"last_login"`
 
@@ -3310,6 +3337,9 @@ type PeerBatch struct {
 	// Version Peer's daemon or cli version
 	Version string `json:"version"`
 }
+
+// PeerKind Peer classification. Automatic uses the default server-side inference.
+type PeerKind string
 
 // PeerLocalFlags defines model for PeerLocalFlags.
 type PeerLocalFlags struct {
@@ -3377,10 +3407,13 @@ type PeerRequest struct {
 	Ip *string `json:"ip,omitempty"`
 
 	// Ipv6 Peer's IPv6 overlay address. Omitted if IPv6 is not enabled for the account.
-	Ipv6                   *string `json:"ipv6,omitempty"`
-	LoginExpirationEnabled bool    `json:"login_expiration_enabled"`
-	Name                   string  `json:"name"`
-	SshEnabled             bool    `json:"ssh_enabled"`
+	Ipv6 *string `json:"ipv6,omitempty"`
+
+	// Kind Peer classification. Automatic uses the default server-side inference.
+	Kind                   *PeerKind `json:"kind,omitempty"`
+	LoginExpirationEnabled bool      `json:"login_expiration_enabled"`
+	Name                   string    `json:"name"`
+	SshEnabled             bool      `json:"ssh_enabled"`
 }
 
 // PeerTemporaryAccessRequest defines model for PeerTemporaryAccessRequest.


### PR DESCRIPTION
## Describe your changes

This PR adds explicit peer kind support to the Management API so peers can be classified as `auto`, `device`, or `server`.

Today, the dashboard has to infer peer type from enrollment behavior: peers enrolled with setup keys are treated as servers, and peers enrolled through SSO are treated as user devices. That inference is probably correct for most installations most of the time, but it is not always true. Some setup-key peers are regular devices, and some SSO-enrolled peers may function as servers, shared infrastructure, or unattended systems. Using enrollment method as the only source of truth makes the implementation clunky and limits the dashboard’s ability to represent the user’s actual environment.

This PR keeps the current behavior compatible by making `auto` the default value. In `auto` mode, dashboards and clients can continue using the existing inference logic. Newer dashboards can optionally let users override the classification by setting `kind` to `device` or `server`.

Changes included:

- Adds a peer `Kind` field in the management server model.
- Supports three values: `auto`, `device`, and `server`.
- Defaults existing and new peers to `auto`.
- Adds a store migration to backfill the new `kind` field on existing peer records.
- Includes `kind` in peer list and single-peer API responses.
- Accepts optional `kind` updates through the peer update API.
- Validates invalid peer kind values server-side and rejects them with an invalid argument error.
- Updates the optimized/raw SQL account loader so peer kind is loaded consistently across store paths.
- Updates the OpenAPI schema and generated API types for the new field.
- Adds tests for valid peer kind updates, invalid peer kind rejection, persistence, preservation when omitted, migration/default behavior, and account copy/store consistency.

This is intended to support the companion dashboard change that restores the combined Peers page and allows the UI to respect explicit peer type when the backend provides it.

## Issue ticket number and link

Supports dashboard issue: https://github.com/netbirdio/dashboard/issues/663  
Supports dashboard PR: https://github.com/netbirdio/dashboard/pull/668

Issue #663 reports that the split Peers UI reduced functionality by forcing users to move between separate User Devices and Servers pages instead of working from one complete peer list. This API change addresses the underlying classification limitation that made the split awkward: the existing server/device distinction is inferred from enrollment method, which is useful as a default but not always accurate.

## Stack

<!-- branch-stack -->

Companion dashboard PR: https://github.com/netbirdio/dashboard/pull/668

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

Because this adds a public REST API field, I left the public API checklist item unchecked unless maintainers consider the linked dashboard issue/PR sufficient prior discussion.

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This change adds a small Management API field used by the dashboard to classify peers as automatic, device, or server. It does not introduce a new setup flow, operator configuration step, CLI flag, or user-facing self-hosting procedure. The dashboard companion PR presents the relevant behavior directly in the UI through the Peers page controls and peer detail field.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Peers can now be classified with a kind field (auto, device, or server)
  * The kind field is included in peer API responses and can be updated
  * Invalid kind values are rejected with appropriate error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->