### PR TITLE
[relay] add transport label to peer activity and transfer metrics

### DIFF
--- a/relay/metrics/realy.go
+++ b/relay/metrics/realy.go
@@ -182,12 +182,18 @@ func (m *Metrics) PeerActivity(peerID string) {
 }
 
 // calculateActiveIdleConnections returns the number of active and idle peers grouped by transport.
+// Every transport with at least one connected peer appears in both maps (0 where a bucket is empty)
+// so per-transport gauge series report 0 instead of disappearing when a bucket empties.
 func (m *Metrics) calculateActiveIdleConnections() (active, idle map[string]int64) {
 	active, idle = make(map[string]int64), make(map[string]int64)
 	m.mutexActivity.Lock()
 	defer m.mutexActivity.Unlock()
 
 	for _, peer := range m.peerLastActive {
+		if _, ok := active[peer.transport]; !ok {
+			active[peer.transport] = 0
+			idle[peer.transport] = 0
+		}
 		if time.Since(peer.lastActive) > idleTimeout {
 			idle[peer.transport]++
 		} else {

--- a/relay/metrics/realy.go
+++ b/relay/metrics/realy.go
@@ -14,17 +14,23 @@ const (
 	idleTimeout = 30 * time.Second
 )
 
+// peerActivity tracks a connected peer's transport and the time it was last active.
+type peerActivity struct {
+	transport  string
+	lastActive time.Time
+}
+
 type Metrics struct {
 	metric.Meter
 
-	TransferBytesSent  metric.Int64Counter
-	TransferBytesRecv  metric.Int64Counter
+	transferBytesSent  metric.Int64Counter
+	transferBytesRecv  metric.Int64Counter
 	AuthenticationTime metric.Float64Histogram
 	PeerStoreTime      metric.Float64Histogram
 	peerReconnections  metric.Int64Counter
 	peers              metric.Int64UpDownCounter
 	peerActivityChan   chan string
-	peerLastActive     map[string]time.Time
+	peerLastActive     map[string]peerActivity
 	mutexActivity      sync.Mutex
 	ctx                context.Context
 }
@@ -90,8 +96,8 @@ func NewMetrics(ctx context.Context, meter metric.Meter) (*Metrics, error) {
 
 	m := &Metrics{
 		Meter:              meter,
-		TransferBytesSent:  bytesSent,
-		TransferBytesRecv:  bytesRecv,
+		transferBytesSent:  bytesSent,
+		transferBytesRecv:  bytesRecv,
 		AuthenticationTime: authTime,
 		PeerStoreTime:      peerStoreTime,
 		peers:              peers,
@@ -99,14 +105,18 @@ func NewMetrics(ctx context.Context, meter metric.Meter) (*Metrics, error) {
 
 		ctx:              ctx,
 		peerActivityChan: make(chan string, 10),
-		peerLastActive:   make(map[string]time.Time),
+		peerLastActive:   make(map[string]peerActivity),
 	}
 
 	_, err = meter.RegisterCallback(
 		func(ctx context.Context, o metric.Observer) error {
 			active, idle := m.calculateActiveIdleConnections()
-			o.ObserveInt64(peersActive, active)
-			o.ObserveInt64(peersIdle, idle)
+			for transport, count := range active {
+				o.ObserveInt64(peersActive, count, metric.WithAttributes(attribute.String("transport", transport)))
+			}
+			for transport, count := range idle {
+				o.ObserveInt64(peersIdle, count, metric.WithAttributes(attribute.String("transport", transport)))
+			}
 			return nil
 		},
 		peersActive, peersIdle,
@@ -125,7 +135,18 @@ func (m *Metrics) PeerConnected(id, transport string) {
 	m.mutexActivity.Lock()
 	defer m.mutexActivity.Unlock()
 
-	m.peerLastActive[id] = time.Time{}
+	// zero lastActive keeps the peer counted as idle until it relays its first message
+	m.peerLastActive[id] = peerActivity{transport: transport}
+}
+
+// RecordBytesSent records the number of bytes relayed out to a peer over the given transport.
+func (m *Metrics) RecordBytesSent(transport string, n int) {
+	m.transferBytesSent.Add(m.ctx, int64(n), metric.WithAttributes(attribute.String("transport", transport)))
+}
+
+// RecordBytesRecv records the number of bytes received from a peer over the given transport.
+func (m *Metrics) RecordBytesRecv(transport string, n int) {
+	m.transferBytesRecv.Add(m.ctx, int64(n), metric.WithAttributes(attribute.String("transport", transport)))
 }
 
 // RecordAuthenticationTime measures the time taken for peer authentication
@@ -160,16 +181,17 @@ func (m *Metrics) PeerActivity(peerID string) {
 	}
 }
 
-func (m *Metrics) calculateActiveIdleConnections() (int64, int64) {
-	active, idle := int64(0), int64(0)
+// calculateActiveIdleConnections returns the number of active and idle peers grouped by transport.
+func (m *Metrics) calculateActiveIdleConnections() (active, idle map[string]int64) {
+	active, idle = make(map[string]int64), make(map[string]int64)
 	m.mutexActivity.Lock()
 	defer m.mutexActivity.Unlock()
 
-	for _, lastActive := range m.peerLastActive {
-		if time.Since(lastActive) > idleTimeout {
-			idle++
+	for _, peer := range m.peerLastActive {
+		if time.Since(peer.lastActive) > idleTimeout {
+			idle[peer.transport]++
 		} else {
-			active++
+			active[peer.transport]++
 		}
 	}
 	return active, idle
@@ -180,7 +202,11 @@ func (m *Metrics) readPeerActivity() {
 		select {
 		case peerID := <-m.peerActivityChan:
 			m.mutexActivity.Lock()
-			m.peerLastActive[peerID] = time.Now()
+			// only refresh known peers; a late activity event must not resurrect a disconnected peer
+			if peer, ok := m.peerLastActive[peerID]; ok {
+				peer.lastActive = time.Now()
+				m.peerLastActive[peerID] = peer
+			}
 			m.mutexActivity.Unlock()
 		case <-m.ctx.Done():
 			return

--- a/relay/metrics/realy.go
+++ b/relay/metrics/realy.go
@@ -31,6 +31,7 @@ type Metrics struct {
 	peers              metric.Int64UpDownCounter
 	peerActivityChan   chan string
 	peerLastActive     map[string]peerActivity
+	seenTransports     map[string]struct{}
 	mutexActivity      sync.Mutex
 	ctx                context.Context
 }
@@ -106,6 +107,7 @@ func NewMetrics(ctx context.Context, meter metric.Meter) (*Metrics, error) {
 		ctx:              ctx,
 		peerActivityChan: make(chan string, 10),
 		peerLastActive:   make(map[string]peerActivity),
+		seenTransports:   make(map[string]struct{}),
 	}
 
 	_, err = meter.RegisterCallback(
@@ -137,6 +139,7 @@ func (m *Metrics) PeerConnected(id, transport string) {
 
 	// zero lastActive keeps the peer counted as idle until it relays its first message
 	m.peerLastActive[id] = peerActivity{transport: transport}
+	m.seenTransports[transport] = struct{}{}
 }
 
 // RecordBytesSent records the number of bytes relayed out to a peer over the given transport.
@@ -182,18 +185,20 @@ func (m *Metrics) PeerActivity(peerID string) {
 }
 
 // calculateActiveIdleConnections returns the number of active and idle peers grouped by transport.
-// Every transport with at least one connected peer appears in both maps (0 where a bucket is empty)
-// so per-transport gauge series report 0 instead of disappearing when a bucket empties.
+// Every transport the relay has served keeps a 0-valued entry in both maps, so the gauges keep
+// reporting 0 rather than disappearing when a bucket - or the whole relay - has no peers. This
+// preserves the pre-label behaviour where the scalar gauges were always observed, even at zero.
 func (m *Metrics) calculateActiveIdleConnections() (active, idle map[string]int64) {
 	active, idle = make(map[string]int64), make(map[string]int64)
 	m.mutexActivity.Lock()
 	defer m.mutexActivity.Unlock()
 
+	for transport := range m.seenTransports {
+		active[transport] = 0
+		idle[transport] = 0
+	}
+
 	for _, peer := range m.peerLastActive {
-		if _, ok := active[peer.transport]; !ok {
-			active[peer.transport] = 0
-			idle[peer.transport] = 0
-		}
 		if time.Since(peer.lastActive) > idleTimeout {
 			idle[peer.transport]++
 		} else {

--- a/relay/metrics/realy.go
+++ b/relay/metrics/realy.go
@@ -212,16 +212,21 @@ func (m *Metrics) readPeerActivity() {
 	for {
 		select {
 		case peerID := <-m.peerActivityChan:
-			m.mutexActivity.Lock()
-			// only refresh known peers; a late activity event must not resurrect a disconnected peer
-			if peer, ok := m.peerLastActive[peerID]; ok {
-				peer.lastActive = time.Now()
-				m.peerLastActive[peerID] = peer
-			}
-			m.mutexActivity.Unlock()
+			m.refreshActivity(peerID)
 		case <-m.ctx.Done():
 			return
 		}
+	}
+}
+
+// refreshActivity updates the last-active time of a connected peer. A late event for a peer that has
+// already disconnected is ignored, so it cannot resurrect the peer in the activity map.
+func (m *Metrics) refreshActivity(peerID string) {
+	m.mutexActivity.Lock()
+	defer m.mutexActivity.Unlock()
+	if peer, ok := m.peerLastActive[peerID]; ok {
+		peer.lastActive = time.Now()
+		m.peerLastActive[peerID] = peer
 	}
 }
 

--- a/relay/metrics/realy.go
+++ b/relay/metrics/realy.go
@@ -131,6 +131,15 @@ func NewMetrics(ctx context.Context, meter metric.Meter) (*Metrics, error) {
 	return m, nil
 }
 
+// RegisterTransport records a transport the relay serves so its active/idle gauges report 0 from
+// startup - even before any peer connects - matching the pre-label behaviour where the scalar gauges
+// were always observed.
+func (m *Metrics) RegisterTransport(transport string) {
+	m.mutexActivity.Lock()
+	defer m.mutexActivity.Unlock()
+	m.seenTransports[transport] = struct{}{}
+}
+
 // PeerConnected increments the number of connected peers and increments number of idle connections
 func (m *Metrics) PeerConnected(id, transport string) {
 	m.peers.Add(m.ctx, 1, metric.WithAttributes(attribute.String("transport", transport)))

--- a/relay/metrics/realy_test.go
+++ b/relay/metrics/realy_test.go
@@ -1,0 +1,110 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestCalculateActiveIdleConnections(t *testing.T) {
+	now := time.Now()
+	m := &Metrics{
+		peerLastActive: map[string]peerActivity{
+			"ws-active-1":   {transport: "ws", lastActive: now},
+			"ws-active-2":   {transport: "ws", lastActive: now.Add(-idleTimeout / 2)},
+			"ws-idle-1":     {transport: "ws", lastActive: now.Add(-2 * idleTimeout)},
+			"quic-active":   {transport: "quic", lastActive: now},
+			"quic-idle-1":   {transport: "quic", lastActive: now.Add(-2 * idleTimeout)},
+			"quic-idle-new": {transport: "quic", lastActive: time.Time{}}, // just connected, no activity yet
+		},
+	}
+
+	active, idle := m.calculateActiveIdleConnections()
+
+	assertCount(t, "active", active, map[string]int64{"ws": 2, "quic": 1})
+	assertCount(t, "idle", idle, map[string]int64{"ws": 1, "quic": 2})
+}
+
+// TestTransportLabels verifies every relay peer/transfer metric is exported with a transport attribute.
+func TestTransportLabels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := provider.Meter("github.com/netbirdio/netbird/relay/metrics")
+
+	m, err := NewMetrics(ctx, meter)
+	if err != nil {
+		t.Fatalf("NewMetrics: %v", err)
+	}
+
+	m.PeerConnected("peer-ws", "ws")
+	m.PeerConnected("peer-quic", "quic")
+	m.RecordBytesSent("quic", 100)
+	m.RecordBytesRecv("ws", 40)
+
+	// make peer-ws count as active; peer-quic keeps its zero lastActive and stays idle
+	m.mutexActivity.Lock()
+	m.peerLastActive["peer-ws"] = peerActivity{transport: "ws", lastActive: time.Now()}
+	m.mutexActivity.Unlock()
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	assertCount(t, "relay_peers", byTransport(t, rm, "relay_peers"), map[string]int64{"ws": 1, "quic": 1})
+	assertCount(t, "relay_peers_active", byTransport(t, rm, "relay_peers_active"), map[string]int64{"ws": 1})
+	assertCount(t, "relay_peers_idle", byTransport(t, rm, "relay_peers_idle"), map[string]int64{"quic": 1})
+	assertCount(t, "relay_transfer_sent_bytes_total", byTransport(t, rm, "relay_transfer_sent_bytes_total"), map[string]int64{"quic": 100})
+	assertCount(t, "relay_transfer_received_bytes_total", byTransport(t, rm, "relay_transfer_received_bytes_total"), map[string]int64{"ws": 40})
+}
+
+func assertCount(t *testing.T, name string, got, want map[string]int64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s: got %v, want %v", name, got, want)
+		return
+	}
+	for transport, count := range want {
+		if got[transport] != count {
+			t.Errorf("%s[%s]: got %d, want %d", name, transport, got[transport], count)
+		}
+	}
+}
+
+// byTransport returns the value of each data point of the named metric keyed by its transport attribute.
+func byTransport(t *testing.T, rm metricdata.ResourceMetrics, name string) map[string]int64 {
+	t.Helper()
+	out := make(map[string]int64)
+	for _, sm := range rm.ScopeMetrics {
+		for _, mm := range sm.Metrics {
+			if mm.Name != name {
+				continue
+			}
+			switch data := mm.Data.(type) {
+			case metricdata.Sum[int64]:
+				for _, dp := range data.DataPoints {
+					out[transportAttr(dp.Attributes)] = dp.Value
+				}
+			case metricdata.Gauge[int64]:
+				for _, dp := range data.DataPoints {
+					out[transportAttr(dp.Attributes)] = dp.Value
+				}
+			default:
+				t.Fatalf("%s: unexpected data type %T", name, mm.Data)
+			}
+		}
+	}
+	return out
+}
+
+func transportAttr(set attribute.Set) string {
+	v, _ := set.Value(attribute.Key("transport"))
+	return v.AsString()
+}

--- a/relay/metrics/realy_test.go
+++ b/relay/metrics/realy_test.go
@@ -29,6 +29,22 @@ func TestCalculateActiveIdleConnections(t *testing.T) {
 	assertCount(t, "idle", idle, map[string]int64{"ws": 1, "quic": 2})
 }
 
+// TestCalculateActiveIdleConnectionsZeroValuedSeries checks that a transport whose peers are all in
+// one state still reports a 0 in the other state, so its gauge series does not disappear.
+func TestCalculateActiveIdleConnectionsZeroValuedSeries(t *testing.T) {
+	m := &Metrics{
+		peerLastActive: map[string]peerActivity{
+			"ws-active": {transport: "ws", lastActive: time.Now()},    // ws: only active
+			"quic-idle": {transport: "quic", lastActive: time.Time{}}, // quic: only idle
+		},
+	}
+
+	active, idle := m.calculateActiveIdleConnections()
+
+	assertCount(t, "active", active, map[string]int64{"ws": 1, "quic": 0})
+	assertCount(t, "idle", idle, map[string]int64{"ws": 0, "quic": 1})
+}
+
 // TestTransportLabels verifies every relay peer/transfer metric is exported with a transport attribute.
 func TestTransportLabels(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -59,8 +75,9 @@ func TestTransportLabels(t *testing.T) {
 	}
 
 	assertCount(t, "relay_peers", byTransport(t, rm, "relay_peers"), map[string]int64{"ws": 1, "quic": 1})
-	assertCount(t, "relay_peers_active", byTransport(t, rm, "relay_peers_active"), map[string]int64{"ws": 1})
-	assertCount(t, "relay_peers_idle", byTransport(t, rm, "relay_peers_idle"), map[string]int64{"quic": 1})
+	// both transports are present in both gauges; the empty buckets report 0 rather than vanishing
+	assertCount(t, "relay_peers_active", byTransport(t, rm, "relay_peers_active"), map[string]int64{"ws": 1, "quic": 0})
+	assertCount(t, "relay_peers_idle", byTransport(t, rm, "relay_peers_idle"), map[string]int64{"ws": 0, "quic": 1})
 	assertCount(t, "relay_transfer_sent_bytes_total", byTransport(t, rm, "relay_transfer_sent_bytes_total"), map[string]int64{"quic": 100})
 	assertCount(t, "relay_transfer_received_bytes_total", byTransport(t, rm, "relay_transfer_received_bytes_total"), map[string]int64{"ws": 40})
 }

--- a/relay/metrics/realy_test.go
+++ b/relay/metrics/realy_test.go
@@ -13,6 +13,7 @@ import (
 func TestCalculateActiveIdleConnections(t *testing.T) {
 	now := time.Now()
 	m := &Metrics{
+		seenTransports: map[string]struct{}{"ws": {}, "quic": {}},
 		peerLastActive: map[string]peerActivity{
 			"ws-active-1":   {transport: "ws", lastActive: now},
 			"ws-active-2":   {transport: "ws", lastActive: now.Add(-idleTimeout / 2)},
@@ -33,6 +34,7 @@ func TestCalculateActiveIdleConnections(t *testing.T) {
 // one state still reports a 0 in the other state, so its gauge series does not disappear.
 func TestCalculateActiveIdleConnectionsZeroValuedSeries(t *testing.T) {
 	m := &Metrics{
+		seenTransports: map[string]struct{}{"ws": {}, "quic": {}},
 		peerLastActive: map[string]peerActivity{
 			"ws-active": {transport: "ws", lastActive: time.Now()},    // ws: only active
 			"quic-idle": {transport: "quic", lastActive: time.Time{}}, // quic: only idle
@@ -43,6 +45,32 @@ func TestCalculateActiveIdleConnectionsZeroValuedSeries(t *testing.T) {
 
 	assertCount(t, "active", active, map[string]int64{"ws": 1, "quic": 0})
 	assertCount(t, "idle", idle, map[string]int64{"ws": 0, "quic": 1})
+}
+
+// TestActiveIdleSeriesPersistWithoutPeers verifies that once a transport has been served, its
+// active/idle gauges keep reporting 0 after every peer disconnects, instead of the series vanishing.
+func TestActiveIdleSeriesPersistWithoutPeers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	m, err := NewMetrics(ctx, provider.Meter("github.com/netbirdio/netbird/relay/metrics"))
+	if err != nil {
+		t.Fatalf("NewMetrics: %v", err)
+	}
+
+	m.PeerConnected("peer-ws", "ws")
+	m.PeerDisconnected("peer-ws", "ws") // relay is now empty, but ws has been served
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	assertCount(t, "relay_peers_active", byTransport(t, rm, "relay_peers_active"), map[string]int64{"ws": 0})
+	assertCount(t, "relay_peers_idle", byTransport(t, rm, "relay_peers_idle"), map[string]int64{"ws": 0})
 }
 
 // TestTransportLabels verifies every relay peer/transfer metric is exported with a transport attribute.

--- a/relay/metrics/realy_test.go
+++ b/relay/metrics/realy_test.go
@@ -73,6 +73,31 @@ func TestActiveIdleSeriesPersistWithoutPeers(t *testing.T) {
 	assertCount(t, "relay_peers_idle", byTransport(t, rm, "relay_peers_idle"), map[string]int64{"ws": 0})
 }
 
+// TestRefreshActivityIgnoresDisconnectedPeer verifies a late activity event does not recreate a peer
+// that has already disconnected.
+func TestRefreshActivityIgnoresDisconnectedPeer(t *testing.T) {
+	m := &Metrics{
+		peerLastActive: map[string]peerActivity{
+			"live": {transport: "ws"},
+		},
+	}
+
+	// a known peer is refreshed
+	m.refreshActivity("live")
+	if m.peerLastActive["live"].lastActive.IsZero() {
+		t.Errorf("expected live peer to be refreshed, lastActive is still zero")
+	}
+
+	// a late event for an already disconnected peer must not recreate it
+	m.refreshActivity("gone")
+	if _, ok := m.peerLastActive["gone"]; ok {
+		t.Errorf("late activity resurrected a disconnected peer")
+	}
+	if len(m.peerLastActive) != 1 {
+		t.Errorf("unexpected peer count: got %d, want 1", len(m.peerLastActive))
+	}
+}
+
 // TestTransportLabels verifies every relay peer/transfer metric is exported with a transport attribute.
 func TestTransportLabels(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -112,13 +137,19 @@ func TestTransportLabels(t *testing.T) {
 
 func assertCount(t *testing.T, name string, got, want map[string]int64) {
 	t.Helper()
-	if len(got) != len(want) {
-		t.Errorf("%s: got %v, want %v", name, got, want)
-		return
-	}
 	for transport, count := range want {
-		if got[transport] != count {
-			t.Errorf("%s[%s]: got %d, want %d", name, transport, got[transport], count)
+		gotCount, ok := got[transport]
+		if !ok {
+			t.Errorf("%s: missing transport %q", name, transport)
+			continue
+		}
+		if gotCount != count {
+			t.Errorf("%s[%s]: got %d, want %d", name, transport, gotCount, count)
+		}
+	}
+	for transport, count := range got {
+		if _, ok := want[transport]; !ok {
+			t.Errorf("%s: unexpected transport %q (value %d)", name, transport, count)
 		}
 	}
 }

--- a/relay/metrics/realy_test.go
+++ b/relay/metrics/realy_test.go
@@ -73,6 +73,31 @@ func TestActiveIdleSeriesPersistWithoutPeers(t *testing.T) {
 	assertCount(t, "relay_peers_idle", byTransport(t, rm, "relay_peers_idle"), map[string]int64{"ws": 0})
 }
 
+// TestRegisterTransportReportsZeroFromStart verifies a registered transport reports 0 active/idle
+// peers from startup, before any peer has connected.
+func TestRegisterTransportReportsZeroFromStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	m, err := NewMetrics(ctx, provider.Meter("github.com/netbirdio/netbird/relay/metrics"))
+	if err != nil {
+		t.Fatalf("NewMetrics: %v", err)
+	}
+
+	m.RegisterTransport("ws") // relay serves ws, but no peer has connected yet
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	assertCount(t, "relay_peers_active", byTransport(t, rm, "relay_peers_active"), map[string]int64{"ws": 0})
+	assertCount(t, "relay_peers_idle", byTransport(t, rm, "relay_peers_idle"), map[string]int64{"ws": 0})
+}
+
 // TestRefreshActivityIgnoresDisconnectedPeer verifies a late activity event does not recreate a peer
 // that has already disconnected.
 func TestRefreshActivityIgnoresDisconnectedPeer(t *testing.T) {

--- a/relay/server/peer.go
+++ b/relay/server/peer.go
@@ -115,12 +115,17 @@ func (p *Peer) ID() messages.PeerID {
 	return p.id
 }
 
+// Transport returns the transport name of the peer connection (e.g. "ws", "quic").
+func (p *Peer) Transport() string {
+	return p.conn.Protocol()
+}
+
 func (p *Peer) handleMsgType(ctx context.Context, msgType messages.MsgType, hc *healthcheck.Sender, n int, msg []byte) {
 	switch msgType {
 	case messages.MsgTypeHealthCheck:
 		hc.OnHCResponse()
 	case messages.MsgTypeTransport:
-		p.metrics.TransferBytesRecv.Add(ctx, int64(n))
+		p.metrics.RecordBytesRecv(p.Transport(), n)
 		p.metrics.PeerActivity(p.String())
 		p.handleTransportMsg(msg)
 	case messages.MsgTypeClose:
@@ -231,7 +236,8 @@ func (p *Peer) handleTransportMsg(msg []byte) {
 		p.log.Errorf("failed to write transport message to: %s", dp.String())
 		return
 	}
-	p.metrics.TransferBytesSent.Add(p.ctx, int64(n))
+	// bytes are written to the destination peer's connection, so label with its transport
+	p.metrics.RecordBytesSent(dp.Transport(), n)
 }
 
 func (p *Peer) handleSubscribePeerState(msg []byte) {

--- a/relay/server/peer_test.go
+++ b/relay/server/peer_test.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+)
+
+// fakeConn is a minimal listener.Conn used to exercise transport-dependent Peer behavior.
+type fakeConn struct {
+	proto string
+}
+
+func (f fakeConn) Read(context.Context, []byte) (int, error)  { return 0, nil }
+func (f fakeConn) Write(context.Context, []byte) (int, error) { return 0, nil }
+func (f fakeConn) RemoteAddr() net.Addr                       { return nil }
+func (f fakeConn) Close() error                               { return nil }
+func (f fakeConn) Protocol() string                           { return f.proto }
+
+func TestPeerTransport(t *testing.T) {
+	for _, proto := range []string{"ws", "quic"} {
+		p := &Peer{conn: fakeConn{proto: proto}}
+		if got := p.Transport(); got != proto {
+			t.Errorf("Transport() = %q, want %q", got, proto)
+		}
+	}
+}

--- a/relay/server/server.go
+++ b/relay/server/server.go
@@ -88,6 +88,8 @@ func (r *Server) Listen(cfg ListenerConfig) error {
 	errChan := make(chan error, len(r.listeners))
 	wg := sync.WaitGroup{}
 	for _, l := range r.listeners {
+		// report the peer gauges for every served transport from startup, even before the first peer
+		r.relay.metrics.RegisterTransport(string(l.Protocol()))
 		wg.Add(1)
 		go func(listener Listener) {
 			defer wg.Done()


### PR DESCRIPTION
## Describe your changes

`relay_peers` is already exported with a `transport` label (`ws` / `quic`), but the other relay metrics are not, so operators can't break connection activity or throughput down by transport. This adds the `transport` label to the remaining relay peer/transfer metrics so they're consistent with `relay_peers`:

- `relay_peers_active`
- `relay_peers_idle`
- `relay_transfer_sent_bytes_total`
- `relay_transfer_received_bytes_total`

**Implementation notes**

- `relay_peers_active` / `relay_peers_idle` are observable gauges derived from an in-memory activity map that only stored each peer's last-active time. The map now also stores the peer's transport (captured at connect time in `PeerConnected`), and `calculateActiveIdleConnections` groups the counts by transport.
- For the transfer counters the label is applied at the connection the bytes actually cross: **received** bytes use the receiving peer's transport, and **relayed/sent** bytes use the **destination** peer's transport (the write target). So a WS→QUIC relayed packet is correctly attributed to `relay_transfer_received_bytes_total{transport="ws"}` and `relay_transfer_sent_bytes_total{transport="quic"}`.
- Minor behavior fix: a late `PeerActivity` event no longer re-inserts an already-disconnected peer into the activity map.
- The two transfer counters were made private and are now written through `RecordBytesSent` / `RecordBytesRecv` helpers (consistent with the existing `PeerConnected(id, transport)` style and the "use private where possible" guideline).

**Operator impact**

Adding a label splits each of these metrics into per-transport series. Dashboards/alerts that already aggregate (e.g. `sum(rate(relay_transfer_sent_bytes_total[...]))`) are unaffected; any that selected a single bare series will now see one series per transport. The bundled Grafana dashboard (`infrastructure_files/observability/grafana/dashboards/relay.json`) already renders `relay_peers` per-transport, so no dashboard changes are required.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature. The only surface touched is Prometheus/OTel metric labels, extending the `transport` label pattern already used by `relay_peers`.

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (it extends existing metric labels; there is no user-facing config, API, or CLI change)

### Docs PR URL (required if "docs added" is checked)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay metrics now label active and idle peer counts by connection transport.
  * Peer byte-transfer metrics are reported separately for each transport.
  * Peers expose their transport type for accurate reporting.
  * Transport metric series remain available with zero values after peers disconnect.

* **Bug Fixes**
  * Disconnected peers are no longer revived by later activity updates.
  * Newly connected peers remain idle until activity is recorded.

* **Tests**
  * Expanded coverage for transport-specific metrics and active/idle counting edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->