### PR TITLE
[client] Fix profile regressions in `up --profile` and `status`

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -248,7 +248,7 @@ func switchOrCreateProfile(ctx context.Context, pm *profilemanager.ProfileManage
 		// have created the profile between the NotFound above and this
 		// call, in which case the retried switch still succeeds. Only
 		// surface the create error if the switch also fails.
-		createErr := createProfile(ctx, handle, username)
+		_, createErr := createProfile(ctx, handle, username)
 		if resolvedID, err = switchProfile(ctx, handle, username); err != nil {
 			if createErr != nil {
 				return fmt.Errorf("create profile: %w", createErr)
@@ -264,13 +264,14 @@ func switchOrCreateProfile(ctx context.Context, pm *profilemanager.ProfileManage
 }
 
 // createProfile asks the daemon to create a new profile with the given
-// display name. Helpful for `netbird up --profile <name>` which
-// auto-creates a missing profile.
-func createProfile(ctx context.Context, profileName, username string) error {
+// display name and returns its generated ID. It is the single entry point
+// for profile creation, shared by `netbird profile add` and the
+// `netbird up --profile <name>` auto-create path.
+func createProfile(ctx context.Context, profileName, username string) (profilemanager.ID, error) {
 	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {
 		//nolint
-		return fmt.Errorf("failed to connect to daemon error: %v\n"+
+		return "", fmt.Errorf("failed to connect to daemon error: %v\n"+
 			"If the daemon is not running please run: "+
 			"\nnetbird service install \nnetbird service start\n", err)
 	}
@@ -278,14 +279,15 @@ func createProfile(ctx context.Context, profileName, username string) error {
 
 	client := proto.NewDaemonServiceClient(conn)
 
-	if _, err := client.AddProfile(ctx, &proto.AddProfileRequest{
+	resp, err := client.AddProfile(ctx, &proto.AddProfileRequest{
 		ProfileName: profileName,
 		Username:    username,
-	}); err != nil {
-		return fmt.Errorf("add profile failed: %w", err)
+	})
+	if err != nil {
+		return "", fmt.Errorf("add profile failed: %w", err)
 	}
 
-	return nil
+	return profilemanager.ID(resp.Id), nil
 }
 
 func doForegroundLogin(ctx context.Context, cmd *cobra.Command, setupKey string, activeProf *profilemanager.Profile) error {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -227,10 +227,35 @@ func switchProfile(ctx context.Context, handle string, username string) (profile
 		Username:    &username,
 	})
 	if err != nil {
-		return "", fmt.Errorf("switch profile failed: %v", err)
+		return "", fmt.Errorf("switch profile failed: %w", err)
 	}
 
 	return profilemanager.ID(resp.Id), nil
+}
+
+// createProfile asks the daemon to create a new profile with the given
+// display name. Helpful for `netbird up --profile <name>` which
+// auto-creates a missing profile.
+func createProfile(ctx context.Context, profileName, username string) error {
+	conn, err := DialClientGRPCServer(ctx, daemonAddr)
+	if err != nil {
+		//nolint
+		return fmt.Errorf("failed to connect to daemon error: %v\n"+
+			"If the daemon is not running please run: "+
+			"\nnetbird service install \nnetbird service start\n", err)
+	}
+	defer conn.Close()
+
+	client := proto.NewDaemonServiceClient(conn)
+
+	if _, err := client.AddProfile(ctx, &proto.AddProfileRequest{
+		ProfileName: profileName,
+		Username:    username,
+	}); err != nil {
+		return fmt.Errorf("add profile failed: %w", err)
+	}
+
+	return nil
 }
 
 func doForegroundLogin(ctx context.Context, cmd *cobra.Command, setupKey string, activeProf *profilemanager.Profile) error {

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -233,6 +233,31 @@ func switchProfile(ctx context.Context, handle string, username string) (profile
 	return profilemanager.ID(resp.Id), nil
 }
 
+// switchOrCreateProfile switches the active profile to the one identified by
+// handle, creating it first when it does not exist yet. This restores the
+// pre-0.73 behaviour where `netbird up --profile <name>` auto-creates a
+// missing profile instead of failing.
+func switchOrCreateProfile(ctx context.Context, pm *profilemanager.ProfileManager, handle, username string) error {
+	resolvedID, err := switchProfile(ctx, handle, username)
+	if err != nil {
+		st, ok := gstatus.FromError(err)
+		if !ok || st.Code() != codes.NotFound {
+			return err
+		}
+		if cerr := createProfile(ctx, handle, username); cerr != nil {
+			return fmt.Errorf("create profile: %v", cerr)
+		}
+		if resolvedID, err = switchProfile(ctx, handle, username); err != nil {
+			return err
+		}
+	}
+
+	if err := pm.SwitchProfile(resolvedID); err != nil {
+		return err
+	}
+	return nil
+}
+
 // createProfile asks the daemon to create a new profile with the given
 // display name. Helpful for `netbird up --profile <name>` which
 // auto-creates a missing profile.

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -244,10 +244,15 @@ func switchOrCreateProfile(ctx context.Context, pm *profilemanager.ProfileManage
 		if !ok || st.Code() != codes.NotFound {
 			return err
 		}
-		if cerr := createProfile(ctx, handle, username); cerr != nil {
-			return fmt.Errorf("create profile: %v", cerr)
-		}
+		// Don't fail immediately on a create error: a concurrent run may
+		// have created the profile between the NotFound above and this
+		// call, in which case the retried switch still succeeds. Only
+		// surface the create error if the switch also fails.
+		createErr := createProfile(ctx, handle, username)
 		if resolvedID, err = switchProfile(ctx, handle, username); err != nil {
+			if createErr != nil {
+				return fmt.Errorf("create profile: %w", createErr)
+			}
 			return err
 		}
 	}

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -263,10 +263,9 @@ func switchOrCreateProfile(ctx context.Context, pm *profilemanager.ProfileManage
 	return nil
 }
 
-// createProfile asks the daemon to create a new profile with the given
-// display name and returns its generated ID. It is the single entry point
-// for profile creation, shared by `netbird profile add` and the
-// `netbird up --profile <name>` auto-create path.
+// createProfile dials the daemon and creates a new profile with the given
+// display name, returning its generated ID. Use addProfileOnDaemon directly
+// when a daemon client is already available to reuse the connection.
 func createProfile(ctx context.Context, profileName, username string) (profilemanager.ID, error) {
 	conn, err := DialClientGRPCServer(ctx, daemonAddr)
 	if err != nil {
@@ -277,8 +276,14 @@ func createProfile(ctx context.Context, profileName, username string) (profilema
 	}
 	defer conn.Close()
 
-	client := proto.NewDaemonServiceClient(conn)
+	return addProfileOnDaemon(ctx, proto.NewDaemonServiceClient(conn), profileName, username)
+}
 
+// addProfileOnDaemon issues the AddProfile RPC on an existing daemon client
+// and returns the new profile's ID. It is the single entry point for profile
+// creation, shared by `netbird profile add` and the `netbird up --profile
+// <name>` auto-create path.
+func addProfileOnDaemon(ctx context.Context, client proto.DaemonServiceClient, profileName, username string) (profilemanager.ID, error) {
 	resp, err := client.AddProfile(ctx, &proto.AddProfileRequest{
 		ProfileName: profileName,
 		Username:    username,

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -233,68 +233,6 @@ func switchProfile(ctx context.Context, handle string, username string) (profile
 	return profilemanager.ID(resp.Id), nil
 }
 
-// switchOrCreateProfile switches the active profile to the one identified by
-// handle, creating it first when it does not exist yet. This restores the
-// pre-0.73 behaviour where `netbird up --profile <name>` auto-creates a
-// missing profile instead of failing.
-func switchOrCreateProfile(ctx context.Context, pm *profilemanager.ProfileManager, handle, username string) error {
-	resolvedID, err := switchProfile(ctx, handle, username)
-	if err != nil {
-		st, ok := gstatus.FromError(err)
-		if !ok || st.Code() != codes.NotFound {
-			return err
-		}
-		// Don't fail immediately on a create error: a concurrent run may
-		// have created the profile between the NotFound above and this
-		// call, in which case the retried switch still succeeds. Only
-		// surface the create error if the switch also fails.
-		_, createErr := createProfile(ctx, handle, username)
-		if resolvedID, err = switchProfile(ctx, handle, username); err != nil {
-			if createErr != nil {
-				return fmt.Errorf("create profile: %w", createErr)
-			}
-			return err
-		}
-	}
-
-	if err := pm.SwitchProfile(resolvedID); err != nil {
-		return err
-	}
-	return nil
-}
-
-// createProfile dials the daemon and creates a new profile with the given
-// display name, returning its generated ID. Use addProfileOnDaemon directly
-// when a daemon client is already available to reuse the connection.
-func createProfile(ctx context.Context, profileName, username string) (profilemanager.ID, error) {
-	conn, err := DialClientGRPCServer(ctx, daemonAddr)
-	if err != nil {
-		//nolint
-		return "", fmt.Errorf("failed to connect to daemon error: %v\n"+
-			"If the daemon is not running please run: "+
-			"\nnetbird service install \nnetbird service start\n", err)
-	}
-	defer conn.Close()
-
-	return addProfileOnDaemon(ctx, proto.NewDaemonServiceClient(conn), profileName, username)
-}
-
-// addProfileOnDaemon issues the AddProfile RPC on an existing daemon client
-// and returns the new profile's ID. It is the single entry point for profile
-// creation, shared by `netbird profile add` and the `netbird up --profile
-// <name>` auto-create path.
-func addProfileOnDaemon(ctx context.Context, client proto.DaemonServiceClient, profileName, username string) (profilemanager.ID, error) {
-	resp, err := client.AddProfile(ctx, &proto.AddProfileRequest{
-		ProfileName: profileName,
-		Username:    username,
-	})
-	if err != nil {
-		return "", fmt.Errorf("add profile failed: %w", err)
-	}
-
-	return profilemanager.ID(resp.Id), nil
-}
-
 func doForegroundLogin(ctx context.Context, cmd *cobra.Command, setupKey string, activeProf *profilemanager.Profile) error {
 
 	err := handleRebrand(cmd)

--- a/client/cmd/profile.go
+++ b/client/cmd/profile.go
@@ -326,3 +326,19 @@ func wrapAmbiguityError(err error, handle string) error {
 	}
 	return err
 }
+
+// addProfileOnDaemon issues the AddProfile RPC on an existing daemon client
+// and returns the new profile's ID. It is the single entry point for profile
+// creation, shared by `netbird profile add` and the `netbird up --profile
+// <name>` auto-create path.
+func addProfileOnDaemon(ctx context.Context, client proto.DaemonServiceClient, profileName, username string) (profilemanager.ID, error) {
+	resp, err := client.AddProfile(ctx, &proto.AddProfileRequest{
+		ProfileName: profileName,
+		Username:    username,
+	})
+	if err != nil {
+		return "", fmt.Errorf("add profile failed: %w", err)
+	}
+
+	return profilemanager.ID(resp.Id), nil
+}

--- a/client/cmd/profile.go
+++ b/client/cmd/profile.go
@@ -138,35 +138,31 @@ func addProfileFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	currUser, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("get current user: %w", err)
+	}
+
+	profileName := args[0]
+
+	id, err := createProfile(cmd.Context(), profileName, currUser.Username)
+	if err != nil {
+		return err
+	}
+
 	conn, err := DialClientGRPCServer(cmd.Context(), daemonAddr)
 	if err != nil {
 		return fmt.Errorf("connect to service CLI interface: %w", err)
 	}
 	defer conn.Close()
 
-	currUser, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("get current user: %w", err)
-	}
-
 	daemonClient := proto.NewDaemonServiceClient(conn)
-	profileName := args[0]
-
-	resp, err := daemonClient.AddProfile(cmd.Context(), &proto.AddProfileRequest{
-		ProfileName: profileName,
-		Username:    currUser.Username,
-	})
-	if err != nil {
-		return fmt.Errorf("add profile request: %w", err)
-	}
-
 	dupCount, _ := countProfilesWithName(cmd.Context(), daemonClient, currUser.Username, profileName)
 	if dupCount > 1 {
 		cmd.Printf("Warning: %d other profile(s) already use the name %q.\n", dupCount-1, profileName)
 		cmd.Println("Use `netbird profile list --show-id` to disambiguate later.")
 	}
 
-	id := profilemanager.ID(resp.Id)
 	cmd.Printf("Profile added: %s  %s\n", id.ShortID(), profilemanager.StripCtrlChars(profileName))
 	return nil
 

--- a/client/cmd/profile.go
+++ b/client/cmd/profile.go
@@ -143,13 +143,6 @@ func addProfileFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get current user: %w", err)
 	}
 
-	profileName := args[0]
-
-	id, err := createProfile(cmd.Context(), profileName, currUser.Username)
-	if err != nil {
-		return err
-	}
-
 	conn, err := DialClientGRPCServer(cmd.Context(), daemonAddr)
 	if err != nil {
 		return fmt.Errorf("connect to service CLI interface: %w", err)
@@ -157,6 +150,13 @@ func addProfileFunc(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	daemonClient := proto.NewDaemonServiceClient(conn)
+	profileName := args[0]
+
+	id, err := addProfileOnDaemon(cmd.Context(), daemonClient, profileName, currUser.Username)
+	if err != nil {
+		return err
+	}
+
 	dupCount, _ := countProfilesWithName(cmd.Context(), daemonClient, currUser.Username, profileName)
 	if dupCount > 1 {
 		cmd.Printf("Warning: %d other profile(s) already use the name %q.\n", dupCount-1, profileName)

--- a/client/cmd/status.go
+++ b/client/cmd/status.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/netbirdio/netbird/client/internal"
-	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
 	nbstatus "github.com/netbirdio/netbird/client/status"
 	"github.com/netbirdio/netbird/util"
@@ -111,11 +110,10 @@ func statusFunc(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	pm := profilemanager.NewProfileManager()
-	var profName string
-	if activeProf, err := pm.GetActiveProfile(); err == nil {
-		profName = activeProf.Name
-	}
+	// Resolve the active profile's display name via the daemon, which runs
+	// as root and can read the per-user profile files. The local profile
+	// manager only knows the active profile ID, not its display name.
+	profName := getActiveProfileName(ctx)
 
 	var outputInformationHolder = nbstatus.ConvertToStatusOutputOverview(resp.GetFullStatus(), nbstatus.ConvertOptions{
 		Anonymize:            anonymizeFlag,
@@ -165,6 +163,25 @@ func getStatus(ctx context.Context, fullPeerStatus bool, shouldRunProbes bool) (
 	}
 
 	return resp, nil
+}
+
+// getActiveProfileName asks the daemon for the active profile's display
+// name. The daemon runs as root and can read the per-user profile files to
+// resolve the ID to its human-readable name. Returns an empty string on any
+// error so status output degrades gracefully.
+func getActiveProfileName(ctx context.Context) string {
+	conn, err := DialClientGRPCServer(ctx, daemonAddr)
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+
+	resp, err := proto.NewDaemonServiceClient(conn).GetActiveProfile(ctx, &proto.GetActiveProfileRequest{})
+	if err != nil {
+		return ""
+	}
+
+	return resp.GetProfileName()
 }
 
 func parseFilters() error {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -128,25 +128,9 @@ func upFunc(cmd *cobra.Command, args []string) error {
 	var profileSwitched bool
 	// switch profile if provided
 	if profileName != "" {
-		resolvedID, err := switchProfile(cmd.Context(), profileName, username.Username)
-		if err != nil {
-			//`netbird up --profile <name>`
-			// auto-creates the profile when it does not exist yet.
-			if st, ok := gstatus.FromError(err); ok && st.Code() == codes.NotFound {
-				if cerr := createProfile(cmd.Context(), profileName, username.Username); cerr != nil {
-					return fmt.Errorf("create profile: %v", cerr)
-				}
-				resolvedID, err = switchProfile(cmd.Context(), profileName, username.Username)
-			}
-			if err != nil {
-				return fmt.Errorf("switch profile: %v", err)
-			}
-		}
-
-		if err := pm.SwitchProfile(resolvedID); err != nil {
+		if err := switchOrCreateProfile(cmd.Context(), pm, profileName, username.Username); err != nil {
 			return fmt.Errorf("switch profile: %v", err)
 		}
-
 		profileSwitched = true
 	}
 

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -130,7 +130,17 @@ func upFunc(cmd *cobra.Command, args []string) error {
 	if profileName != "" {
 		resolvedID, err := switchProfile(cmd.Context(), profileName, username.Username)
 		if err != nil {
-			return fmt.Errorf("switch profile: %v", err)
+			//`netbird up --profile <name>`
+			// auto-creates the profile when it does not exist yet.
+			if st, ok := gstatus.FromError(err); ok && st.Code() == codes.NotFound {
+				if cerr := createProfile(cmd.Context(), profileName, username.Username); cerr != nil {
+					return fmt.Errorf("create profile: %v", cerr)
+				}
+				resolvedID, err = switchProfile(cmd.Context(), profileName, username.Username)
+			}
+			if err != nil {
+				return fmt.Errorf("switch profile: %v", err)
+			}
 		}
 
 		if err := pm.SwitchProfile(resolvedID); err != nil {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -145,6 +145,52 @@ func upFunc(cmd *cobra.Command, args []string) error {
 	return runInDaemonMode(ctx, cmd, pm, activeProf, profileSwitched)
 }
 
+// switchOrCreateProfile switches the active profile to the one identified by
+// handle, creating it first when it does not exist yet. This restores the
+// pre-0.73 behaviour where `netbird up --profile <name>` auto-creates a
+// missing profile instead of failing.
+func switchOrCreateProfile(ctx context.Context, pm *profilemanager.ProfileManager, handle, username string) error {
+	resolvedID, err := switchProfile(ctx, handle, username)
+	if err != nil {
+		st, ok := gstatus.FromError(err)
+		if !ok || st.Code() != codes.NotFound {
+			return err
+		}
+		// Don't fail immediately on a create error: a concurrent run may
+		// have created the profile between the NotFound above and this
+		// call, in which case the retried switch still succeeds. Only
+		// surface the create error if the switch also fails.
+		_, createErr := createProfile(ctx, handle, username)
+		if resolvedID, err = switchProfile(ctx, handle, username); err != nil {
+			if createErr != nil {
+				return fmt.Errorf("create profile: %w", createErr)
+			}
+			return err
+		}
+	}
+
+	if err := pm.SwitchProfile(resolvedID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createProfile dials the daemon and creates a new profile with the given
+// display name, returning its generated ID. Use addProfileOnDaemon directly
+// when a daemon client is already available to reuse the connection.
+func createProfile(ctx context.Context, profileName, username string) (profilemanager.ID, error) {
+	conn, err := DialClientGRPCServer(ctx, daemonAddr)
+	if err != nil {
+		//nolint
+		return "", fmt.Errorf("failed to connect to daemon error: %v\n"+
+			"If the daemon is not running please run: "+
+			"\nnetbird service install \nnetbird service start\n", err)
+	}
+	defer conn.Close()
+
+	return addProfileOnDaemon(ctx, proto.NewDaemonServiceClient(conn), profileName, username)
+}
+
 func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *profilemanager.Profile) error {
 	// override the default profile filepath if provided
 	if configPath != "" {


### PR DESCRIPTION
## Describe your changes

PR #6367 (migrating profile identity from display name to ID) introduced two regressions in the CLI profile flow. This PR fixes both.

1. **`netbird up --profile <name>` no longer auto-created a missing profile.** Before #6367, switching to a non-existent profile name simply recorded it as the active profile and the config file was created lazily. After the migration, the daemon resolves the supplied handle against existing profiles and returns `codes.NotFound`, which broke ephemeral CI workflows relying on `netbird up --profile <name> --setup-key <key>` to provision the profile on the fly (reported in discussion #6476).

   `upFunc` in `client/cmd/up.go` now detects `codes.NotFound` from `switchProfile`, creates the profile via the daemon's existing `AddProfile` RPC (`createProfile` helper in `client/cmd/login.go`), and retries the switch. To make the status code inspectable by the caller, `switchProfile` now wraps the daemon error with `%w` instead of `%v`.

2. **`netbird status` showed an empty `Profile:` field** for both the default and custom profiles. After #6367, `ProfileManager.GetActiveProfile` returns only the profile ID (not the display name), and the CLI — running as the invoking user — cannot read the per-user profile files under `/var/lib/netbird/<user>/` (root-owned, `0700`) to resolve the name itself.

   `client/cmd/status.go` now resolves the display name through the daemon's existing `GetActiveProfile` RPC, which runs as root and maps the active ID to its display name. Added the `getActiveProfileName` helper and removed the now-unused `profilemanager` import.

Manually verified: `netbird up --profile <new-name> --setup-key <key>` provisions and connects, and `netbird status` shows the correct profile name for both default and custom profiles.

## Issue ticket number and link

https://github.com/netbirdio/netbird/discussions/6476 — regression report for `netbird up --profile` + setup-key failing on v0.73.0 after #6367.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

These are regression fixes that restore the documented pre-0.73.0 behavior of `netbird up --profile` and the `netbird status` output. No public CLI flags, API surface, or configuration options change, so existing documentation remains accurate.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC error handling for profile-related operations, including clearer error wrapping during daemon failures.
* **New Features**
  * The `up` command now switches to a specified profile, and if it doesn’t exist, creates it and then retries activation.
* **Improvements**
  * The `status` command now pulls the active profile’s display name from the running daemon.
  * Profile creation output is more reliable by using the daemon-returned profile ID after creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->