### PR TITLE
[management] validate network resource existence when creating or updating groups

### DIFF
--- a/management/server/group.go
+++ b/management/server/group.go
@@ -683,7 +683,7 @@ func validateNewGroup(ctx context.Context, transaction store.Store, accountID st
 		newGroup.ID = xid.New().String()
 	}
 
-	return nil
+	return validateGroupResources(ctx, transaction, accountID, newGroup.Resources)
 }
 
 func validateDeleteGroup(ctx context.Context, transaction store.Store, group *types.Group, userID string, flowGroups []string) error {

--- a/management/server/group_resource_validation.go
+++ b/management/server/group_resource_validation.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"context"
+
+	"github.com/netbirdio/netbird/management/server/store"
+	"github.com/netbirdio/netbird/management/server/types"
+)
+
+// validateGroupResources ensures every network resource referenced by the group
+// exists in the account. Without this check the groups endpoint silently accepts
+// non-existent resource IDs, leaving the group pointing at resources that never
+// show up in the dashboard (see issue #3495).
+func validateGroupResources(ctx context.Context, transaction store.Store, accountID string, resources []types.Resource) error {
+	for _, resource := range resources {
+		if _, err := transaction.GetNetworkResourceByID(ctx, store.LockingStrengthNone, accountID, resource.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/management/server/group_test.go
+++ b/management/server/group_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/netbirdio/netbird/management/server/groups"
 	"github.com/netbirdio/netbird/management/server/networks"
 	"github.com/netbirdio/netbird/management/server/networks/resources"
+	resourceTypes "github.com/netbirdio/netbird/management/server/networks/resources/types"
 	"github.com/netbirdio/netbird/management/server/networks/routers"
 	routerTypes "github.com/netbirdio/netbird/management/server/networks/routers/types"
 	networkTypes "github.com/netbirdio/netbird/management/server/networks/types"
@@ -72,6 +73,50 @@ func TestDefaultAccountManager_CreateGroup(t *testing.T) {
 			t.Errorf("should not create api group with the same name, %s", group.Name)
 		}
 	}
+}
+
+func TestDefaultAccountManager_CreateGroupWithResources(t *testing.T) {
+	am, _, err := createManager(t)
+	if err != nil {
+		t.Fatalf("failed to create account manager: %s", err)
+	}
+
+	_, account, err := initTestGroupAccount(am)
+	if err != nil {
+		t.Fatalf("failed to init testing account: %s", err)
+	}
+
+	// A group referencing a network resource that does not exist must be rejected
+	// instead of being silently created (issue #3495).
+	groupWithMissingResource := &types.Group{
+		Name:   "group-with-missing-resource",
+		Issued: types.GroupIssuedAPI,
+		Peers:  make([]string, 0),
+		Resources: []types.Resource{
+			{ID: "non-existent-resource", Type: types.ResourceTypeHost},
+		},
+	}
+	err = am.CreateGroup(context.Background(), account.Id, groupAdminUserID, groupWithMissingResource)
+	require.Error(t, err, "creating a group with a non-existent resource should fail")
+	s, ok := status.FromError(err)
+	require.True(t, ok, "expected a management status error")
+	assert.Equal(t, status.NotFound, s.Type())
+
+	// Persisting a real network resource makes the same request succeed.
+	resource, err := resourceTypes.NewNetworkResource(account.Id, "test-network", "test-resource", "", "192.0.2.1", []string{}, true)
+	require.NoError(t, err)
+	require.NoError(t, am.Store.SaveNetworkResource(context.Background(), resource))
+
+	groupWithResource := &types.Group{
+		Name:   "group-with-resource",
+		Issued: types.GroupIssuedAPI,
+		Peers:  make([]string, 0),
+		Resources: []types.Resource{
+			{ID: resource.ID, Type: types.ResourceTypeHost},
+		},
+	}
+	err = am.CreateGroup(context.Background(), account.Id, groupAdminUserID, groupWithResource)
+	require.NoError(t, err, "creating a group with an existing resource should succeed")
 }
 
 func TestDefaultAccountManager_DeleteGroup(t *testing.T) {


### PR DESCRIPTION
## Describe your changes

The groups endpoint accepted any resource ID without checking that the referenced
network resource actually exists. Sending a POST or PUT to /api/groups with a
non-existent resource ID returned a 200 and created the group, but the resource
never showed up in the dashboard and was awkward to remove afterwards.

validateNewGroup now looks up every referenced resource with GetNetworkResourceByID,
so create, update and bulk group operations reject unknown resource IDs with a
NotFound error. Clearing a group's resources with an empty list still works, which
preserves the recovery path described in the issue.

Note on the error type: I reused the store's existing NewNetworkResourceNotFoundError
(NotFound, which maps to a 4xx) for consistency with the rest of the codebase. Happy
to switch it to InvalidArgument if a 400 is preferred.

## Issue ticket number and link

Closes #3495

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (TestDefaultAccountManager_CreateGroupWithResources)
- [x] This change does not modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature, OR I have discussed it with the NetBird team beforehand. The assigned maintainer requested this exact validation in issue #3495.

## Documentation

- [x] Documentation is not needed for this change. It only rejects resource IDs that were previously accepted by mistake; there is no new user-facing behavior to document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Group creation and updates now verify that all referenced network resources exist.
  * Requests containing missing or invalid resource IDs are rejected with a not-found error.
* **Tests**
  * Added coverage for group creation with both invalid and valid network resource references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->