### PR TITLE
[client] Increase system info gathering timeout to 60s

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -88,7 +88,7 @@ const (
 	// check gathering. The gathering runs uncancellable system calls (process scan,
 	// exec, os.Stat); without this bound a single stuck call freezes handleSync, and
 	// thus syncMsgMux, for as long as the call hangs (observed multi-minute freezes).
-	systemInfoTimeout = 15 * time.Second
+	systemInfoTimeout = 60 * time.Second
 )
 
 var ErrResetConnection = fmt.Errorf("reset connection")


### PR DESCRIPTION
## Describe your changes

Increase the system info / posture check gathering timeout from 15s to 60s. On slower machines gathering regularly exceeds 15s, so the meta sync is skipped and the management stream connects with base info only. The timeout still bounds the sync loop against genuinely stuck system calls, and shutdown is unaffected since gathering cancels immediately with the engine context.

- Raise systemInfoTimeout in the engine from 15s to 60s

## Issue ticket number and link

## Stack

- `0.74.3-branch` - :warning: No PR associated with branch <!-- branch-stack -->
  - \#6686 :point\_left:

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal timeout constant, no user-facing behavior change)

### Docs PR URL (required if "docs added" is checked)

Paste the PR link from <https://github.com/netbirdio/docs> here:

<https://github.com/netbirdio/docs/pull/>\_\_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the time allowed for collecting system information, reducing premature timeouts during startup.
  * Helps the app wait longer before falling back to limited information, improving reliability of management and posture-related checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->