### PR TITLE
rebase lneto diff

### DIFF
--- a/.github/workflows/wasm-build-validation.yml
+++ b/.github/workflows/wasm-build-validation.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       GOOS: js
       GOARCH: wasm
+      GOFLAGS: -tags=wglneto
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -52,7 +53,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Build Wasm client
-        run: GOOS=js GOARCH=wasm go build -o netbird.wasm ./client/wasm/cmd
+        run: GOOS=js GOARCH=wasm go build -tags wglneto -o netbird.wasm ./client/wasm/cmd
         env:
           CGO_ENABLED: 0
       - name: Check Wasm build size
@@ -65,7 +66,7 @@ jobs:
 
           echo "Size: ${SIZE} bytes (${SIZE_MB} MB)"
 
-          if [ ${SIZE} -gt 62914560 ]; then
-            echo "Wasm binary size (${SIZE_MB}MB) exceeds 60MB limit!"
+          if [ ${SIZE} -gt 67108864 ]; then
+            echo "Wasm binary size (${SIZE_MB}MB) exceeds 64MB limit!"
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ management/netbird-mgmt
 */netbird
 **/netbird.wasm
 **/wasm_exec.js
+**/size-report.html

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ vendor/
 /netbird
 client/netbird-electron/
 management/server/types/testdata/
+
+signal/netbird-signal
+*/netbird-relay
+management/netbird-mgmt
+*/netbird
+**/netbird.wasm
+**/wasm_exec.js

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,8 @@ builds:
     ldflags:
       - -s -w -X github.com/netbirdio/netbird/version.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
     mod_timestamp: "{{ .CommitTimestamp }}"
+    tags:
+      - wglneto
 
   - id: netbird
     dir: client

--- a/client/firewall/create.go
+++ b/client/firewall/create.go
@@ -1,4 +1,4 @@
-//go:build !linux || android
+//go:build (!linux || android) && !js
 
 package firewall
 

--- a/client/firewall/create_js.go
+++ b/client/firewall/create_js.go
@@ -1,0 +1,67 @@
+//go:build js
+
+package firewall
+
+import (
+	"net"
+	"net/netip"
+
+	log "github.com/sirupsen/logrus"
+
+	firewall "github.com/netbirdio/netbird/client/firewall/manager"
+	nftypes "github.com/netbirdio/netbird/client/internal/netflow/types"
+	"github.com/netbirdio/netbird/client/internal/statemanager"
+)
+
+// NewFirewall returns a no-op firewall manager for the js/wasm build. The
+// userspace firewall (uspfilter) pulls in github.com/google/gopacket (~450KB of
+// protocol decoders) for packet filtering/NAT/conntrack, none of which is
+// meaningful in the browser client — it tunnels through the netstack rather than
+// filtering a real device. engine.go requires a non-nil Manager, so we satisfy
+// the interface with a permissive no-op.
+func NewFirewall(iface IFaceMapper, _ *statemanager.Manager, _ nftypes.FlowLogger, _ bool, _ uint16) (firewall.Manager, error) {
+	return &noopFirewall{}, nil
+}
+
+// noopFirewall implements firewall.Manager doing nothing (allow-all).
+type noopFirewall struct{}
+
+func (noopFirewall) Init(*statemanager.Manager) error { return nil }
+func (noopFirewall) AllowNetbird() error              { return nil }
+
+func (noopFirewall) AddPeerFiltering(_ []byte, _ net.IP, _ firewall.Protocol, _ *firewall.Port, _ *firewall.Port, _ firewall.Action, _ string) ([]firewall.Rule, error) {
+	return nil, nil
+}
+func (noopFirewall) DeletePeerRule(firewall.Rule) error { return nil }
+func (noopFirewall) IsServerRouteSupported() bool       { return false }
+func (noopFirewall) IsStateful() bool                   { return false }
+
+func (noopFirewall) AddRouteFiltering(_ []byte, _ []netip.Prefix, _ firewall.Network, _ firewall.Protocol, _, _ *firewall.Port, _ firewall.Action) (firewall.Rule, error) {
+	return nil, nil
+}
+func (noopFirewall) DeleteRouteRule(firewall.Rule) error        { return nil }
+func (noopFirewall) AddNatRule(firewall.RouterPair) error       { return nil }
+func (noopFirewall) RemoveNatRule(firewall.RouterPair) error    { return nil }
+func (noopFirewall) SetLegacyManagement(bool) error             { return nil }
+func (noopFirewall) Close(*statemanager.Manager) error          { return nil }
+func (noopFirewall) Flush() error                               { return nil }
+func (noopFirewall) SetLogLevel(log.Level)                      {}
+func (noopFirewall) EnableRouting() error                       { return nil }
+func (noopFirewall) DisableRouting() error                      { return nil }
+func (noopFirewall) AddDNATRule(firewall.ForwardRule) (firewall.Rule, error) { return nil, nil }
+func (noopFirewall) DeleteDNATRule(firewall.Rule) error         { return nil }
+func (noopFirewall) UpdateSet(firewall.Set, []netip.Prefix) error { return nil }
+
+func (noopFirewall) AddInboundDNAT(_ netip.Addr, _ firewall.Protocol, _, _ uint16) error {
+	return nil
+}
+func (noopFirewall) RemoveInboundDNAT(_ netip.Addr, _ firewall.Protocol, _, _ uint16) error {
+	return nil
+}
+func (noopFirewall) AddOutputDNAT(_ netip.Addr, _ firewall.Protocol, _, _ uint16) error {
+	return nil
+}
+func (noopFirewall) RemoveOutputDNAT(_ netip.Addr, _ firewall.Protocol, _, _ uint16) error {
+	return nil
+}
+func (noopFirewall) SetupEBPFProxyNoTrack(_, _ uint16) error { return nil }

--- a/client/firewall/uspfilter/forwarder/endpoint.go
+++ b/client/firewall/uspfilter/forwarder/endpoint.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package forwarder
 
 import (

--- a/client/firewall/uspfilter/forwarder/forwarder.go
+++ b/client/firewall/uspfilter/forwarder/forwarder.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package forwarder
 
 import (

--- a/client/firewall/uspfilter/forwarder/forwarder_js.go
+++ b/client/firewall/uspfilter/forwarder/forwarder_js.go
@@ -1,0 +1,41 @@
+//go:build js
+
+package forwarder
+
+import (
+	"errors"
+	"net/netip"
+
+	"github.com/netbirdio/netbird/client/firewall/uspfilter/common"
+	nblog "github.com/netbirdio/netbird/client/firewall/uspfilter/log"
+	nftypes "github.com/netbirdio/netbird/client/internal/netflow/types"
+)
+
+// PacketCapture captures raw packets for debugging. Implementations must be
+// safe for concurrent use and must not block.
+type PacketCapture interface {
+	Offer(data []byte, outbound bool)
+}
+
+// Forwarder is a no-op stub for the js/wasm build. The userspace-firewall packet
+// forwarder relies on the gvisor netstack, which is not compiled for the browser
+// client (it uses the lneto netstack + websocket transport).
+type Forwarder struct{}
+
+// New always fails under wasm so the firewall cleanly disables forwarding
+// (see filter.go: a New error sets routingEnabled=false and leaves forwarder nil).
+func New(iface common.IFaceMapper, logger *nblog.Logger, flowLogger nftypes.FlowLogger, netstack bool, mtu uint16) (*Forwarder, error) {
+	return nil, errors.New("packet forwarding not supported under wasm")
+}
+
+func (f *Forwarder) SetCapture(pc PacketCapture) {}
+
+func (f *Forwarder) InjectIncomingPacket(payload []byte) error {
+	return errors.New("packet forwarding not supported under wasm")
+}
+
+func (f *Forwarder) Stop() {}
+
+func (f *Forwarder) RegisterRuleID(srcIP, dstIP netip.Addr, srcPort, dstPort uint16, ruleID []byte) {}
+
+func (f *Forwarder) DeleteRuleID(srcIP, dstIP netip.Addr, srcPort, dstPort uint16) {}

--- a/client/firewall/uspfilter/forwarder/icmp.go
+++ b/client/firewall/uspfilter/forwarder/icmp.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package forwarder
 
 import (

--- a/client/firewall/uspfilter/forwarder/tcp.go
+++ b/client/firewall/uspfilter/forwarder/tcp.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package forwarder
 
 import (

--- a/client/firewall/uspfilter/forwarder/udp.go
+++ b/client/firewall/uspfilter/forwarder/udp.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package forwarder
 
 import (

--- a/client/iface/netstack/proxy.go
+++ b/client/iface/netstack/proxy.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package netstack
 
 import (

--- a/client/iface/netstack/proxy_js.go
+++ b/client/iface/netstack/proxy_js.go
@@ -1,0 +1,28 @@
+//go:build js
+
+package netstack
+
+// The js/wasm build excludes the real SOCKS5 proxy: go-socks5 pulls in
+// net.ListenUDP, which TinyGo's net package does not implement. The browser
+// client never runs the SOCKS5 proxy (NB_NETSTACK_SKIP_PROXY is effectively the
+// only path that matters), so these no-op stubs satisfy the references in
+// tun.go without dragging in the dependency.
+
+const (
+	DefaultSocks5Port = 1080
+)
+
+// Proxy is a no-op SOCKS5 proxy stub for js/wasm.
+type Proxy struct{}
+
+func NewSocks5(dialer Dialer) (*Proxy, error) {
+	return &Proxy{}, nil
+}
+
+func (s *Proxy) ListenAndServe(addr string) error {
+	return nil
+}
+
+func (s *Proxy) Close() error {
+	return nil
+}

--- a/client/internal/dns/tcpstack.go
+++ b/client/internal/dns/tcpstack.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package dns
 
 import (

--- a/client/internal/dns/tcpstack_js.go
+++ b/client/internal/dns/tcpstack_js.go
@@ -1,0 +1,22 @@
+//go:build js
+
+package dns
+
+import (
+	"net/netip"
+
+	"github.com/miekg/dns"
+	"golang.zx2c4.com/wireguard/tun"
+)
+
+// tcpDNSServer is a no-op stub for the js/wasm build. The real on-demand TCP DNS
+// server ([tcpstack.go]) is backed by the gvisor netstack, which is not compiled
+// for the browser client (it uses the lneto netstack + websocket transport).
+type tcpDNSServer struct{}
+
+func newTCPDNSServer(mux *dns.ServeMux, tunDev tun.Device, ip netip.Addr, port uint16, mtu uint16) *tcpDNSServer {
+	return &tcpDNSServer{}
+}
+
+func (t *tcpDNSServer) InjectPacket(payload []byte) {}
+func (t *tcpDNSServer) Stop()                       {}

--- a/go.mod
+++ b/go.mod
@@ -306,6 +306,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.8 // indirect
 	github.com/shoenig/go-m1cpu v0.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/soypat/lneto v0.1.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c // indirect
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef // indirect
@@ -341,7 +342,9 @@ replace github.com/kardianos/service => github.com/netbirdio/service v0.0.0-2024
 
 replace github.com/getlantern/systray => github.com/netbirdio/systray v0.0.0-20231030152038-ef1ed2a27949
 
-replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f
+replace github.com/soypat/lneto => ../lneto
+
+replace golang.zx2c4.com/wireguard => ../wg-nb2 // github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f
 
 replace github.com/cloudflare/circl => codeberg.org/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6
 

--- a/go.mod
+++ b/go.mod
@@ -344,7 +344,7 @@ replace github.com/getlantern/systray => github.com/netbirdio/systray v0.0.0-202
 
 replace github.com/soypat/lneto => ../lneto
 
-replace golang.zx2c4.com/wireguard => ../wg-nb2 // github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f
+replace golang.zx2c4.com/wireguard => ../wireguard-go-netbird // github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f
 
 replace github.com/cloudflare/circl => codeberg.org/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6
 

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,6 @@ github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502 h1:3tHlFmhTdX9ax
 github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45 h1:ujgviVYmx243Ksy7NdSwrdGPSRNE3pb8kEDSpH0QuAQ=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
-github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f h1:ff2D57RBjWtyQ2wVwJOxOgXAXOe/J2lJWtSX0Bz/BRk=
-github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/nicksnyder/go-i18n/v2 v2.5.1 h1:IxtPxYsR9Gp60cGXjfuR/llTqV8aYMsC472zD0D1vHk=

--- a/lneto.diff
+++ b/lneto.diff
@@ -1,0 +1,95 @@
+diff --git a/.github/workflows/wasm-build-validation.yml b/.github/workflows/wasm-build-validation.yml
+index a5ae59720..b1beb2a56 100644
+--- a/.github/workflows/wasm-build-validation.yml
++++ b/.github/workflows/wasm-build-validation.yml
+@@ -17,6 +17,7 @@ jobs:
+     env:
+       GOOS: js
+       GOARCH: wasm
++      GOFLAGS: -tags=wglneto
+     steps:
+       - name: Checkout repository
+         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+@@ -52,7 +53,7 @@ jobs:
+         with:
+           go-version-file: "go.mod"
+       - name: Build Wasm client
+-        run: GOOS=js GOARCH=wasm go build -o netbird.wasm ./client/wasm/cmd
++        run: GOOS=js GOARCH=wasm go build -tags wglneto -o netbird.wasm ./client/wasm/cmd
+         env:
+           CGO_ENABLED: 0
+       - name: Check Wasm build size
+@@ -65,7 +66,7 @@ jobs:
+ 
+           echo "Size: ${SIZE} bytes (${SIZE_MB} MB)"
+ 
+-          if [ ${SIZE} -gt 62914560 ]; then
+-            echo "Wasm binary size (${SIZE_MB}MB) exceeds 60MB limit!"
++          if [ ${SIZE} -gt 67108864 ]; then
++            echo "Wasm binary size (${SIZE_MB}MB) exceeds 64MB limit!"
+             exit 1
+           fi
+diff --git a/.gitignore b/.gitignore
+index 783fe77f3..bb8f128d9 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -34,3 +34,10 @@ vendor/
+ /netbird
+ client/netbird-electron/
+ management/server/types/testdata/
++
++signal/netbird-signal
++*/netbird-relay
++management/netbird-mgmt
++*/netbird
++**/netbird.wasm
++**/wasm_exec.js
+diff --git a/.goreleaser.yaml b/.goreleaser.yaml
+index a2640dc8e..8a56899fc 100644
+--- a/.goreleaser.yaml
++++ b/.goreleaser.yaml
+@@ -15,6 +15,8 @@ builds:
+     ldflags:
+       - -s -w -X github.com/netbirdio/netbird/version.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+     mod_timestamp: "{{ .CommitTimestamp }}"
++    tags:
++      - wglneto
+ 
+   - id: netbird
+     dir: client
+diff --git a/go.mod b/go.mod
+index 2858d2044..80d2ff78b 100644
+--- a/go.mod
++++ b/go.mod
+@@ -306,6 +306,7 @@ require (
+ 	github.com/shirou/gopsutil/v4 v4.25.8 // indirect
+ 	github.com/shoenig/go-m1cpu v0.2.1 // indirect
+ 	github.com/shopspring/decimal v1.4.0 // indirect
++	github.com/soypat/lneto v0.1.0 // indirect
+ 	github.com/spf13/cast v1.7.0 // indirect
+ 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c // indirect
+ 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef // indirect
+@@ -341,7 +342,9 @@ replace github.com/kardianos/service => github.com/netbirdio/service v0.0.0-2024
+ 
+ replace github.com/getlantern/systray => github.com/netbirdio/systray v0.0.0-20231030152038-ef1ed2a27949
+ 
+-replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f
++replace github.com/soypat/lneto => ../lneto
++
++replace golang.zx2c4.com/wireguard => ../wg-nb2 // github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f
+ 
+ replace github.com/cloudflare/circl => codeberg.org/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6
+ 
+diff --git a/go.sum b/go.sum
+index 1768ee069..216241061 100644
+--- a/go.sum
++++ b/go.sum
+@@ -510,8 +510,6 @@ github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502 h1:3tHlFmhTdX9ax
+ github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
+ github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45 h1:ujgviVYmx243Ksy7NdSwrdGPSRNE3pb8kEDSpH0QuAQ=
+ github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
+-github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f h1:ff2D57RBjWtyQ2wVwJOxOgXAXOe/J2lJWtSX0Bz/BRk=
+-github.com/netbirdio/wireguard-go v0.0.0-20260523085312-4b4a4e36017f/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
+ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
+ github.com/nicksnyder/go-i18n/v2 v2.5.1 h1:IxtPxYsR9Gp60cGXjfuR/llTqV8aYMsC472zD0D1vHk=

--- a/util/log.go
+++ b/util/log.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"slices"
 	"strconv"
 
-	"github.com/DeRuina/timberjack"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/grpclog"
 
@@ -122,19 +120,6 @@ func setupLogFile(logPath string, disableRotation bool) (io.Writer, error) {
 		return file, nil
 	}
 	return newRotatedOutput(logPath), nil
-}
-
-func newRotatedOutput(logPath string) io.Writer {
-	maxLogSize := getLogMaxSize()
-	timberjackLogger := &timberjack.Logger{
-		// Log file absolute path, os agnostic
-		Filename:    filepath.ToSlash(logPath),
-		MaxSize:     maxLogSize, // MB
-		MaxBackups:  10,
-		MaxAge:      30, // days
-		Compression: "gzip",
-	}
-	return timberjackLogger
 }
 
 func setGRPCLibLogger(logger *log.Logger) {

--- a/util/log_rotate.go
+++ b/util/log_rotate.go
@@ -1,0 +1,27 @@
+//go:build !js
+
+package util
+
+import (
+	"io"
+	"path/filepath"
+
+	"github.com/DeRuina/timberjack"
+)
+
+// newRotatedOutput returns a size/age-rotating log file writer backed by
+// timberjack. Kept out of the js build: timberjack pulls in
+// github.com/klauspost/compress/zstd (~1.5MB) for compressed rotation, which is
+// useless in the browser (no persistent log files). See log_rotate_js.go.
+func newRotatedOutput(logPath string) io.Writer {
+	maxLogSize := getLogMaxSize()
+	timberjackLogger := &timberjack.Logger{
+		// Log file absolute path, os agnostic
+		Filename:    filepath.ToSlash(logPath),
+		MaxSize:     maxLogSize, // MB
+		MaxBackups:  10,
+		MaxAge:      30, // days
+		Compression: "gzip",
+	}
+	return timberjackLogger
+}

--- a/util/log_rotate_js.go
+++ b/util/log_rotate_js.go
@@ -1,0 +1,21 @@
+//go:build js
+
+package util
+
+import (
+	"io"
+	"os"
+)
+
+// newRotatedOutput has no log rotation on js/wasm. The browser has no
+// persistent log files worth rotating, and the timberjack rotator drags in
+// github.com/klauspost/compress/zstd (~1.5MB). Fall back to a plain append-only
+// file, matching the rotation-disabled path in setupLogFile; if the file cannot
+// be opened (e.g. no writable fs), discard rather than fail logging.
+func newRotatedOutput(logPath string) io.Writer {
+	file, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	if err != nil {
+		return io.Discard
+	}
+	return file
+}


### PR DESCRIPTION
WIP though almost ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Build Updates**
  * Updated WebAssembly builds to use the `wglneto` build tag.
  * Increased wasm artifact size validation limit to **64MB** (with updated failure messaging).
  * Updated build/release configuration and expanded ignored generated wasm/Netbird-related outputs.

* **New Features**
  * Added JS/wasm-friendly SOCKS5 proxy stub (default port **1080**).

* **Bug Fixes / Compatibility**
  * Ensured packet forwarding and TCP DNS safely degrade on JS/wasm builds (no-op/unsupported behavior instead of build/runtime issues).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->