### PR TITLE
[misc] handle release candidates when fetching tags in FreeBSD port scripts

### DIFF
--- a/release_files/freebsd-port-diff.sh
+++ b/release_files/freebsd-port-diff.sh
@@ -21,7 +21,8 @@ AWK_FIRST_FIELD='{print $1}'
 
 fetch_all_tags() {
     curl -sL "https://github.com/${GITHUB_REPO}/tags" 2>/dev/null | \
-        grep -oE '/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+' | \
+        grep -oE '/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+([^"]+)?' | \
+        grep -v 'rc' | \
         sed 's/.*\/v//' | \
         sort -u -V
     return 0

--- a/release_files/freebsd-port-diff.sh
+++ b/release_files/freebsd-port-diff.sh
@@ -22,6 +22,7 @@ AWK_FIRST_FIELD='{print $1}'
 fetch_all_tags() {
     curl -sL "https://github.com/${GITHUB_REPO}/tags" 2>/dev/null | \
         grep -oE '/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+([^"]+)?' | \
+        grep -iv 'rc' | \
         sed 's/.*\/v//' | \
         sort -u -V
     return 0

--- a/release_files/freebsd-port-diff.sh
+++ b/release_files/freebsd-port-diff.sh
@@ -22,7 +22,6 @@ AWK_FIRST_FIELD='{print $1}'
 fetch_all_tags() {
     curl -sL "https://github.com/${GITHUB_REPO}/tags" 2>/dev/null | \
         grep -oE '/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+([^"]+)?' | \
-        grep -v 'rc' | \
         sed 's/.*\/v//' | \
         sort -u -V
     return 0

--- a/release_files/freebsd-port-issue-body.sh
+++ b/release_files/freebsd-port-issue-body.sh
@@ -33,6 +33,7 @@ fetch_all_tags() {
     # Fetch tags from GitHub tags page (no rate limiting, no auth needed)
     curl -sL "https://github.com/${GITHUB_REPO}/tags" 2>/dev/null | \
         grep -oE '/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+([^"]+)?' | \
+        grep -iv 'rc' | \
         sed 's/.*\/v//' | \
         sort -u -V
     return 0

--- a/release_files/freebsd-port-issue-body.sh
+++ b/release_files/freebsd-port-issue-body.sh
@@ -33,7 +33,6 @@ fetch_all_tags() {
     # Fetch tags from GitHub tags page (no rate limiting, no auth needed)
     curl -sL "https://github.com/${GITHUB_REPO}/tags" 2>/dev/null | \
         grep -oE '/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+([^"]+)?' | \
-        grep -v 'rc' | \
         sed 's/.*\/v//' | \
         sort -u -V
     return 0

--- a/release_files/freebsd-port-issue-body.sh
+++ b/release_files/freebsd-port-issue-body.sh
@@ -32,7 +32,8 @@ fetch_current_ports_version() {
 fetch_all_tags() {
     # Fetch tags from GitHub tags page (no rate limiting, no auth needed)
     curl -sL "https://github.com/${GITHUB_REPO}/tags" 2>/dev/null | \
-        grep -oE '/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+' | \
+        grep -oE '/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+([^"]+)?' | \
+        grep -v 'rc' | \
         sed 's/.*\/v//' | \
         sort -u -V
     return 0


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release tag recognition so version tags are correctly detected even when the tag URL includes an extra optional suffix after `vMAJOR.MINOR.PATCH`.
  * Tag handling remains selective, continuing to avoid release candidate versions and preserving the existing filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->