### PR TITLE
[management] bring back client version check on login filter hash

### DIFF
--- a/management/internals/shared/grpc/loginfilter.go
+++ b/management/internals/shared/grpc/loginfilter.go
@@ -11,9 +11,9 @@ import (
 
 const (
 	reconnThreshold   = 5 * time.Minute
-	baseBlockDuration = 30 * time.Minute // Duration for which a peer is banned after exceeding the reconnection limit
+	baseBlockDuration = 10 * time.Minute // Duration for which a peer is banned after exceeding the reconnection limit
 	reconnLimitForBan = 30               // Number of reconnections within the reconnTreshold that triggers a ban
-	metaChangeLimit   = 3                // Number of reconnections with different metadata that triggers a ban of one peer
+	metaChangeLimit   = 5                // Number of reconnections with different metadata that triggers a ban of one peer
 )
 
 type lfConfig struct {

--- a/management/internals/shared/grpc/loginfilter.go
+++ b/management/internals/shared/grpc/loginfilter.go
@@ -142,6 +142,7 @@ func (l *loginFilter) addLogin(wgPubKey string, metaHash uint64) {
 func metaHash(meta nbpeer.PeerSystemMeta) uint64 {
 	h := fnv.New64a()
 
+	h.Write([]byte(meta.WtVersion))
 	h.Write([]byte(meta.OSVersion))
 	h.Write([]byte(meta.KernelVersion))
 	h.Write([]byte(meta.Hostname))


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of peer device metadata changes by treating version-only differences as distinct.
  * Adjusted login-filter ban/throttling behavior: shorter base block duration and a higher tolerance for repeated metadata changes, resulting in more consistent connection handling over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->