### PR TITLE
[client] Tear down idle lazy connections in kernel mode

### DIFF
--- a/client/iface/configurer/kernel_activity_test.go
+++ b/client/iface/configurer/kernel_activity_test.go
@@ -1,0 +1,99 @@
+//go:build (linux && !android) || freebsd
+
+package configurer
+
+import (
+	"testing"
+
+	"github.com/netbirdio/netbird/monotime"
+)
+
+func TestUpdateActivity_NewPeerSeededActive(t *testing.T) {
+	c := NewKernelConfigurer("")
+
+	now := monotime.Time(1000)
+	got := c.updateActivity(map[string]WGStats{
+		"peerA": {TxBytes: 500, RxBytes: 500},
+	}, now)
+
+	if got["peerA"] != now {
+		t.Fatalf("new peer should be seeded active at now=%d, got %d", now, got["peerA"])
+	}
+}
+
+func TestUpdateActivity_GrowthPastThresholdIsActive(t *testing.T) {
+	c := NewKernelConfigurer("")
+
+	t0 := monotime.Time(1000)
+	c.updateActivity(map[string]WGStats{"peerA": {TxBytes: 1000}}, t0)
+
+	// Grow well past the threshold.
+	t1 := monotime.Time(2000)
+	got := c.updateActivity(map[string]WGStats{
+		"peerA": {TxBytes: 1000 + activityByteThreshold + 1},
+	}, t1)
+
+	if got["peerA"] != t1 {
+		t.Fatalf("peer with >threshold growth should be active at t1=%d, got %d", t1, got["peerA"])
+	}
+}
+
+func TestUpdateActivity_SubThresholdStaysIdleNoAccumulation(t *testing.T) {
+	c := NewKernelConfigurer("")
+
+	t0 := monotime.Time(1000)
+	c.updateActivity(map[string]WGStats{"peerA": {TxBytes: 0}}, t0)
+
+	// Several polls, each growing by less than the threshold (keepalive noise).
+	// Even though the cumulative growth far exceeds the threshold, the per-poll
+	// delta never does, so the peer must keep reporting its original activity.
+	bytes := int64(0)
+	step := int64(activityByteThreshold / 2)
+	for i, ts := range []monotime.Time{2000, 3000, 4000, 5000, 6000} {
+		bytes += step
+		got := c.updateActivity(map[string]WGStats{"peerA": {TxBytes: bytes}}, ts)
+		if got["peerA"] != t0 {
+			t.Fatalf("poll %d: idle peer should stay at t0=%d, got %d", i, t0, got["peerA"])
+		}
+	}
+}
+
+func TestUpdateActivity_CounterResetIsActive(t *testing.T) {
+	c := NewKernelConfigurer("")
+
+	t0 := monotime.Time(1000)
+	c.updateActivity(map[string]WGStats{"peerA": {TxBytes: 10_000, RxBytes: 5_000}}, t0)
+
+	// Counter resets (peer suspended and re-added): total drops below baseline.
+	t1 := monotime.Time(2000)
+	got := c.updateActivity(map[string]WGStats{"peerA": {TxBytes: 0, RxBytes: 0}}, t1)
+
+	if got["peerA"] != t1 {
+		t.Fatalf("counter reset should be treated as activity at t1=%d, got %d", t1, got["peerA"])
+	}
+}
+
+func TestUpdateActivity_PrunesRemovedPeers(t *testing.T) {
+	c := NewKernelConfigurer("")
+
+	t0 := monotime.Time(1000)
+	c.updateActivity(map[string]WGStats{
+		"peerA": {TxBytes: 1},
+		"peerB": {TxBytes: 1},
+	}, t0)
+
+	// peerB disappears from the device dump.
+	t1 := monotime.Time(2000)
+	got := c.updateActivity(map[string]WGStats{"peerA": {TxBytes: 1}}, t1)
+
+	if _, ok := got["peerB"]; ok {
+		t.Fatalf("removed peer should not appear in returned activities")
+	}
+
+	c.mu.Lock()
+	_, tracked := c.activity["peerB"]
+	c.mu.Unlock()
+	if tracked {
+		t.Fatalf("removed peer should be pruned from the tracker")
+	}
+}

--- a/client/iface/configurer/kernel_unix.go
+++ b/client/iface/configurer/kernel_unix.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -15,13 +16,37 @@ import (
 	"github.com/netbirdio/netbird/monotime"
 )
 
+// activityByteThreshold is the minimum growth in a peer's combined Tx+Rx byte
+// counters between two polls for the peer to be considered active.
+//
+// Kernel WireGuard only exposes aggregate transfer counters, with no way to
+// distinguish data from protocol overhead. An idle tunnel still accrues a steady
+// noise floor: the 25s persistent keepalive NetBird sets for NAT traversal, plus
+// a rekey handshake (~every 2 min, kept alive by the keepalive itself) that also
+// lands in the counters. Measured on idle kernel-WireGuard peers this floor
+// peaks around ~400 bytes per 60s poll (≈64 B keepalive-only, ≈400 B on a poll
+// containing a rekey). The threshold sits above that with margin so
+// keepalive/rekey-only tunnels read as idle, while real traffic (orders of
+// magnitude larger) reads as active. The baseline advances every poll so the
+// floor cannot accumulate across intervals into a false positive.
+const activityByteThreshold = 1024
+
+type peerActivity struct {
+	lastBytes  int64         // Tx+Rx total observed at the previous poll
+	lastActive monotime.Time // last poll where the byte delta exceeded the threshold
+}
+
 type KernelConfigurer struct {
 	deviceName string
+
+	mu       sync.Mutex
+	activity map[string]peerActivity // peer public key -> activity tracker
 }
 
 func NewKernelConfigurer(deviceName string) *KernelConfigurer {
 	return &KernelConfigurer{
 		deviceName: deviceName,
+		activity:   make(map[string]peerActivity),
 	}
 }
 
@@ -327,6 +352,66 @@ func (c *KernelConfigurer) GetStats() (map[string]WGStats, error) {
 	return stats, nil
 }
 
+// LastActivities returns the last time genuine data activity was observed for
+// each peer, derived from the kernel's aggregate Tx/Rx byte counters. It is
+// consumed by the lazy-connection inactivity monitor to tear down idle peers.
+//
+// Unlike userspace mode, where the bind sees every packet and can filter
+// keepalives directly, kernel mode only exposes aggregate counters via wgctrl,
+// so activity is inferred from byte-counter deltas across polls.
 func (c *KernelConfigurer) LastActivities() map[string]monotime.Time {
-	return nil
+	stats, err := c.GetStats()
+	if err != nil {
+		log.Errorf("failed to get wg stats for activity tracking: %v", err)
+		return nil
+	}
+	return c.updateActivity(stats, monotime.Now())
+}
+
+// updateActivity folds a fresh stats snapshot into the per-peer activity tracker
+// and returns the last-active timestamp for every peer currently present.
+//
+// A peer is considered active for this poll when its combined Tx+Rx counter
+// grows by more than activityByteThreshold since the previous poll, or when the
+// counter resets (peer re-added). The baseline is advanced on every poll so
+// keepalive bytes cannot accumulate across intervals into a false positive.
+// Newly seen peers are seeded as active, mirroring the userspace recorder which
+// seeds LastActivity on UpsertAddress.
+func (c *KernelConfigurer) updateActivity(stats map[string]WGStats, now monotime.Time) map[string]monotime.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	activities := make(map[string]monotime.Time, len(stats))
+	for key, s := range stats {
+		total := s.TxBytes + s.RxBytes
+
+		entry, ok := c.activity[key]
+		switch {
+		case !ok:
+			// First time we see this peer: treat as just-activated.
+			entry = peerActivity{lastBytes: total, lastActive: now}
+		case total < entry.lastBytes:
+			// Counter reset (peer suspended/re-added): treat as activity.
+			entry.lastBytes = total
+			entry.lastActive = now
+		case total-entry.lastBytes > activityByteThreshold:
+			entry.lastBytes = total
+			entry.lastActive = now
+		default:
+			// Idle / keepalive-only: keep lastActive, advance the baseline.
+			entry.lastBytes = total
+		}
+
+		c.activity[key] = entry
+		activities[key] = entry.lastActive
+	}
+
+	// Prune peers that are no longer present in the device.
+	for key := range c.activity {
+		if _, ok := stats[key]; !ok {
+			delete(c.activity, key)
+		}
+	}
+
+	return activities
 }

--- a/client/internal/lazyconn/manager/manager.go
+++ b/client/internal/lazyconn/manager/manager.go
@@ -75,11 +75,10 @@ func NewManager(config Config, engineCtx context.Context, peerStore *peerstore.S
 		haGroupToPeers:       make(map[route.HAUniqueID][]string),
 	}
 
-	if wgIface.IsUserspaceBind() {
-		m.inactivityManager = inactivity.NewManager(wgIface, config.InactivityThreshold)
-	} else {
-		log.Warnf("inactivity manager not supported for kernel mode, wait for remote peer to close the connection")
-	}
+	// Both userspace and kernel modes expose a per-peer activity signal via
+	// WGIface.LastActivities (kernel mode infers it from wgctrl byte counters),
+	// so the inactivity monitor runs in either mode.
+	m.inactivityManager = inactivity.NewManager(wgIface, config.InactivityThreshold)
 
 	return m
 }


### PR DESCRIPTION
## Describe your changes

Lazy connections have two halves: **activation** (establish a peer on first traffic) and **inactivity teardown** (drop a peer once it goes idle). Activation already works in both userspace and kernel-WireGuard mode, but teardown was gated to userspace only:

- `lazyconn/manager.NewManager` created the inactivity monitor only `if wgIface.IsUserspaceBind()`, otherwise logging `"inactivity manager not supported for kernel mode, wait for remote peer to close the connection"`.
- `KernelConfigurer.LastActivities()` returned `nil`, so the monitor never saw a kernel-mode peer as idle.

As a result a kernel-mode peer relied entirely on the *remote* peer's `GO_IDLE`. Two kernel-mode peers (e.g. two Linux hosts) would connect on demand and then stay up indefinitely, since neither side ever idled out. This becomes more visible as lazy connections move to default-on (#6571).

**This PR** gives kernel mode a real per-peer activity signal and removes the gate:

- `KernelConfigurer.LastActivities()` now infers activity from the aggregate Tx/Rx byte counters already exposed via `wgctrl` (reusing `GetStats()`). A peer counts as active when its combined counter grows past a small threshold between polls. The baseline advances every poll so the 25s persistent keepalive can't accumulate into a false positive; a counter reset (peer re-added) counts as activity; newly seen peers are seeded active, mirroring the userspace `ActivityRecorder`.
- The inactivity manager is now created unconditionally, so kernel mode reaches parity with userspace.

**Why byte counters and not packet capture:** in the linked discussion I initially floated tapping packets via AF_PACKET (before deleting it). On closer look that's the wrong tool for an always-on signal — it runs a continuous userspace read loop copying every decrypted overlay packet (negating kernel mode's performance benefit), is Linux-only (kernel mode also runs on FreeBSD), and shares the single debug-capture slot. The `wgctrl` counter dump is a once-a-minute netlink read the inactivity monitor already polls at, works on Linux + FreeBSD, and needs no extra privileges.

The change is split into two bisect-friendly commits: (1) add the kernel activity signal (no behavior change on its own), (2) remove the gate (activates teardown).

### Threshold, validated on real hardware
Kernel mode only exposes aggregate counters, so the idle noise floor is handled with a fixed `activityByteThreshold`. I measured it on idle kernel-WireGuard peers (Teltonika TRB500, ARMv7, OpenWrt 21.02, kernel 4.14) by sampling per-peer `wg show transfer` every 60s: a keepalive-only poll grows the combined Tx+Rx counter by ~64 bytes, and a poll that contains a WireGuard rekey handshake (which recurs ~every 2 min, kept alive by the persistent keepalive itself) grows it by ~400 bytes. The rekey overhead is the non-obvious part — handshake messages land in the per-peer counters too, so the floor is higher than keepalives alone. The threshold is set to **1024 bytes/poll**, comfortably above the measured ~400-byte ceiling and far below any real traffic. The per-poll baseline advances every poll so the floor can't accumulate across intervals. Happy to make it configurable if maintainers prefer.

## Issue ticket number and link

Discussed on the default-on PR: https://github.com/netbirdio/netbird/pull/6571#issuecomment-4841303542
Related connection-mode RFCs: #5989, #5990

## Stack

N/A

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). — *This changes kernel-mode behavior (idle lazy connections now tear down); raised on #6571 (link above) before submitting.*

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why) — *No code-repo docs assert "userspace only" for inactivity. If the netbirdio/docs site notes that lazy/idle teardown is userspace-only, that note should be dropped — flag if so and I'll open a docs PR.*

### Docs PR URL (required if "docs added" is checked)
N/A

---

## Test plan (not part of template — for our review)

Verified in a `golang:1.25.5` container:
- `gofmt -l` clean on all three changed files
- `go vet ./client/iface/configurer/... ./client/internal/lazyconn/...` — OK
- `go build` of both package trees — OK
- `go test ./client/iface/configurer/... ./client/internal/lazyconn/...` — all pass, including new table-driven tests for the tracker (new peer seeded active, growth > threshold → active, sub-threshold growth across polls → stays idle, counter reset → active, removed-peer pruning)

Validated against live hardware (kernel WireGuard, lazy enabled):
- Sampled per-peer `wg show transfer` on idle TRB500 peers over 6 min → idle floor ~64 B/poll (keepalive) rising to ~400 B/poll on rekey polls; drove the `activityByteThreshold = 1024` choice (see above). Real traffic on the same interface was orders of magnitude higher, cleanly separable.

Not yet done (needs deploying a patched build to two peers):
- End-to-end: two kernel-WireGuard peers with lazy enabled + low `NB_LAZY_CONN_INACTIVITY_THRESHOLD`, confirming connect-on-traffic → teardown-on-idle → re-activate. (The current released agent in kernel mode keeps idle peers connected indefinitely — reproduced live: a P2P peer idle for 6+ min with only keepalive/rekey traffic stayed `Connected`.)
