### PR TITLE
[management] log peer meta diff

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1017,7 +1017,7 @@ func (am *DefaultAccountManager) SyncPeer(ctx context.Context, sync types.PeerSy
 		}
 
 		oldHasIPv6Cap := peer.HasCapability(nbpeer.PeerCapabilityIPv6Overlay)
-		updated, versionChanged = peer.UpdateMetaIfNew(sync.Meta)
+		updated, versionChanged = peer.UpdateMetaIfNew(ctx, sync.Meta)
 		ipv6CapabilityChanged = oldHasIPv6Cap != peer.HasCapability(nbpeer.PeerCapabilityIPv6Overlay)
 		if updated {
 			am.metrics.AccountManagerMetrics().CountPeerMetUpdate()
@@ -1176,7 +1176,7 @@ func (am *DefaultAccountManager) LoginPeer(ctx context.Context, login types.Peer
 		}
 
 		// This is needed to keep in memory for the peer config. Otherwise browser client will end in a retry loop
-		peer.UpdateMetaIfNew(login.Meta)
+		peer.UpdateMetaIfNew(ctx, login.Meta)
 
 		return nil
 	})

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -284,7 +284,7 @@ func (p *Peer) UpdateMetaIfNew(meta PeerSystemMeta) (updated, versionChanged boo
 	}
 
 	log.WithFields(log.Fields{"peer": p.ID, "key": p.Key}).
-		Debugf("peer meta updated, %s%d field(s) changed: %s", versionInfo, len(diff), strings.Join(diff, ", "))
+		Infof("peer meta updated, %s%d field(s) changed: %s", versionInfo, len(diff), strings.Join(diff, ", "))
 	return updated, versionChanged
 }
 

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -1,6 +1,7 @@
 package peer
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/netip"
@@ -258,7 +259,7 @@ func (p *Peer) Copy() *Peer {
 
 // UpdateMetaIfNew updates peer's system metadata if new information is provided
 // returns true if meta was updated, false otherwise
-func (p *Peer) UpdateMetaIfNew(meta PeerSystemMeta) (updated, versionChanged bool) {
+func (p *Peer) UpdateMetaIfNew(ctx context.Context, meta PeerSystemMeta) (updated, versionChanged bool) {
 	if meta.isEmpty() {
 		return updated, versionChanged
 	}
@@ -283,8 +284,11 @@ func (p *Peer) UpdateMetaIfNew(meta PeerSystemMeta) (updated, versionChanged boo
 		versionInfo = fmt.Sprintf("version changed: %s -> %s, ", oldVersion, meta.WtVersion)
 	}
 
-	log.WithFields(log.Fields{"peer": p.ID, "key": p.Key}).
-		Infof("peer meta updated, %s%d field(s) changed: %s", versionInfo, len(diff), strings.Join(diff, ", "))
+	if len(diff) > 0 || versionChanged {
+		log.WithContext(ctx).
+			Debugf("peer meta updated, %s%d field(s) changed: %s", versionInfo, len(diff), strings.Join(diff, ", "))
+	}
+
 	return updated, versionChanged
 }
 

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -1,11 +1,15 @@
 package peer
 
 import (
+	"fmt"
 	"net"
 	"net/netip"
 	"slices"
 	"sort"
+	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/netbirdio/netbird/management/server/util"
 	"github.com/netbirdio/netbird/shared/management/http/api"
@@ -162,49 +166,7 @@ type PeerSystemMeta struct { //nolint:revive
 }
 
 func (p PeerSystemMeta) isEqual(other PeerSystemMeta) bool {
-	sort.Slice(p.NetworkAddresses, func(i, j int) bool {
-		return p.NetworkAddresses[i].Mac < p.NetworkAddresses[j].Mac
-	})
-	sort.Slice(other.NetworkAddresses, func(i, j int) bool {
-		return other.NetworkAddresses[i].Mac < other.NetworkAddresses[j].Mac
-	})
-	equalNetworkAddresses := slices.EqualFunc(p.NetworkAddresses, other.NetworkAddresses, func(addr NetworkAddress, oAddr NetworkAddress) bool {
-		return addr.Mac == oAddr.Mac && addr.NetIP == oAddr.NetIP
-	})
-	if !equalNetworkAddresses {
-		return false
-	}
-
-	sort.Slice(p.Files, func(i, j int) bool {
-		return p.Files[i].Path < p.Files[j].Path
-	})
-	sort.Slice(other.Files, func(i, j int) bool {
-		return other.Files[i].Path < other.Files[j].Path
-	})
-	equalFiles := slices.EqualFunc(p.Files, other.Files, func(file File, oFile File) bool {
-		return file.Path == oFile.Path && file.Exist == oFile.Exist && file.ProcessIsRunning == oFile.ProcessIsRunning
-	})
-	if !equalFiles {
-		return false
-	}
-
-	return p.Hostname == other.Hostname &&
-		p.GoOS == other.GoOS &&
-		p.Kernel == other.Kernel &&
-		p.KernelVersion == other.KernelVersion &&
-		p.Core == other.Core &&
-		p.Platform == other.Platform &&
-		p.OS == other.OS &&
-		p.OSVersion == other.OSVersion &&
-		p.WtVersion == other.WtVersion &&
-		p.UIVersion == other.UIVersion &&
-		p.SystemSerialNumber == other.SystemSerialNumber &&
-		p.SystemProductName == other.SystemProductName &&
-		p.SystemManufacturer == other.SystemManufacturer &&
-		p.Environment.Cloud == other.Environment.Cloud &&
-		p.Environment.Platform == other.Environment.Platform &&
-		p.Flags.isEqual(other.Flags) &&
-		capabilitiesEqual(p.Capabilities, other.Capabilities)
+	return len(metaDiff(p, other)) == 0
 }
 
 func (p PeerSystemMeta) isEmpty() bool {
@@ -308,12 +270,102 @@ func (p *Peer) UpdateMetaIfNew(meta PeerSystemMeta) (updated, versionChanged boo
 		meta.UIVersion = p.Meta.UIVersion
 	}
 
-	if p.Meta.isEqual(meta) {
+	diff := metaDiff(p.Meta, meta)
+	if len(diff) == 0 {
 		return updated, versionChanged
 	}
+
 	p.Meta = meta
 	updated = true
+	log.WithFields(log.Fields{"peer": p.ID, "key": p.Key}).
+		Debugf("peer meta updated, %d field(s) changed: %s", len(diff), strings.Join(diff, ", "))
 	return updated, versionChanged
+}
+
+// metaDiff returns a human-readable list of the fields that differ between the
+// old and new meta, each formatted as `field: <old> -> <new>`. It is the single
+// source of truth for meta comparison: isEqual reports equality as an empty
+// diff, so the log line can never disagree with the change decision. Slices are
+// cloned before sorting, so callers' meta is not mutated.
+func metaDiff(old, new PeerSystemMeta) []string {
+	var diff []string
+	add := func(field string, oldVal, newVal any) {
+		diff = append(diff, fmt.Sprintf("%s: %v -> %v", field, oldVal, newVal))
+	}
+
+	if old.Hostname != new.Hostname {
+		add("hostname", old.Hostname, new.Hostname)
+	}
+	if old.GoOS != new.GoOS {
+		add("goos", old.GoOS, new.GoOS)
+	}
+	if old.Kernel != new.Kernel {
+		add("kernel", old.Kernel, new.Kernel)
+	}
+	if old.KernelVersion != new.KernelVersion {
+		add("kernel_version", old.KernelVersion, new.KernelVersion)
+	}
+	if old.Core != new.Core {
+		add("core", old.Core, new.Core)
+	}
+	if old.Platform != new.Platform {
+		add("platform", old.Platform, new.Platform)
+	}
+	if old.OS != new.OS {
+		add("os", old.OS, new.OS)
+	}
+	if old.OSVersion != new.OSVersion {
+		add("os_version", old.OSVersion, new.OSVersion)
+	}
+	if old.WtVersion != new.WtVersion {
+		add("wt_version", old.WtVersion, new.WtVersion)
+	}
+	if old.UIVersion != new.UIVersion {
+		add("ui_version", old.UIVersion, new.UIVersion)
+	}
+	if old.SystemSerialNumber != new.SystemSerialNumber {
+		add("system_serial_number", old.SystemSerialNumber, new.SystemSerialNumber)
+	}
+	if old.SystemProductName != new.SystemProductName {
+		add("system_product_name", old.SystemProductName, new.SystemProductName)
+	}
+	if old.SystemManufacturer != new.SystemManufacturer {
+		add("system_manufacturer", old.SystemManufacturer, new.SystemManufacturer)
+	}
+	if old.Environment.Cloud != new.Environment.Cloud {
+		add("environment_cloud", old.Environment.Cloud, new.Environment.Cloud)
+	}
+	if old.Environment.Platform != new.Environment.Platform {
+		add("environment_platform", old.Environment.Platform, new.Environment.Platform)
+	}
+	if !old.Flags.isEqual(new.Flags) {
+		add("flags", fmt.Sprintf("%+v", old.Flags), fmt.Sprintf("%+v", new.Flags))
+	}
+	if !capabilitiesEqual(old.Capabilities, new.Capabilities) {
+		add("capabilities", old.Capabilities, new.Capabilities)
+	}
+
+	oldAddrs := slices.Clone(old.NetworkAddresses)
+	newAddrs := slices.Clone(new.NetworkAddresses)
+	sort.Slice(oldAddrs, func(i, j int) bool { return oldAddrs[i].Mac < oldAddrs[j].Mac })
+	sort.Slice(newAddrs, func(i, j int) bool { return newAddrs[i].Mac < newAddrs[j].Mac })
+	if !slices.EqualFunc(oldAddrs, newAddrs, func(a, b NetworkAddress) bool {
+		return a.Mac == b.Mac && a.NetIP == b.NetIP
+	}) {
+		add("network_addresses", fmt.Sprintf("%v", oldAddrs), fmt.Sprintf("%v", newAddrs))
+	}
+
+	oldFiles := slices.Clone(old.Files)
+	newFiles := slices.Clone(new.Files)
+	sort.Slice(oldFiles, func(i, j int) bool { return oldFiles[i].Path < oldFiles[j].Path })
+	sort.Slice(newFiles, func(i, j int) bool { return newFiles[i].Path < newFiles[j].Path })
+	if !slices.EqualFunc(oldFiles, newFiles, func(a, b File) bool {
+		return a.Path == b.Path && a.Exist == b.Exist && a.ProcessIsRunning == b.ProcessIsRunning
+	}) {
+		add("files", fmt.Sprintf("%v", oldFiles), fmt.Sprintf("%v", newFiles))
+	}
+
+	return diff
 }
 
 // GetLastLogin returns the last login time of the peer.

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -270,15 +270,21 @@ func (p *Peer) UpdateMetaIfNew(meta PeerSystemMeta) (updated, versionChanged boo
 		meta.UIVersion = p.Meta.UIVersion
 	}
 
+	oldVersion := p.Meta.WtVersion
+
 	diff := metaDiff(p.Meta, meta)
-	if len(diff) == 0 {
-		return updated, versionChanged
+	if len(diff) != 0 {
+		p.Meta = meta
+		updated = true
 	}
 
-	p.Meta = meta
-	updated = true
+	versionInfo := ""
+	if versionChanged {
+		versionInfo = fmt.Sprintf("version changed: %s -> %s, ", oldVersion, meta.WtVersion)
+	}
+
 	log.WithFields(log.Fields{"peer": p.ID, "key": p.Key}).
-		Debugf("peer meta updated, %d field(s) changed: %s", len(diff), strings.Join(diff, ", "))
+		Debugf("peer meta updated, %s%d field(s) changed: %s", versionInfo, len(diff), strings.Join(diff, ", "))
 	return updated, versionChanged
 }
 

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -297,66 +297,66 @@ func (p *Peer) UpdateMetaIfNew(ctx context.Context, meta PeerSystemMeta) (update
 // source of truth for meta comparison: isEqual reports equality as an empty
 // diff, so the log line can never disagree with the change decision. Slices are
 // cloned before sorting, so callers' meta is not mutated.
-func metaDiff(old, new PeerSystemMeta) []string {
+func metaDiff(oldMeta, newMeta PeerSystemMeta) []string {
 	var diff []string
 	add := func(field string, oldVal, newVal any) {
 		diff = append(diff, fmt.Sprintf("%s: %v -> %v", field, oldVal, newVal))
 	}
 
-	if old.Hostname != new.Hostname {
-		add("hostname", old.Hostname, new.Hostname)
+	if oldMeta.Hostname != newMeta.Hostname {
+		add("hostname", oldMeta.Hostname, newMeta.Hostname)
 	}
-	if old.GoOS != new.GoOS {
-		add("goos", old.GoOS, new.GoOS)
+	if oldMeta.GoOS != newMeta.GoOS {
+		add("goos", oldMeta.GoOS, newMeta.GoOS)
 	}
-	if old.Kernel != new.Kernel {
-		add("kernel", old.Kernel, new.Kernel)
+	if oldMeta.Kernel != newMeta.Kernel {
+		add("kernel", oldMeta.Kernel, newMeta.Kernel)
 	}
-	if old.KernelVersion != new.KernelVersion {
-		add("kernel_version", old.KernelVersion, new.KernelVersion)
+	if oldMeta.KernelVersion != newMeta.KernelVersion {
+		add("kernel_version", oldMeta.KernelVersion, newMeta.KernelVersion)
 	}
-	if old.Core != new.Core {
-		add("core", old.Core, new.Core)
+	if oldMeta.Core != newMeta.Core {
+		add("core", oldMeta.Core, newMeta.Core)
 	}
-	if old.Platform != new.Platform {
-		add("platform", old.Platform, new.Platform)
+	if oldMeta.Platform != newMeta.Platform {
+		add("platform", oldMeta.Platform, newMeta.Platform)
 	}
-	if old.OS != new.OS {
-		add("os", old.OS, new.OS)
+	if oldMeta.OS != newMeta.OS {
+		add("os", oldMeta.OS, newMeta.OS)
 	}
-	if old.OSVersion != new.OSVersion {
-		add("os_version", old.OSVersion, new.OSVersion)
+	if oldMeta.OSVersion != newMeta.OSVersion {
+		add("os_version", oldMeta.OSVersion, newMeta.OSVersion)
 	}
-	if old.WtVersion != new.WtVersion {
-		add("wt_version", old.WtVersion, new.WtVersion)
+	if oldMeta.WtVersion != newMeta.WtVersion {
+		add("wt_version", oldMeta.WtVersion, newMeta.WtVersion)
 	}
-	if old.UIVersion != new.UIVersion {
-		add("ui_version", old.UIVersion, new.UIVersion)
+	if oldMeta.UIVersion != newMeta.UIVersion {
+		add("ui_version", oldMeta.UIVersion, newMeta.UIVersion)
 	}
-	if old.SystemSerialNumber != new.SystemSerialNumber {
-		add("system_serial_number", old.SystemSerialNumber, new.SystemSerialNumber)
+	if oldMeta.SystemSerialNumber != newMeta.SystemSerialNumber {
+		add("system_serial_number", oldMeta.SystemSerialNumber, newMeta.SystemSerialNumber)
 	}
-	if old.SystemProductName != new.SystemProductName {
-		add("system_product_name", old.SystemProductName, new.SystemProductName)
+	if oldMeta.SystemProductName != newMeta.SystemProductName {
+		add("system_product_name", oldMeta.SystemProductName, newMeta.SystemProductName)
 	}
-	if old.SystemManufacturer != new.SystemManufacturer {
-		add("system_manufacturer", old.SystemManufacturer, new.SystemManufacturer)
+	if oldMeta.SystemManufacturer != newMeta.SystemManufacturer {
+		add("system_manufacturer", oldMeta.SystemManufacturer, newMeta.SystemManufacturer)
 	}
-	if old.Environment.Cloud != new.Environment.Cloud {
-		add("environment_cloud", old.Environment.Cloud, new.Environment.Cloud)
+	if oldMeta.Environment.Cloud != newMeta.Environment.Cloud {
+		add("environment_cloud", oldMeta.Environment.Cloud, newMeta.Environment.Cloud)
 	}
-	if old.Environment.Platform != new.Environment.Platform {
-		add("environment_platform", old.Environment.Platform, new.Environment.Platform)
+	if oldMeta.Environment.Platform != newMeta.Environment.Platform {
+		add("environment_platform", oldMeta.Environment.Platform, newMeta.Environment.Platform)
 	}
-	if !old.Flags.isEqual(new.Flags) {
-		add("flags", fmt.Sprintf("%+v", old.Flags), fmt.Sprintf("%+v", new.Flags))
+	if !oldMeta.Flags.isEqual(newMeta.Flags) {
+		add("flags", fmt.Sprintf("%+v", oldMeta.Flags), fmt.Sprintf("%+v", newMeta.Flags))
 	}
-	if !capabilitiesEqual(old.Capabilities, new.Capabilities) {
-		add("capabilities", old.Capabilities, new.Capabilities)
+	if !capabilitiesEqual(oldMeta.Capabilities, newMeta.Capabilities) {
+		add("capabilities", oldMeta.Capabilities, newMeta.Capabilities)
 	}
 
-	oldAddrs := slices.Clone(old.NetworkAddresses)
-	newAddrs := slices.Clone(new.NetworkAddresses)
+	oldAddrs := slices.Clone(oldMeta.NetworkAddresses)
+	newAddrs := slices.Clone(newMeta.NetworkAddresses)
 	sort.Slice(oldAddrs, func(i, j int) bool { return oldAddrs[i].Mac < oldAddrs[j].Mac })
 	sort.Slice(newAddrs, func(i, j int) bool { return newAddrs[i].Mac < newAddrs[j].Mac })
 	if !slices.EqualFunc(oldAddrs, newAddrs, func(a, b NetworkAddress) bool {
@@ -365,8 +365,8 @@ func metaDiff(old, new PeerSystemMeta) []string {
 		add("network_addresses", fmt.Sprintf("%v", oldAddrs), fmt.Sprintf("%v", newAddrs))
 	}
 
-	oldFiles := slices.Clone(old.Files)
-	newFiles := slices.Clone(new.Files)
+	oldFiles := slices.Clone(oldMeta.Files)
+	newFiles := slices.Clone(newMeta.Files)
 	sort.Slice(oldFiles, func(i, j int) bool { return oldFiles[i].Path < oldFiles[j].Path })
 	sort.Slice(newFiles, func(i, j int) bool { return newFiles[i].Path < newFiles[j].Path })
 	if !slices.EqualFunc(oldFiles, newFiles, func(a, b File) bool {

--- a/management/server/peer/peer.go
+++ b/management/server/peer/peer.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/netip"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -355,27 +354,35 @@ func metaDiff(oldMeta, newMeta PeerSystemMeta) []string {
 		add("capabilities", oldMeta.Capabilities, newMeta.Capabilities)
 	}
 
-	oldAddrs := slices.Clone(oldMeta.NetworkAddresses)
-	newAddrs := slices.Clone(newMeta.NetworkAddresses)
-	sort.Slice(oldAddrs, func(i, j int) bool { return oldAddrs[i].Mac < oldAddrs[j].Mac })
-	sort.Slice(newAddrs, func(i, j int) bool { return newAddrs[i].Mac < newAddrs[j].Mac })
-	if !slices.EqualFunc(oldAddrs, newAddrs, func(a, b NetworkAddress) bool {
-		return a.Mac == b.Mac && a.NetIP == b.NetIP
-	}) {
-		add("network_addresses", fmt.Sprintf("%v", oldAddrs), fmt.Sprintf("%v", newAddrs))
+	if !sameMultiset(oldMeta.NetworkAddresses, newMeta.NetworkAddresses) {
+		add("network_addresses", fmt.Sprintf("%v", oldMeta.NetworkAddresses), fmt.Sprintf("%v", newMeta.NetworkAddresses))
 	}
 
-	oldFiles := slices.Clone(oldMeta.Files)
-	newFiles := slices.Clone(newMeta.Files)
-	sort.Slice(oldFiles, func(i, j int) bool { return oldFiles[i].Path < oldFiles[j].Path })
-	sort.Slice(newFiles, func(i, j int) bool { return newFiles[i].Path < newFiles[j].Path })
-	if !slices.EqualFunc(oldFiles, newFiles, func(a, b File) bool {
-		return a.Path == b.Path && a.Exist == b.Exist && a.ProcessIsRunning == b.ProcessIsRunning
-	}) {
-		add("files", fmt.Sprintf("%v", oldFiles), fmt.Sprintf("%v", newFiles))
+	if !sameMultiset(oldMeta.Files, newMeta.Files) {
+		add("files", fmt.Sprintf("%v", oldMeta.Files), fmt.Sprintf("%v", newMeta.Files))
 	}
 
 	return diff
+}
+
+// sameMultiset reports whether two slices contain the same elements with the
+// same multiplicity, ignoring order. The element type is the comparison key, so
+// every field participates in equality.
+func sameMultiset[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[T]int, len(a))
+	for _, v := range a {
+		counts[v]++
+	}
+	for _, v := range b {
+		counts[v]--
+		if counts[v] == 0 {
+			delete(counts, v)
+		}
+	}
+	return len(counts) == 0
 }
 
 // GetLastLogin returns the last login time of the peer.

--- a/management/server/peer/peer_metadiff_test.go
+++ b/management/server/peer/peer_metadiff_test.go
@@ -1,0 +1,113 @@
+package peer
+
+import (
+	"net/netip"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// metaDiffExtraEntries accounts for PeerSystemMeta fields that metaDiff does not
+// map 1:1 to a single diff entry. Today the only such field is Environment, which
+// is exploded into two checks (Cloud, Platform) and therefore yields one extra
+// entry beyond its single struct field. If you teach metaDiff to explode another
+// field into N entries, bump this by N-1; if you collapse a field, lower it.
+const metaDiffExtraEntries = 1
+
+// TestMetaDiff_CoversAllFields fully populates a PeerSystemMeta with non-zero
+// values and diffs it against the zero value, then asserts metaDiff emits exactly
+// one entry per exported field (plus metaDiffExtraEntries for fields it explodes).
+//
+// The expected count is derived from the struct via reflection, so adding a field
+// to PeerSystemMeta raises the expectation automatically — but the actual diff
+// only grows if metaDiff was taught to compare the new field. A mismatch means
+// someone changed the struct without updating metaDiff (or this test's
+// extra-entry accounting), which is exactly what we want to catch.
+func TestMetaDiff_CoversAllFields(t *testing.T) {
+	var full PeerSystemMeta
+	exported := populateAll(t, reflect.ValueOf(&full).Elem())
+	require.NotZero(t, exported, "expected PeerSystemMeta to expose fields")
+
+	diff := metaDiff(PeerSystemMeta{}, full)
+
+	require.Len(t, diff, exported+metaDiffExtraEntries,
+		"metaDiff entry count no longer matches PeerSystemMeta's fields: a field was "+
+			"likely added or removed without updating metaDiff (or metaDiffExtraEntries). "+
+			"diff was: %v", diff)
+
+	require.False(t, full.isEqual(PeerSystemMeta{}),
+		"isEqual must report a fully-populated meta as different from the zero value")
+}
+
+// TestFlags_isEqualChecksEveryField guards the one field that the count-based
+// TestMetaDiff_CoversAllFields cannot: metaDiff collapses all of Flags into a
+// single "flags" diff entry, so a new Flags field that Flags.isEqual forgets to
+// compare would not change the diff count. This flips each Flags field on its own
+// and asserts Flags.isEqual notices, so adding a Flags field without comparing it
+// fails here.
+func TestFlags_isEqualChecksEveryField(t *testing.T) {
+	typ := reflect.TypeOf(Flags{})
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		require.Equal(t, reflect.Bool, f.Type.Kind(),
+			"Flags.%s is not a bool; extend this test to set it non-zero", f.Name)
+
+		var a, b Flags
+		reflect.ValueOf(&b).Elem().Field(i).SetBool(true)
+		require.False(t, a.isEqual(b), "Flags.isEqual ignores field %s", f.Name)
+	}
+}
+
+// populateAll sets every exported field of the struct to a deterministic non-zero
+// value, recursing into nested structs and the element type of struct slices so
+// that each leaf differs from zero. It returns the number of exported fields on
+// the top-level struct. netip.Prefix is treated as an opaque leaf (it has no
+// settable exported fields and is comparable with ==).
+func populateAll(t *testing.T, v reflect.Value) int {
+	t.Helper()
+
+	typ := v.Type()
+	exported := 0
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		exported++
+		setNonZero(t, v.Field(i))
+	}
+	return exported
+}
+
+// setNonZero assigns a deterministic non-zero value to a field based on its kind,
+// recursing into nested structs and populating one element of slice fields.
+func setNonZero(t *testing.T, field reflect.Value) {
+	t.Helper()
+
+	if field.Type() == reflect.TypeOf(netip.Prefix{}) {
+		field.Set(reflect.ValueOf(netip.MustParsePrefix("10.0.0.0/24")))
+		return
+	}
+
+	switch field.Kind() {
+	case reflect.String:
+		field.SetString("non-zero")
+	case reflect.Bool:
+		field.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		field.SetInt(7)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		field.SetUint(7)
+	case reflect.Float32, reflect.Float64:
+		field.SetFloat(7)
+	case reflect.Struct:
+		populateAll(t, field)
+	case reflect.Slice:
+		s := reflect.MakeSlice(field.Type(), 1, 1)
+		setNonZero(t, s.Index(0))
+		field.Set(s)
+	default:
+		t.Fatalf("unhandled field kind %s; extend setNonZero", field.Kind())
+	}
+}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detailed, context-based debug logs for peer metadata updates, including human-readable field-by-field differences and version change tracking.
* **Refactor**
  * Reworked peer metadata comparison to use a unified diff helper, with order-insensitive handling for list-like fields.
* **Bug Fixes**
  * Ensured metadata update logic uses the active request context during synchronization and login flows.
* **Tests**
  * Added tests to verify the metadata diff covers all relevant fields, and that flags equality checks every flag field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->