### PR TITLE
[management] When collecting group and peer IDs from policies, do so directionally

### DIFF
--- a/management/server/affected_peers_coverage_test.go
+++ b/management/server/affected_peers_coverage_test.go
@@ -32,7 +32,7 @@ func TestAffectedPeers_DependencyCoverageMatrix(t *testing.T) {
 				_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
 				require.NoError(t, err)
 				return affectedpeers.Change{ChangedGroupIDs: []string{s.sourceGroupID}},
-					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID} // TODO (dmitri) routerPeer is missing
 			},
 		},
 		{
@@ -106,12 +106,8 @@ func TestAffectedPeers_DependencyCoverageMatrix(t *testing.T) {
 			change, mustContain, mustExclude := r.build(t, s, ctx)
 			affected := resolveAffected(t, s.manager.Store, s.accountID, change)
 
-			for _, id := range mustContain {
-				assert.Contains(t, affected, id, "expected peer to be affected")
-			}
-			for _, id := range mustExclude {
-				assert.NotContains(t, affected, id, "peer must not be affected")
-			}
+			assert.ElementsMatch(t, affected, mustContain, "expected peer to be affected")
+			assert.NotElementsMatch(t, affected, mustExclude, "peer must not be affected")
 		})
 	}
 }

--- a/management/server/affected_peers_coverage_test.go
+++ b/management/server/affected_peers_coverage_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/netbirdio/netbird/management/server/affectedpeers"
-	resourceTypes "github.com/netbirdio/netbird/management/server/networks/resources/types"
-	networkTypes "github.com/netbirdio/netbird/management/server/networks/types"
-	"github.com/netbirdio/netbird/management/server/posture"
-	"github.com/netbirdio/netbird/management/server/types"
 )
 
 // TestAffectedPeers_DependencyCoverageMatrix enumerates each network-map
@@ -26,6 +22,7 @@ func TestAffectedPeers_DependencyCoverageMatrix(t *testing.T) {
 	}
 
 	rows := []row{
+<<<<<<< Updated upstream
 		{
 			name: "policy-groups/source-group-change refreshes source+routing, excludes unrelated",
 			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
@@ -35,6 +32,17 @@ func TestAffectedPeers_DependencyCoverageMatrix(t *testing.T) {
 					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID} // TODO (dmitri) routerPeer is missing
 			},
 		},
+=======
+		// {
+		// 	name: "policy-groups/source-group-change refreshes source+routing, excludes unrelated",
+		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+		// 		_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
+		// 		require.NoError(t, err)
+		// 		return affectedpeers.Change{ChangedGroupIDs: []string{s.sourceGroupID}},
+		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+		// 	},
+		// },
+>>>>>>> Stashed changes
 		{
 			name: "resource-routing-bridge/router-peer-change refreshes policy sources",
 			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
@@ -44,58 +52,58 @@ func TestAffectedPeers_DependencyCoverageMatrix(t *testing.T) {
 					[]string{s.sourcePeerID}, []string{s.unrelatedPeerID}
 			},
 		},
-		{
-			name: "policy-change/explicit-policy refreshes source+routing",
-			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-				policy := peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID)
-				return affectedpeers.Change{Policies: []*types.Policy{policy}},
-					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-			},
-		},
-		{
-			name: "policy-destinationresource/explicit-policy bridges to routing peer",
-			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-				policy := peerToResourcePolicyByResource(s.sourceGroupID, s.resourceID)
-				return affectedpeers.Change{Policies: []*types.Policy{policy}},
-					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-			},
-		},
-		{
-			name: "resource-change refreshes source+routing on its network",
-			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-				_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
-				require.NoError(t, err)
-				return affectedpeers.Change{Resources: []*resourceTypes.NetworkResource{
-						{ID: s.resourceID, NetworkID: s.networkID, GroupIDs: []string{s.resourceGroupID}},
-					}},
-					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-			},
-		},
-		{
-			name: "network-change refreshes source+routing on that network",
-			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-				_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
-				require.NoError(t, err)
-				return affectedpeers.Change{Networks: []*networkTypes.Network{{ID: s.networkID}}},
-					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-			},
-		},
-		{
-			name: "posture-check-change refreshes source+routing of gated policy",
-			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-				check, err := s.manager.SavePostureChecks(ctx, s.accountID, userID, &posture.Checks{
-					Name:   "cov-min-version",
-					Checks: posture.ChecksDefinition{NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.30.0"}},
-				}, true)
-				require.NoError(t, err)
-				policy := peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID)
-				policy.SourcePostureChecks = []string{check.ID}
-				_, err = s.manager.SavePolicy(ctx, s.accountID, userID, policy, true)
-				require.NoError(t, err)
-				return affectedpeers.Change{PostureCheckIDs: []string{check.ID}},
-					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-			},
-		},
+		// {
+		// 	name: "policy-change/explicit-policy refreshes source+routing",
+		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+		// 		policy := peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID)
+		// 		return affectedpeers.Change{Policies: []*types.Policy{policy}},
+		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+		// 	},
+		// },
+		// {
+		// 	name: "policy-destinationresource/explicit-policy bridges to routing peer",
+		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+		// 		policy := peerToResourcePolicyByResource(s.sourceGroupID, s.resourceID)
+		// 		return affectedpeers.Change{Policies: []*types.Policy{policy}},
+		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+		// 	},
+		// },
+		// {
+		// 	name: "resource-change refreshes source+routing on its network",
+		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+		// 		_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
+		// 		require.NoError(t, err)
+		// 		return affectedpeers.Change{Resources: []*resourceTypes.NetworkResource{
+		// 				{ID: s.resourceID, NetworkID: s.networkID, GroupIDs: []string{s.resourceGroupID}},
+		// 			}},
+		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+		// 	},
+		// },
+		// {
+		// 	name: "network-change refreshes source+routing on that network",
+		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+		// 		_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
+		// 		require.NoError(t, err)
+		// 		return affectedpeers.Change{Networks: []*networkTypes.Network{{ID: s.networkID}}},
+		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+		// 	},
+		// },
+		// {
+		// 	name: "posture-check-change refreshes source+routing of gated policy",
+		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+		// 		check, err := s.manager.SavePostureChecks(ctx, s.accountID, userID, &posture.Checks{
+		// 			Name:   "cov-min-version",
+		// 			Checks: posture.ChecksDefinition{NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.30.0"}},
+		// 		}, true)
+		// 		require.NoError(t, err)
+		// 		policy := peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID)
+		// 		policy.SourcePostureChecks = []string{check.ID}
+		// 		_, err = s.manager.SavePolicy(ctx, s.accountID, userID, policy, true)
+		// 		require.NoError(t, err)
+		// 		return affectedpeers.Change{PostureCheckIDs: []string{check.ID}},
+		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+		// 	},
+		// },
 	}
 
 	for _, r := range rows {

--- a/management/server/affected_peers_coverage_test.go
+++ b/management/server/affected_peers_coverage_test.go
@@ -107,7 +107,7 @@ func TestAffectedPeers_DependencyCoverageMatrix(t *testing.T) {
 			affected := resolveAffected(t, s.manager.Store, s.accountID, change)
 
 			assert.ElementsMatch(t, affected, mustContain, "expected peer to be affected")
-			assert.NotElementsMatch(t, affected, mustExclude, "peer must not be affected")
+			assert.NotContains(t, affected, mustExclude, "peer must not be affected")
 		})
 	}
 }

--- a/management/server/affected_peers_coverage_test.go
+++ b/management/server/affected_peers_coverage_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/netbirdio/netbird/management/server/affectedpeers"
+	resourceTypes "github.com/netbirdio/netbird/management/server/networks/resources/types"
+	networkTypes "github.com/netbirdio/netbird/management/server/networks/types"
+	"github.com/netbirdio/netbird/management/server/posture"
+	"github.com/netbirdio/netbird/management/server/types"
 )
 
 // TestAffectedPeers_DependencyCoverageMatrix enumerates each network-map
@@ -22,88 +26,76 @@ func TestAffectedPeers_DependencyCoverageMatrix(t *testing.T) {
 	}
 
 	rows := []row{
-<<<<<<< Updated upstream
 		{
 			name: "policy-groups/source-group-change refreshes source+routing, excludes unrelated",
 			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
 				_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
 				require.NoError(t, err)
 				return affectedpeers.Change{ChangedGroupIDs: []string{s.sourceGroupID}},
-					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID} // TODO (dmitri) routerPeer is missing
+					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
 			},
 		},
-=======
-		// {
-		// 	name: "policy-groups/source-group-change refreshes source+routing, excludes unrelated",
-		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-		// 		_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
-		// 		require.NoError(t, err)
-		// 		return affectedpeers.Change{ChangedGroupIDs: []string{s.sourceGroupID}},
-		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-		// 	},
-		// },
->>>>>>> Stashed changes
 		{
 			name: "resource-routing-bridge/router-peer-change refreshes policy sources",
 			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
 				_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
 				require.NoError(t, err)
 				return affectedpeers.Change{ChangedPeerIDs: []string{s.routerPeerID}},
-					[]string{s.sourcePeerID}, []string{s.unrelatedPeerID}
+					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
 			},
 		},
-		// {
-		// 	name: "policy-change/explicit-policy refreshes source+routing",
-		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-		// 		policy := peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID)
-		// 		return affectedpeers.Change{Policies: []*types.Policy{policy}},
-		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-		// 	},
-		// },
-		// {
-		// 	name: "policy-destinationresource/explicit-policy bridges to routing peer",
-		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-		// 		policy := peerToResourcePolicyByResource(s.sourceGroupID, s.resourceID)
-		// 		return affectedpeers.Change{Policies: []*types.Policy{policy}},
-		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-		// 	},
-		// },
-		// {
-		// 	name: "resource-change refreshes source+routing on its network",
-		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-		// 		_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
-		// 		require.NoError(t, err)
-		// 		return affectedpeers.Change{Resources: []*resourceTypes.NetworkResource{
-		// 				{ID: s.resourceID, NetworkID: s.networkID, GroupIDs: []string{s.resourceGroupID}},
-		// 			}},
-		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-		// 	},
-		// },
-		// {
-		// 	name: "network-change refreshes source+routing on that network",
-		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-		// 		_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
-		// 		require.NoError(t, err)
-		// 		return affectedpeers.Change{Networks: []*networkTypes.Network{{ID: s.networkID}}},
-		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-		// 	},
-		// },
-		// {
-		// 	name: "posture-check-change refreshes source+routing of gated policy",
-		// 	build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
-		// 		check, err := s.manager.SavePostureChecks(ctx, s.accountID, userID, &posture.Checks{
-		// 			Name:   "cov-min-version",
-		// 			Checks: posture.ChecksDefinition{NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.30.0"}},
-		// 		}, true)
-		// 		require.NoError(t, err)
-		// 		policy := peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID)
-		// 		policy.SourcePostureChecks = []string{check.ID}
-		// 		_, err = s.manager.SavePolicy(ctx, s.accountID, userID, policy, true)
-		// 		require.NoError(t, err)
-		// 		return affectedpeers.Change{PostureCheckIDs: []string{check.ID}},
-		// 			[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
-		// 	},
-		// },
+		{
+			name: "policy-change/explicit-policy refreshes source+routing",
+			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+				policy := peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID)
+				return affectedpeers.Change{Policies: []*types.Policy{policy}},
+					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+			},
+		},
+		{
+			name: "policy-destinationresource/explicit-policy bridges to routing peer",
+			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+				policy := peerToResourcePolicyByResource(s.sourceGroupID, s.resourceID)
+				return affectedpeers.Change{Policies: []*types.Policy{policy}},
+					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+			},
+		},
+		{
+			name: "resource-change refreshes source+routing on its network",
+			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+				_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
+				require.NoError(t, err)
+				return affectedpeers.Change{Resources: []*resourceTypes.NetworkResource{
+						{ID: s.resourceID, NetworkID: s.networkID, GroupIDs: []string{s.resourceGroupID}},
+					}},
+					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+			},
+		},
+		{
+			name: "network-change refreshes source+routing on that network",
+			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+				_, err := s.manager.SavePolicy(ctx, s.accountID, userID, peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID), true)
+				require.NoError(t, err)
+				return affectedpeers.Change{Networks: []*networkTypes.Network{{ID: s.networkID}}},
+					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+			},
+		},
+		{
+			name: "posture-check-change refreshes source+routing of gated policy",
+			build: func(t *testing.T, s *routerScenario, ctx context.Context) (affectedpeers.Change, []string, []string) {
+				check, err := s.manager.SavePostureChecks(ctx, s.accountID, userID, &posture.Checks{
+					Name:   "cov-min-version",
+					Checks: posture.ChecksDefinition{NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.30.0"}},
+				}, true)
+				require.NoError(t, err)
+				policy := peerToResourcePolicyByGroup(s.sourceGroupID, s.resourceGroupID)
+				policy.SourcePostureChecks = []string{check.ID}
+				_, err = s.manager.SavePolicy(ctx, s.accountID, userID, policy, true)
+				require.NoError(t, err)
+				return affectedpeers.Change{PostureCheckIDs: []string{check.ID}},
+					[]string{s.sourcePeerID, s.routerPeerID}, []string{s.unrelatedPeerID}
+			},
+		},
 	}
 
 	for _, r := range rows {

--- a/management/server/affected_peers_test.go
+++ b/management/server/affected_peers_test.go
@@ -96,31 +96,54 @@ func affectedGroupID(i int) string   { return fmt.Sprintf("affected-grp-%d", i) 
 func affectedGroupName(i int) string { return fmt.Sprintf("AffectedGroup%d", i) }
 
 func TestCollectGroupChange_PolicyLinked(t *testing.T) {
-	manager, s, accountID, _, groupIDs := setupAffectedPeersTest(t)
+	manager, s, accountID, peerIDs, groupIDs := setupAffectedPeersTest(t)
 	ctx := context.Background()
 
 	_, err := manager.SavePolicy(ctx, accountID, userID, &types.Policy{
 		Enabled: true,
 		Rules: []*types.PolicyRule{
 			{
-				Enabled:       true,
-				Sources:       []string{groupIDs[0]},
-				Destinations:  []string{groupIDs[1]},
-				Bidirectional: true,
-				Action:        types.PolicyTrafficActionAccept,
+				Enabled:             true,
+				Sources:             []string{groupIDs[0]},
+				Destinations:        []string{groupIDs[1]},
+				SourceResource:      types.Resource{ID: peerIDs[0], Type: types.ResourceTypePeer},
+				DestinationResource: types.Resource{ID: peerIDs[1], Type: types.ResourceTypePeer},
+				Bidirectional:       true,
+				Action:              types.PolicyTrafficActionAccept,
+			},
+			{
+				Enabled:             true,
+				Sources:             []string{groupIDs[0]},
+				Destinations:        []string{groupIDs[1]},
+				SourceResource:      types.Resource{ID: peerIDs[2], Type: types.ResourceTypeHost},
+				DestinationResource: types.Resource{ID: peerIDs[3], Type: types.ResourceTypeHost},
+				Bidirectional:       true,
+				Action:              types.PolicyTrafficActionAccept,
+			},
+			{
+				Enabled:             true,
+				Sources:             []string{groupIDs[0]},
+				Destinations:        []string{groupIDs[1]},
+				SourceResource:      types.Resource{ID: "", Type: types.ResourceTypePeer},
+				DestinationResource: types.Resource{ID: "", Type: types.ResourceTypePeer},
+				Bidirectional:       true,
+				Action:              types.PolicyTrafficActionAccept,
 			},
 		},
 	}, true)
 	require.NoError(t, err)
 
-	groups, _ := collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[0]})
-	assert.ElementsMatch(t, groups, []string{groupIDs[1]})
+	groups, directPeers := collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[0]})
+	assert.ElementsMatch(t, groups, []string{groupIDs[0], groupIDs[1]})
+	assert.ElementsMatch(t, directPeers, []string{peerIDs[1]})
 
-	groups, _ = collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[1]})
-	assert.ElementsMatch(t, groups, []string{groupIDs[0]})
+	groups, directPeers = collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[1]})
+	assert.ElementsMatch(t, groups, []string{groupIDs[0], groupIDs[1]})
+	assert.ElementsMatch(t, directPeers, []string{peerIDs[0]})
 
-	groups, _ = collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[2]})
+	groups, directPeers = collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[2]})
 	assert.Empty(t, groups)
+	assert.Empty(t, directPeers)
 }
 
 func TestCollectGroupChange_PolicyWithDirectPeerResource(t *testing.T) {
@@ -138,13 +161,37 @@ func TestCollectGroupChange_PolicyWithDirectPeerResource(t *testing.T) {
 				Destinations:        []string{groupIDs[1]},
 				Action:              types.PolicyTrafficActionAccept,
 			},
+			{
+				Enabled:             true,
+				Sources:             []string{groupIDs[0]},
+				SourceResource:      types.Resource{ID: peerIDs[1], Type: types.ResourceTypeHost},
+				DestinationResource: types.Resource{ID: peerIDs[2], Type: types.ResourceTypeHost},
+				Destinations:        []string{groupIDs[1]},
+				Action:              types.PolicyTrafficActionAccept,
+			},
+			{
+				Enabled:             true,
+				Sources:             []string{groupIDs[0]},
+				SourceResource:      types.Resource{ID: "", Type: types.ResourceTypePeer},
+				DestinationResource: types.Resource{ID: "", Type: types.ResourceTypePeer},
+				Destinations:        []string{groupIDs[1]},
+				Action:              types.PolicyTrafficActionAccept,
+			},
 		},
 	}, true)
 	require.NoError(t, err)
 
 	groups, directPeers := collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[0]})
-	assert.ElementsMatch(t, groups, []string{groupIDs[1]})
+	assert.ElementsMatch(t, groups, []string{groupIDs[0], groupIDs[1]})
 	assert.ElementsMatch(t, directPeers, []string{peerIDs[4]})
+
+	groups, directPeers = collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[1]})
+	assert.ElementsMatch(t, groups, []string{groupIDs[0], groupIDs[1]})
+	assert.ElementsMatch(t, directPeers, []string{peerIDs[3]})
+
+	groups, directPeers = collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[2]})
+	assert.Empty(t, groups)
+	assert.Empty(t, directPeers)
 }
 
 func TestCollectGroupChange_PolicyWithNonPeerResource_NoDirectPeers(t *testing.T) {
@@ -166,7 +213,7 @@ func TestCollectGroupChange_PolicyWithNonPeerResource_NoDirectPeers(t *testing.T
 	require.NoError(t, err)
 
 	groups, directPeers := collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[0]})
-	assert.ElementsMatch(t, groups, []string{groupIDs[1]})
+	assert.ElementsMatch(t, groups, []string{groupIDs[0], groupIDs[1]})
 	assert.Empty(t, directPeers, "non-peer resources should not produce direct peer IDs")
 }
 
@@ -370,17 +417,11 @@ func TestCollectGroupChange_MultipleEntities(t *testing.T) {
 	require.NoError(t, err)
 
 	groups, directPeers := collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[0]})
-	assert.NotContains(t, groups, groupIDs[0])
-	assert.Contains(t, groups, groupIDs[1])
-	assert.NotContains(t, groups, groupIDs[2])
-	assert.NotContains(t, groups, groupIDs[3])
+	assert.ElementsMatch(t, groups, []string{groupIDs[0], groupIDs[1]})
 	assert.Empty(t, directPeers)
 
 	groups, directPeers = collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[3]})
-	assert.Contains(t, groups, groupIDs[2])
-	assert.Contains(t, groups, groupIDs[3])
-	assert.NotContains(t, groups, groupIDs[0])
-	assert.NotContains(t, groups, groupIDs[1])
+	assert.ElementsMatch(t, groups, []string{groupIDs[2], groupIDs[3]})
 	assert.Empty(t, directPeers)
 }
 
@@ -444,10 +485,10 @@ func TestResolveAffectedPeers_PolicyBetweenTwoGroups(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[1]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1]}, result)
 
 	result = manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[1]})
-	assert.ElementsMatch(t, []string{peerIDs[0]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1]}, result)
 
 	result = manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[2]})
 	assert.Empty(t, result)
@@ -471,7 +512,7 @@ func TestResolveAffectedPeers_PolicyThreeGroups(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[2]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[2]}, result)
 }
 
 func TestResolveAffectedPeers_RoutePeerGroups(t *testing.T) {
@@ -658,7 +699,7 @@ func TestResolveAffectedPeers_PeerInMultipleGroups(t *testing.T) {
 
 	// peer0 is in group0 AND group1, so both policies apply
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[2], peerIDs[3]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1], peerIDs[2], peerIDs[3]}, result)
 }
 
 func TestResolveAffectedPeers_MultipleChangedPeers(t *testing.T) {
@@ -694,7 +735,7 @@ func TestResolveAffectedPeers_MultipleChangedPeers(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0], peerIDs[2]})
-	assert.ElementsMatch(t, []string{peerIDs[1], peerIDs[3]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[2], peerIDs[1], peerIDs[3]}, result)
 }
 
 func TestResolveAffectedPeers_SharedGroupAcrossPolicyAndRoute(t *testing.T) {
@@ -842,12 +883,12 @@ func TestAffectedPeers_IsolatedPolicies(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[1]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1]}, result)
 	assert.NotContains(t, result, peerIDs[2])
 	assert.NotContains(t, result, peerIDs[3])
 
 	result = manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[2]})
-	assert.ElementsMatch(t, []string{peerIDs[3]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[2], peerIDs[3]}, result)
 	assert.NotContains(t, result, peerIDs[0])
 	assert.NotContains(t, result, peerIDs[1])
 
@@ -893,7 +934,7 @@ func TestAffectedPeers_IsolatedRouteAndPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[1]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1]}, result)
 	assert.NotContains(t, result, peerIDs[2])
 	assert.NotContains(t, result, peerIDs[3])
 
@@ -948,14 +989,13 @@ func TestAffectedPeers_GroupUpdateOnlyAffectsLinkedPeers(t *testing.T) {
 	})
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, manager.Store, accountID, []string{peer1.ID})
-	assert.ElementsMatch(t, []string{peer2.ID}, result)
+	assert.ElementsMatch(t, []string{peer1.ID, peer2.ID}, result)
 
 	t.Run("group change updates all peers in policy groups", func(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
-			peerShouldNotReceiveUpdate(t, updMsg1)
+			peerShouldReceiveUpdate(t, updMsg1)
 			peerShouldReceiveUpdate(t, updMsg2)
-			// TODO (dmitri) what's going on here?
 			peerShouldReceiveUpdate(t, updMsg3)
 			close(done)
 		}()

--- a/management/server/affected_peers_test.go
+++ b/management/server/affected_peers_test.go
@@ -114,12 +114,10 @@ func TestCollectGroupChange_PolicyLinked(t *testing.T) {
 	require.NoError(t, err)
 
 	groups, _ := collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[0]})
-	assert.Contains(t, groups, groupIDs[0])
-	assert.Contains(t, groups, groupIDs[1])
+	assert.ElementsMatch(t, groups, []string{groupIDs[1]})
 
 	groups, _ = collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[1]})
-	assert.Contains(t, groups, groupIDs[0])
-	assert.Contains(t, groups, groupIDs[1])
+	assert.ElementsMatch(t, groups, []string{groupIDs[0]})
 
 	groups, _ = collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[2]})
 	assert.Empty(t, groups)
@@ -133,20 +131,20 @@ func TestCollectGroupChange_PolicyWithDirectPeerResource(t *testing.T) {
 		Enabled: true,
 		Rules: []*types.PolicyRule{
 			{
-				Enabled:        true,
-				Sources:        []string{groupIDs[0]},
-				SourceResource: types.Resource{ID: peerIDs[3], Type: types.ResourceTypePeer},
-				Destinations:   []string{groupIDs[1]},
-				Action:         types.PolicyTrafficActionAccept,
+				Enabled:             true,
+				Sources:             []string{groupIDs[0]},
+				SourceResource:      types.Resource{ID: peerIDs[3], Type: types.ResourceTypePeer},
+				DestinationResource: types.Resource{ID: peerIDs[4], Type: types.ResourceTypePeer},
+				Destinations:        []string{groupIDs[1]},
+				Action:              types.PolicyTrafficActionAccept,
 			},
 		},
 	}, true)
 	require.NoError(t, err)
 
 	groups, directPeers := collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[0]})
-	assert.Contains(t, groups, groupIDs[0])
-	assert.Contains(t, groups, groupIDs[1])
-	assert.Contains(t, directPeers, peerIDs[3])
+	assert.ElementsMatch(t, groups, []string{groupIDs[1]})
+	assert.ElementsMatch(t, directPeers, []string{peerIDs[4]})
 }
 
 func TestCollectGroupChange_PolicyWithNonPeerResource_NoDirectPeers(t *testing.T) {
@@ -168,8 +166,7 @@ func TestCollectGroupChange_PolicyWithNonPeerResource_NoDirectPeers(t *testing.T
 	require.NoError(t, err)
 
 	groups, directPeers := collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[0]})
-	assert.Contains(t, groups, groupIDs[0])
-	assert.Contains(t, groups, groupIDs[1])
+	assert.ElementsMatch(t, groups, []string{groupIDs[1]})
 	assert.Empty(t, directPeers, "non-peer resources should not produce direct peer IDs")
 }
 
@@ -373,7 +370,7 @@ func TestCollectGroupChange_MultipleEntities(t *testing.T) {
 	require.NoError(t, err)
 
 	groups, directPeers := collectGroupChangeAffectedGroups(ctx, s, accountID, []string{groupIDs[0]})
-	assert.Contains(t, groups, groupIDs[0])
+	assert.NotContains(t, groups, groupIDs[0])
 	assert.Contains(t, groups, groupIDs[1])
 	assert.NotContains(t, groups, groupIDs[2])
 	assert.NotContains(t, groups, groupIDs[3])
@@ -447,10 +444,10 @@ func TestResolveAffectedPeers_PolicyBetweenTwoGroups(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[1]}, result)
 
 	result = manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[1]})
-	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[0]}, result)
 
 	result = manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[2]})
 	assert.Empty(t, result)
@@ -474,7 +471,7 @@ func TestResolveAffectedPeers_PolicyThreeGroups(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1], peerIDs[2]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[2]}, result)
 }
 
 func TestResolveAffectedPeers_RoutePeerGroups(t *testing.T) {
@@ -661,7 +658,7 @@ func TestResolveAffectedPeers_PeerInMultipleGroups(t *testing.T) {
 
 	// peer0 is in group0 AND group1, so both policies apply
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1], peerIDs[2], peerIDs[3]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[2], peerIDs[3]}, result)
 }
 
 func TestResolveAffectedPeers_MultipleChangedPeers(t *testing.T) {
@@ -697,7 +694,7 @@ func TestResolveAffectedPeers_MultipleChangedPeers(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0], peerIDs[2]})
-	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1], peerIDs[2], peerIDs[3]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[1], peerIDs[3]}, result)
 }
 
 func TestResolveAffectedPeers_SharedGroupAcrossPolicyAndRoute(t *testing.T) {
@@ -845,12 +842,12 @@ func TestAffectedPeers_IsolatedPolicies(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[1]}, result)
 	assert.NotContains(t, result, peerIDs[2])
 	assert.NotContains(t, result, peerIDs[3])
 
 	result = manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[2]})
-	assert.ElementsMatch(t, []string{peerIDs[2], peerIDs[3]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[3]}, result)
 	assert.NotContains(t, result, peerIDs[0])
 	assert.NotContains(t, result, peerIDs[1])
 
@@ -896,7 +893,7 @@ func TestAffectedPeers_IsolatedRouteAndPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, s, accountID, []string{peerIDs[0]})
-	assert.ElementsMatch(t, []string{peerIDs[0], peerIDs[1]}, result)
+	assert.ElementsMatch(t, []string{peerIDs[1]}, result)
 	assert.NotContains(t, result, peerIDs[2])
 	assert.NotContains(t, result, peerIDs[3])
 
@@ -951,13 +948,14 @@ func TestAffectedPeers_GroupUpdateOnlyAffectsLinkedPeers(t *testing.T) {
 	})
 
 	result := manager.resolveAffectedPeersForPeerChanges(ctx, manager.Store, accountID, []string{peer1.ID})
-	assert.ElementsMatch(t, []string{peer1.ID, peer2.ID}, result)
+	assert.ElementsMatch(t, []string{peer2.ID}, result)
 
 	t.Run("group change updates all peers in policy groups", func(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
-			peerShouldReceiveUpdate(t, updMsg1)
+			peerShouldNotReceiveUpdate(t, updMsg1)
 			peerShouldReceiveUpdate(t, updMsg2)
+			// TODO (dmitri) what's going on here?
 			peerShouldReceiveUpdate(t, updMsg3)
 			close(done)
 		}()

--- a/management/server/affectedpeers/resolver.go
+++ b/management/server/affectedpeers/resolver.go
@@ -11,6 +11,8 @@ package affectedpeers
 
 import (
 	"context"
+	"maps"
+	"slices"
 
 	log "github.com/sirupsen/logrus"
 
@@ -774,26 +776,29 @@ func getGroupsAndPeersFromPolicyViaGroups(policy *types.Policy, groupSet map[str
 // i.e. if a peer is present in the policy rule sourceResources, return destination group IDs and the destinationResource from the rule
 // and vice-versa
 func getGroupsAndPeersFromPolicyViaPeers(policy *types.Policy, changedSet map[string]struct{}) ([]string, []string) {
-	var groupIds, peerIds []string
+	peerIds := make(map[string]struct{})
+	var groupIds []string
 	if len(changedSet) == 0 {
-		return peerIds, groupIds
+		return []string{}, groupIds
 	}
 	for _, rule := range policy.Rules {
 		if isDirectPeerInSet(rule.SourceResource, changedSet) {
 			groupIds = append(groupIds, rule.Destinations...)
-			peerIds = append(peerIds, rule.SourceResource.ID)
+			peerIds[rule.SourceResource.ID] = struct{}{}
 			if rule.DestinationResource.Type == types.ResourceTypePeer && rule.DestinationResource.ID != "" {
-				peerIds = append(peerIds, rule.DestinationResource.ID)
+				peerIds[rule.DestinationResource.ID] = struct{}{}
 			}
-		} else if isDirectPeerInSet(rule.DestinationResource, changedSet) {
+		}
+		// it's possible that the changeSet contains peer ids of both source and destination resources
+		if isDirectPeerInSet(rule.DestinationResource, changedSet) {
 			groupIds = append(groupIds, rule.Sources...)
-			peerIds = append(peerIds, rule.DestinationResource.ID)
+			peerIds[rule.DestinationResource.ID] = struct{}{}
 			if rule.SourceResource.Type == types.ResourceTypePeer && rule.SourceResource.ID != "" {
-				peerIds = append(peerIds, rule.SourceResource.ID)
+				peerIds[rule.SourceResource.ID] = struct{}{}
 			}
 		}
 	}
-	return peerIds, groupIds
+	return slices.Collect(maps.Keys(peerIds)), groupIds
 }
 
 func policyReferencesPostureChecks(policy *types.Policy, ids map[string]struct{}) bool {

--- a/management/server/affectedpeers/resolver.go
+++ b/management/server/affectedpeers/resolver.go
@@ -447,15 +447,23 @@ func (r *resolver) collectFromPostureChecks(postureCheckIDs []string) {
 
 func (r *resolver) collectFromPolicies() {
 	for _, policy := range r.policies() {
-		matchedByGroup := policyReferencesGroups(policy, r.changedGroupSet)
-		matchedByPeer := len(r.changedPeerSet) > 0 && policyReferencesDirectPeers(policy, r.changedPeerSet)
-		if !matchedByGroup && !matchedByPeer {
+		// changed peer IDs have been mapped to changedGroupSet on resolver creation (see seedChangedGroupsFromPeers)
+		// there's no change to the groupSet if the same policies have been changed directly
+		groupIds := groupsFromPolicyDirectionally(policy, r.changedGroupSet)
+		addAll(r.groupSet, groupIds)
+
+		var peerIds []string
+		if len(r.changedPeerSet) > 0 {
+			peerIds = peersFromPolicyDirectionally(policy, r.changedPeerSet)
+			addAll(r.peerSet, peerIds)
+		}
+
+		if len(groupIds) == 0 && len(peerIds) == 0 {
 			continue
 		}
+
 		log.WithContext(r.ctx).Tracef("collectFromPolicies: policy %s (%s) matched (byGroup=%t byPeer=%t) -> folding rule groups %v + direct peers",
-			policy.ID, policy.Name, matchedByGroup, matchedByPeer, policy.RuleGroups())
-		addAll(r.groupSet, policy.RuleGroups())
-		collectPolicyDirectPeers(policy, r.peerSet)
+			policy.ID, policy.Name, len(groupIds) > 0, len(peerIds) > 0, policy.RuleGroups())
 		r.matchedPolicies = append(r.matchedPolicies, policy)
 	}
 }
@@ -734,22 +742,40 @@ func collectPolicySources(policy *types.Policy, groupSet, peerSet map[string]str
 	}
 }
 
-func policyReferencesGroups(policy *types.Policy, groupSet map[string]struct{}) bool {
+// returns group IDs of groups on the opposite side of the policy:
+// i.e. if a group is present in the policy rule sources, use group IDs from the rule's destinations
+// and vice-versa
+func groupsFromPolicyDirectionally(policy *types.Policy, groupSet map[string]struct{}) []string {
+	groupIds := make([]string, 0)
 	for _, rule := range policy.Rules {
-		if anyInSet(rule.Sources, groupSet) || anyInSet(rule.Destinations, groupSet) {
-			return true
+		// TODO (dmitri) can a group to be present on both sides of a policy?
+		if anyInSet(rule.Sources, groupSet) {
+			groupIds = append(groupIds, rule.Destinations...)
+		} else if anyInSet(rule.Destinations, groupSet) {
+			groupIds = append(groupIds, rule.Sources...)
 		}
 	}
-	return false
+	return groupIds
 }
 
-func policyReferencesDirectPeers(policy *types.Policy, changedSet map[string]struct{}) bool {
+// returns peer IDs of peers on the opposite side of the policy:
+// i.e. if a peer is present in the policy rule sourceResources, use destinationResources of the policy
+// and vice-versa
+func peersFromPolicyDirectionally(policy *types.Policy, changedSet map[string]struct{}) []string {
+	peerIds := make([]string, 0)
 	for _, rule := range policy.Rules {
-		if isDirectPeerInSet(rule.SourceResource, changedSet) || isDirectPeerInSet(rule.DestinationResource, changedSet) {
-			return true
+		// TODO (dmitri) can a peer to be present on both sides of a policy?
+		if isDirectPeerInSet(rule.SourceResource, changedSet) {
+			if rule.DestinationResource.Type == types.ResourceTypePeer && rule.DestinationResource.ID != "" {
+				peerIds = append(peerIds, rule.DestinationResource.ID)
+			}
+		} else if isDirectPeerInSet(rule.DestinationResource, changedSet) {
+			if rule.SourceResource.Type == types.ResourceTypePeer && rule.SourceResource.ID != "" {
+				peerIds = append(peerIds, rule.SourceResource.ID)
+			}
 		}
 	}
-	return false
+	return peerIds
 }
 
 func policyReferencesPostureChecks(policy *types.Policy, ids map[string]struct{}) bool {

--- a/management/server/affectedpeers/resolver.go
+++ b/management/server/affectedpeers/resolver.go
@@ -449,14 +449,13 @@ func (r *resolver) collectFromPolicies() {
 	for _, policy := range r.policies() {
 		// changed peer IDs have been mapped to changedGroupSet on resolver creation (see seedChangedGroupsFromPeers)
 		// there's no change to the groupSet if the same policies have been changed directly
-		groupIds := groupsFromPolicyDirectionally(policy, r.changedGroupSet)
+		peerIds, groupIds := getGroupsAndPeersFromPolicyViaGroups(policy, r.changedGroupSet)
 		addAll(r.groupSet, groupIds)
+		addAll(r.peerSet, peerIds)
 
-		var peerIds []string
-		if len(r.changedPeerSet) > 0 {
-			peerIds = peersFromPolicyDirectionally(policy, r.changedPeerSet)
-			addAll(r.peerSet, peerIds)
-		}
+		peerIds, groupIds = getGroupsAndPeersFromPolicyViaPeers(policy, r.changedPeerSet)
+		addAll(r.groupSet, groupIds)
+		addAll(r.peerSet, peerIds)
 
 		if len(groupIds) == 0 && len(peerIds) == 0 {
 			continue
@@ -742,40 +741,57 @@ func collectPolicySources(policy *types.Policy, groupSet, peerSet map[string]str
 	}
 }
 
-// returns group IDs of groups on the opposite side of the policy:
-// i.e. if a group is present in the policy rule sources, use group IDs from the rule's destinations
+// returns group and peer IDs on the opposite side of the policy:
+// i.e. if a group is present in the policy rule sources, return destination group IDs and the destinationResource from the rule
 // and vice-versa
-func groupsFromPolicyDirectionally(policy *types.Policy, groupSet map[string]struct{}) []string {
-	groupIds := make([]string, 0)
-	for _, rule := range policy.Rules {
-		// TODO (dmitri) can a group to be present on both sides of a policy?
-		if anyInSet(rule.Sources, groupSet) {
-			groupIds = append(groupIds, rule.Destinations...)
-		} else if anyInSet(rule.Destinations, groupSet) {
-			groupIds = append(groupIds, rule.Sources...)
-		}
+func getGroupsAndPeersFromPolicyViaGroups(policy *types.Policy, groupSet map[string]struct{}) ([]string, []string) {
+	var groupIds, peerIds []string
+	if len(groupSet) == 0 {
+		return peerIds, groupIds
 	}
-	return groupIds
-}
-
-// returns peer IDs of peers on the opposite side of the policy:
-// i.e. if a peer is present in the policy rule sourceResources, use destinationResources of the policy
-// and vice-versa
-func peersFromPolicyDirectionally(policy *types.Policy, changedSet map[string]struct{}) []string {
-	peerIds := make([]string, 0)
 	for _, rule := range policy.Rules {
-		// TODO (dmitri) can a peer to be present on both sides of a policy?
-		if isDirectPeerInSet(rule.SourceResource, changedSet) {
+		if matchedIds, ok := allInSet(rule.Sources, groupSet); ok {
+			groupIds = append(groupIds, matchedIds...)
+			groupIds = append(groupIds, rule.Destinations...)
 			if rule.DestinationResource.Type == types.ResourceTypePeer && rule.DestinationResource.ID != "" {
 				peerIds = append(peerIds, rule.DestinationResource.ID)
 			}
-		} else if isDirectPeerInSet(rule.DestinationResource, changedSet) {
+		}
+		if matchedIds, ok := allInSet(rule.Destinations, groupSet); ok {
+			groupIds = append(groupIds, matchedIds...)
+			groupIds = append(groupIds, rule.Sources...)
 			if rule.SourceResource.Type == types.ResourceTypePeer && rule.SourceResource.ID != "" {
 				peerIds = append(peerIds, rule.SourceResource.ID)
 			}
 		}
 	}
-	return peerIds
+	return peerIds, groupIds
+}
+
+// returns group and peer IDs on the opposite side of the policy:
+// i.e. if a peer is present in the policy rule sourceResources, return destination group IDs and the destinationResource from the rule
+// and vice-versa
+func getGroupsAndPeersFromPolicyViaPeers(policy *types.Policy, changedSet map[string]struct{}) ([]string, []string) {
+	var groupIds, peerIds []string
+	if len(changedSet) == 0 {
+		return peerIds, groupIds
+	}
+	for _, rule := range policy.Rules {
+		if isDirectPeerInSet(rule.SourceResource, changedSet) {
+			groupIds = append(groupIds, rule.Destinations...)
+			peerIds = append(peerIds, rule.SourceResource.ID)
+			if rule.DestinationResource.Type == types.ResourceTypePeer && rule.DestinationResource.ID != "" {
+				peerIds = append(peerIds, rule.DestinationResource.ID)
+			}
+		} else if isDirectPeerInSet(rule.DestinationResource, changedSet) {
+			groupIds = append(groupIds, rule.Sources...)
+			peerIds = append(peerIds, rule.DestinationResource.ID)
+			if rule.SourceResource.Type == types.ResourceTypePeer && rule.SourceResource.ID != "" {
+				peerIds = append(peerIds, rule.SourceResource.ID)
+			}
+		}
+	}
+	return peerIds, groupIds
 }
 
 func policyReferencesPostureChecks(policy *types.Policy, ids map[string]struct{}) bool {
@@ -819,6 +835,16 @@ func anyInSet(ids []string, set map[string]struct{}) bool {
 		}
 	}
 	return false
+}
+
+func allInSet(ids []string, set map[string]struct{}) ([]string, bool) {
+	var matchedIds []string
+	for _, id := range ids {
+		if _, ok := set[id]; ok {
+			matchedIds = append(matchedIds, id)
+		}
+	}
+	return matchedIds, len(matchedIds) > 0
 }
 
 func isInSet(id string, set map[string]struct{}) bool {

--- a/management/server/affectedpeers/resolver.go
+++ b/management/server/affectedpeers/resolver.go
@@ -449,20 +449,22 @@ func (r *resolver) collectFromPolicies() {
 	for _, policy := range r.policies() {
 		// changed peer IDs have been mapped to changedGroupSet on resolver creation (see seedChangedGroupsFromPeers)
 		// there's no change to the groupSet if the same policies have been changed directly
-		peerIds, groupIds := getGroupsAndPeersFromPolicyViaGroups(policy, r.changedGroupSet)
-		addAll(r.groupSet, groupIds)
-		addAll(r.peerSet, peerIds)
+		peerIdsViaGroups, groupIdsViaGroups := getGroupsAndPeersFromPolicyViaGroups(policy, r.changedGroupSet)
+		addAll(r.groupSet, groupIdsViaGroups)
+		addAll(r.peerSet, peerIdsViaGroups)
 
-		peerIds, groupIds = getGroupsAndPeersFromPolicyViaPeers(policy, r.changedPeerSet)
-		addAll(r.groupSet, groupIds)
-		addAll(r.peerSet, peerIds)
+		peerIdsViaPeers, groupIdsViaPeers := getGroupsAndPeersFromPolicyViaPeers(policy, r.changedPeerSet)
+		addAll(r.groupSet, groupIdsViaPeers)
+		addAll(r.peerSet, peerIdsViaPeers)
 
-		if len(groupIds) == 0 && len(peerIds) == 0 {
+		hasGroupChanges := len(groupIdsViaPeers) > 0 || len(groupIdsViaGroups) > 0
+		hasPeerChanges := len(peerIdsViaPeers) > 0 || len(peerIdsViaGroups) > 0
+		if !hasGroupChanges && !hasPeerChanges {
 			continue
 		}
 
 		log.WithContext(r.ctx).Tracef("collectFromPolicies: policy %s (%s) matched (byGroup=%t byPeer=%t) -> folding rule groups %v + direct peers",
-			policy.ID, policy.Name, len(groupIds) > 0, len(peerIds) > 0, policy.RuleGroups())
+			policy.ID, policy.Name, hasGroupChanges, hasPeerChanges, policy.RuleGroups())
 		r.matchedPolicies = append(r.matchedPolicies, policy)
 	}
 }

--- a/management/server/affectedpeers/resolver_test.go
+++ b/management/server/affectedpeers/resolver_test.go
@@ -210,43 +210,55 @@ func TestPolicyReferencesDirectPeers(t *testing.T) {
 			Sources:             []string{"sg6"},
 			Destinations:        []string{"dg6"},
 		},
+		{
+			SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p7"},
+			DestinationResource: types.Resource{Type: types.ResourceTypePeer, ID: "r7"},
+			Sources:             []string{"sg7"},
+			Destinations:        []string{"dg7"},
+		},
 	}}
 
 	var tests = []struct {
 		name             string
-		inGroups         map[string]struct{}
+		changedPeerIds   map[string]struct{}
 		expectedPeerIds  []string
 		expectedGroupIds []string
 	}{
 		{
 			name:             "match sources",
-			inGroups:         map[string]struct{}{"p1": {}, "p2": {}},
+			changedPeerIds:   map[string]struct{}{"p1": {}, "p2": {}},
 			expectedPeerIds:  []string{"p1", "p2", "r1", "r2"},
 			expectedGroupIds: []string{"dg1", "dg2"},
 		},
 		{
 			name:             "match destinations",
-			inGroups:         map[string]struct{}{"r1": {}, "r2": {}},
+			changedPeerIds:   map[string]struct{}{"r1": {}, "r2": {}},
 			expectedPeerIds:  []string{"r1", "r2", "p1", "p2"},
 			expectedGroupIds: []string{"sg1", "sg2"},
 		},
 		{
 			name:             "wrong opposing peer types, only changed peer ids and groups on the opposing end of the rule",
-			inGroups:         map[string]struct{}{"p3": {}, "r4": {}},
+			changedPeerIds:   map[string]struct{}{"p3": {}, "r4": {}},
 			expectedPeerIds:  []string{"p3", "r4"},
 			expectedGroupIds: []string{"dg3", "sg4"},
 		},
 		{
 			name:             "wrong peer type, no matching peer ids",
-			inGroups:         map[string]struct{}{"p5": {}, "r6": {}},
+			changedPeerIds:   map[string]struct{}{"p5": {}, "r6": {}},
 			expectedPeerIds:  []string{},
 			expectedGroupIds: []string{},
+		},
+		{
+			name:             "changed peers on both sides of the policy",
+			changedPeerIds:   map[string]struct{}{"p7": {}, "r7": {}},
+			expectedPeerIds:  []string{"p7", "r7"},
+			expectedGroupIds: []string{"sg7", "dg7"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			peerIds, groupIds := getGroupsAndPeersFromPolicyViaPeers(policy, tt.inGroups)
+			peerIds, groupIds := getGroupsAndPeersFromPolicyViaPeers(policy, tt.changedPeerIds)
 			assert.ElementsMatch(t, peerIds, tt.expectedPeerIds)
 			assert.ElementsMatch(t, groupIds, tt.expectedGroupIds)
 		})

--- a/management/server/affectedpeers/resolver_test.go
+++ b/management/server/affectedpeers/resolver_test.go
@@ -80,24 +80,50 @@ func TestChangeIsEmpty(t *testing.T) {
 	assert.False(t, Change{PostureCheckIDs: []string{"pc"}}.isEmpty())
 }
 
-func TestPolicyReferencesGroups(t *testing.T) {
-	policy := &types.Policy{Rules: []*types.PolicyRule{{Sources: []string{"g1", "g2"}, Destinations: []string{"g3"}}}}
+func TestGroupsFromPolicyDirectionally(t *testing.T) {
+	policy := &types.Policy{Rules: []*types.PolicyRule{
+		{Sources: []string{"g1", "g2"}, Destinations: []string{"g3"}},
+		{Sources: []string{"g4"}, Destinations: []string{"g5", "g6"}},
+	}}
 
-	assert.True(t, policyReferencesGroups(policy, map[string]struct{}{"g1": {}}))
-	assert.True(t, policyReferencesGroups(policy, map[string]struct{}{"g3": {}}))
-	assert.False(t, policyReferencesGroups(policy, map[string]struct{}{"g4": {}}))
-	assert.False(t, policyReferencesGroups(policy, map[string]struct{}{}))
+	assert.Equal(t, groupsFromPolicyDirectionally(policy, map[string]struct{}{"g1": {}, "g4": {}}), []string{"g3", "g5", "g6"})
+	assert.Equal(t, groupsFromPolicyDirectionally(policy, map[string]struct{}{"g3": {}, "g6": {}}), []string{"g1", "g2", "g4"})
+	assert.Equal(t, groupsFromPolicyDirectionally(policy, map[string]struct{}{"g33": {}}), []string{})
+	assert.Equal(t, groupsFromPolicyDirectionally(policy, map[string]struct{}{}), []string{})
 }
 
 func TestPolicyReferencesDirectPeers(t *testing.T) {
-	policy := &types.Policy{Rules: []*types.PolicyRule{{
-		SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p1"},
-		DestinationResource: types.Resource{Type: types.ResourceTypeHost, ID: "r1"},
-	}}}
+	policy := &types.Policy{Rules: []*types.PolicyRule{
+		{
+			SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p1"},
+			DestinationResource: types.Resource{Type: types.ResourceTypePeer, ID: "r1"},
+		},
+		{
+			SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p2"},
+			DestinationResource: types.Resource{Type: types.ResourceTypePeer, ID: "r2"},
+		},
+		{
+			SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p3"},
+			DestinationResource: types.Resource{Type: types.ResourceTypeHost, ID: "r3"},
+		},
+		{
+			SourceResource:      types.Resource{Type: types.ResourceTypeHost, ID: "p4"},
+			DestinationResource: types.Resource{Type: types.ResourceTypePeer, ID: "r4"},
+		},
+		{
+			SourceResource:      types.Resource{Type: types.ResourceTypeHost, ID: "p5"},
+			DestinationResource: types.Resource{Type: types.ResourceTypePeer, ID: "r5"},
+		},
+		{
+			SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p6"},
+			DestinationResource: types.Resource{Type: types.ResourceTypeHost, ID: "r6"},
+		},
+	}}
 
-	assert.True(t, policyReferencesDirectPeers(policy, map[string]struct{}{"p1": {}}))
-	assert.False(t, policyReferencesDirectPeers(policy, map[string]struct{}{"r1": {}}))
-	assert.False(t, policyReferencesDirectPeers(policy, map[string]struct{}{"p2": {}}))
+	assert.Equal(t, []string{"r1", "r2"}, peersFromPolicyDirectionally(policy, map[string]struct{}{"p1": {}, "p2": {}}))
+	assert.Equal(t, []string{"p1", "p2"}, peersFromPolicyDirectionally(policy, map[string]struct{}{"r1": {}, "r2": {}}))
+	assert.Empty(t, peersFromPolicyDirectionally(policy, map[string]struct{}{"p3": {}, "r4": {}}))
+	assert.Empty(t, peersFromPolicyDirectionally(policy, map[string]struct{}{"p5": {}, "r6": {}}))
 }
 
 func TestPolicyReferencesPostureChecks(t *testing.T) {

--- a/management/server/affectedpeers/resolver_test.go
+++ b/management/server/affectedpeers/resolver_test.go
@@ -84,12 +84,92 @@ func TestGroupsFromPolicyDirectionally(t *testing.T) {
 	policy := &types.Policy{Rules: []*types.PolicyRule{
 		{Sources: []string{"g1", "g2"}, Destinations: []string{"g3"}},
 		{Sources: []string{"g4"}, Destinations: []string{"g5", "g6"}},
+		{Sources: []string{"g7"}, Destinations: []string{"g8"},
+			SourceResource:      types.Resource{ID: "r7", Type: types.ResourceTypePeer},
+			DestinationResource: types.Resource{ID: "r8", Type: types.ResourceTypePeer}},
+		{Sources: []string{"g9"}, Destinations: []string{"g10"},
+			SourceResource:      types.Resource{ID: "", Type: types.ResourceTypePeer},
+			DestinationResource: types.Resource{ID: "", Type: types.ResourceTypePeer}},
+		{Sources: []string{"g11"}, Destinations: []string{"g12"},
+			SourceResource:      types.Resource{ID: "r11", Type: types.ResourceTypeHost},
+			DestinationResource: types.Resource{ID: "r12", Type: types.ResourceTypeHost}},
 	}}
 
-	assert.Equal(t, groupsFromPolicyDirectionally(policy, map[string]struct{}{"g1": {}, "g4": {}}), []string{"g3", "g5", "g6"})
-	assert.Equal(t, groupsFromPolicyDirectionally(policy, map[string]struct{}{"g3": {}, "g6": {}}), []string{"g1", "g2", "g4"})
-	assert.Equal(t, groupsFromPolicyDirectionally(policy, map[string]struct{}{"g33": {}}), []string{})
-	assert.Equal(t, groupsFromPolicyDirectionally(policy, map[string]struct{}{}), []string{})
+	var tests = []struct {
+		name             string
+		inGroups         map[string]struct{}
+		expectedPeerIds  []string
+		expectedGroupIds []string
+	}{
+		{
+			name:             "match sources",
+			inGroups:         map[string]struct{}{"g1": {}, "g4": {}},
+			expectedPeerIds:  []string{},
+			expectedGroupIds: []string{"g1", "g4", "g3", "g5", "g6"},
+		},
+		{
+			name:             "match destinations",
+			inGroups:         map[string]struct{}{"g3": {}, "g6": {}},
+			expectedPeerIds:  []string{},
+			expectedGroupIds: []string{"g1", "g2", "g4", "g3", "g6"},
+		},
+		{
+			name:             "should return destinations and destination resource",
+			inGroups:         map[string]struct{}{"g7": {}},
+			expectedPeerIds:  []string{"r8"},
+			expectedGroupIds: []string{"g7", "g8"},
+		},
+		{
+			name:             "should return sources and source resource",
+			inGroups:         map[string]struct{}{"g8": {}},
+			expectedPeerIds:  []string{"r7"},
+			expectedGroupIds: []string{"g7", "g8"},
+		},
+		{
+			name:             "should not return source resource (empty id)",
+			inGroups:         map[string]struct{}{"g10": {}},
+			expectedPeerIds:  []string{},
+			expectedGroupIds: []string{"g9", "g10"},
+		},
+		{
+			name:             "should not return destination resource (empty id)",
+			inGroups:         map[string]struct{}{"g9": {}},
+			expectedPeerIds:  []string{},
+			expectedGroupIds: []string{"g9", "g10"},
+		},
+		{
+			name:             "should not return source resource (non-peer type)",
+			inGroups:         map[string]struct{}{"g12": {}},
+			expectedPeerIds:  []string{},
+			expectedGroupIds: []string{"g11", "g12"},
+		},
+		{
+			name:             "should not return destination resource (non-peer type)",
+			inGroups:         map[string]struct{}{"g12": {}},
+			expectedPeerIds:  []string{},
+			expectedGroupIds: []string{"g11", "g12"},
+		},
+		{
+			name:             "non-existing group",
+			inGroups:         map[string]struct{}{"g33": {}},
+			expectedPeerIds:  []string{},
+			expectedGroupIds: []string{},
+		},
+		{
+			name:             "empty groupset",
+			inGroups:         map[string]struct{}{},
+			expectedPeerIds:  []string{},
+			expectedGroupIds: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peerIds, groupIds := getGroupsAndPeersFromPolicyViaGroups(policy, tt.inGroups)
+			assert.ElementsMatch(t, peerIds, tt.expectedPeerIds)
+			assert.ElementsMatch(t, groupIds, tt.expectedGroupIds)
+		})
+	}
 }
 
 func TestPolicyReferencesDirectPeers(t *testing.T) {
@@ -97,33 +177,80 @@ func TestPolicyReferencesDirectPeers(t *testing.T) {
 		{
 			SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p1"},
 			DestinationResource: types.Resource{Type: types.ResourceTypePeer, ID: "r1"},
+			Sources:             []string{"sg1"},
+			Destinations:        []string{"dg1"},
 		},
 		{
 			SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p2"},
 			DestinationResource: types.Resource{Type: types.ResourceTypePeer, ID: "r2"},
+			Sources:             []string{"sg2"},
+			Destinations:        []string{"dg2"},
 		},
 		{
 			SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p3"},
 			DestinationResource: types.Resource{Type: types.ResourceTypeHost, ID: "r3"},
+			Sources:             []string{"sg3"},
+			Destinations:        []string{"dg3"},
 		},
 		{
 			SourceResource:      types.Resource{Type: types.ResourceTypeHost, ID: "p4"},
 			DestinationResource: types.Resource{Type: types.ResourceTypePeer, ID: "r4"},
+			Sources:             []string{"sg4"},
+			Destinations:        []string{"dg4"},
 		},
 		{
 			SourceResource:      types.Resource{Type: types.ResourceTypeHost, ID: "p5"},
 			DestinationResource: types.Resource{Type: types.ResourceTypePeer, ID: "r5"},
+			Sources:             []string{"sg5"},
+			Destinations:        []string{"dg5"},
 		},
 		{
 			SourceResource:      types.Resource{Type: types.ResourceTypePeer, ID: "p6"},
 			DestinationResource: types.Resource{Type: types.ResourceTypeHost, ID: "r6"},
+			Sources:             []string{"sg6"},
+			Destinations:        []string{"dg6"},
 		},
 	}}
 
-	assert.Equal(t, []string{"r1", "r2"}, peersFromPolicyDirectionally(policy, map[string]struct{}{"p1": {}, "p2": {}}))
-	assert.Equal(t, []string{"p1", "p2"}, peersFromPolicyDirectionally(policy, map[string]struct{}{"r1": {}, "r2": {}}))
-	assert.Empty(t, peersFromPolicyDirectionally(policy, map[string]struct{}{"p3": {}, "r4": {}}))
-	assert.Empty(t, peersFromPolicyDirectionally(policy, map[string]struct{}{"p5": {}, "r6": {}}))
+	var tests = []struct {
+		name             string
+		inGroups         map[string]struct{}
+		expectedPeerIds  []string
+		expectedGroupIds []string
+	}{
+		{
+			name:             "match sources",
+			inGroups:         map[string]struct{}{"p1": {}, "p2": {}},
+			expectedPeerIds:  []string{"p1", "p2", "r1", "r2"},
+			expectedGroupIds: []string{"dg1", "dg2"},
+		},
+		{
+			name:             "match destinations",
+			inGroups:         map[string]struct{}{"r1": {}, "r2": {}},
+			expectedPeerIds:  []string{"r1", "r2", "p1", "p2"},
+			expectedGroupIds: []string{"sg1", "sg2"},
+		},
+		{
+			name:             "wrong opposing peer types, only changed peer ids and groups on the opposing end of the rule",
+			inGroups:         map[string]struct{}{"p3": {}, "r4": {}},
+			expectedPeerIds:  []string{"p3", "r4"},
+			expectedGroupIds: []string{"dg3", "sg4"},
+		},
+		{
+			name:             "wrong peer type, no matching peer ids",
+			inGroups:         map[string]struct{}{"p5": {}, "r6": {}},
+			expectedPeerIds:  []string{},
+			expectedGroupIds: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peerIds, groupIds := getGroupsAndPeersFromPolicyViaPeers(policy, tt.inGroups)
+			assert.ElementsMatch(t, peerIds, tt.expectedPeerIds)
+			assert.ElementsMatch(t, groupIds, tt.expectedGroupIds)
+		})
+	}
 }
 
 func TestPolicyReferencesPostureChecks(t *testing.T) {


### PR DESCRIPTION
## Describe your changes
In affected peer calculation, when walking policies of groups and peers, only use opposite sides of those policies; i.e. if a policy rule sources include the group, use the rule's destinations, and vice-versa. Similarly, if a rule's SourceResource matches a peer from the change set, use rule's DesstinationResource and vice-versa.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how policy changes are analyzed to determine the affected peer and group impact, using directionally-derived extraction from policy rules for more accurate and deterministic results.

* **Tests**
  * Reworked resolver unit tests to validate precise affected peer/group sets derived from policy source/destination direction rules, including expanded coverage for mixed resource types and allowlist edge cases.
  * Updated affected-peers coverage-matrix expectations and tightened assertions to compare exact included/excluded sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->