### PR TITLE
[client] Fix browser relay WebSocket close and raise RDP dial timeout

### DIFF
--- a/client/internal/conn_mgr.go
+++ b/client/internal/conn_mgr.go
@@ -109,7 +109,7 @@ func (e *ConnMgr) UpdatedRemoteFeatureFlag(ctx context.Context, enabled bool) er
 			return nil
 		}
 
-		log.Warnf("lazy connection manager is enabled by management feature flag")
+		log.Infof("lazy connection manager is enabled by the management feature flag")
 		e.initLazyManager(ctx)
 		e.statusRecorder.UpdateLazyConnection(true)
 		return e.addPeersToLazyConnManager()

--- a/client/internal/profilemanager/service.go
+++ b/client/internal/profilemanager/service.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"syscall"
 
 	log "github.com/sirupsen/logrus"
 
@@ -439,7 +440,11 @@ func (s *ServiceManager) GetStatePath() string {
 
 	activeProf, err := s.GetActiveProfileState()
 	if err != nil {
-		log.Warnf("failed to get active profile state: %v", err)
+		if errors.Is(err, syscall.ENOSYS) {
+			log.Debugf("active profile state unavailable on this platform: %v", err)
+		} else {
+			log.Warnf("failed to get active profile state: %v", err)
+		}
 		return defaultStatePath
 	}
 

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -264,7 +265,11 @@ func (m *DefaultManager) initSelector() *routeselector.RouteSelector {
 
 	// restore selector state if it exists
 	if err := m.stateManager.LoadState(state); err != nil {
-		log.Warnf("failed to load state: %v", err)
+		if errors.Is(err, syscall.ENOSYS) {
+			log.Debugf("route selector state unavailable on this platform: %v", err)
+		} else {
+			log.Warnf("failed to load state: %v", err)
+		}
 		return routeselector.NewRouteSelector()
 	}
 

--- a/client/wasm/internal/rdp/rdcleanpath.go
+++ b/client/wasm/internal/rdp/rdcleanpath.go
@@ -23,7 +23,7 @@ const (
 	RDCleanPathProxyHost   = "rdcleanpath.proxy.local"
 	RDCleanPathProxyScheme = "ws"
 
-	rdpDialTimeout = 15 * time.Second
+	rdpDialTimeout = 30 * time.Second
 
 	GeneralErrorCode = 1
 	WSAETimedOut     = 10060

--- a/shared/relay/client/dialer/ws/close_generic.go
+++ b/shared/relay/client/dialer/ws/close_generic.go
@@ -1,0 +1,9 @@
+//go:build !js
+
+package ws
+
+// closeConn closes the underlying WebSocket immediately, skipping the close
+// handshake.
+func (c *Conn) closeConn() error {
+	return c.Conn.CloseNow()
+}

--- a/shared/relay/client/dialer/ws/close_js.go
+++ b/shared/relay/client/dialer/ws/close_js.go
@@ -1,0 +1,25 @@
+//go:build js
+
+package ws
+
+import (
+	"github.com/coder/websocket"
+	log "github.com/sirupsen/logrus"
+)
+
+// closeConn closes the browser WebSocket without blocking the caller.
+//
+// The browser close API only accepts codes 1000 and 3000-4999, so CloseNow's
+// 1001 (going away) throws an InvalidAccessError. Close with a valid code
+// waits for the browser close event before returning, which can park the
+// calling goroutine (the relay teardown path holds its mutexes while closing)
+// until the close handshake finishes. Run the close in the background and
+// report success; a teardown close error is not actionable.
+func (c *Conn) closeConn() error {
+	go func() {
+		if err := c.Conn.Close(websocket.StatusNormalClosure, ""); err != nil {
+			log.Debugf("failed to close relay websocket: %v", err)
+		}
+	}()
+	return nil
+}

--- a/shared/relay/client/dialer/ws/conn.go
+++ b/shared/relay/client/dialer/ws/conn.go
@@ -77,5 +77,5 @@ func (c *Conn) SetDeadline(t time.Time) error {
 }
 
 func (c *Conn) Close() error {
-	return c.Conn.CloseNow()
+	return c.closeConn()
 }


### PR DESCRIPTION
## Describe your changes

Fixes browser (WASM) client teardown and connection issues.

- Close the relay WebSocket with a browser-valid close code and without blocking: the browser close API rejects the going-away code used by CloseNow, and waiting for the close handshake could block the relay teardown path
- Raise the WASM RDP dial timeout from 15s to 30s to match the SSH dial timeout
- Log expected state and profile file errors at debug instead of warn on js, where the filesystem is unavailable
- Lower the lazy connection manager enablement log from warning to info now that it is enabled by default

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal fix, no user-facing behavior change)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when platform state APIs aren’t supported, using graceful fallbacks instead of warning-level failures.
  * Adjusted connection-related logging to be less noisy in supported environments.
  * Strengthened WebSocket teardown by using a dedicated close path for both browser and non-browser builds.
* **Performance**
  * Increased the direct RDP dial timeout to improve connection reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->