### PR TITLE
[management] detach JWT group sync write from request cancellation

### DIFF
--- a/management/server/http/middleware/auth_middleware.go
+++ b/management/server/http/middleware/auth_middleware.go
@@ -152,7 +152,11 @@ func (m *AuthMiddleware) checkJWTFromRequest(r *http.Request, authHeaderParts []
 		return err
 	}
 
-	err = m.syncUserJWTGroups(ctx, userAuth)
+	// Detach the group-sync write from the request's cancellation: the dashboard
+	// SPA aborts in-flight requests on re-render, which would otherwise cancel the
+	// DB transaction mid-write and silently drop the synced groups. Context values
+	// (request id, logger) are preserved; the store bounds the tx with its own timeout.
+	err = m.syncUserJWTGroups(context.WithoutCancel(ctx), userAuth)
 	if err != nil {
 		log.WithContext(ctx).Errorf("HTTP server failed to sync user JWT groups: %s", err)
 	}

--- a/management/server/http/middleware/auth_middleware_test.go
+++ b/management/server/http/middleware/auth_middleware_test.go
@@ -241,6 +241,66 @@ func TestAuthMiddleware_Handler(t *testing.T) {
 	}
 }
 
+// TestAuthMiddleware_SyncUserJWTGroupsDetachedFromRequestCancellation ensures the
+// JWT group sync write is not bound to the request context. The dashboard SPA
+// routinely aborts in-flight requests on re-render/navigation; if the sync ran in
+// the request context, the cancellation would roll back the DB transaction and the
+// synced groups would silently never persist. The sync must receive a context that
+// is not cancelled even when the originating request is.
+func TestAuthMiddleware_SyncUserJWTGroupsDetachedFromRequestCancellation(t *testing.T) {
+	var (
+		syncCalled bool
+		syncCtxErr error
+	)
+
+	mockAuth := &auth.MockManager{
+		ValidateAndParseTokenFunc:       mockValidateAndParseToken,
+		EnsureUserAccessByJWTGroupsFunc: mockEnsureUserAccessByJWTGroups,
+		MarkPATUsedFunc:                 mockMarkPATUsed,
+		GetPATInfoFunc:                  mockGetAccountInfoFromPAT,
+	}
+
+	disabledLimiter := NewAPIRateLimiter(nil)
+	disabledLimiter.SetEnabled(false)
+
+	authMiddleware := NewAuthMiddleware(
+		mockAuth,
+		func(ctx context.Context, userAuth nbauth.UserAuth) (string, string, error) {
+			return userAuth.AccountId, userAuth.UserId, nil
+		},
+		func(ctx context.Context, userAuth nbauth.UserAuth) error {
+			syncCalled = true
+			syncCtxErr = ctx.Err()
+			return nil
+		},
+		func(ctx context.Context, userAuth nbauth.UserAuth) (*types.User, error) {
+			return &types.User{}, nil
+		},
+		disabledLimiter,
+		nil,
+		func(_ context.Context, _, _, _ string) bool { return false },
+	)
+
+	handlerToTest := authMiddleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	// Simulate the dashboard aborting the request: it arrives already cancelled.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req := httptest.NewRequest("GET", "http://testing/test", nil).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+JWT)
+	rec := httptest.NewRecorder()
+
+	handlerToTest.ServeHTTP(rec, req)
+
+	if !syncCalled {
+		t.Fatal("syncUserJWTGroups was not called")
+	}
+	if syncCtxErr != nil {
+		t.Fatalf("syncUserJWTGroups received a cancelled context (%v); the group-sync write must be detached from request cancellation", syncCtxErr)
+	}
+}
+
 func TestAuthMiddleware_RateLimiting(t *testing.T) {
 	mockAuth := &auth.MockManager{
 		ValidateAndParseTokenFunc:       mockValidateAndParseToken,


### PR DESCRIPTION
## Describe your changes

The HTTP auth middleware persists a user's JWT-derived groups (`users.auto_groups`) by calling `syncUserJWTGroups` inside the **request context**. The dashboard SPA routinely aborts in-flight `fetch()` calls on re-render/navigation, which cancels the request context mid-write. The group-sync write runs in a DB transaction bound to that context, so it is rolled back and the synced groups never persist. The error is logged but swallowed (no `return`), so it repeats silently on every request and `auto_groups` stays empty.

**Root cause:** a server-side persistence side effect was tied to the client request lifecycle.

**Fix:** detach the group-sync write with `context.WithoutCancel(ctx)` so it commits regardless of the client connection, while preserving context values (request id, logger). This matches the existing `context.WithoutCancel` usage in the management server (`peer.go`, the gRPC server, the network-map controller). The transaction stays bounded by the store's own timeout (`ExecuteInTransaction`, default 5 min).

Scoped to the HTTP middleware call-site where the SPA-abort symptom reproduces. The gRPC login path (`internals/shared/grpc/server.go`) calls the same method but isn't driven by an aborting SPA and is intentionally left out of this change.

A regression test (`TestAuthMiddleware_SyncUserJWTGroupsDetachedFromRequestCancellation`) dispatches an already-cancelled request and asserts the injected `syncUserJWTGroups` receives a non-cancelled context — it fails without the change (`context canceled`) and passes with it.

## Issue ticket number and link

Fixes #6620

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): internal server bug fix in the auth middleware, no user-facing surface.
