### PR TITLE
[client] Fix stuck Windows tray dark icon on state change

### DIFF
--- a/client/ui/icons.go
+++ b/client/ui/icons.go
@@ -18,8 +18,14 @@ var iconDisconnected []byte
 //go:embed assets/netbird-systemtray-connecting.png
 var iconConnecting []byte
 
+//go:embed assets/netbird-systemtray-connecting-dark.png
+var iconConnectingDark []byte
+
 //go:embed assets/netbird-systemtray-error.png
 var iconError []byte
+
+//go:embed assets/netbird-systemtray-error-dark.png
+var iconErrorDark []byte
 
 //go:embed assets/netbird-systemtray-needs-login.png
 var iconNeedsLogin []byte
@@ -27,8 +33,14 @@ var iconNeedsLogin []byte
 //go:embed assets/netbird-systemtray-update-connected.png
 var iconUpdateConnected []byte
 
+//go:embed assets/netbird-systemtray-update-connected-dark.png
+var iconUpdateConnectedDark []byte
+
 //go:embed assets/netbird-systemtray-update-disconnected.png
 var iconUpdateDisconnected []byte
+
+//go:embed assets/netbird-systemtray-update-disconnected-dark.png
+var iconUpdateDisconnectedDark []byte
 
 //go:embed assets/netbird-systemtray-connected-macos.png
 var iconConnectedMacOS []byte

--- a/client/ui/tray_icon.go
+++ b/client/ui/tray_icon.go
@@ -119,18 +119,18 @@ func (t *Tray) iconForState() (icon, dark []byte) {
 	// Windows: colored PNGs.
 	switch {
 	case connecting:
-		return iconConnecting, nil
+		return iconConnecting, iconConnectingDark
 	case errored:
-		return iconError, nil
+		return iconError, iconErrorDark
 	case needsLogin:
-		return iconNeedsLogin, nil
+		return iconNeedsLogin, iconNeedsLogin
 	case connected && hasUpdate:
-		return iconUpdateConnected, nil
+		return iconUpdateConnected, iconUpdateConnectedDark
 	case connected:
 		return iconConnected, iconConnectedDark
 	case hasUpdate:
-		return iconUpdateDisconnected, nil
+		return iconUpdateDisconnected, iconUpdateDisconnectedDark
 	default:
-		return iconDisconnected, nil
+		return iconDisconnected, iconDisconnected
 	}
 }


### PR DESCRIPTION
Only the connected state passed a dark variant to SetDarkModeIcon, so on dark Windows themes the connected-dark icon stuck for connecting, error and update-* states. Pass a dark variant for every state.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
