### PR TITLE
[client] fix MDM managementURL conflict on default-port URL echo

### DIFF
--- a/client/server/mdm.go
+++ b/client/server/mdm.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -181,6 +182,37 @@ func conflictBool(key string, p *bool) conflictCheck {
 	}
 }
 
+func canonicalURL(s string) string {
+	u, err := url.ParseRequestURI(s)
+	if err != nil {
+		return s
+	}
+	if u.Port() == "" {
+		switch u.Scheme {
+		case "https":
+			u.Host += ":443"
+		case "http":
+			u.Host += ":80"
+		}
+	}
+	return u.String()
+}
+
+// conflictURL is conflictString for URL-typed keys: both sides are
+// normalized via canonicalURL before comparison.
+func conflictURL(key, got string) conflictCheck {
+	return conflictCheck{
+		key: key,
+		check: func(pol *mdm.Policy) bool {
+			if got == "" {
+				return true
+			}
+			want, ok := pol.GetString(key)
+			return ok && canonicalURL(want) == canonicalURL(got)
+		},
+	}
+}
+
 // conflictString builds a conflictCheck for a string MDM key. An empty
 // `got` is treated as "field not set" (no override requested); otherwise
 // the check returns true only when the policy contains the key and its
@@ -256,7 +288,7 @@ func mdmManagedFieldConflicts(msg *proto.SetConfigRequest, policy *mdm.Policy) [
 	}
 
 	return resolveConflicts(policy, []conflictCheck{
-		conflictString(mdm.KeyManagementURL, msg.ManagementUrl),
+		conflictURL(mdm.KeyManagementURL, msg.ManagementUrl),
 		conflictString(mdm.KeyPreSharedKey, pskGot),
 		conflictBool(mdm.KeyRosenpassEnabled, msg.RosenpassEnabled),
 		conflictBool(mdm.KeyRosenpassPermissive, msg.RosenpassPermissive),
@@ -377,7 +409,7 @@ func loginRequestMDMConflicts(msg *proto.LoginRequest, policy *mdm.Policy) []str
 	}
 
 	return resolveConflicts(policy, []conflictCheck{
-		conflictString(mdm.KeyManagementURL, msg.ManagementUrl),
+		conflictURL(mdm.KeyManagementURL, msg.ManagementUrl),
 		conflictString(mdm.KeyPreSharedKey, pskGot),
 		conflictBool(mdm.KeyRosenpassEnabled, msg.RosenpassEnabled),
 		conflictBool(mdm.KeyRosenpassPermissive, msg.RosenpassPermissive),

--- a/client/server/setconfig_mdm_test.go
+++ b/client/server/setconfig_mdm_test.go
@@ -181,6 +181,53 @@ func TestSetConfig_MDMAllow_NonManagedFields(t *testing.T) {
 	require.NotNil(t, resp)
 }
 
+// TestSetConfig_MDMAllow_ManagementURLPortNormalized reproduces the
+// regression reported in discussion #6483: an Intune-pushed
+// ManagementURL without an explicit port trips the MDM conflict gate
+// when the UI echoes the parsed URL back — profilemanager.parseURL
+// auto-appends ":443" for https (and ":80" for http), so the config
+// on disk (and thus the GetConfig response the UI echoes) always
+// carries the default port even when the MDM registry / plist value
+// did not. A no-port MDM URL and a default-port UI echo of the same
+// host are semantically identical; the conflict check must normalize
+// both sides before comparing or every settings save from an
+// MDM-enrolled host is falsely rejected as "managementURL managed by MDM".
+func TestSetConfig_MDMAllow_ManagementURLPortNormalized(t *testing.T) {
+	tests := []struct {
+		name      string
+		mdmURL    string
+		submitURL string
+	}{
+		{"policy_no_port_submit_with_443", "https://netbird.corp.example", "https://netbird.corp.example:443"},
+		{"policy_with_443_submit_no_port", "https://netbird.corp.example:443", "https://netbird.corp.example"},
+		{"http_policy_no_port_submit_with_80", "http://netbird.corp.example", "http://netbird.corp.example:80"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withMDMPolicy(t, mdm.NewPolicy(map[string]any{
+				mdm.KeyManagementURL: tc.mdmURL,
+			}))
+
+			s, ctx, profName, username, _ := setupServerWithProfile(t)
+
+			// Toggle an unrelated non-MDM-managed field so the request
+			// exercises the "user saved settings in the UI" flow. The
+			// ManagementUrl echo must not trip the conflict gate.
+			rosenpassEnabled := true
+			resp, err := s.SetConfig(ctx, &proto.SetConfigRequest{
+				ProfileName:      profName,
+				Username:         username,
+				ManagementUrl:    tc.submitURL,
+				RosenpassEnabled: &rosenpassEnabled,
+			})
+
+			require.NoError(t, err, "port-normalized URL echo must not trip MDM conflict gate")
+			require.NotNil(t, resp)
+		})
+	}
+}
+
 func TestSetConfig_MDMEmpty_NoEnforcement(t *testing.T) {
 	// No MDM policy active: any field can be written.
 	withMDMPolicy(t, mdm.NewPolicy(nil))

--- a/client/server/setconfig_mdm_test.go
+++ b/client/server/setconfig_mdm_test.go
@@ -181,17 +181,10 @@ func TestSetConfig_MDMAllow_NonManagedFields(t *testing.T) {
 	require.NotNil(t, resp)
 }
 
-// TestSetConfig_MDMAllow_ManagementURLPortNormalized reproduces the
-// regression reported in discussion #6483: an Intune-pushed
-// ManagementURL without an explicit port trips the MDM conflict gate
-// when the UI echoes the parsed URL back — profilemanager.parseURL
-// auto-appends ":443" for https (and ":80" for http), so the config
-// on disk (and thus the GetConfig response the UI echoes) always
-// carries the default port even when the MDM registry / plist value
-// did not. A no-port MDM URL and a default-port UI echo of the same
-// host are semantically identical; the conflict check must normalize
-// both sides before comparing or every settings save from an
-// MDM-enrolled host is falsely rejected as "managementURL managed by MDM".
+// TestSetConfig_MDMAllow_ManagementURLPortNormalized covers the
+// regression from discussion #6483: MDM URL without explicit port vs
+// UI echo with the parseURL-appended default port must be treated as
+// a no-op echo, not a conflict.
 func TestSetConfig_MDMAllow_ManagementURLPortNormalized(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -211,9 +204,6 @@ func TestSetConfig_MDMAllow_ManagementURLPortNormalized(t *testing.T) {
 
 			s, ctx, profName, username, _ := setupServerWithProfile(t)
 
-			// Toggle an unrelated non-MDM-managed field so the request
-			// exercises the "user saved settings in the UI" flow. The
-			// ManagementUrl echo must not trip the conflict gate.
 			rosenpassEnabled := true
 			resp, err := s.SetConfig(ctx, &proto.SetConfigRequest{
 				ProfileName:      profName,


### PR DESCRIPTION
## Describe your changes

Fix MDM `managementURL` conflict false-positive on every settings save
from an MDM-enrolled host. `profilemanager.parseURL` auto-appends `:443`
(or `:80`) to the on-disk config URL, so any later SetConfig / Login report a divergent value.

## Issue ticket number and link

Reported by @KiskaLE on Intune-managed Windows 11 in
https://github.com/netbirdio/netbird/discussions/6483.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal MDM conflict-check normalization. No change to the public CLI,
API, MDM key surface, or documented URL syntax.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Managed MDM URL settings now normalize default ports, preventing false conflict errors when values differ only by implicit vs explicit ports (for example, `https://example` vs `https://example:443`).
  * Configuration saving is more reliable when an enforced URL and the displayed URL vary only by default-port formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->