### PR TITLE
[misc] Remove version prefix `v` docker tags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -247,7 +247,7 @@ dockers_v2:
        - netbirdio/netbird
        - ghcr.io/netbirdio/netbird
      tags:
-       - "v{{ .Version }}"
+       - "{{ .Version }}"
        - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}latest{{ end }}"
      dockerfile: client/Dockerfile
      extra_files:
@@ -295,7 +295,7 @@ dockers_v2:
        - netbirdio/relay
        - ghcr.io/netbirdio/relay
      tags:
-       - "v{{ .Version }}"
+       - "{{ .Version }}"
        - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}latest{{ end }}"
      dockerfile: relay/Dockerfile
      platforms:
@@ -317,7 +317,7 @@ dockers_v2:
        - netbirdio/signal
        - ghcr.io/netbirdio/signal
      tags:
-       - "v{{ .Version }}"
+       - "{{ .Version }}"
        - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}latest{{ end }}"
      dockerfile: signal/Dockerfile
      platforms:
@@ -339,7 +339,7 @@ dockers_v2:
        - netbirdio/management
        - ghcr.io/netbirdio/management
      tags:
-       - "v{{ .Version }}"
+       - "{{ .Version }}"
        - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}latest{{ end }}"
      dockerfile: management/Dockerfile
      platforms:
@@ -361,7 +361,7 @@ dockers_v2:
        - netbirdio/upload
        - ghcr.io/netbirdio/upload
      tags:
-       - "v{{ .Version }}"
+       - "{{ .Version }}"
        - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}latest{{ end }}"
      dockerfile: upload-server/Dockerfile
      platforms:
@@ -383,7 +383,7 @@ dockers_v2:
        - netbirdio/netbird-server
        - ghcr.io/netbirdio/netbird-server
      tags:
-       - "v{{ .Version }}"
+       - "{{ .Version }}"
        - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}latest{{ end }}"
      dockerfile: combined/Dockerfile
      platforms:
@@ -405,7 +405,7 @@ dockers_v2:
        - netbirdio/reverse-proxy
        - ghcr.io/netbirdio/reverse-proxy
      tags:
-       - "v{{ .Version }}"
+       - "{{ .Version }}"
        - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}latest{{ end }}"
      dockerfile: proxy/Dockerfile
      platforms:


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
fixes #6469
## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image versioning scheme to remove the 'v' prefix from version tags across multiple services (netbird, relay, signal, management, upload, netbird-server, and netbird-proxy).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->