### PR TITLE
[management] treat ci- builds as development for remote jobs

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -17,6 +17,10 @@ const DevelopmentVersion = "development"
 // are treated as development versions by IsDevelopmentVersion.
 const CIVersionPrefix = "ci-"
 
+// DevVersionPrefix marks dev snapshot builds (e.g. "dev-7470fbdd"). Such builds
+// are treated as development versions by IsDevelopmentVersion.
+const DevVersionPrefix = "dev-"
+
 // will be replaced with the release version when using goreleaser
 var version = DevelopmentVersion
 
@@ -74,8 +78,10 @@ func NetbirdCommit() string {
 //
 // Matches the bare DevelopmentVersion constant as well as any future
 // extension such as "development-<sha>" or "development-<sha>-dirty", and
-// CI snapshot builds prefixed with "ci-", while excluding tagged prereleases
-// like "v0.31.1-dev".
+// CI/dev snapshot builds prefixed with "ci-" or "dev-", while excluding
+// tagged prereleases like "v0.31.1-dev".
 func IsDevelopmentVersion(v string) bool {
-	return strings.HasPrefix(v, DevelopmentVersion) || strings.HasPrefix(v, CIVersionPrefix)
+	return strings.HasPrefix(v, DevelopmentVersion) ||
+		strings.HasPrefix(v, CIVersionPrefix) ||
+		strings.HasPrefix(v, DevVersionPrefix)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -13,6 +13,10 @@ import (
 // string, so it must not change without coordinating those consumers.
 const DevelopmentVersion = "development"
 
+// CIVersionPrefix marks CI snapshot builds (e.g. "ci-7470fbdd"). Such builds
+// are treated as development versions by IsDevelopmentVersion.
+const CIVersionPrefix = "ci-"
+
 // will be replaced with the release version when using goreleaser
 var version = DevelopmentVersion
 
@@ -69,8 +73,9 @@ func NetbirdCommit() string {
 // comparing against the "development" literal or ad-hoc substring checks.
 //
 // Matches the bare DevelopmentVersion constant as well as any future
-// extension such as "development-<sha>" or "development-<sha>-dirty",
-// while excluding tagged prereleases like "v0.31.1-dev".
+// extension such as "development-<sha>" or "development-<sha>-dirty", and
+// CI snapshot builds prefixed with "ci-", while excluding tagged prereleases
+// like "v0.31.1-dev".
 func IsDevelopmentVersion(v string) bool {
-	return strings.HasPrefix(v, DevelopmentVersion)
+	return strings.HasPrefix(v, DevelopmentVersion) || strings.HasPrefix(v, CIVersionPrefix)
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -11,6 +11,7 @@ func TestIsDevelopmentVersion(t *testing.T) {
 		{"development-0823f3ff9ab1", true},
 		{"development-0823f3ff9ab1-dirty", true},
 		{"ci-7470fbdd", true},
+		{"dev-7470fbdd", true},
 		{"0.50.0", false},
 		{"v0.31.1-dev", false},
 		{"1.0.0-dev", false},

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -10,6 +10,7 @@ func TestIsDevelopmentVersion(t *testing.T) {
 		{"development", true},
 		{"development-0823f3ff9ab1", true},
 		{"development-0823f3ff9ab1-dirty", true},
+		{"ci-7470fbdd", true},
 		{"0.50.0", false},
 		{"v0.31.1-dev", false},
 		{"1.0.0-dev", false},


### PR DESCRIPTION
CI snapshot builds use a "ci-<sha>" version string that did not match IsDevelopmentVersion, so the remote-jobs minimum-version gate rejected them. Recognize the "ci-" prefix as a development build.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated version detection to recognize CI snapshot versions with the `ci-` prefix, and dev snapshot versions with the `dev-` prefix, as development builds for consistent classification.

* **Tests**
  * Expanded `IsDevelopmentVersion` test coverage to include `ci-<hash>` and `dev-<hash>` cases to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->