### PR TITLE
fix(management): refresh user name/email from ID-token claims on login

### DIFF
--- a/management/server/user.go
+++ b/management/server/user.go
@@ -234,6 +234,19 @@ func (am *DefaultAccountManager) GetUserFromUserAuth(ctx context.Context, userAu
 		return nil, err
 	}
 
+	// Refresh name/email from ID-token claims on each login (parity with JWT group sync)
+	if (userAuth.Name != "" && user.Name != userAuth.Name) || (userAuth.Email != "" && user.Email != userAuth.Email) {
+		if userAuth.Name != "" {
+			user.Name = userAuth.Name
+		}
+		if userAuth.Email != "" {
+			user.Email = userAuth.Email
+		}
+		if err := am.Store.SaveUser(ctx, user); err != nil {
+			log.WithContext(ctx).Debugf("failed to update user name/email: %v", err)
+		}
+	}
+
 	// this code should be outside of the am.GetAccountIDFromToken(claims) because this method is called also by the gRPC
 	// server when user authenticates a device. And we need to separate the Dashboard login event from the Device login event.
 	newLogin := user.LastDashboardLoginChanged(userAuth.LastLogin)

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -235,6 +235,7 @@ func (am *DefaultAccountManager) GetUserFromUserAuth(ctx context.Context, userAu
 	}
 
 	// Refresh name/email from ID-token claims on each login (parity with JWT group sync)
+	origName, origEmail := user.Name, user.Email
 	if (userAuth.Name != "" && user.Name != userAuth.Name) || (userAuth.Email != "" && user.Email != userAuth.Email) {
 		if userAuth.Name != "" {
 			user.Name = userAuth.Name
@@ -243,6 +244,7 @@ func (am *DefaultAccountManager) GetUserFromUserAuth(ctx context.Context, userAu
 			user.Email = userAuth.Email
 		}
 		if err := am.Store.SaveUser(ctx, user); err != nil {
+			user.Name, user.Email = origName, origEmail
 			log.WithContext(ctx).Debugf("failed to update user name/email: %v", err)
 		}
 	}


### PR DESCRIPTION
### Problem
On subsequent logins, `GetUserFromUserAuth` only updates `last_login` but never refreshes `name`/`email` from the ID-token claims. Users created by older versions keep empty name/email forever, and those running with `IdpManagerConfig.ManagerType: "none"` also see blank fields.

### Fix
After retrieving the user, check if `userAuth.Name` or `userAuth.Email` differ from stored values (and are non-empty). If so, update and save — mirroring the existing JWT group sync (`JWTGroupsClaimName`) pattern.

### Scope
- 1 file: `management/server/user.go`
- +13 lines
- No new dependencies
- No config changes
- No IdP API calls
- No SCIM/license needed

Fixes #6652
Related #2073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * During login, the app now refreshes the stored user profile details (name and/or email) from the latest authentication token claims when available.
  * If updating those saved details fails, login still succeeds and the sign-in flow remains reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->