### PR TITLE
[client] Suppress Quick Actions popup when DisableAutoConnect=true

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -418,7 +418,14 @@ func newServiceClient(args *newServiceClientArgs) *serviceClient {
 	case args.showProfiles:
 		s.showProfilesUI()
 	case args.showQuickActions:
-		s.showQuickActionsUI()
+		// Suppress the on-boot Quick Actions popup when the daemon
+		// reports DisableAutoConnect=true — that flag carries both the
+		// user's "Connect on Startup = off" preference AND any MDM-
+		// enforced override (applyMDMPolicy writes the policy value
+		// into the same Config field). See netbirdio/netbird#5744.
+		if !s.disableAutoConnectFromDaemon() {
+			s.showQuickActionsUI()
+		}
 	case args.showUpdate:
 		s.showUpdateProgress(ctx, args.showUpdateVersion)
 	}
@@ -1336,6 +1343,40 @@ func (s *serviceClient) getFeatures() (*proto.GetFeaturesResponse, error) {
 	}
 
 	return features, nil
+}
+
+// disableAutoConnectFromDaemon returns true when the daemon reports
+// the active profile has DisableAutoConnect=true. Used by the
+// --quick-actions startup path to suppress the on-boot popup when the
+// user (or an MDM admin) opted out of auto-connecting; both cases
+// converge on the same Config field because applyMDMPolicy writes the
+// policy value into it. Returns false on any RPC / lookup failure so a
+// daemon hiccup does not silently swallow the popup.
+func (s *serviceClient) disableAutoConnectFromDaemon() bool {
+	activeProf, err := s.profileManager.GetActiveProfile()
+	if err != nil {
+		log.Warnf("disableAutoConnectFromDaemon: get active profile: %v", err)
+		return false
+	}
+	currUser, err := user.Current()
+	if err != nil {
+		log.Warnf("disableAutoConnectFromDaemon: get current user: %v", err)
+		return false
+	}
+	conn, err := s.getSrvClient(failFastTimeout)
+	if err != nil {
+		log.Warnf("disableAutoConnectFromDaemon: get daemon client: %v", err)
+		return false
+	}
+	srvCfg, err := conn.GetConfig(s.ctx, &proto.GetConfigRequest{
+		ProfileName: activeProf.ID.String(),
+		Username:    currUser.Username,
+	})
+	if err != nil {
+		log.Warnf("disableAutoConnectFromDaemon: GetConfig RPC: %v", err)
+		return false
+	}
+	return srvCfg.GetDisableAutoConnect()
 }
 
 // getSrvConfig from the service to show it in the settings window.


### PR DESCRIPTION
## Describe your changes


#### Why
Users that disable auto-connect possibly don't want to connect at startup (auto-connect). So showing the Connect pop up is uselessly noisy.

The Windows installer launches `netbird-ui --quick-actions` on every
login, which calls `showQuickActionsUI()` unconditionally and shows the Connect pop-up.

#### What
Adds a one-shot check to the desktop UI's `--quick-actions` startup path so the on-boot "Connect" popup is no longer shown when the user (or an MDM admin) opted out of auto-connecting.


## Issue ticket number and link

https://github.com/netbirdio/netbird/issues/5744

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

The behavioural contract of `DisableAutoConnect` is unchanged from
the user's perspective: "Connect on Startup = off" means the client
does not auto-connect at boot. This PR aligns the Windows
`--quick-actions` popup with that documented contract — it was the
only path that ignored the flag. No new CLI flag, settings entry or
proto field is added; the existing `GetConfigResponse.DisableAutoConnect`
field already carries the value the UI now consults.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quick Actions now respects the active profile’s auto-connect setting and won’t appear when auto-connect is disabled.
  * If the app can’t verify that setting, Quick Actions will continue to show as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->