### PR TITLE
[management] fix: prevent reverse proxy domain from being pushed as DNS search domain

### DIFF
--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -305,7 +305,8 @@ func (a *Account) SynthesizePrivateServiceZones(peerID string) []nbdns.CustomZon
 			zone = &nbdns.CustomZone{
 				Domain:           dns.Fqdn(serviceDomainZone),
 				Records:          []nbdns.SimpleRecord{},
-				NonAuthoritative: true,
+				NonAuthoritative:     true,
+				SearchDomainDisabled: true,
 			}
 			zonesByApex[serviceDomainZone] = zone
 		}


### PR DESCRIPTION
## Problem

`SynthesizePrivateServiceZones` creates `CustomZone` entries for private reverse proxy services without setting `SearchDomainDisabled`. Since Go defaults unset booleans to `false`, the reverse proxy domain gets pushed as a **search domain suffix** to all connected peers.

This causes short hostname resolution to break: a query for `myserver` gets expanded to `myserver.app.example.com` (the reverse proxy domain) and matched there — before the peer's local DNS search domains (e.g. pushed via DHCP) are tried. If a real DNS record exists under the reverse proxy domain with that name, it silently resolves to the wrong host.

The bug is hard to diagnose because it appears and disappears dynamically as reverse proxy services are toggled on/off.

Verified on macOS via `scutil --dns` — the reverse proxy domain appears at order `102801` (same range as Magic DNS `nb.cloud` at `102800`), meaning it goes through a different, higher-priority path than nameserver groups (`103xxx`) and bypasses any user-controlled search domain toggle.

## Fix

Set `SearchDomainDisabled: true` in the `CustomZone` created by `SynthesizePrivateServiceZones`, so the zone is registered only as a supplemental resolver (explicit `*.app.example.com` queries go through NetBird DNS) — but not as a search domain suffix appended to unqualified hostnames.

This is consistent with the `NonAuthoritative: true` already set on the same zone.

```go
zone = &nbdns.CustomZone{
    Domain:               dns.Fqdn(serviceDomainZone),
    Records:              []nbdns.SimpleRecord{},
    NonAuthoritative:     true,
    SearchDomainDisabled: true, // ← added
}
```

## Verification

Tested on a self-hosted NetBird stack with the patched binary (macOS peer, reverse proxy service active throughout):

**Before:**
```
resolver #1
  search domain[0] : nb.cloud
  search domain[1] : app.example.com    ← injected, breaks local resolution
  search domain[2] : internal.lan
```

**After:**
```
resolver #1
  search domain[0] : nb.cloud
  search domain[1] : internal.lan       ← reverse proxy domain gone
```

Short hostname resolution now correctly falls through to local DNS search domains.

Related discussion: https://github.com/netbirdio/netbird/discussions/6497

## Documentation

- [x] Documentation is **not needed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNS custom zones for private services now have the search domain feature disabled, improving zone behavior for private service lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->