### PR TITLE
[client] Fix empty profile handle regression in debug config

### DIFF
--- a/client/cmd/debug.go
+++ b/client/cmd/debug.go
@@ -130,7 +130,7 @@ func debugConfigDump(cmd *cobra.Command, _ []string) error {
 
 	client := proto.NewDaemonServiceClient(conn)
 	resp, err := client.GetConfig(cmd.Context(), &proto.GetConfigRequest{
-		ProfileName: activeProf.Name,
+		ProfileName: string(activeProf.ID),
 		Username:    currUser.Username,
 	})
 	if err != nil {


### PR DESCRIPTION
## Describe your changes

`netbird debug config` failed with `failed to get config: resolve profile:
profile handle is empty`.

PR #6367 (commit ee360963) migrated profile identity from display name to ID.
After it, `ProfileManager.GetActiveProfile` returns a `Profile` with only `ID`
populated and an empty `Name`:
https://github.com/netbirdio/netbird/blob/main/client/internal/profilemanager/profilemanager.go#L92

But `debugConfigDump` still sent `activeProf.Name` as the `GetConfigRequest`
profile handle:
https://github.com/netbirdio/netbird/blob/main/client/cmd/debug.go#L133

The empty handle reached `ServiceManager.ResolveProfile`, which rejects it with
`profile handle is empty`, surfaced through the daemon's `resolve profile`
wrapper.

Fix: send `string(activeProf.ID)` instead. `ResolveProfile` matches an exact ID
first, so the active profile resolves correctly.

## Issue ticket number and link

No public issue. Regression introduced by PR https://github.com/netbirdio/netbird/pull/6367
(profile display-name → ID migration); the `debug config` call site was not
updated to the ID-based handle. Offending line on main:
https://github.com/netbirdio/netbird/blob/main/client/cmd/debug.go#L133

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal CLI fix. The `debug config` command, its flags, and output format are
unchanged — the one-line fix only repairs the profile handle passed to the
daemon so the command stops erroring. No public API, config option, or behavior
surface changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile identification in debug configuration output to use the correct profile identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->