### PR TITLE
[client] fix WaitStreamConnected test call after ctx signature change

### DIFF
--- a/shared/signal/client/watchdog_test.go
+++ b/shared/signal/client/watchdog_test.go
@@ -65,7 +65,7 @@ func TestReceiveProbeRoundTrips(t *testing.T) {
 
 	streamReady := make(chan struct{})
 	go func() {
-		client.WaitStreamConnected()
+		client.WaitStreamConnected(ctx)
 		close(streamReady)
 	}()
 	select {


### PR DESCRIPTION
watchdog_test.go called WaitStreamConnected() without the context.Context argument added in #6443, breaking the signal client test build.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test lifecycle management by tying stream connection waits to test context cancellation and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->