### PR TITLE
[client] lower ICE handshake offer/answer log level to debug

### DIFF
--- a/client/internal/peer/handshaker.go
+++ b/client/internal/peer/handshaker.go
@@ -195,14 +195,14 @@ func (h *Handshaker) sendOffer() error {
 	}
 
 	offer := h.buildOfferAnswer()
-	h.log.Infof("sending offer with serial: %s", offer.SessionIDString())
+	h.log.Debugf("sending offer with serial: %s", offer.SessionIDString())
 
 	return h.signaler.SignalOffer(offer, h.config.Key)
 }
 
 func (h *Handshaker) sendAnswer() error {
 	answer := h.buildOfferAnswer()
-	h.log.Infof("sending answer with serial: %s", answer.SessionIDString())
+	h.log.Debugf("sending answer with serial: %s", answer.SessionIDString())
 
 	return h.signaler.SignalAnswer(answer, h.config.Key)
 }


### PR DESCRIPTION
## Describe your changes

Lower the log level of the ICE offer/answer signaling logs in
`client/internal/peer/handshaker.go` from `Info` to `Debug`.

These info are per handshake, and usually needed only when troubleshooting.

## Issue ticket number and link

No public issue. Internal log-noise cleanup: the ICE handshake offer/answer
logs are demoted from Info to Debug so they no longer flood default-level
client logs while remaining available for troubleshooting at Debug.

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Log-level-only change with no user-facing CLI, API, or behavior impact. The
log lines still exist; they just emit at Debug instead of Info.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the visibility of peer signaling messages by moving outbound offer/answer logs to debug level, helping keep normal logs cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->