### PR TITLE
[misc] Run agent-network e2e nightly + on manual dispatch

### DIFF
--- a/.github/workflows/agent-network-e2e.yml
+++ b/.github/workflows/agent-network-e2e.yml
@@ -1,10 +1,10 @@
 name: Agent Network E2E
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  # Nightly at 03:00 UTC, plus on demand from the Actions tab.
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   e2e:
     name: Agent Network E2E
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
## Describe your changes

The agent-network e2e suite builds combined/proxy/client from source and drives live provider traffic, so triggering it on every push/PR is too costly. Switch it to run **nightly at 03:00 UTC** plus **manual `workflow_dispatch`**, and drop the fork guard that was only relevant for `pull_request` runs.

## Issue ticket number and link

N/A — CI scheduling for the agent-network e2e suite.

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

CI-only scheduling change; no product or API surface affected.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the end-to-end test workflow to run nightly and support manual execution.
  * The test suite now runs whenever the scheduled or manual workflow is started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->