### PR TITLE
[management] Add vLLM support for Agent Network

### DIFF
--- a/management/internals/modules/agentnetwork/catalog/catalog.go
+++ b/management/internals/modules/agentnetwork/catalog/catalog.go
@@ -628,6 +628,21 @@ var providers = []Provider{
 		Models: []Model{},
 	},
 	{
+		// vLLM is an OpenAI-compatible self-hosted server. It behaves like
+		// the generic custom entry; it gets its own catalog id purely so it
+		// surfaces as a named "vLLM" choice in the provider picker.
+		ID:                 "vllm",
+		Kind:               KindCustom,
+		Name:               "vLLM",
+		Description:        "Self-hosted vLLM (OpenAI-compatible)",
+		DefaultHost:        "",
+		AuthHeaderName:     "Authorization",
+		AuthHeaderTemplate: "Bearer ${API_KEY}",
+		DefaultContentType: "application/json",
+		BrandColor:         "#30A2FF",
+		Models:             []Model{},
+	},
+	{
 		ID:                 "custom",
 		Kind:               KindCustom,
 		Name:               "Custom / Self-hosted",


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new self-hosted **vLLM** provider in the Agent Network catalog.
  * The provider now appears in catalog listings and API responses alongside other available providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->