### PR TITLE
[client] Fix ios route notify ordering

### DIFF
--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -333,6 +333,8 @@ func (m *DefaultManager) Stop(stateManager *statemanager.Manager) {
 		}
 	}
 
+	m.notifier.Close()
+
 	m.mux.Lock()
 	defer m.mux.Unlock()
 	m.clientRoutes = nil

--- a/client/internal/routemanager/notifier/notifier_android.go
+++ b/client/internal/routemanager/notifier/notifier_android.go
@@ -16,7 +16,7 @@ import (
 type Notifier struct {
 	initialRoutes []*route.Route
 	currentRoutes []*route.Route
-	fakeIPRoutes []*route.Route
+	fakeIPRoutes  []*route.Route
 
 	listener    listener.NetworkChangeListener
 	listenerMux sync.Mutex
@@ -118,4 +118,8 @@ func (n *Notifier) GetInitialRouteRanges() []string {
 	initialStrings := n.routesToStrings(n.initialRoutes)
 	sort.Strings(initialStrings)
 	return initialStrings
+}
+
+func (n *Notifier) Close() {
+	// unused
 }

--- a/client/internal/routemanager/notifier/notifier_ios.go
+++ b/client/internal/routemanager/notifier/notifier_ios.go
@@ -14,19 +14,51 @@ import (
 )
 
 type Notifier struct {
+	mu              sync.Mutex
 	currentPrefixes []string
+	listener        listener.NetworkChangeListener
 
-	listener    listener.NetworkChangeListener
-	listenerMux sync.Mutex
+	// updates carries route snapshots to the single delivery goroutine. A
+	// dedicated worker (rather than a fresh goroutine per notify) guarantees
+	// the listener observes updates in the exact order they were produced.
+	//
+	// Without this ordering guarantee a stale snapshot can be delivered last
+	// and clobber the correct one. On exit-node disable the ::/0 removal
+	// arrives as a separate prefix update right after the 0.0.0.0/0 removal;
+	// with a goroutine-per-notify the two could be reordered, leaving the
+	// synthesized ::/0 default route installed on the tunnel and black-holing
+	// all IPv6 traffic while IPv4 worked.
+	updates chan string
 }
 
 func NewNotifier() *Notifier {
-	return &Notifier{}
+	n := &Notifier{
+		// Buffered so producers (route updates run under the route manager
+		// lock) don't block on the listener callback. A small buffer absorbs
+		// the bursts seen during exit-node toggles.
+		updates: make(chan string, 16),
+	}
+	go n.deliverLoop()
+	return n
+}
+
+// deliverLoop is the single consumer of n.updates. Serializing delivery here
+// is what preserves ordering: snapshots reach the listener one at a time, in
+// production order.
+func (n *Notifier) deliverLoop() {
+	for routes := range n.updates {
+		n.mu.Lock()
+		l := n.listener
+		n.mu.Unlock()
+		if l != nil {
+			l.OnNetworkChanged(routes)
+		}
+	}
 }
 
 func (n *Notifier) SetListener(listener listener.NetworkChangeListener) {
-	n.listenerMux.Lock()
-	defer n.listenerMux.Unlock()
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	n.listener = listener
 }
 
@@ -43,30 +75,25 @@ func (n *Notifier) OnNewRoutes(route.HAMap) {
 }
 
 func (n *Notifier) OnNewPrefixes(prefixes []netip.Prefix) {
-	newNets := make([]string, 0)
+	newNets := make([]string, 0, len(prefixes))
 	for _, prefix := range prefixes {
 		newNets = append(newNets, prefix.String())
 	}
 
 	sort.Strings(newNets)
 
+	n.mu.Lock()
 	if slices.Equal(n.currentPrefixes, newNets) {
+		n.mu.Unlock()
 		return
 	}
-
 	n.currentPrefixes = newNets
-	n.notify()
-}
-func (n *Notifier) notify() {
-	n.listenerMux.Lock()
-	defer n.listenerMux.Unlock()
-	if n.listener == nil {
-		return
-	}
+	// Snapshot the delivered string under the lock so it is consistent and
+	// can't race with the next update mutating currentPrefixes.
+	routes := strings.Join(n.currentPrefixes, ",")
+	n.mu.Unlock()
 
-	go func(l listener.NetworkChangeListener) {
-		l.OnNetworkChanged(strings.Join(n.currentPrefixes, ","))
-	}(n.listener)
+	n.updates <- routes
 }
 
 func (n *Notifier) GetInitialRouteRanges() []string {

--- a/client/internal/routemanager/notifier/notifier_ios.go
+++ b/client/internal/routemanager/notifier/notifier_ios.go
@@ -3,6 +3,7 @@
 package notifier
 
 import (
+	"container/list"
 	"net/netip"
 	"slices"
 	"sort"
@@ -15,45 +16,20 @@ import (
 
 type Notifier struct {
 	mu              sync.Mutex
+	cond            *sync.Cond
 	currentPrefixes []string
 	listener        listener.NetworkChangeListener
-
-	// updates carries route snapshots to the single delivery goroutine. A
-	// dedicated worker (rather than a fresh goroutine per notify) guarantees
-	// the listener observes updates in the exact order they were produced.
-	//
-	// Without this ordering guarantee a stale snapshot can be delivered last
-	// and clobber the correct one. On exit-node disable the ::/0 removal
-	// arrives as a separate prefix update right after the 0.0.0.0/0 removal;
-	// with a goroutine-per-notify the two could be reordered, leaving the
-	// synthesized ::/0 default route installed on the tunnel and black-holing
-	// all IPv6 traffic while IPv4 worked.
-	updates chan string
+	queue           *list.List
+	closed          bool
 }
 
 func NewNotifier() *Notifier {
 	n := &Notifier{
-		// Buffered so producers (route updates run under the route manager
-		// lock) don't block on the listener callback. A small buffer absorbs
-		// the bursts seen during exit-node toggles.
-		updates: make(chan string, 16),
+		queue: list.New(),
 	}
+	n.cond = sync.NewCond(&n.mu)
 	go n.deliverLoop()
 	return n
-}
-
-// deliverLoop is the single consumer of n.updates. Serializing delivery here
-// is what preserves ordering: snapshots reach the listener one at a time, in
-// production order.
-func (n *Notifier) deliverLoop() {
-	for routes := range n.updates {
-		n.mu.Lock()
-		l := n.listener
-		n.mu.Unlock()
-		if l != nil {
-			l.OnNetworkChanged(routes)
-		}
-	}
 }
 
 func (n *Notifier) SetListener(listener listener.NetworkChangeListener) {
@@ -88,14 +64,39 @@ func (n *Notifier) OnNewPrefixes(prefixes []netip.Prefix) {
 		return
 	}
 	n.currentPrefixes = newNets
-	// Snapshot the delivered string under the lock so it is consistent and
-	// can't race with the next update mutating currentPrefixes.
 	routes := strings.Join(n.currentPrefixes, ",")
+	n.queue.PushBack(routes)
+	n.cond.Signal()
 	n.mu.Unlock()
+}
 
-	n.updates <- routes
+func (n *Notifier) Close() {
+	n.mu.Lock()
+	n.closed = true
+	n.cond.Signal()
+	n.mu.Unlock()
 }
 
 func (n *Notifier) GetInitialRouteRanges() []string {
 	return nil
+}
+
+func (n *Notifier) deliverLoop() {
+	for {
+		n.mu.Lock()
+		for n.queue.Len() == 0 && !n.closed {
+			n.cond.Wait()
+		}
+		if n.closed && n.queue.Len() == 0 {
+			n.mu.Unlock()
+			return
+		}
+		routes := n.queue.Remove(n.queue.Front()).(string)
+		l := n.listener
+		n.mu.Unlock()
+
+		if l != nil {
+			l.OnNetworkChanged(routes)
+		}
+	}
 }

--- a/client/internal/routemanager/notifier/notifier_other.go
+++ b/client/internal/routemanager/notifier/notifier_other.go
@@ -38,3 +38,7 @@ func (n *Notifier) OnNewPrefixes(prefixes []netip.Prefix) {
 func (n *Notifier) GetInitialRouteRanges() []string {
 	return []string{}
 }
+
+func (n *Notifier) Close() {
+	// unused
+}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route manager now properly shuts down notification systems across all platforms, improving resource cleanup during shutdown.

* **Improvements**
  * Enhanced internal synchronization for route notification delivery to ensure more reliable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->