### PR TITLE
[management] pass meta update for browser clients

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1159,7 +1159,6 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 			return err
 		}
 
-		updated, versionChanged := peer.UpdateMetaIfNew(login.Meta)
 		if peer.SSHKey != login.SSHKey {
 			peer.SSHKey = login.SSHKey
 			shouldStorePeer = true
@@ -1169,7 +1168,9 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 			return status.Errorf(status.PreconditionFailed, "couldn't login peer: setup key doesn't allow extra DNS labels")
 		}
 
-		if shouldStorePeer || updated || versionChanged {
+		peer.UpdateMetaIfNew(login.Meta)
+
+		if shouldStorePeer {
 			if err = transaction.SavePeer(ctx, accountID, peer); err != nil {
 				return err
 			}

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1175,6 +1175,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 			}
 		}
 
+		// This is needed to keep in memory for the peer config. Otherwise browser client will end in a retry loop
 		peer.UpdateMetaIfNew(login.Meta)
 
 		return nil
@@ -1194,9 +1195,8 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 	}
 
 	if shouldUpdatePeers {
-		log.Infof("sending peer update form Login")
 		changedPeerIDs := []string{peer.ID}
-		affectedPeerIDs := excludePeer(am.resolveAffectedPeersForPeerChanges(ctx, am.Store, accountID, changedPeerIDs), peer.ID)
+		affectedPeerIDs := am.resolveAffectedPeersForPeerChanges(ctx, am.Store, accountID, changedPeerIDs)
 		if err = am.networkMapController.OnPeersUpdated(ctx, accountID, changedPeerIDs, affectedPeerIDs); err != nil {
 			return nil, nil, nil, false, fmt.Errorf("notify network map controller of peer update: %w", err)
 		}
@@ -1596,21 +1596,6 @@ func (am *DefaultAccountManager) resolveAffectedPeersForPeerChanges(ctx context.
 		return nil
 	}
 	return snap.Expand(ctx, accountID, change)
-}
-
-// excludePeer returns peerIDs without excludeID.
-func excludePeer(peerIDs []string, excludeID string) []string {
-	if len(peerIDs) == 0 {
-		return peerIDs
-	}
-	filtered := make([]string, 0, len(peerIDs))
-	for _, id := range peerIDs {
-		if id == excludeID {
-			continue
-		}
-		filtered = append(filtered, id)
-	}
-	return filtered
 }
 
 func (am *DefaultAccountManager) BufferUpdateAccountPeers(ctx context.Context, accountID string, reason types.UpdateReason) {

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1168,6 +1168,8 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 			return status.Errorf(status.PreconditionFailed, "couldn't login peer: setup key doesn't allow extra DNS labels")
 		}
 
+		// This is needed so that toPeerConfig will run the IPv6 capability check and assign the capability to the peer if needed.
+		// Otherwise temporary peers or browser clients will end up in a restart loop
 		peer.UpdateMetaIfNew(login.Meta)
 
 		if shouldStorePeer {

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1175,6 +1175,8 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 			}
 		}
 
+		peer.UpdateMetaIfNew(login.Meta)
+
 		return nil
 	})
 	if err != nil {
@@ -1192,8 +1194,9 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 	}
 
 	if shouldUpdatePeers {
+		log.Infof("sending peer update form Login")
 		changedPeerIDs := []string{peer.ID}
-		affectedPeerIDs := am.resolveAffectedPeersForPeerChanges(ctx, am.Store, accountID, changedPeerIDs)
+		affectedPeerIDs := excludePeer(am.resolveAffectedPeersForPeerChanges(ctx, am.Store, accountID, changedPeerIDs), peer.ID)
 		if err = am.networkMapController.OnPeersUpdated(ctx, accountID, changedPeerIDs, affectedPeerIDs); err != nil {
 			return nil, nil, nil, false, fmt.Errorf("notify network map controller of peer update: %w", err)
 		}
@@ -1593,6 +1596,21 @@ func (am *DefaultAccountManager) resolveAffectedPeersForPeerChanges(ctx context.
 		return nil
 	}
 	return snap.Expand(ctx, accountID, change)
+}
+
+// excludePeer returns peerIDs without excludeID.
+func excludePeer(peerIDs []string, excludeID string) []string {
+	if len(peerIDs) == 0 {
+		return peerIDs
+	}
+	filtered := make([]string, 0, len(peerIDs))
+	for _, id := range peerIDs {
+		if id == excludeID {
+			continue
+		}
+		filtered = append(filtered, id)
+	}
+	return filtered
 }
 
 func (am *DefaultAccountManager) BufferUpdateAccountPeers(ctx context.Context, accountID string, reason types.UpdateReason) {

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1169,6 +1169,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 		}
 
 		if shouldStorePeer {
+			log.Infof("Save Peer on Login")
 			if err = transaction.SavePeer(ctx, accountID, peer); err != nil {
 				return err
 			}
@@ -1195,6 +1196,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 	}
 
 	if isStatusChanged || shouldStorePeer {
+		log.Info("Sending nmap update on Login")
 		changedPeerIDs := []string{peer.ID}
 		affectedPeerIDs := am.resolveAffectedPeersForPeerChanges(ctx, am.Store, accountID, changedPeerIDs)
 		if err = am.networkMapController.OnPeersUpdated(ctx, accountID, changedPeerIDs, affectedPeerIDs); err != nil {

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1168,15 +1168,15 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 			return status.Errorf(status.PreconditionFailed, "couldn't login peer: setup key doesn't allow extra DNS labels")
 		}
 
-		// This is needed so that toPeerConfig will run the IPv6 capability check and assign the capability to the peer if needed.
-		// Otherwise temporary peers or browser clients will end up in a restart loop
-		peer.UpdateMetaIfNew(login.Meta)
-
 		if shouldStorePeer {
 			if err = transaction.SavePeer(ctx, accountID, peer); err != nil {
 				return err
 			}
 		}
+
+		// This is needed so that toPeerConfig will run the IPv6 capability check and assign the capability to the peer if needed.
+		// Otherwise temporary peers or browser clients will end up in a restart loop
+		peer.UpdateMetaIfNew(login.Meta)
 
 		return nil
 	})

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1185,7 +1185,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 		return nil, nil, nil, false, err
 	}
 
-	isRequiresApproval, isStatusChanged, err := am.integratedPeerValidator.IsNotValidPeer(ctx, accountID, peer, peerGroupIDs, settings.Extra)
+	isRequiresApproval, _, err := am.integratedPeerValidator.IsNotValidPeer(ctx, accountID, peer, peerGroupIDs, settings.Extra)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -1195,14 +1195,14 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 		return nil, nil, nil, false, err
 	}
 
-	if isStatusChanged || shouldStorePeer {
-		log.Info("Sending nmap update on Login")
-		changedPeerIDs := []string{peer.ID}
-		affectedPeerIDs := am.resolveAffectedPeersForPeerChanges(ctx, am.Store, accountID, changedPeerIDs)
-		if err = am.networkMapController.OnPeersUpdated(ctx, accountID, changedPeerIDs, affectedPeerIDs); err != nil {
-			return nil, nil, nil, false, fmt.Errorf("notify network map controller of peer update: %w", err)
-		}
-	}
+	// if isStatusChanged || shouldStorePeer {
+	// 	log.Info("Sending nmap update on Login")
+	// 	changedPeerIDs := []string{peer.ID}
+	// 	affectedPeerIDs := am.resolveAffectedPeersForPeerChanges(ctx, am.Store, accountID, changedPeerIDs)
+	// 	if err = am.networkMapController.OnPeersUpdated(ctx, accountID, changedPeerIDs, affectedPeerIDs); err != nil {
+	// 		return nil, nil, nil, false, fmt.Errorf("notify network map controller of peer update: %w", err)
+	// 	}
+	// }
 
 	return peer, network, postureChecks, enableSSH, nil
 }

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1159,6 +1159,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 			return err
 		}
 
+		updated, versionChanged := peer.UpdateMetaIfNew(login.Meta)
 		if peer.SSHKey != login.SSHKey {
 			peer.SSHKey = login.SSHKey
 			shouldStorePeer = true
@@ -1168,7 +1169,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 			return status.Errorf(status.PreconditionFailed, "couldn't login peer: setup key doesn't allow extra DNS labels")
 		}
 
-		if shouldStorePeer {
+		if shouldStorePeer || updated || versionChanged {
 			if err = transaction.SavePeer(ctx, accountID, peer); err != nil {
 				return err
 			}

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1124,7 +1124,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 	}
 
 	var peer *nbpeer.Peer
-	var shouldStorePeer bool
+	var shouldStorePeer, shouldUpdatePeers bool
 	var peerGroupIDs []string
 
 	settings, err := am.Store.GetAccountSettings(ctx, store.LockingStrengthNone, accountID)
@@ -1151,6 +1151,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 
 			if changed {
 				shouldStorePeer = true
+				shouldUpdatePeers = true
 			}
 		}
 
@@ -1169,15 +1170,10 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 		}
 
 		if shouldStorePeer {
-			log.Infof("Save Peer on Login")
 			if err = transaction.SavePeer(ctx, accountID, peer); err != nil {
 				return err
 			}
 		}
-
-		// This is needed so that toPeerConfig will run the IPv6 capability check and assign the capability to the peer if needed.
-		// Otherwise temporary peers or browser clients will end up in a restart loop
-		peer.UpdateMetaIfNew(login.Meta)
 
 		return nil
 	})
@@ -1195,14 +1191,13 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 		return nil, nil, nil, false, err
 	}
 
-	// if isStatusChanged || shouldStorePeer {
-	// 	log.Info("Sending nmap update on Login")
-	// 	changedPeerIDs := []string{peer.ID}
-	// 	affectedPeerIDs := am.resolveAffectedPeersForPeerChanges(ctx, am.Store, accountID, changedPeerIDs)
-	// 	if err = am.networkMapController.OnPeersUpdated(ctx, accountID, changedPeerIDs, affectedPeerIDs); err != nil {
-	// 		return nil, nil, nil, false, fmt.Errorf("notify network map controller of peer update: %w", err)
-	// 	}
-	// }
+	if shouldUpdatePeers {
+		changedPeerIDs := []string{peer.ID}
+		affectedPeerIDs := am.resolveAffectedPeersForPeerChanges(ctx, am.Store, accountID, changedPeerIDs)
+		if err = am.networkMapController.OnPeersUpdated(ctx, accountID, changedPeerIDs, affectedPeerIDs); err != nil {
+			return nil, nil, nil, false, fmt.Errorf("notify network map controller of peer update: %w", err)
+		}
+	}
 
 	return peer, network, postureChecks, enableSSH, nil
 }


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Improved peer authentication and network synchronization to ensure reliable status updates and consistent metadata management during login processes
- Enhanced network map refresh triggering logic to properly respond to peer login and status changes
- Refined peer state handling to deliver more accurate and timely network propagation of peer status updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->