### PR TITLE
[client] Skip restarting unchanged routes

### DIFF
--- a/client/internal/networkmonitor/monitor.go
+++ b/client/internal/networkmonitor/monitor.go
@@ -28,11 +28,16 @@ type NetworkMonitor struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 	mu     sync.Mutex
+
+	// nexthopChanged reports whether the default next hop changed; overridable in tests.
+	nexthopChanged func(oldv4, oldv6 systemops.Nexthop) bool
 }
 
 // New creates a new network monitor.
 func New() *NetworkMonitor {
-	return &NetworkMonitor{}
+	return &NetworkMonitor{
+		nexthopChanged: nexthopChanged,
+	}
 }
 
 // Listen begins monitoring network changes. When a change is detected, this function will return without error.
@@ -99,7 +104,7 @@ func (nw *NetworkMonitor) Listen(ctx context.Context) (err error) {
 		case <-timer.C:
 			// A flapping NIC may return to the same default route after the
 			// debounce window; only restart if the next hop actually changed.
-			if nexthopChanged(nexthop4, nexthop6) {
+			if nw.nexthopChanged(nexthop4, nexthop6) {
 				return nil
 			}
 			log.Debug("Network monitor: default route unchanged after debounce, ignoring")

--- a/client/internal/networkmonitor/monitor.go
+++ b/client/internal/networkmonitor/monitor.go
@@ -141,14 +141,12 @@ func (nw *NetworkMonitor) checkChanges(ctx context.Context, event chan struct{},
 }
 
 // nexthopChanged reports whether the current default next hop differs from the
-// given baseline. A lookup error is treated as a change so we fail safe and
-// restart rather than miss a real network change.
+// given baseline, per protocol. A failed lookup is treated as an absent route
+// (zero Nexthop), so a protocol that had no default route to begin with (e.g.
+// IPv6 in a single-stack network) does not by itself count as a change.
 func nexthopChanged(oldv4, oldv6 systemops.Nexthop) bool {
-	newv4, errv4 := systemops.GetNextHop(netip.IPv4Unspecified())
-	newv6, errv6 := systemops.GetNextHop(netip.IPv6Unspecified())
-	if errv4 != nil || errv6 != nil {
-		return true
-	}
+	newv4, _ := systemops.GetNextHop(netip.IPv4Unspecified())
+	newv6, _ := systemops.GetNextHop(netip.IPv6Unspecified())
 	return !sameNexthop(oldv4, newv4) || !sameNexthop(oldv6, newv6)
 }
 

--- a/client/internal/networkmonitor/monitor.go
+++ b/client/internal/networkmonitor/monitor.go
@@ -97,7 +97,12 @@ func (nw *NetworkMonitor) Listen(ctx context.Context) (err error) {
 		case <-event:
 			timer.Reset(debounceTime)
 		case <-timer.C:
-			return nil
+			// A flapping NIC may return to the same default route after the
+			// debounce window; only restart if the next hop actually changed.
+			if nexthopChanged(nexthop4, nexthop6) {
+				return nil
+			}
+			log.Debug("Network monitor: default route unchanged after debounce, ignoring")
 		case <-ctx.Done():
 			timer.Stop()
 			return ctx.Err()
@@ -133,4 +138,29 @@ func (nw *NetworkMonitor) checkChanges(ctx context.Context, event chan struct{},
 		default:
 		}
 	}
+}
+
+// nexthopChanged reports whether the current default next hop differs from the
+// given baseline. A lookup error is treated as a change so we fail safe and
+// restart rather than miss a real network change.
+func nexthopChanged(oldv4, oldv6 systemops.Nexthop) bool {
+	newv4, errv4 := systemops.GetNextHop(netip.IPv4Unspecified())
+	newv6, errv6 := systemops.GetNextHop(netip.IPv6Unspecified())
+	if errv4 != nil || errv6 != nil {
+		return true
+	}
+	return !sameNexthop(oldv4, newv4) || !sameNexthop(oldv6, newv6)
+}
+
+func sameNexthop(a, b systemops.Nexthop) bool {
+	if a.IP != b.IP {
+		return false
+	}
+	if (a.Intf == nil) != (b.Intf == nil) {
+		return false
+	}
+	if a.Intf != nil && a.Intf.Index != b.Intf.Index {
+		return false
+	}
+	return true
 }

--- a/client/internal/networkmonitor/monitor_test.go
+++ b/client/internal/networkmonitor/monitor_test.go
@@ -61,6 +61,7 @@ func TestNetworkMonitor_Event(t *testing.T) {
 		}
 	}
 	nw := New()
+	nw.nexthopChanged = func(_, _ systemops.Nexthop) bool { return true }
 	defer nw.Stop()
 
 	var resErr error
@@ -82,6 +83,7 @@ func TestNetworkMonitor_MultiEvent(t *testing.T) {
 	checkChangeFn = me.checkChange
 
 	nw := New()
+	nw.nexthopChanged = func(_, _ systemops.Nexthop) bool { return true }
 	defer nw.Stop()
 
 	done := make(chan struct{})

--- a/client/internal/networkmonitor/monitor_test.go
+++ b/client/internal/networkmonitor/monitor_test.go
@@ -3,6 +3,8 @@ package networkmonitor
 import (
 	"context"
 	"errors"
+	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -95,5 +97,33 @@ func TestNetworkMonitor_MultiEvent(t *testing.T) {
 	expectedResponseTime := time.Duration(eventsRepeated)*time.Second + debounceTime
 	if time.Since(started) < expectedResponseTime {
 		t.Errorf("unexpected duration: %v", time.Since(started))
+	}
+}
+
+func TestSameNexthop(t *testing.T) {
+	eth0 := &net.Interface{Index: 1, Name: "eth0"}
+	eth1 := &net.Interface{Index: 2, Name: "eth1"}
+	ip1 := netip.MustParseAddr("192.168.1.1")
+	ip2 := netip.MustParseAddr("192.168.2.1")
+
+	tests := []struct {
+		name string
+		a, b systemops.Nexthop
+		want bool
+	}{
+		{"identical", systemops.Nexthop{IP: ip1, Intf: eth0}, systemops.Nexthop{IP: ip1, Intf: eth0}, true},
+		{"same index different pointer", systemops.Nexthop{IP: ip1, Intf: eth0}, systemops.Nexthop{IP: ip1, Intf: &net.Interface{Index: 1, Name: "eth0"}}, true},
+		{"different ip", systemops.Nexthop{IP: ip1, Intf: eth0}, systemops.Nexthop{IP: ip2, Intf: eth0}, false},
+		{"different interface", systemops.Nexthop{IP: ip1, Intf: eth0}, systemops.Nexthop{IP: ip1, Intf: eth1}, false},
+		{"both nil interface", systemops.Nexthop{IP: ip1}, systemops.Nexthop{IP: ip1}, true},
+		{"one nil interface", systemops.Nexthop{IP: ip1, Intf: eth0}, systemops.Nexthop{IP: ip1}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameNexthop(tt.a, tt.b); got != tt.want {
+				t.Errorf("sameNexthop() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Describe your changes

Skip engine restart when the default route is unchanged

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network route monitoring now correctly identifies actual route changes after detecting network activity, improving the accuracy of network state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->