### PR TITLE
[client] fix nil pointer panic when applying SSH server setting to an existing config

### DIFF
--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -433,7 +433,7 @@ func (config *Config) apply(input ConfigInput) (updated bool, err error) {
 		updated = true
 	}
 
-	if input.ServerSSHAllowed != nil && *input.ServerSSHAllowed != *config.ServerSSHAllowed {
+	if input.ServerSSHAllowed != nil && (config.ServerSSHAllowed == nil || *input.ServerSSHAllowed != *config.ServerSSHAllowed) {
 		if *input.ServerSSHAllowed {
 			log.Infof("enabling SSH server")
 		} else {

--- a/client/internal/profilemanager/config_test.go
+++ b/client/internal/profilemanager/config_test.go
@@ -242,6 +242,35 @@ func TestWireguardPortDefaultVsExplicit(t *testing.T) {
 	}
 }
 
+func TestUpdateConfigServerSSHAllowedNotSet(t *testing.T) {
+	// Configs written before ServerSSHAllowed was introduced lack the field and
+	// unmarshal to nil. Supplying the SSH server flag on top of such a config must
+	// apply the value instead of panicking on a nil pointer dereference.
+	tests := []struct {
+		name  string
+		input *bool
+		want  bool
+	}{
+		{"enable", util.True(), true},
+		{"disable", util.False(), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.json")
+			require.NoError(t, os.WriteFile(configPath, []byte("{}"), 0600))
+
+			config, err := UpdateConfig(ConfigInput{
+				ConfigPath:       configPath,
+				ServerSSHAllowed: tt.input,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, config.ServerSSHAllowed, "ServerSSHAllowed should be set from input")
+			assert.Equal(t, tt.want, *config.ServerSSHAllowed)
+		})
+	}
+}
+
 func TestUpdateOldManagementURL(t *testing.T) {
 	origProber := newMgmProber
 	newMgmProber = func(_ context.Context, _ string, _ wgtypes.Key, _ bool) (mgmProber, error) {


### PR DESCRIPTION
## Describe your changes

`Config.apply` dereferenced `*config.ServerSSHAllowed` when comparing the stored value
against the incoming `ConfigInput.ServerSSHAllowed`. New configs are safe because
`createNewConfig` seeds the field (`util.False()`), but configs written before
`ServerSSHAllowed` was introduced do not contain the field and unmarshal it to `nil`.
Updating such a config while also supplying the SSH server flag therefore panicked:

```
panic: runtime error: invalid memory address or nil pointer dereference
  (*Config).apply  client/internal/profilemanager/config.go:436
  update           client/internal/profilemanager/config.go:828
  UpdateConfig     client/internal/profilemanager/config.go:792
```

The `nil` case was already meant to be handled — the `else if config.ServerSSHAllowed == nil`
backwards-compatibility branch right below restores SSH for configs from older versions — but
the crash happens before that branch is reached. Every other `*bool` field in `apply` compares
pointers safely; only this one dereferenced `*config`.

The fix guards the dereference: when the stored value is `nil`, the user-supplied value is
applied directly. Added a table-driven test that reproduces the panic (it fails without the
change) for both enabling and disabling the SSH server.

## Issue ticket number and link

N/A — found while reviewing client config handling.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [[CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first)](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [[Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md)](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal crash fix with no user-facing change: the `--allow-server-ssh` flag and its behavior
are unchanged; this only stops a nil pointer panic when the value is applied to a config that
predates the field.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when updating SSH access settings on older configurations that did not yet have that value set.
  * Updates now apply correctly whether the existing setting is missing or already defined.

* **Tests**
  * Added coverage for updating SSH access settings from an older saved configuration to ensure the value is set as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->