### PR TITLE
[management] Trim trailing slash from Keycloak AdminEndpoint

### DIFF
--- a/management/server/idp/keycloak.go
+++ b/management/server/idp/keycloak.go
@@ -97,7 +97,7 @@ func NewKeycloakManager(config KeycloakClientConfig, appMetrics telemetry.AppMet
 	}
 
 	return &KeycloakManager{
-		adminEndpoint: config.AdminEndpoint,
+		adminEndpoint: strings.TrimRight(config.AdminEndpoint, "/"),
 		httpClient:    httpClient,
 		credentials:   credentials,
 		helper:        helper,

--- a/management/server/idp/keycloak_url_test.go
+++ b/management/server/idp/keycloak_url_test.go
@@ -1,0 +1,66 @@
+package idp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/management/server/telemetry"
+)
+
+type mockKeycloakCredentials struct {
+	token JWTToken
+	err   error
+}
+
+func (m *mockKeycloakCredentials) Authenticate(_ context.Context) (JWTToken, error) {
+	return m.token, m.err
+}
+
+// capturingHTTPClient records the URL of every request it receives and
+// answers with a fixed status/body, without making a real network call.
+type capturingHTTPClient struct {
+	code       int
+	resBody    string
+	requestURL string
+}
+
+func (c *capturingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.requestURL = req.URL.String()
+	return &http.Response{
+		StatusCode: c.code,
+		Body:       io.NopCloser(strings.NewReader(c.resBody)),
+	}, nil
+}
+
+// TestKeycloakManager_AdminEndpointTrailingSlash reproduces netbirdio/netbird#4979:
+// a trailing slash in the configured AdminEndpoint (e.g. because the realm name
+// requires special handling, or simply an operator convention) produces a
+// double slash in admin API request paths such as
+// ".../admin/realms/<realm>//users/count". Keycloak >= 26.4.3 requires
+// normalised paths and rejects the double slash with a 400, breaking
+// authentication entirely.
+func TestKeycloakManager_AdminEndpointTrailingSlash(t *testing.T) {
+	km, err := NewKeycloakManager(KeycloakClientConfig{
+		ClientID:      "client_id",
+		ClientSecret:  "client_secret",
+		AdminEndpoint: "https://id.example.com/admin/realms/test123/",
+		TokenEndpoint: "https://id.example.com/realms/test123/protocol/openid-connect/token",
+		GrantType:     "client_credentials",
+	}, &telemetry.MockAppMetrics{})
+	require.NoError(t, err)
+
+	httpClient := &capturingHTTPClient{code: http.StatusOK, resBody: "3"}
+	km.httpClient = httpClient
+	km.credentials = &mockKeycloakCredentials{token: JWTToken{AccessToken: "token"}}
+
+	_, err = km.totalUsersCount(context.Background())
+	require.NoError(t, err)
+
+	require.NotContains(t, httpClient.requestURL, "//users",
+		"admin endpoint with a trailing slash must not produce a double slash in the request path: got %s", httpClient.requestURL)
+}


### PR DESCRIPTION
## Summary
- A trailing slash in the configured Keycloak `AdminEndpoint` produced a double slash in admin API request paths, e.g. `https://<host>/admin/realms/<realm>//users/count?`.
- Keycloak >= 26.4.3 requires normalised admin API request paths and rejects the double slash with a 400, which breaks dashboard login and VPN client authentication entirely (see #4979).
- Root cause: `management/server/idp/keycloak.go` builds request URLs with `fmt.Sprintf("%s/%s", km.adminEndpoint, resource)` in two call sites (`get`, `DeleteUser`); if the configured endpoint already ends in `/`, this yields `//`.
- Fix: normalize once at construction time in `NewKeycloakManager` (`strings.TrimRight(config.AdminEndpoint, "/")`) instead of patching every call site individually.

Fixes #4979.

## Test plan
- [x] Added `TestKeycloakManager_AdminEndpointTrailingSlash` (red before the fix, green after) asserting the built request URL never contains `//users` when `AdminEndpoint` has a trailing slash
- [x] `go test ./management/server/idp/...` passes (full package, no regressions)
- [x] `golangci-lint run ./management/server/idp/...` clean
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where admin API requests could be built with an extra slash when the server URL ended in `/`.
  * Improved URL handling so management calls use a normalized base path and avoid malformed requests.
* **Tests**
  * Added coverage for admin endpoint URLs with trailing slashes to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->