### PR TITLE
[management] fix flaky Test_SaveAccount_Large from random IP collision

### DIFF
--- a/management/server/store/sql_store_test.go
+++ b/management/server/store/sql_store_test.go
@@ -6,7 +6,6 @@ import (
 	b64 "encoding/base64"
 	"encoding/binary"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/netip"
 	"os"
@@ -92,7 +91,7 @@ func runLargeTest(t *testing.T, store Store) {
 	account.SetupKeys[setupKey.Key] = setupKey
 	const numPerAccount = 6000
 	for n := 0; n < numPerAccount; n++ {
-		netIP := randomIPv4()
+		netIP := sequentialIPv4(n)
 		peerID := fmt.Sprintf("%s-peer-%d", account.Id, n)
 		addr, _ := netip.AddrFromSlice(netIP)
 
@@ -216,12 +215,12 @@ func runLargeTest(t *testing.T, store Store) {
 	}
 }
 
-func randomIPv4() net.IP {
-	rand.New(rand.NewSource(time.Now().UnixNano()))
+// sequentialIPv4 returns a unique IPv4 address for the given index, avoiding
+// the random collisions that would otherwise violate the unique (account_id, ip)
+// index when generating a large number of peers.
+func sequentialIPv4(n int) net.IP {
 	b := make([]byte, 4)
-	for i := range b {
-		b[i] = byte(rand.Intn(256))
-	}
+	binary.BigEndian.PutUint32(b, 0x0A000000+uint32(n))
 	return net.IP(b)
 }
 


### PR DESCRIPTION
## Describe your changes

`Test_SaveAccount_Large` was flaky on the `mysql` (and any) engine, failing intermittently with:

    sql_store_test.go:79: expecting Account to have 6000 peers stored after SaveAccount(), got 5999

Root cause: each of the 6000 test peers got its IP from `randomIPv4()`, which
returned 4 fully random bytes with no de-duplication. The `peers` table has a
unique index `idx_account_ip ON peers (account_id, ip)`, and since every peer
belongs to the same account, two colliding random IPv4 addresses caused the
unique index to drop one peer on insert — leaving 5999 instead of 6000. With
6000 addresses in a 32-bit space the birthday-collision probability is ~0.4%
per run.

Fix: replace `randomIPv4()` with `sequentialIPv4(n)`, which derives a unique,
deterministic address (`10.0.0.0 + n`, base `0x0A000000`) per peer index. With
6000 peers the range stays inside `10.0.0.0/8` (max `10.0.23.111`) and every IP
is unique, so the unique index never drops a row. Removed the now-unused
`math/rand` import.

## Issue ticket number and link

No public issue. Internal flaky-test fix for the management store suite; the
collision happens in `randomIPv4` used by `runLargeTest` in
`management/server/store/sql_store_test.go`.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Test-only change. No public CLI, API, configuration, or behavior change — only
the test's peer-IP generation is made deterministic to remove a pre-existing
flake.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the large-account test data generator to use predictable, non-colliding IPv4 addresses.
  * Reduced the chance of intermittent uniqueness-related test failures during large save scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->