### PR TITLE
[client] Resolve management cache domains asynchronously

### DIFF
--- a/client/internal/dns/mgmt/export_test.go
+++ b/client/internal/dns/mgmt/export_test.go
@@ -1,0 +1,25 @@
+package mgmt
+
+import "time"
+
+// pendingCount returns the number of domains whose initial resolve is still in
+// flight. Test-only: lets tests wait for background resolves kicked off by
+// UpdateFromServerDomains.
+func (m *Resolver) pendingCount() int {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return len(m.pending)
+}
+
+// waitForPendingResolves blocks until all background initial resolves have
+// settled, or the timeout elapses. Returns true if all settled. Test-only.
+func (m *Resolver) waitForPendingResolves(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for m.pendingCount() > 0 {
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return true
+}

--- a/client/internal/dns/mgmt/export_test.go
+++ b/client/internal/dns/mgmt/export_test.go
@@ -2,17 +2,15 @@ package mgmt
 
 import "time"
 
-// pendingCount returns the number of domains whose initial resolve is still in
-// flight. Test-only: lets tests wait for background resolves kicked off by
-// UpdateFromServerDomains.
+// pendingCount returns how many initial resolves are still in flight. Test-only.
 func (m *Resolver) pendingCount() int {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 	return len(m.pending)
 }
 
-// waitForPendingResolves blocks until all background initial resolves have
-// settled, or the timeout elapses. Returns true if all settled. Test-only.
+// waitForPendingResolves blocks until all pending resolves settle or the
+// timeout elapses, returning true if all settled. Test-only.
 func (m *Resolver) waitForPendingResolves(timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for m.pendingCount() > 0 {

--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -50,11 +50,8 @@ type cachedRecord struct {
 	consecFailures    int
 }
 
-// pendingEntry marks a domain whose initial resolution was kicked off by a
-// network-map update but has not completed yet. It lets ServeDNS wait on the
-// in-flight resolve (instead of falling through to the upstream, which may be
-// the dead DNS path the cache exists to bypass) and lets handler registration
-// claim the name before any record exists.
+// pendingEntry marks a domain whose initial resolve is in flight, so ServeDNS
+// can wait on it instead of falling through to upstream.
 type pendingEntry struct{}
 
 // Resolver caches critical NetBird infrastructure domains.
@@ -65,18 +62,15 @@ type Resolver struct {
 	serverDomains *dnsconfig.ServerDomains
 	mutex         sync.RWMutex
 
-	// pending holds domains whose initial resolution is in flight, keyed by
-	// the punycode FQDN (trailing dot). A ServeDNS miss for a pending domain
-	// waits on the resolve via resolveGroup instead of going to upstream.
+	// pending holds domains whose initial resolve is in flight, keyed by
+	// punycode FQDN (trailing dot).
 	pending map[string]pendingEntry
 
 	chain            ChainResolver
 	chainMaxPriority int
 	refreshGroup     singleflight.Group
-	// resolveGroup dedups initial (cold-cache) resolves kicked off by
-	// UpdateFromServerDomains and joined by ServeDNS waiters. Kept separate
-	// from refreshGroup so a stale-refresh and an initial-resolve for the same
-	// name don't collapse into one flight with mismatched semantics.
+	// resolveGroup dedups initial (cold-cache) resolves; kept separate from
+	// refreshGroup so initial and stale-refresh flights don't collapse.
 	resolveGroup singleflight.Group
 
 	// refreshing tracks questions whose refresh is running via the OS
@@ -145,11 +139,8 @@ func (m *Resolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	m.mutex.RUnlock()
 
 	if !found {
-		// A network-map update registered this domain but its initial resolve
-		// has not landed yet. Wait on the in-flight resolve rather than falling
-		// through to upstream, which may be the dead DNS path the cache exists
-		// to bypass (e.g. relay hostnames resolved while the DNS-carrying peer
-		// has no handshake). Bounded by dnsTimeout inside awaitPendingResolve.
+		// Registered but not resolved yet: wait on the in-flight resolve
+		// rather than falling through to (possibly dead) upstream.
 		if isPending && m.awaitPendingResolve(question.Name) {
 			m.mutex.RLock()
 			cached, found = m.records[question]
@@ -498,11 +489,9 @@ func (m *Resolver) RemoveDomain(d domain.Domain) error {
 	return nil
 }
 
-// RequestedDomains returns the cacheable infrastructure domains for the given
-// server config (signal, relay, STUN, TURN; flow excluded). Used to register
-// the cache handler for these names immediately, before resolution completes,
-// so ServeDNS can intercept their lookups (and wait on a pending resolve)
-// instead of letting them fall through to upstream.
+// RequestedDomains returns the cacheable infrastructure domains (signal, relay,
+// STUN, TURN; flow excluded) so the cache handler can be registered for them
+// before resolution completes.
 func (m *Resolver) RequestedDomains(serverDomains dnsconfig.ServerDomains) domain.List {
 	return m.extractDomainsFromServerDomains(serverDomains)
 }
@@ -530,15 +519,9 @@ func (m *Resolver) GetCachedDomains() domain.List {
 // It merges new domains with existing ones, replacing entire domain types when updated.
 // Empty updates are ignored to prevent clearing infrastructure domains during partial updates.
 // UpdateFromServerDomains records the requested domains and kicks off their
-// resolution in the background. It does NOT block on DNS: resolution is handed
-// to resolveGroup and the actual waiting, if any, happens later on the
-// ServeDNS path (when the relay/signal client looks the name up), not here.
-// This keeps it off the engine sync lock, which a network-map update holds
-// while calling this.
-//
-// The ctx is intentionally unused for resolution — background resolves use
-// context.Background() with their own dnsTimeout so a fast-returning sync
-// cannot cancel an in-flight resolve.
+// resolution in the background, returning without blocking on DNS so it stays
+// off the engine sync lock held by the caller. ctx is unused: background
+// resolves use context.Background() so a fast-returning sync can't cancel them.
 func (m *Resolver) UpdateFromServerDomains(_ context.Context, serverDomains dnsconfig.ServerDomains) (domain.List, error) {
 	newDomains := m.extractDomainsFromServerDomains(serverDomains)
 	var removedDomains domain.List
@@ -562,9 +545,8 @@ func (m *Resolver) UpdateFromServerDomains(_ context.Context, serverDomains dnsc
 	return removedDomains, nil
 }
 
-// kickoffResolve marks each domain pending and starts its resolution in the
-// background via resolveGroup. Returns immediately; callers must not block on
-// the result. A domain that already has a fresh cache entry is skipped.
+// kickoffResolve marks each domain pending and starts a background resolve,
+// skipping ones already fresh or in flight. Returns immediately.
 func (m *Resolver) kickoffResolve(domains domain.List) {
 	for _, d := range domains {
 		dnsName := strings.ToLower(dns.Fqdn(d.PunycodeString()))
@@ -586,8 +568,7 @@ func (m *Resolver) kickoffResolve(domains domain.List) {
 }
 
 // scheduleInitialResolve runs AddDomain in the background, deduped per domain
-// by resolveGroup. The pending marker is cleared once resolution finishes
-// (success or failure) so ServeDNS stops waiting and a later update can retry.
+// by resolveGroup, clearing the pending marker when it finishes.
 func (m *Resolver) scheduleInitialResolve(d domain.Domain, dnsName string) {
 	key := "initial|" + dnsName
 	_ = m.resolveGroup.DoChan(key, func() (any, error) {
@@ -619,10 +600,8 @@ func (m *Resolver) clearPending(dnsName string) {
 	m.mutex.Unlock()
 }
 
-// awaitPendingResolve waits for an in-flight initial resolve of dnsName to
-// finish, bounded by dnsTimeout. It joins the existing resolveGroup flight so
-// concurrent ServeDNS waiters share one resolution. Returns true if a record
-// became available.
+// awaitPendingResolve joins the in-flight resolve for dnsName (bounded by
+// dnsTimeout) and reports whether a record became available.
 func (m *Resolver) awaitPendingResolve(dnsName string) bool {
 	key := "initial|" + dnsName
 	d, err := domain.FromString(strings.TrimSuffix(dnsName, "."))

--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -520,9 +520,10 @@ func (m *Resolver) GetCachedDomains() domain.List {
 // Empty updates are ignored to prevent clearing infrastructure domains during partial updates.
 // UpdateFromServerDomains records the requested domains and kicks off their
 // resolution in the background, returning without blocking on DNS so it stays
-// off the engine sync lock held by the caller. ctx is unused: background
-// resolves use context.Background() so a fast-returning sync can't cancel them.
-func (m *Resolver) UpdateFromServerDomains(_ context.Context, serverDomains dnsconfig.ServerDomains) (domain.List, error) {
+// off the engine sync lock held by the caller. ctx scopes the background
+// resolves to the server lifetime: it is not per-sync, so a fast-returning
+// sync won't cancel them, but a server Stop will.
+func (m *Resolver) UpdateFromServerDomains(ctx context.Context, serverDomains dnsconfig.ServerDomains) (domain.List, error) {
 	newDomains := m.extractDomainsFromServerDomains(serverDomains)
 	var removedDomains domain.List
 
@@ -540,14 +541,14 @@ func (m *Resolver) UpdateFromServerDomains(_ context.Context, serverDomains dnsc
 		removedDomains = m.removeStaleDomains(currentDomains, allDomains)
 	}
 
-	m.kickoffResolve(newDomains)
+	m.kickoffResolve(ctx, newDomains)
 
 	return removedDomains, nil
 }
 
 // kickoffResolve marks each domain pending and starts a background resolve,
 // skipping ones already fresh or in flight. Returns immediately.
-func (m *Resolver) kickoffResolve(domains domain.List) {
+func (m *Resolver) kickoffResolve(ctx context.Context, domains domain.List) {
 	for _, d := range domains {
 		dnsName := strings.ToLower(dns.Fqdn(d.PunycodeString()))
 
@@ -563,17 +564,18 @@ func (m *Resolver) kickoffResolve(domains domain.List) {
 			continue
 		}
 
-		m.scheduleInitialResolve(d, dnsName)
+		m.scheduleInitialResolve(ctx, d, dnsName)
 	}
 }
 
 // scheduleInitialResolve runs AddDomain in the background, deduped per domain
-// by resolveGroup, clearing the pending marker when it finishes.
-func (m *Resolver) scheduleInitialResolve(d domain.Domain, dnsName string) {
+// by resolveGroup, clearing the pending marker when it finishes. ctx is the
+// server-lifetime context so a Stop cancels in-flight resolves.
+func (m *Resolver) scheduleInitialResolve(ctx context.Context, d domain.Domain, dnsName string) {
 	key := "initial|" + dnsName
 	_ = m.resolveGroup.DoChan(key, func() (any, error) {
 		defer m.clearPending(dnsName)
-		if err := m.AddDomain(context.Background(), d); err != nil {
+		if err := m.AddDomain(ctx, d); err != nil {
 			log.Warnf("failed to add/update domain=%s: %v", d.SafeString(), err)
 			return struct{}{}, err
 		}

--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -50,17 +50,34 @@ type cachedRecord struct {
 	consecFailures    int
 }
 
+// pendingEntry marks a domain whose initial resolution was kicked off by a
+// network-map update but has not completed yet. It lets ServeDNS wait on the
+// in-flight resolve (instead of falling through to the upstream, which may be
+// the dead DNS path the cache exists to bypass) and lets handler registration
+// claim the name before any record exists.
+type pendingEntry struct{}
+
 // Resolver caches critical NetBird infrastructure domains.
-// records, refreshing, mgmtDomain and serverDomains are all guarded by mutex.
+// records, refreshing, pending, mgmtDomain and serverDomains are all guarded by mutex.
 type Resolver struct {
 	records       map[dns.Question]*cachedRecord
 	mgmtDomain    *domain.Domain
 	serverDomains *dnsconfig.ServerDomains
 	mutex         sync.RWMutex
 
+	// pending holds domains whose initial resolution is in flight, keyed by
+	// the punycode FQDN (trailing dot). A ServeDNS miss for a pending domain
+	// waits on the resolve via resolveGroup instead of going to upstream.
+	pending map[string]pendingEntry
+
 	chain            ChainResolver
 	chainMaxPriority int
 	refreshGroup     singleflight.Group
+	// resolveGroup dedups initial (cold-cache) resolves kicked off by
+	// UpdateFromServerDomains and joined by ServeDNS waiters. Kept separate
+	// from refreshGroup so a stale-refresh and an initial-resolve for the same
+	// name don't collapse into one flight with mismatched semantics.
+	resolveGroup singleflight.Group
 
 	// refreshing tracks questions whose refresh is running via the OS
 	// fallback path. A ServeDNS hit for a question in this map indicates
@@ -78,6 +95,7 @@ func NewResolver() *Resolver {
 	return &Resolver{
 		records:    make(map[dns.Question]*cachedRecord),
 		refreshing: make(map[dns.Question]*atomic.Bool),
+		pending:    make(map[string]pendingEntry),
 		cacheTTL:   resolveCacheTTL(),
 	}
 }
@@ -117,6 +135,7 @@ func (m *Resolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	m.mutex.RLock()
 	cached, found := m.records[question]
 	inflight := m.refreshing[question]
+	_, isPending := m.pending[question.Name]
 	var shouldRefresh bool
 	if found {
 		stale := time.Since(cached.cachedAt) > m.cacheTTL
@@ -126,8 +145,20 @@ func (m *Resolver) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	m.mutex.RUnlock()
 
 	if !found {
-		m.continueToNext(w, r)
-		return
+		// A network-map update registered this domain but its initial resolve
+		// has not landed yet. Wait on the in-flight resolve rather than falling
+		// through to upstream, which may be the dead DNS path the cache exists
+		// to bypass (e.g. relay hostnames resolved while the DNS-carrying peer
+		// has no handshake). Bounded by dnsTimeout inside awaitPendingResolve.
+		if isPending && m.awaitPendingResolve(question.Name) {
+			m.mutex.RLock()
+			cached, found = m.records[question]
+			m.mutex.RUnlock()
+		}
+		if !found {
+			m.continueToNext(w, r)
+			return
+		}
 	}
 
 	if inflight != nil && inflight.CompareAndSwap(false, true) {
@@ -467,6 +498,15 @@ func (m *Resolver) RemoveDomain(d domain.Domain) error {
 	return nil
 }
 
+// RequestedDomains returns the cacheable infrastructure domains for the given
+// server config (signal, relay, STUN, TURN; flow excluded). Used to register
+// the cache handler for these names immediately, before resolution completes,
+// so ServeDNS can intercept their lookups (and wait on a pending resolve)
+// instead of letting them fall through to upstream.
+func (m *Resolver) RequestedDomains(serverDomains dnsconfig.ServerDomains) domain.List {
+	return m.extractDomainsFromServerDomains(serverDomains)
+}
+
 // GetCachedDomains returns a list of all cached domains.
 func (m *Resolver) GetCachedDomains() domain.List {
 	m.mutex.RLock()
@@ -489,7 +529,17 @@ func (m *Resolver) GetCachedDomains() domain.List {
 // UpdateFromServerDomains updates the cache with server domains from network configuration.
 // It merges new domains with existing ones, replacing entire domain types when updated.
 // Empty updates are ignored to prevent clearing infrastructure domains during partial updates.
-func (m *Resolver) UpdateFromServerDomains(ctx context.Context, serverDomains dnsconfig.ServerDomains) (domain.List, error) {
+// UpdateFromServerDomains records the requested domains and kicks off their
+// resolution in the background. It does NOT block on DNS: resolution is handed
+// to resolveGroup and the actual waiting, if any, happens later on the
+// ServeDNS path (when the relay/signal client looks the name up), not here.
+// This keeps it off the engine sync lock, which a network-map update holds
+// while calling this.
+//
+// The ctx is intentionally unused for resolution — background resolves use
+// context.Background() with their own dnsTimeout so a fast-returning sync
+// cannot cancel an in-flight resolve.
+func (m *Resolver) UpdateFromServerDomains(_ context.Context, serverDomains dnsconfig.ServerDomains) (domain.List, error) {
 	newDomains := m.extractDomainsFromServerDomains(serverDomains)
 	var removedDomains domain.List
 
@@ -507,9 +557,120 @@ func (m *Resolver) UpdateFromServerDomains(ctx context.Context, serverDomains dn
 		removedDomains = m.removeStaleDomains(currentDomains, allDomains)
 	}
 
-	m.addNewDomains(ctx, newDomains)
+	m.kickoffResolve(newDomains)
 
 	return removedDomains, nil
+}
+
+// kickoffResolve marks each domain pending and starts its resolution in the
+// background via resolveGroup. Returns immediately; callers must not block on
+// the result. A domain that already has a fresh cache entry is skipped.
+func (m *Resolver) kickoffResolve(domains domain.List) {
+	for _, d := range domains {
+		dnsName := strings.ToLower(dns.Fqdn(d.PunycodeString()))
+
+		m.mutex.Lock()
+		_, hasPending := m.pending[dnsName]
+		cached := m.hasFreshRecordLocked(dnsName)
+		if !hasPending && !cached {
+			m.pending[dnsName] = pendingEntry{}
+		}
+		m.mutex.Unlock()
+
+		if hasPending || cached {
+			continue
+		}
+
+		m.scheduleInitialResolve(d, dnsName)
+	}
+}
+
+// scheduleInitialResolve runs AddDomain in the background, deduped per domain
+// by resolveGroup. The pending marker is cleared once resolution finishes
+// (success or failure) so ServeDNS stops waiting and a later update can retry.
+func (m *Resolver) scheduleInitialResolve(d domain.Domain, dnsName string) {
+	key := "initial|" + dnsName
+	_ = m.resolveGroup.DoChan(key, func() (any, error) {
+		defer m.clearPending(dnsName)
+		if err := m.AddDomain(context.Background(), d); err != nil {
+			log.Warnf("failed to add/update domain=%s: %v", d.SafeString(), err)
+			return struct{}{}, err
+		}
+		log.Debugf("added/updated management cache domain=%s", d.SafeString())
+		return struct{}{}, nil
+	})
+}
+
+// hasFreshRecordLocked reports whether a non-stale A or AAAA record exists for
+// the name. Caller holds m.mutex.
+func (m *Resolver) hasFreshRecordLocked(dnsName string) bool {
+	for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA} {
+		q := dns.Question{Name: dnsName, Qtype: qtype, Qclass: dns.ClassINET}
+		if c, ok := m.records[q]; ok && time.Since(c.cachedAt) <= m.cacheTTL {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Resolver) clearPending(dnsName string) {
+	m.mutex.Lock()
+	delete(m.pending, dnsName)
+	m.mutex.Unlock()
+}
+
+// pendingCount returns the number of domains whose initial resolve is still in
+// flight. Primarily useful for tests that need to wait for background resolves
+// kicked off by UpdateFromServerDomains.
+func (m *Resolver) pendingCount() int {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return len(m.pending)
+}
+
+// WaitForPendingResolves blocks until all background initial resolves kicked
+// off by UpdateFromServerDomains have settled, or the timeout elapses. It
+// returns true if all settled. Intended for tests and shutdown paths that need
+// the cache populated synchronously.
+func (m *Resolver) WaitForPendingResolves(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for m.pendingCount() > 0 {
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return true
+}
+
+// awaitPendingResolve waits for an in-flight initial resolve of dnsName to
+// finish, bounded by dnsTimeout. It joins the existing resolveGroup flight so
+// concurrent ServeDNS waiters share one resolution. Returns true if a record
+// became available.
+func (m *Resolver) awaitPendingResolve(dnsName string) bool {
+	key := "initial|" + dnsName
+	d, err := domain.FromString(strings.TrimSuffix(dnsName, "."))
+	if err != nil {
+		return false
+	}
+
+	ch := m.resolveGroup.DoChan(key, func() (any, error) {
+		defer m.clearPending(dnsName)
+		if err := m.AddDomain(context.Background(), d); err != nil {
+			return struct{}{}, err
+		}
+		return struct{}{}, nil
+	})
+
+	select {
+	case <-ch:
+	case <-time.After(dnsTimeout):
+		return false
+	}
+
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return m.hasFreshRecordLocked(dnsName)
 }
 
 // removeStaleDomains removes cached domains not present in the target domain list.
@@ -575,17 +736,6 @@ func (m *Resolver) isManagementDomain(domain domain.Domain) bool {
 	defer m.mutex.RUnlock()
 
 	return m.mgmtDomain != nil && domain == *m.mgmtDomain
-}
-
-// addNewDomains resolves and caches all domains from the update
-func (m *Resolver) addNewDomains(ctx context.Context, newDomains domain.List) {
-	for _, newDomain := range newDomains {
-		if err := m.AddDomain(ctx, newDomain); err != nil {
-			log.Warnf("failed to add/update domain=%s: %v", newDomain.SafeString(), err)
-		} else {
-			log.Debugf("added/updated management cache domain=%s", newDomain.SafeString())
-		}
-	}
 }
 
 func (m *Resolver) extractDomainsFromServerDomains(serverDomains dnsconfig.ServerDomains) domain.List {

--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -519,15 +519,12 @@ func (m *Resolver) GetCachedDomains() domain.List {
 	return domains
 }
 
-// UpdateFromServerDomains updates the cache with server domains from network configuration.
-// It merges new domains with existing ones, replacing entire domain types when updated.
-// Empty updates are ignored to prevent clearing infrastructure domains during partial updates.
-// UpdateFromServerDomains records the requested domains and kicks off their
-// resolution in the background, returning without blocking on DNS so it stays
-// off the engine sync lock held by the caller. ctx scopes the background
-// resolves to the server lifetime: it is not per-sync, so a fast-returning
-// sync won't cancel them, but a server Stop will.
-func (m *Resolver) UpdateFromServerDomains(ctx context.Context, serverDomains dnsconfig.ServerDomains) (domain.List, error) {
+// UpdateFromServerDomains merges server domains into the cache and resolves
+// them. New types replace whole types; empty updates are ignored. Resolution is
+// async (off the caller's sync lock) except for cold domains when dnsWillBeServed
+// and takeover is pending, which kickoffResolve primes synchronously. ctx is the
+// server lifetime, so a fast sync won't cancel resolves but Stop will.
+func (m *Resolver) UpdateFromServerDomains(ctx context.Context, serverDomains dnsconfig.ServerDomains, dnsWillBeServed bool) (domain.List, error) {
 	newDomains := m.extractDomainsFromServerDomains(serverDomains)
 	var removedDomains domain.List
 
@@ -545,31 +542,60 @@ func (m *Resolver) UpdateFromServerDomains(ctx context.Context, serverDomains dn
 		removedDomains = m.removeStaleDomains(currentDomains, allDomains)
 	}
 
-	m.kickoffResolve(ctx, newDomains)
+	m.kickoffResolve(ctx, newDomains, dnsWillBeServed)
 
 	return removedDomains, nil
 }
 
-// kickoffResolve marks each domain pending and starts a background resolve,
-// skipping ones already fresh or in flight. Returns immediately.
-func (m *Resolver) kickoffResolve(ctx context.Context, domains domain.List) {
+// kickoffResolve resolves each unresolved domain, skipping fresh/in-flight ones.
+// Cold domains resolve synchronously only before takeover (no upstream root
+// handler) and when dnsWillBeServed, to prime the cache via the working OS
+// resolver before OS DNS routes through the tunnel; otherwise async.
+func (m *Resolver) kickoffResolve(ctx context.Context, domains domain.List, dnsWillBeServed bool) {
+	m.mutex.RLock()
+	chain := m.chain
+	maxPriority := m.chainMaxPriority
+	m.mutex.RUnlock()
+	preTakeover := chain == nil || !chain.HasRootHandlerAtOrBelow(maxPriority)
+
 	for _, d := range domains {
 		dnsName := strings.ToLower(dns.Fqdn(d.PunycodeString()))
 
 		m.mutex.Lock()
 		_, hasPending := m.pending[dnsName]
-		cached := m.hasFreshRecordLocked(dnsName)
-		if !hasPending && !cached {
+		fresh := m.hasFreshRecordLocked(dnsName)
+		cold := !m.hasAnyRecordLocked(dnsName)
+		if !hasPending && !fresh {
 			m.pending[dnsName] = pendingEntry{}
 		}
 		m.mutex.Unlock()
 
-		if hasPending || cached {
+		if hasPending || fresh {
+			continue
+		}
+
+		if cold && preTakeover && dnsWillBeServed {
+			m.resolveInitial(ctx, d, dnsName)
 			continue
 		}
 
 		m.scheduleInitialResolve(ctx, d, dnsName)
 	}
+}
+
+// resolveInitial resolves a cold domain synchronously, deduped via resolveGroup
+// so a concurrent ServeDNS await joins the same flight. Clears pending when done.
+func (m *Resolver) resolveInitial(ctx context.Context, d domain.Domain, dnsName string) {
+	key := "initial|" + dnsName
+	_, _, _ = m.resolveGroup.Do(key, func() (any, error) {
+		defer m.clearPending(dnsName)
+		if err := m.AddDomain(ctx, d); err != nil {
+			log.Warnf("initial resolve mgmt domain=%s: %v", d.SafeString(), err)
+			return struct{}{}, err
+		}
+		log.Debugf("added/updated management cache domain=%s", d.SafeString())
+		return struct{}{}, nil
+	})
 }
 
 // scheduleInitialResolve runs AddDomain in the background, deduped per domain
@@ -594,6 +620,18 @@ func (m *Resolver) hasFreshRecordLocked(dnsName string) bool {
 	for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA} {
 		q := dns.Question{Name: dnsName, Qtype: qtype, Qclass: dns.ClassINET}
 		if c, ok := m.records[q]; ok && time.Since(c.cachedAt) <= m.cacheTTL {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAnyRecordLocked reports whether any A or AAAA record exists for the name,
+// fresh or stale. Caller holds m.mutex.
+func (m *Resolver) hasAnyRecordLocked(dnsName string) bool {
+	for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA} {
+		q := dns.Question{Name: dnsName, Qtype: qtype, Qclass: dns.ClassINET}
+		if _, ok := m.records[q]; ok {
 			return true
 		}
 	}

--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -57,6 +57,9 @@ type pendingEntry struct{}
 // Resolver caches critical NetBird infrastructure domains.
 // records, refreshing, pending, mgmtDomain and serverDomains are all guarded by mutex.
 type Resolver struct {
+	// ctx is the server-lifetime context for background resolves.
+	ctx context.Context
+
 	records       map[dns.Question]*cachedRecord
 	mgmtDomain    *domain.Domain
 	serverDomains *dnsconfig.ServerDomains
@@ -85,8 +88,9 @@ type Resolver struct {
 }
 
 // NewResolver creates a new management domains cache resolver.
-func NewResolver() *Resolver {
+func NewResolver(ctx context.Context) *Resolver {
 	return &Resolver{
+		ctx:        ctx,
 		records:    make(map[dns.Question]*cachedRecord),
 		refreshing: make(map[dns.Question]*atomic.Bool),
 		pending:    make(map[string]pendingEntry),
@@ -613,7 +617,7 @@ func (m *Resolver) awaitPendingResolve(dnsName string) bool {
 
 	ch := m.resolveGroup.DoChan(key, func() (any, error) {
 		defer m.clearPending(dnsName)
-		if err := m.AddDomain(context.Background(), d); err != nil {
+		if err := m.AddDomain(m.ctx, d); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil

--- a/client/internal/dns/mgmt/mgmt.go
+++ b/client/internal/dns/mgmt/mgmt.go
@@ -619,30 +619,6 @@ func (m *Resolver) clearPending(dnsName string) {
 	m.mutex.Unlock()
 }
 
-// pendingCount returns the number of domains whose initial resolve is still in
-// flight. Primarily useful for tests that need to wait for background resolves
-// kicked off by UpdateFromServerDomains.
-func (m *Resolver) pendingCount() int {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	return len(m.pending)
-}
-
-// WaitForPendingResolves blocks until all background initial resolves kicked
-// off by UpdateFromServerDomains have settled, or the timeout elapses. It
-// returns true if all settled. Intended for tests and shutdown paths that need
-// the cache populated synchronously.
-func (m *Resolver) WaitForPendingResolves(timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for m.pendingCount() > 0 {
-		if time.Now().After(deadline) {
-			return false
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return true
-}
-
 // awaitPendingResolve waits for an in-flight initial resolve of dnsName to
 // finish, bounded by dnsTimeout. It joins the existing resolveGroup flight so
 // concurrent ServeDNS waiters share one resolution. Returns true if a record

--- a/client/internal/dns/mgmt/mgmt_refresh_test.go
+++ b/client/internal/dns/mgmt/mgmt_refresh_test.go
@@ -130,7 +130,7 @@ func TestResolver_CacheTTLGatesRefresh(t *testing.T) {
 	q := dns.Question{Name: "mgmt.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 
 	t.Run("short TTL treats entry as stale and refreshes", func(t *testing.T) {
-		r := NewResolver()
+		r := NewResolver(context.Background())
 		r.cacheTTL = 10 * time.Millisecond
 		chain := newFakeChain()
 		chain.setAnswer(q.Name, dns.TypeA, "10.0.0.2")
@@ -146,7 +146,7 @@ func TestResolver_CacheTTLGatesRefresh(t *testing.T) {
 	})
 
 	t.Run("long TTL keeps entry fresh and skips refresh", func(t *testing.T) {
-		r := NewResolver()
+		r := NewResolver(context.Background())
 		r.cacheTTL = time.Hour
 		chain := newFakeChain()
 		chain.setAnswer(q.Name, dns.TypeA, "10.0.0.2")
@@ -162,7 +162,7 @@ func TestResolver_CacheTTLGatesRefresh(t *testing.T) {
 }
 
 func TestResolver_ServeFresh_NoRefresh(t *testing.T) {
-	r := NewResolver()
+	r := NewResolver(context.Background())
 	chain := newFakeChain()
 	chain.setAnswer("mgmt.example.com.", dns.TypeA, "10.0.0.2")
 	r.SetChainResolver(chain, 50)
@@ -183,7 +183,7 @@ func TestResolver_ServeFresh_NoRefresh(t *testing.T) {
 }
 
 func TestResolver_StaleTriggersAsyncRefresh(t *testing.T) {
-	r := NewResolver()
+	r := NewResolver(context.Background())
 	chain := newFakeChain()
 	chain.setAnswer("mgmt.example.com.", dns.TypeA, "10.0.0.2")
 	r.SetChainResolver(chain, 50)
@@ -213,7 +213,7 @@ func TestResolver_StaleTriggersAsyncRefresh(t *testing.T) {
 }
 
 func TestResolver_ConcurrentStaleHitsCollapseRefresh(t *testing.T) {
-	r := NewResolver()
+	r := NewResolver(context.Background())
 	chain := newFakeChain()
 	chain.setAnswer("mgmt.example.com.", dns.TypeA, "10.0.0.2")
 
@@ -262,7 +262,7 @@ func TestResolver_ConcurrentStaleHitsCollapseRefresh(t *testing.T) {
 }
 
 func TestResolver_RefreshFailureArmsBackoff(t *testing.T) {
-	r := NewResolver()
+	r := NewResolver(context.Background())
 	chain := newFakeChain()
 	chain.err = errors.New("boom")
 	r.SetChainResolver(chain, 50)
@@ -299,7 +299,7 @@ func TestResolver_RefreshFailureArmsBackoff(t *testing.T) {
 }
 
 func TestResolver_NoRootHandler_SkipsChain(t *testing.T) {
-	r := NewResolver()
+	r := NewResolver(context.Background())
 	chain := newFakeChain()
 	chain.hasRoot = false
 	chain.setAnswer("mgmt.example.com.", dns.TypeA, "10.0.0.2")
@@ -320,7 +320,7 @@ func TestResolver_ServeDuringRefreshSetsLoopFlag(t *testing.T) {
 	// ServeDNS being invoked for a question while a refresh for that question
 	// is inflight indicates a resolver loop (OS resolver sent the recursive
 	// query back to us). The inflightRefresh.loopLoggedOnce flag must be set.
-	r := NewResolver()
+	r := NewResolver(context.Background())
 
 	q := dns.Question{Name: "mgmt.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	r.records[q] = &cachedRecord{
@@ -346,7 +346,7 @@ func TestResolver_ServeDuringRefreshSetsLoopFlag(t *testing.T) {
 }
 
 func TestResolver_LoopFlagOnlyTrippedOncePerRefresh(t *testing.T) {
-	r := NewResolver()
+	r := NewResolver(context.Background())
 
 	q := dns.Question{Name: "mgmt.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	r.records[q] = &cachedRecord{
@@ -373,7 +373,7 @@ func TestResolver_LoopFlagOnlyTrippedOncePerRefresh(t *testing.T) {
 }
 
 func TestResolver_NoLoopFlagWhenNotRefreshing(t *testing.T) {
-	r := NewResolver()
+	r := NewResolver(context.Background())
 
 	q := dns.Question{Name: "mgmt.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	r.records[q] = &cachedRecord{
@@ -393,7 +393,7 @@ func TestResolver_NoLoopFlagWhenNotRefreshing(t *testing.T) {
 }
 
 func TestResolver_AddDomain_UsesChainWhenRootRegistered(t *testing.T) {
-	r := NewResolver()
+	r := NewResolver(context.Background())
 	chain := newFakeChain()
 	chain.setAnswer("mgmt.example.com.", dns.TypeA, "10.0.0.2")
 	chain.setAnswer("mgmt.example.com.", dns.TypeAAAA, "fd00::2")

--- a/client/internal/dns/mgmt/mgmt_test.go
+++ b/client/internal/dns/mgmt/mgmt_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestResolver_NewResolver(t *testing.T) {
-	resolver := NewResolver()
+	resolver := NewResolver(context.Background())
 
 	assert.NotNil(t, resolver)
 	assert.NotNil(t, resolver.records)
@@ -49,7 +49,7 @@ func TestResolveCacheTTL(t *testing.T) {
 
 func TestNewResolver_CacheTTLFromEnv(t *testing.T) {
 	t.Setenv(envMgmtCacheTTL, "7s")
-	r := NewResolver()
+	r := NewResolver(context.Background())
 	assert.Equal(t, 7*time.Second, r.cacheTTL, "NewResolver should evaluate cacheTTL once from env")
 }
 
@@ -169,7 +169,7 @@ func TestResolver_PopulateFromConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	resolver := NewResolver()
+	resolver := NewResolver(context.Background())
 
 	// Test with IP address - should return error since IP addresses are rejected
 	mgmtURL, _ := url.Parse("https://127.0.0.1")
@@ -184,7 +184,7 @@ func TestResolver_PopulateFromConfig(t *testing.T) {
 }
 
 func TestResolver_ServeDNS(t *testing.T) {
-	resolver := NewResolver()
+	resolver := NewResolver(context.Background())
 	ctx := context.Background()
 
 	// Add a test domain to the cache - use example.org which is reserved for testing
@@ -284,7 +284,7 @@ func TestResolver_ServeDNS(t *testing.T) {
 }
 
 func TestResolver_GetCachedDomains(t *testing.T) {
-	resolver := NewResolver()
+	resolver := NewResolver(context.Background())
 	ctx := context.Background()
 
 	testDomain, err := domain.FromString("example.org")
@@ -304,7 +304,7 @@ func TestResolver_GetCachedDomains(t *testing.T) {
 }
 
 func TestResolver_ManagementDomainProtection(t *testing.T) {
-	resolver := NewResolver()
+	resolver := NewResolver(context.Background())
 	ctx := context.Background()
 
 	mgmtURL, _ := url.Parse("https://example.org")
@@ -352,7 +352,7 @@ func extractDomainFromURL(u *url.URL) (domain.Domain, error) {
 }
 
 func TestResolver_EmptyUpdateDoesNotRemoveDomains(t *testing.T) {
-	resolver := NewResolver()
+	resolver := NewResolver(context.Background())
 	ctx := context.Background()
 
 	// Set up initial domains using resolvable domains
@@ -387,7 +387,7 @@ func TestResolver_EmptyUpdateDoesNotRemoveDomains(t *testing.T) {
 }
 
 func TestResolver_PartialUpdateReplacesOnlyUpdatedTypes(t *testing.T) {
-	resolver := NewResolver()
+	resolver := NewResolver(context.Background())
 	ctx := context.Background()
 
 	// Set up initial complete domains using resolvable domains
@@ -433,7 +433,7 @@ func TestResolver_PartialUpdateReplacesOnlyUpdatedTypes(t *testing.T) {
 }
 
 func TestResolver_PartialUpdateAddsNewTypePreservesExisting(t *testing.T) {
-	resolver := NewResolver()
+	resolver := NewResolver(context.Background())
 	ctx := context.Background()
 
 	// Set up initial complete domains using resolvable domains

--- a/client/internal/dns/mgmt/mgmt_test.go
+++ b/client/internal/dns/mgmt/mgmt_test.go
@@ -325,7 +325,7 @@ func TestResolver_ManagementDomainProtection(t *testing.T) {
 		Relay:  []domain.Domain{"cloudflare.com"},
 	}
 
-	_, err = resolver.UpdateFromServerDomains(ctx, serverDomains)
+	_, err = resolver.UpdateFromServerDomains(ctx, serverDomains, true)
 	if err != nil {
 		t.Logf("Server domains update failed: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestResolver_EmptyUpdateDoesNotRemoveDomains(t *testing.T) {
 	}
 
 	// Add initial domains
-	_, err := resolver.UpdateFromServerDomains(ctx, initialDomains)
+	_, err := resolver.UpdateFromServerDomains(ctx, initialDomains, true)
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
@@ -375,7 +375,7 @@ func TestResolver_EmptyUpdateDoesNotRemoveDomains(t *testing.T) {
 
 	// Update with empty ServerDomains (simulating partial network map update)
 	emptyDomains := dnsconfig.ServerDomains{}
-	removedDomains, err := resolver.UpdateFromServerDomains(ctx, emptyDomains)
+	removedDomains, err := resolver.UpdateFromServerDomains(ctx, emptyDomains, true)
 	assert.NoError(t, err)
 
 	// Verify no domains were removed
@@ -398,7 +398,7 @@ func TestResolver_PartialUpdateReplacesOnlyUpdatedTypes(t *testing.T) {
 	}
 
 	// Add initial domains
-	_, err := resolver.UpdateFromServerDomains(ctx, initialDomains)
+	_, err := resolver.UpdateFromServerDomains(ctx, initialDomains, true)
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
@@ -409,7 +409,7 @@ func TestResolver_PartialUpdateReplacesOnlyUpdatedTypes(t *testing.T) {
 	partialDomains := dnsconfig.ServerDomains{
 		Signal: "github.com",
 	}
-	removedDomains, err := resolver.UpdateFromServerDomains(ctx, partialDomains)
+	removedDomains, err := resolver.UpdateFromServerDomains(ctx, partialDomains, true)
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestResolver_PartialUpdateAddsNewTypePreservesExisting(t *testing.T) {
 	}
 
 	// Add initial domains
-	_, err := resolver.UpdateFromServerDomains(ctx, initialDomains)
+	_, err := resolver.UpdateFromServerDomains(ctx, initialDomains, true)
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
@@ -456,7 +456,7 @@ func TestResolver_PartialUpdateAddsNewTypePreservesExisting(t *testing.T) {
 	partialDomains := dnsconfig.ServerDomains{
 		Flow: "github.com",
 	}
-	removedDomains, err := resolver.UpdateFromServerDomains(ctx, partialDomains)
+	removedDomains, err := resolver.UpdateFromServerDomains(ctx, partialDomains, true)
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}

--- a/client/internal/dns/mgmt/mgmt_test.go
+++ b/client/internal/dns/mgmt/mgmt_test.go
@@ -329,7 +329,7 @@ func TestResolver_ManagementDomainProtection(t *testing.T) {
 	if err != nil {
 		t.Logf("Server domains update failed: %v", err)
 	}
-	resolver.WaitForPendingResolves(10 * time.Second)
+	resolver.waitForPendingResolves(10 * time.Second)
 
 	finalDomains := resolver.GetCachedDomains()
 
@@ -367,7 +367,7 @@ func TestResolver_EmptyUpdateDoesNotRemoveDomains(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
-	resolver.WaitForPendingResolves(10 * time.Second)
+	resolver.waitForPendingResolves(10 * time.Second)
 
 	// Verify domains were added
 	cachedDomains := resolver.GetCachedDomains()
@@ -402,7 +402,7 @@ func TestResolver_PartialUpdateReplacesOnlyUpdatedTypes(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
-	resolver.WaitForPendingResolves(10 * time.Second)
+	resolver.waitForPendingResolves(10 * time.Second)
 	assert.Len(t, resolver.GetCachedDomains(), 3)
 
 	// Update with partial ServerDomains (only signal domain - this should replace signal but preserve stun/turn)
@@ -413,7 +413,7 @@ func TestResolver_PartialUpdateReplacesOnlyUpdatedTypes(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
-	resolver.WaitForPendingResolves(10 * time.Second)
+	resolver.waitForPendingResolves(10 * time.Second)
 
 	// Should remove only the old signal domain
 	assert.Len(t, removedDomains, 1, "Should remove only the old signal domain")
@@ -448,7 +448,7 @@ func TestResolver_PartialUpdateAddsNewTypePreservesExisting(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
-	resolver.WaitForPendingResolves(10 * time.Second)
+	resolver.waitForPendingResolves(10 * time.Second)
 	assert.Len(t, resolver.GetCachedDomains(), 3)
 
 	// Update with partial ServerDomains (only flow domain - flow is intentionally excluded from
@@ -460,7 +460,7 @@ func TestResolver_PartialUpdateAddsNewTypePreservesExisting(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
-	resolver.WaitForPendingResolves(10 * time.Second)
+	resolver.waitForPendingResolves(10 * time.Second)
 
 	assert.Len(t, removedDomains, 0, "Should not remove any domains when only flow domain is provided")
 

--- a/client/internal/dns/mgmt/mgmt_test.go
+++ b/client/internal/dns/mgmt/mgmt_test.go
@@ -329,6 +329,7 @@ func TestResolver_ManagementDomainProtection(t *testing.T) {
 	if err != nil {
 		t.Logf("Server domains update failed: %v", err)
 	}
+	resolver.WaitForPendingResolves(10 * time.Second)
 
 	finalDomains := resolver.GetCachedDomains()
 
@@ -366,6 +367,7 @@ func TestResolver_EmptyUpdateDoesNotRemoveDomains(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
+	resolver.WaitForPendingResolves(10 * time.Second)
 
 	// Verify domains were added
 	cachedDomains := resolver.GetCachedDomains()
@@ -400,6 +402,7 @@ func TestResolver_PartialUpdateReplacesOnlyUpdatedTypes(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
+	resolver.WaitForPendingResolves(10 * time.Second)
 	assert.Len(t, resolver.GetCachedDomains(), 3)
 
 	// Update with partial ServerDomains (only signal domain - this should replace signal but preserve stun/turn)
@@ -410,6 +413,7 @@ func TestResolver_PartialUpdateReplacesOnlyUpdatedTypes(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
+	resolver.WaitForPendingResolves(10 * time.Second)
 
 	// Should remove only the old signal domain
 	assert.Len(t, removedDomains, 1, "Should remove only the old signal domain")
@@ -444,6 +448,7 @@ func TestResolver_PartialUpdateAddsNewTypePreservesExisting(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
+	resolver.WaitForPendingResolves(10 * time.Second)
 	assert.Len(t, resolver.GetCachedDomains(), 3)
 
 	// Update with partial ServerDomains (only flow domain - flow is intentionally excluded from
@@ -455,6 +460,7 @@ func TestResolver_PartialUpdateAddsNewTypePreservesExisting(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping test due to DNS resolution failure: %v", err)
 	}
+	resolver.WaitForPendingResolves(10 * time.Second)
 
 	assert.Len(t, removedDomains, 0, "Should not remove any domains when only flow domain is provided")
 

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -622,7 +622,12 @@ func (s *DefaultServer) UpdateServerConfig(domains dnsconfig.ServerDomains) erro
 			s.deregisterHandler(removedDomains.ToPunycodeList(), PriorityMgmtCache)
 		}
 
-		newDomains := s.mgmtCacheResolver.GetCachedDomains()
+		// Register the handler for the requested domains, not just the already
+		// resolved ones: UpdateFromServerDomains now resolves in the background,
+		// so the cache may still be empty here. Claiming the names up front lets
+		// the resolver's ServeDNS wait on the pending resolve instead of the
+		// lookup falling through to (possibly dead) upstream.
+		newDomains := s.mgmtCacheResolver.RequestedDomains(domains)
 		if len(newDomains) > 0 {
 			s.registerHandler(newDomains.ToPunycodeList(), s.mgmtCacheResolver, PriorityMgmtCache)
 		}

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -282,7 +282,7 @@ func newDefaultServer(
 	handlerChain := NewHandlerChain()
 	ctx, stop := context.WithCancel(ctx)
 
-	mgmtCacheResolver := mgmt.NewResolver()
+	mgmtCacheResolver := mgmt.NewResolver(ctx)
 	mgmtCacheResolver.SetChainResolver(handlerChain, PriorityUpstream)
 
 	defaultServer := &DefaultServer{

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -622,11 +622,8 @@ func (s *DefaultServer) UpdateServerConfig(domains dnsconfig.ServerDomains) erro
 			s.deregisterHandler(removedDomains.ToPunycodeList(), PriorityMgmtCache)
 		}
 
-		// Register the handler for the requested domains, not just the already
-		// resolved ones: UpdateFromServerDomains now resolves in the background,
-		// so the cache may still be empty here. Claiming the names up front lets
-		// the resolver's ServeDNS wait on the pending resolve instead of the
-		// lookup falling through to (possibly dead) upstream.
+		// Register for the requested domains, not just resolved ones: resolution
+		// now runs in the background, so the cache may still be empty here.
 		newDomains := s.mgmtCacheResolver.RequestedDomains(domains)
 		if len(newDomains) > 0 {
 			s.registerHandler(newDomains.ToPunycodeList(), s.mgmtCacheResolver, PriorityMgmtCache)

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -613,7 +613,11 @@ func (s *DefaultServer) UpdateServerConfig(domains dnsconfig.ServerDomains) erro
 	defer s.mux.Unlock()
 
 	if s.mgmtCacheResolver != nil {
-		removedDomains, err := s.mgmtCacheResolver.UpdateFromServerDomains(s.ctx, domains)
+		// Mirrors the Initialize guard: without it NetBird never becomes the
+		// system resolver, so the mgmt cache is never queried and need not be
+		// primed synchronously.
+		dnsWillBeServed := !s.disableSys && !netstack.IsEnabled()
+		removedDomains, err := s.mgmtCacheResolver.UpdateFromServerDomains(s.ctx, domains, dnsWillBeServed)
 		if err != nil {
 			return fmt.Errorf("update management cache resolver: %w", err)
 		}


### PR DESCRIPTION
UpdateFromServerDomains resolved the infrastructure domains (signal, relay, STUN, TURN) synchronously, in a serial loop with a 5s timeout per domain. It runs deep inside handleSync, under the engine syncMsgMux (and the DNS server mutex). When DNS is unhealthy each lookup waits out its full timeout, so the sync lock is held for many seconds — observed as a 16.6s wait for the lock by a signal handler in the field. That starves the signal/p2p processing that shares syncMsgMux, which in turn prevents the handshake that would make DNS healthy again: a self-reinforcing loop.

The cache cannot simply be skipped: it is a prerequisite for the relay connection. The relay dials its server by hostname, resolved through the NetBird DNS chain where this resolver sits on top (PriorityMgmtCache); on a miss it falls through to upstream — the dead path the cache exists to bypass.

Instead, record intent on sync and resolve on demand:

- UpdateFromServerDomains now marks each requested domain pending and kicks off resolution in the background via a dedicated singleflight group (resolveGroup), then returns immediately. No DNS I/O, no timeout, no blocking under the lock.
- ServeDNS, on a miss for a pending domain, waits on the in-flight resolve (joining the same singleflight flight, bounded by dnsTimeout) instead of falling through to the dead upstream. The wait now happens in the relay/DNS-serving goroutine, never under syncMsgMux.
- UpdateServerConfig registers the cache handler from the requested domains (RequestedDomains) rather than the already-resolved ones, so the resolver owns the names before resolution completes and can intercept the lookup.

Background resolves use context.Background() so a fast-returning sync cannot cancel an in-flight resolve. WaitForPendingResolves lets tests (and any warm-cache path) wait for the background work to settle.

Cache semantics are otherwise unchanged: TTL, stale-while-revalidate refresh, backoff, and the flow-domain exclusion all stay.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate cold-cache DNS queries by deduplicating in-flight initial resolutions for the same domain.
  * Improved DNS cache-miss behavior for A/AAAA queries by waiting for pending initial resolutions before falling back upstream.

* **Refactor**
  * Updated management-cache domain configuration to resolve newly needed domains asynchronously, without blocking the update flow.
  * Handler registration now includes newly requested cacheable infrastructure domains, even before records are fully populated.

* **Tests**
  * Updated DNS management tests to use resolver context and to wait for pending resolutions before assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->