### PR TITLE
[misc] Fix GHCR image push after dockers_v2 migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,8 +293,11 @@ jobs:
           ${{ steps.goreleaser.outputs.artifacts }}
           JSON
 
+          # dockers_v2 artifacts have no top-level goarch field, so match the
+          # per-platform -amd64 tag suffix instead; it works for both the old
+          # dockers and the new dockers_v2 image naming.
           mapfile -t src_images < <(
-            jq -r '.[] | select(.type == "Docker Image") | select(.goarch == "amd64") | .name | select(startswith("ghcr.io/"))' /tmp/goreleaser-artifacts.json
+            jq -r '.[] | select(.type == "Docker Image") | .name | select(startswith("ghcr.io/") and endswith("-amd64"))' /tmp/goreleaser-artifacts.json
           )
 
           for src in "${src_images[@]}"; do


### PR DESCRIPTION
### Describe your changes

Since #6438 migrated `.goreleaser.yaml` from the classic `dockers:` pipe to `dockers_v2`, the "Tag and push images (amd64 only)" step in the Release workflow has silently pushed **zero** images to GHCR on PR and main-push runs.

`dockers_v2` artifacts no longer carry a top-level `goarch` field — the platform moved to `extra.Platforms` (e.g. `["linux/amd64"]`). The step's jq filter `select(.goarch == "amd64")` therefore matches nothing, `src_images` ends up empty, and the step exits green having pushed nothing. As a result, no `pr-N`, `main`, or `sha-*` images have been published since June 17. Tagged releases are unaffected because GoReleaser pushes those itself.

This updates the filter to match the per-platform `-amd64` tag suffix on the image name instead, which works for both the old `dockers` and the new `dockers_v2` naming.

Verified against the actual `artifacts.json` from run [28578053510](https://github.com/netbirdio/netbird/actions/runs/28578053510) (main push): the old filter selects 0 images, the fixed one selects the expected 8 (`netbird`, `netbird` rootless, `relay`, `signal`, `management`, `upload`, `netbird-server`, `reverse-proxy`).

### Issue ticket number and link

### Stack

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

### Documentation

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): CI-internal fix, no user-facing behavior change.

### Docs PR URL (required if "docs added" is checked)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image tagging during releases so the correct amd64 container images are selected and pushed reliably.
  * Updated tagging logic to work with both older and newer image naming formats, reducing release failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->