### PR TITLE
feat: add enableLocalSTUN/enableLocalRelay

### DIFF
--- a/combined/cmd/config.go
+++ b/combined/cmd/config.go
@@ -62,9 +62,11 @@ type ServerConfig struct {
 	// External service overrides (simplified mode)
 	// When these are set, the corresponding local service is NOT started
 	// and these values are used for client configuration instead
-	Stuns     []HostConfig `yaml:"stuns"`     // External STUN servers (disables local STUN)
-	Relays    RelaysConfig `yaml:"relays"`    // External relay servers (disables local relay)
-	SignalURI string       `yaml:"signalUri"` // External signal server (disables local signal)
+	Stuns             []HostConfig `yaml:"stuns"`             // External STUN servers (disables local STUN)
+	Relays            RelaysConfig `yaml:"relays"`            // External relay servers (disables local relay)
+	SignalURI         string       `yaml:"signalUri"`         // External signal server (disables local signal)
+	EnableLocalSTUN   bool         `yaml:"enableLocalSTUN"`   // Force enable local STUN alongside external STUN
+	EnableLocalRelay  bool         `yaml:"enableLocalRelay"`  // Force enable local relay alongside external relay
 
 	// Management settings (simplified mode)
 	DisableAnonymousMetrics bool               `yaml:"disableAnonymousMetrics"`
@@ -301,7 +303,7 @@ func (c *CombinedConfig) ApplySimplifiedDefaults() {
 
 // applyRelayDefaults configures the relay service if no external relay is configured.
 func (c *CombinedConfig) applyRelayDefaults(exposedProto, exposedHostPort string, hasExternalRelay, hasExternalStuns bool) {
-	if hasExternalRelay {
+	if hasExternalRelay && !c.Server.EnableLocalRelay {
 		return
 	}
 
@@ -316,8 +318,9 @@ func (c *CombinedConfig) applyRelayDefaults(exposedProto, exposedHostPort string
 		c.Relay.LogLevel = c.Server.LogLevel
 	}
 
-	// Enable local STUN only if no external STUN servers and stunPorts are configured
-	if !hasExternalStuns && len(c.Server.StunPorts) > 0 {
+	// Enable local STUN if no external STUN servers and stunPorts are configured,
+	// or if force-enabled via EnableLocalSTUN
+	if (c.Server.EnableLocalSTUN || !hasExternalStuns) && len(c.Server.StunPorts) > 0 {
 		c.Relay.Stun.Enabled = true
 		c.Relay.Stun.Ports = c.Server.StunPorts
 		if c.Relay.Stun.LogLevel == "" {
@@ -381,6 +384,14 @@ func (c *CombinedConfig) autoConfigureClientSettings(exposedProto, exposedHost, 
 	if hasExternalStuns {
 		// Use external STUN servers from server config
 		c.Management.Stuns = c.Server.Stuns
+		// If force-enabling local STUN, append local STUN addresses
+		if c.Server.EnableLocalSTUN && len(c.Server.StunPorts) > 0 {
+			for _, port := range c.Server.StunPorts {
+				c.Management.Stuns = append(c.Management.Stuns, HostConfig{
+					URI: "stun:" + net.JoinHostPort(strings.Trim(exposedHost, "[]"), fmt.Sprintf("%d", port)),
+				})
+			}
+		}
 	} else if len(c.Server.StunPorts) > 0 && len(c.Management.Stuns) == 0 {
 		// Auto-configure local STUN servers for all ports
 		for _, port := range c.Server.StunPorts {
@@ -394,6 +405,10 @@ func (c *CombinedConfig) autoConfigureClientSettings(exposedProto, exposedHost, 
 	if hasExternalRelay {
 		// Use external relay config from server
 		c.Management.Relays = c.Server.Relays
+		// If force-enabling local relay, append local relay address
+		if c.Server.EnableLocalRelay {
+			c.Management.Relays.Addresses = append(c.Management.Relays.Addresses, fmt.Sprintf("%s://%s", relayProto, exposedHostPort))
+		}
 	} else if len(c.Management.Relays.Addresses) == 0 {
 		// Auto-configure local relay
 		c.Management.Relays.Addresses = []string{
@@ -462,8 +477,9 @@ func (c *CombinedConfig) Validate() error {
 	}
 
 	// authSecret is required only if running local relay (no external relay configured)
+	// or if force-enabling local relay via EnableLocalRelay
 	hasExternalRelay := len(c.Server.Relays.Addresses) > 0
-	if !hasExternalRelay && c.Server.AuthSecret == "" {
+	if (!hasExternalRelay || c.Server.EnableLocalRelay) && c.Server.AuthSecret == "" {
 		return fmt.Errorf("server.authSecret is required when running local relay")
 	}
 

--- a/combined/cmd/config.go
+++ b/combined/cmd/config.go
@@ -391,14 +391,14 @@ func (c *CombinedConfig) autoConfigureClientSettings(exposedProto, exposedHost, 
 		// Use external STUN servers from server config
 		c.Management.Stuns = c.Server.Stuns
 		// If force-enabling local STUN, append local STUN addresses
-		if c.Server.EnableLocalSTUN && len(c.Server.StunPorts) > 0 {
+		if c.Server.EnableLocalSTUN && c.Relay.Stun.Enabled && len(c.Server.StunPorts) > 0 {
 			for _, port := range c.Server.StunPorts {
 				c.Management.Stuns = append(c.Management.Stuns, HostConfig{
 					URI: "stun:" + net.JoinHostPort(strings.Trim(exposedHost, "[]"), fmt.Sprintf("%d", port)),
 				})
 			}
 		}
-	} else if len(c.Server.StunPorts) > 0 && len(c.Management.Stuns) == 0 {
+	} else if c.Relay.Stun.Enabled && len(c.Server.StunPorts) > 0 && len(c.Management.Stuns) == 0 {
 		// Auto-configure local STUN servers for all ports
 		for _, port := range c.Server.StunPorts {
 			c.Management.Stuns = append(c.Management.Stuns, HostConfig{

--- a/combined/cmd/config.go
+++ b/combined/cmd/config.go
@@ -299,6 +299,12 @@ func (c *CombinedConfig) ApplySimplifiedDefaults() {
 
 	// Auto-configure client settings (stuns, relays, signalUri)
 	c.autoConfigureClientSettings(exposedProto, exposedHost, exposedHostPort, hasExternalStuns, hasExternalRelay, hasExternalSignal)
+
+	// When both internal and external relay are running, sync the internal relay's
+	// auth secret with the management-facing secret so credentials are consistent.
+	if c.Server.EnableLocalRelay && hasExternalRelay {
+		c.Relay.AuthSecret = c.Management.Relays.Secret
+	}
 }
 
 // applyRelayDefaults configures the relay service if no external relay is configured.

--- a/combined/config.yaml.example
+++ b/combined/config.yaml.example
@@ -61,6 +61,9 @@ server:
   # stuns:
   #   - uri: "stun:stun.example.com:3478"
   #   - uri: "stun:stun.example.com:3479"
+  #
+  # Force-enable local STUN alongside external STUN (only takes effect when 'stuns' is set)
+  # enableLocalSTUN: false
 
   # External relay servers - disables local relay server
   # relays:
@@ -68,6 +71,9 @@ server:
   #     - "rels://relay.example.com:443"
   #   credentialsTTL: "12h"
   #   secret: "relay-shared-secret"
+  #
+  # Force-enable local relay alongside external relay (only takes effect when 'relays' is set)
+  # enableLocalRelay: false
 
   # External signal server - disables local signal server
   # signalUri: "https://signal.example.com:443"

--- a/combined/config.yaml.example
+++ b/combined/config.yaml.example
@@ -45,7 +45,9 @@ server:
       email: ""
       awsRoute53: false
 
-  # Shared secret for relay authentication (required when running local relay)
+  # Shared secret for relay authentication
+  # Required when running local relay (no external relay, or enableLocalRelay: true)
+  # Can be removed when using external relay without enableLocalRelay
   authSecret: "your-secret-key-here"
 
   # Data directory for all services
@@ -54,7 +56,8 @@ server:
   # ============================================================================
   # External Service Overrides (optional)
   # Use these to point to external Signal, Relay, or STUN servers instead of
-  # running them locally. When set, the corresponding local service is disabled.
+  # running them locally. When set, the corresponding local service is disabled
+  # unless the matching enableLocal* flag is set to true.
   # ============================================================================
 
   # External STUN servers - disables local STUN server
@@ -73,6 +76,7 @@ server:
   #   secret: "relay-shared-secret"
   #
   # Force-enable local relay alongside external relay (only takes effect when 'relays' is set)
+  # Note: authSecret is required when this is true
   # enableLocalRelay: false
 
   # External signal server - disables local signal server


### PR DESCRIPTION
## Describe your changes

Add `enableLocalSTUN` and `enableLocalRelay` options to the combined server's simplified config, allowing operators to force-enable the embedded STUN/relay services alongside external ones.

- When `server.stuns` is configured, the embedded STUN is disabled by default. Setting `server.enableLocalSTUN: true` keeps both running.
- When `server.relays` is configured, the embedded relay is disabled by default. Setting `server.enableLocalRelay: true` keeps both running.
- These flags have no effect when the corresponding external service is not configured (embedded services already run by default).
- `server.authSecret` validation now also requires a value when `enableLocalRelay: true`.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/804


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration flags to optionally run local STUN and/or local relay even when external STUN/relay overrides are set.
  * Improved client auto-configuration to include local STUN/relay endpoints when the new force-enable options are enabled.
* **Bug Fixes**
  * Updated validation to require the appropriate authentication secret when local relay is enabled.
* **Documentation**
  * Updated the example configuration file to document the new local service enable/force-enable options and related requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->