### PR TITLE
[management, signal] Read pprof listen address from environment

### DIFF
--- a/management/main.go
+++ b/management/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+
 	// nolint:gosec
 	_ "net/http/pprof"
 	"os"
@@ -10,9 +11,18 @@ import (
 	"github.com/netbirdio/netbird/management/cmd"
 )
 
+func pprofAddr() string {
+	listenAddr := os.Getenv("NB_PPROF_ADDR")
+	if listenAddr == "" {
+		return "localhost:6060"
+	}
+
+	return listenAddr
+}
+
 func main() {
 	go func() {
-		log.Println(http.ListenAndServe("localhost:6060", nil))
+		log.Println(http.ListenAndServe(pprofAddr(), nil))
 	}()
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/signal/cmd/run.go
+++ b/signal/cmd/run.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+
 	// nolint:gosec
 	_ "net/http/pprof"
 	"time"
@@ -194,10 +196,21 @@ var (
 	}
 )
 
+func pprofAddr() string {
+	listenAddr := os.Getenv("NB_PPROF_ADDR")
+	if listenAddr == "" {
+		return "localhost:6060"
+	}
+
+	return listenAddr
+}
+
 func startPprof() {
+	listenAddr := pprofAddr()
+
 	go func() {
-		log.Debugf("Starting pprof server on 127.0.0.1:6060")
-		if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
+		log.Debugf("Starting pprof server on: %s", listenAddr)
+		if err := http.ListenAndServe(listenAddr, nil); err != nil {
 			log.Fatalf("pprof server failed: %v", err)
 		}
 	}()


### PR DESCRIPTION
## Describe your changes

This adds support for configuring the pprof listen address for the standalone management and signal services via the `NB_PPROF_ADDR` environment variable.  The default address and behavior remain the same, i.e. pprof is enabled by default on: `localhost:6060`

## Issue ticket number and link

Fixes: https://linear.app/netbird/issue/NET-1283

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)

https://github.com/netbirdio/docs/pull/798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * pprof profiling server listen address is now configurable via the `NB_PPROF_ADDR` environment variable, with a default fallback to `localhost:6060`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->