### PR TITLE
[management] Allow activityStore DSN via env when using postgres

### DIFF
--- a/combined/cmd/root.go
+++ b/combined/cmd/root.go
@@ -144,7 +144,9 @@ func applyActivityStoreEnv(storeConfig StoreConfig) error {
 	if engine := storeConfig.Engine; engine != "" {
 		engineLower := strings.ToLower(engine)
 		if engineLower == "postgres" && storeConfig.DSN == "" {
-			return fmt.Errorf("activityStore.dsn is required when activityStore.engine is postgres")
+			if _, ok := os.LookupEnv("NB_ACTIVITY_EVENT_POSTGRES_DSN"); !ok {
+				return fmt.Errorf("activityStore.dsn is required when activityStore.engine is postgres (or set NB_ACTIVITY_EVENT_POSTGRES_DSN)")
+			}
 		}
 		os.Setenv("NB_ACTIVITY_EVENT_STORE_ENGINE", engineLower)
 		if dsn := storeConfig.DSN; dsn != "" {

--- a/combined/cmd/root.go
+++ b/combined/cmd/root.go
@@ -144,7 +144,7 @@ func applyActivityStoreEnv(storeConfig StoreConfig) error {
 	if engine := storeConfig.Engine; engine != "" {
 		engineLower := strings.ToLower(engine)
 		if engineLower == "postgres" && storeConfig.DSN == "" {
-			if _, ok := os.LookupEnv("NB_ACTIVITY_EVENT_POSTGRES_DSN"); !ok {
+			if os.Getenv("NB_ACTIVITY_EVENT_POSTGRES_DSN") == "" {
 				return fmt.Errorf("activityStore.dsn is required when activityStore.engine is postgres (or set NB_ACTIVITY_EVENT_POSTGRES_DSN)")
 			}
 		}

--- a/combined/cmd/root_test.go
+++ b/combined/cmd/root_test.go
@@ -70,6 +70,9 @@ server:
 	configPath = cfgFile
 
 	t.Run("env var unset", func(t *testing.T) {
+		if orig, wasSet := os.LookupEnv("NB_ACTIVITY_EVENT_POSTGRES_DSN"); wasSet {
+			t.Cleanup(func() { os.Setenv("NB_ACTIVITY_EVENT_POSTGRES_DSN", orig) })
+		}
 		os.Unsetenv("NB_ACTIVITY_EVENT_POSTGRES_DSN")
 		err := initializeConfig()
 		require.Error(t, err, "initializeConfig should reject missing activityStore DSN when no env var is set")

--- a/combined/cmd/root_test.go
+++ b/combined/cmd/root_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInitializeConfig_ActivityStorePostgresDSNFromEnv reproduces netbirdio/netbird#5976:
+// when server.activityStore.engine is "postgres" but server.activityStore.dsn is not set
+// in config.yaml, initializeConfig() must still succeed if the DSN is supplied via the
+// NB_ACTIVITY_EVENT_POSTGRES_DSN environment variable instead - the store layer
+// (management/server/activity/store/sql_store.go) already reads that env var as a fallback,
+// but the eager validation in initializeConfig() currently rejects the config before it
+// gets a chance to.
+func TestInitializeConfig_ActivityStorePostgresDSNFromEnv(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+
+	yamlContent := `
+server:
+  exposedAddress: "https://netbird.example.com:443"
+  dataDir: "` + dir + `"
+  authSecret: "test-secret"
+  activityStore:
+    engine: postgres
+`
+	require.NoError(t, os.WriteFile(cfgFile, []byte(yamlContent), 0o600))
+
+	t.Setenv("NB_ACTIVITY_EVENT_POSTGRES_DSN", "postgres://user:pass@localhost:5432/activity")
+
+	oldConfigPath := configPath
+	oldConfig := config
+	t.Cleanup(func() {
+		configPath = oldConfigPath
+		config = oldConfig
+	})
+	configPath = cfgFile
+
+	err := initializeConfig()
+	require.NoError(t, err, "initializeConfig should accept activityStore DSN supplied via NB_ACTIVITY_EVENT_POSTGRES_DSN env var")
+}

--- a/combined/cmd/root_test.go
+++ b/combined/cmd/root_test.go
@@ -42,3 +42,42 @@ server:
 	err := initializeConfig()
 	require.NoError(t, err, "initializeConfig should accept activityStore DSN supplied via NB_ACTIVITY_EVENT_POSTGRES_DSN env var")
 }
+
+// TestInitializeConfig_ActivityStorePostgresMissingDSN is the companion regression test:
+// with activityStore.engine=postgres and no DSN in config.yaml, initializeConfig() must
+// still reject the config when NB_ACTIVITY_EVENT_POSTGRES_DSN is either unset or set to
+// an empty string - an empty env var must not be treated as "provided".
+func TestInitializeConfig_ActivityStorePostgresMissingDSN(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+
+	yamlContent := `
+server:
+  exposedAddress: "https://netbird.example.com:443"
+  dataDir: "` + dir + `"
+  authSecret: "test-secret"
+  activityStore:
+    engine: postgres
+`
+	require.NoError(t, os.WriteFile(cfgFile, []byte(yamlContent), 0o600))
+
+	oldConfigPath := configPath
+	oldConfig := config
+	t.Cleanup(func() {
+		configPath = oldConfigPath
+		config = oldConfig
+	})
+	configPath = cfgFile
+
+	t.Run("env var unset", func(t *testing.T) {
+		os.Unsetenv("NB_ACTIVITY_EVENT_POSTGRES_DSN")
+		err := initializeConfig()
+		require.Error(t, err, "initializeConfig should reject missing activityStore DSN when no env var is set")
+	})
+
+	t.Run("env var empty string", func(t *testing.T) {
+		t.Setenv("NB_ACTIVITY_EVENT_POSTGRES_DSN", "")
+		err := initializeConfig()
+		require.Error(t, err, "initializeConfig should reject an empty activityStore DSN env var, not treat it as provided")
+	})
+}

--- a/combined/cmd/root_test.go
+++ b/combined/cmd/root_test.go
@@ -29,6 +29,10 @@ server:
 `
 	require.NoError(t, os.WriteFile(cfgFile, []byte(yamlContent), 0o600))
 
+	// initializeConfig writes the activity-store env vars; register them here so the
+	// test restores the process environment on exit instead of leaking into siblings.
+	t.Setenv("NB_ACTIVITY_EVENT_STORE_ENGINE", "")
+	t.Setenv("NB_ACTIVITY_EVENT_SQLITE_FILE", "")
 	t.Setenv("NB_ACTIVITY_EVENT_POSTGRES_DSN", "postgres://user:pass@localhost:5432/activity")
 
 	oldConfigPath := configPath
@@ -60,6 +64,9 @@ server:
     engine: postgres
 `
 	require.NoError(t, os.WriteFile(cfgFile, []byte(yamlContent), 0o600))
+
+	t.Setenv("NB_ACTIVITY_EVENT_STORE_ENGINE", "")
+	t.Setenv("NB_ACTIVITY_EVENT_SQLITE_FILE", "")
 
 	oldConfigPath := configPath
 	oldConfig := config


### PR DESCRIPTION
## Summary
- `initializeConfig()` rejected `server.activityStore.engine: postgres` whenever `server.activityStore.dsn` was empty in `config.yaml`, even though the store layer (`management/server/activity/store/sql_store.go`) already reads `NB_ACTIVITY_EVENT_POSTGRES_DSN` as a fallback.
- This blocked env-only / Kubernetes-style deployments (secrets via env, not on-disk config) from configuring the activity store on postgres.
- Fix: the eager check in `combined/cmd/root.go` now also accepts the DSN via `NB_ACTIVITY_EVENT_POSTGRES_DSN` before failing.

Fixes #5976.

## Test plan
- [x] Added a red/green unit test (`combined/cmd/root_test.go`) reproducing the exact reported error, now passing after the fix
- [x] `go test ./combined/cmd/...` passes
- [x] `golangci-lint run ./combined/cmd/...` clean
- [x] `gofmt` clean

## Note for maintainers
While investigating this, I found the same class of problem is worse for `authStore` (embedded IdP storage): `combined/cmd/config.go:576` requires `authStore.dsn` in `config.yaml` with **no environment variable fallback at all** anywhere in the codebase (unlike activityStore/main store). Kept out of scope here since it's a separate code path; happy to open a follow-up issue/PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PostgreSQL activity storage configuration validation: when `server.activityStore.engine` is set to `postgres` and the DSN is missing, the required DSN is now taken from the `NB_ACTIVITY_EVENT_POSTGRES_DSN` environment variable.
  * Improved the error message when the PostgreSQL DSN is not provided.
* **Tests**
  * Added regression tests covering successful DSN loading from the environment variable and failure when the environment variable is unset or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->