### PR TITLE
[signal] Serialize concurrent sends to a peer stream

### DIFF
--- a/signal/peer/peer.go
+++ b/signal/peer/peer.go
@@ -26,11 +26,22 @@ type Peer struct {
 
 	// a gRpc connection stream to the Peer
 	Stream proto.SignalExchange_ConnectStreamServer
+	// sendMu serializes writes to Stream. gRPC forbids concurrent SendMsg on
+	// the same ServerStream, and a peer can be the target of many senders at
+	// once.
+	sendMu sync.Mutex
 
 	// registration time
 	RegisteredAt time.Time
 
 	Cancel context.CancelFunc
+}
+
+// Send writes a message to the peer's stream, serializing concurrent senders.
+func (p *Peer) Send(msg *proto.EncryptedMessage) error {
+	p.sendMu.Lock()
+	defer p.sendMu.Unlock()
+	return p.Stream.Send(msg)
 }
 
 // NewPeer creates a new instance of a connected Peer

--- a/signal/server/concurrent_send_test.go
+++ b/signal/server/concurrent_send_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+
+	"github.com/netbirdio/netbird/shared/signal/proto"
+	"github.com/netbirdio/netbird/signal/peer"
+)
+
+// concurrencyCheckStream records the maximum number of Send calls in flight at
+// once. gRPC forbids concurrent SendMsg on the same ServerStream, so a correct
+// server must never have more than one in flight per peer.
+type concurrencyCheckStream struct {
+	proto.SignalExchange_ConnectStreamServer
+	ctx      context.Context
+	inflight atomic.Int32
+	maxSeen  atomic.Int32
+}
+
+func (s *concurrencyCheckStream) Send(*proto.EncryptedMessage) error {
+	n := s.inflight.Add(1)
+	for {
+		old := s.maxSeen.Load()
+		if n <= old || s.maxSeen.CompareAndSwap(old, n) {
+			break
+		}
+	}
+	// Widen the window so overlapping callers are reliably observed.
+	time.Sleep(time.Millisecond)
+	s.inflight.Add(-1)
+	return nil
+}
+
+func (s *concurrencyCheckStream) Context() context.Context { return s.ctx }
+
+// TestForwardMessageToPeerSerializesSend verifies that concurrent forwards to the
+// same peer never call Stream.Send concurrently, which would violate the gRPC
+// ServerStream contract.
+func TestForwardMessageToPeerSerializesSend(t *testing.T) {
+	s, err := NewServer(context.Background(), otel.Meter(""))
+	require.NoError(t, err)
+
+	const peerID = "peerX"
+	stream := &concurrencyCheckStream{ctx: context.Background()}
+	_, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, s.registry.Register(peer.NewPeer(peerID, stream, cancel)))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.forwardMessageToPeer(context.Background(), &proto.EncryptedMessage{Key: "sender", RemoteKey: peerID})
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(1), stream.maxSeen.Load(), "Stream.Send must never run concurrently on the same peer stream")
+}

--- a/signal/server/signal.go
+++ b/signal/server/signal.go
@@ -179,7 +179,7 @@ func (s *Server) forwardMessageToPeer(ctx context.Context, msg *proto.EncryptedM
 	sendResultChan := make(chan error, 1)
 	go func() {
 		select {
-		case sendResultChan <- dstPeer.Stream.Send(msg):
+		case sendResultChan <- dstPeer.Send(msg):
 			return
 		case <-dstPeer.Stream.Context().Done():
 			return


### PR DESCRIPTION
## Describe your changes

The signal server forwarded messages to a peer by calling `Stream.Send` on the same gRPC stream from multiple goroutines at once: `Send` is a unary RPC (one goroutine per call) and every sender targeting a peer ends up calling `forwardMessageToPeer` for that peer concurrently. gRPC does not allow concurrent `SendMsg` on a single `ServerStream`, so a peer that is the destination of many senders at the same time (for example a routing peer with a large fan-in) can have its stream's write path raced, which can stall delivery while the connection stays open. This serializes writes per peer.

- Add a per-peer send mutex and route all stream writes through `Peer.Send`

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal concurrency fix in the signal server; no user-facing behavior or configuration changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a potential race condition in message delivery by ensuring messages to the same peer are sent serially, preventing concurrent write conflicts.

* **Tests**
  * Added test to verify message delivery serialization under concurrent conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->