### PR TITLE
[client] (sync to main) Fix hanging status command during relay dial

### DIFF
--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -294,8 +294,17 @@ func (m *Manager) RelayStates() []RelayConnState {
 
 	// Only connected foreign relays carry state; a failed connect is evicted
 	// immediately (openConnVia), so there is no error state to surface.
+	//
+	// Query each track without blocking: openConnVia holds a track's write-lock
+	// for the whole of relayClient.Connect() (the network dial). A blocking
+	// RLock here would stall the status path (GetFullStatus -> GetRelayStates)
+	// for the full dial timeout. A track mid-Connect has no relayClient set yet
+	// and would be skipped. TryRLock + skip preserves the result while keeping
+	// status responsive.
 	for _, rt := range tracks {
-		rt.RLock()
+		if !rt.TryRLock() {
+			continue
+		}
 		rc := rt.relayClient
 		rt.RUnlock()
 		if rc != nil {

--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -477,7 +477,10 @@ func (m *Manager) cleanUpUnusedRelays() {
 	defer m.relayClientsMutex.Unlock()
 
 	for addr, rt := range m.relayClients {
-		rt.Lock()
+		if !rt.TryRLock() {
+			// Skip while in-progress relay dial.
+			continue
+		}
 		// if the connection failed to the server the relay client will be nil
 		// but the instance will be kept in the relayClients until the next locking
 		if rt.err != nil {

--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -30,11 +30,16 @@ type RelayTrack struct {
 	relayClient *Client
 	err         error
 	created     time.Time
+	// ready is closed once the dial started by openConnVia finishes (relayClient
+	// or err is set). Callers reusing a track wait on this instead of the track
+	// lock, so the dial never runs under rt.Lock.
+	ready chan struct{}
 }
 
 func NewRelayTrack() *RelayTrack {
 	return &RelayTrack{
 		created: time.Now(),
+		ready:   make(chan struct{}),
 	}
 }
 
@@ -294,17 +299,8 @@ func (m *Manager) RelayStates() []RelayConnState {
 
 	// Only connected foreign relays carry state; a failed connect is evicted
 	// immediately (openConnVia), so there is no error state to surface.
-	//
-	// Query each track without blocking: openConnVia holds a track's write-lock
-	// for the whole of relayClient.Connect() (the network dial). A blocking
-	// RLock here would stall the status path (GetFullStatus -> GetRelayStates)
-	// for the full dial timeout. A track mid-Connect has no relayClient set yet
-	// and would be skipped. TryRLock + skip preserves the result while keeping
-	// status responsive.
 	for _, rt := range tracks {
-		if !rt.TryRLock() {
-			continue
-		}
+		rt.RLock()
 		rc := rt.relayClient
 		rt.RUnlock()
 		if rc != nil {
@@ -335,34 +331,24 @@ func (m *Manager) openConnVia(ctx context.Context, serverAddress, peerKey string
 	// check if already has a connection to the desired relay server
 	m.relayClientsMutex.RLock()
 	rt, ok := m.relayClients[serverAddress]
-	if ok {
-		rt.RLock()
-		m.relayClientsMutex.RUnlock()
-		defer rt.RUnlock()
-		if rt.err != nil {
-			return nil, rt.err
-		}
-		return rt.relayClient.OpenConn(ctx, peerKey)
-	}
 	m.relayClientsMutex.RUnlock()
+	if ok {
+		return m.openConnOnTrack(ctx, rt, peerKey)
+	}
 
 	// if not, establish a new connection but check it again (because changed the lock type) before starting the
 	// connection
 	m.relayClientsMutex.Lock()
 	rt, ok = m.relayClients[serverAddress]
 	if ok {
-		rt.RLock()
 		m.relayClientsMutex.Unlock()
-		defer rt.RUnlock()
-		if rt.err != nil {
-			return nil, rt.err
-		}
-		return rt.relayClient.OpenConn(ctx, peerKey)
+		return m.openConnOnTrack(ctx, rt, peerKey)
 	}
 
-	// create a new relay client and store it in the relayClients map
+	// Publish the track and release the map lock BEFORE dialing, so the dial does
+	// not run under rt.Lock (which would block RelayStates and the cleanup loop
+	// for the full dial). Concurrent callers find this track and wait on rt.ready.
 	rt = NewRelayTrack()
-	rt.Lock()
 	m.relayClients[serverAddress] = rt
 	m.relayClientsMutex.Unlock()
 
@@ -370,8 +356,10 @@ func (m *Manager) openConnVia(ctx context.Context, serverAddress, peerKey string
 	relayClient.SetTransportFallback(m.transportFallback)
 	err := relayClient.Connect(m.ctx)
 	if err != nil {
+		rt.Lock()
 		rt.err = err
 		rt.Unlock()
+		close(rt.ready)
 		m.relayClientsMutex.Lock()
 		delete(m.relayClients, serverAddress)
 		m.relayClientsMutex.Unlock()
@@ -379,14 +367,34 @@ func (m *Manager) openConnVia(ctx context.Context, serverAddress, peerKey string
 	}
 	// if connection closed then delete the relay client from the list
 	relayClient.SetOnDisconnectListener(m.onServerDisconnected)
+	rt.Lock()
 	rt.relayClient = relayClient
 	rt.Unlock()
+	close(rt.ready)
 
-	conn, err := relayClient.OpenConn(ctx, peerKey)
-	if err != nil {
-		return nil, err
+	return relayClient.OpenConn(ctx, peerKey)
+}
+
+// openConnOnTrack opens a peer connection through an existing relay track,
+// waiting for the dial started by another openConnVia call to finish. It waits
+// on rt.ready rather than the track lock, so it neither holds nor contends the
+// track lock across the dial.
+func (m *Manager) openConnOnTrack(ctx context.Context, rt *RelayTrack, peerKey string) (net.Conn, error) {
+	select {
+	case <-rt.ready:
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
-	return conn, nil
+
+	rt.RLock()
+	defer rt.RUnlock()
+	if rt.err != nil {
+		return nil, rt.err
+	}
+	if rt.relayClient == nil {
+		return nil, ErrRelayClientNotConnected
+	}
+	return rt.relayClient.OpenConn(ctx, peerKey)
 }
 
 func (m *Manager) onServerConnected() {
@@ -477,13 +485,17 @@ func (m *Manager) cleanUpUnusedRelays() {
 	defer m.relayClientsMutex.Unlock()
 
 	for addr, rt := range m.relayClients {
-		if !rt.TryRLock() {
-			// Skip while in-progress relay dial.
-			continue
-		}
+		rt.Lock()
 		// if the connection failed to the server the relay client will be nil
 		// but the instance will be kept in the relayClients until the next locking
 		if rt.err != nil {
+			rt.Unlock()
+			continue
+		}
+
+		// dial still in progress (openConnVia publishes the track before Connect
+		// completes and no longer holds rt.Lock during it), nothing to clean up.
+		if rt.relayClient == nil {
 			rt.Unlock()
 			continue
 		}

--- a/shared/relay/client/manager_cleanup_test.go
+++ b/shared/relay/client/manager_cleanup_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCleanUpUnusedRelays_DoesNotBlockOnRealHangingDial drives a real, hanging foreign
+// relay dial and asserts cleanUpUnusedRelays does not stall behind it.
+func TestCleanUpUnusedRelays_DoesNotBlockOnRealHangingDial(t *testing.T) {
+	serverAddr := stallingRelayListener(t)
+
+	mCtx, mCancel := context.WithCancel(context.Background())
+	t.Cleanup(mCancel)
+
+	m := NewManager(mCtx, nil, "alice", 1280)
+
+	dialDone := make(chan struct{})
+	go func() {
+		defer close(dialDone)
+		_, _ = m.openConnVia(mCtx, serverAddr, "peerKey", netip.Addr{})
+	}()
+
+	// The track appears in the map once the dial is in flight.
+	require.Eventually(t, func() bool {
+		m.relayClientsMutex.RLock()
+		defer m.relayClientsMutex.RUnlock()
+		_, ok := m.relayClients[serverAddr]
+		return ok
+	}, 5*time.Second, 5*time.Millisecond, "relay dial did not start")
+
+	cleanupDone := make(chan struct{})
+	go func() {
+		defer close(cleanupDone)
+		m.cleanUpUnusedRelays()
+	}()
+
+	select {
+	case <-cleanupDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanUpUnusedRelays blocked on an in-progress relay dial while holding the relay map lock")
+	}
+
+	m.relayClientsMutex.RLock()
+	_, stillTracked := m.relayClients[serverAddr]
+	m.relayClientsMutex.RUnlock()
+	require.True(t, stillTracked, "an in-progress relay dial must not be evicted by cleanup")
+
+	// Release the hanging dial so the goroutine can exit cleanly.
+	mCancel()
+	select {
+	case <-dialDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("openConnVia did not return after context cancellation")
+	}
+}

--- a/shared/relay/client/manager_relaystates_test.go
+++ b/shared/relay/client/manager_relaystates_test.go
@@ -8,30 +8,15 @@ import (
 // TestRelayStates_DoesNotBlockWhileForeignRelayConnecting is a regression test for
 // status calls hanging behind an in-progress relay dial.
 //
-// openConnVia establishes a new foreign relay like this:
-//
-//	rt = NewRelayTrack()
-//	rt.Lock()                          // track write-lock
-//	m.relayClients[serverAddress] = rt
-//	m.relayClientsMutex.Unlock()
-//	...
-//	err := relayClient.Connect(m.ctx)  // network dial, held UNDER rt.Lock()
-//	...
-//	rt.Unlock()                        // released only after Connect returns/times out
-//
-// So while a relay is being dialed, its RelayTrack write-lock is held for the whole
+// While a relay is being dialed, its RelayTrack write-lock is held for the whole
 // dial (up to serverResponseTimeout per transport attempt, times the transport
-// fallback chain, times however many relays are being dialed at once).
+// fallback chain, times however many relays are being dialed at once) in openConnVia.
 //
-// RelayStates() — reached from the daemon status path via
-// peer.Status.GetFullStatus() -> GetRelayStates() -> Manager.RelayStates() — takes
-// rt.RLock() on every tracked relay. A reader lock blocks while a writer holds the
-// lock, so a single foreign relay mid-Connect stalls RelayStates(), and therefore
-// `netbird status -d`, for the full dial timeout. #6547 moved this off the shared
-// map lock but the per-track RLock still blocks the status path.
-//
-// This test recreates the exact in-progress-dial state (track present in the map
-// with its write-lock held) and asserts RelayStates() does not wait on it.
+// RelayStates() is reached from the daemon status path via
+// peer.Status.GetFullStatus() -> GetRelayStates() -> Manager.RelayStates().
+// It takes rt.RLock() on every tracked relay. A reader lock blocks while a
+// writer holds the  lock, so a single foreign relay mid-Connect in openConnVia
+// stalls RelayStates(), and therefore `netbird status -d` hangs for the full dial timeout.
 func TestRelayStates_DoesNotBlockWhileForeignRelayConnecting(t *testing.T) {
 	m := &Manager{
 		relayClients: make(map[string]*RelayTrack),
@@ -42,8 +27,6 @@ func TestRelayStates_DoesNotBlockWhileForeignRelayConnecting(t *testing.T) {
 	rt := NewRelayTrack()
 	rt.Lock()
 	m.relayClients["relay.example.com:443"] = rt
-	// Release at the end so a (buggy) blocked RelayStates goroutine can unwind
-	// instead of leaking past the test.
 	t.Cleanup(rt.Unlock)
 
 	done := make(chan []RelayConnState, 1)
@@ -53,10 +36,7 @@ func TestRelayStates_DoesNotBlockWhileForeignRelayConnecting(t *testing.T) {
 
 	select {
 	case <-done:
-		// RelayStates returned without waiting for the in-progress dial. Good.
 	case <-time.After(2 * time.Second):
-		t.Fatal("RelayStates() blocked on a relay track whose Connect() is in progress " +
-			"(rt.Lock held across the dial in openConnVia); `netbird status -d` hangs for " +
-			"the relay dial timeout")
+		t.Fatal("RelayStates() blocked on a relay track whose Connect() is in progress")
 	}
 }

--- a/shared/relay/client/manager_relaystates_test.go
+++ b/shared/relay/client/manager_relaystates_test.go
@@ -1,33 +1,76 @@
 package client
 
 import (
+	"context"
+	"net"
+	"net/netip"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
-// TestRelayStates_DoesNotBlockWhileForeignRelayConnecting is a regression test for
+// stallingRelayListener accepts TCP connections and holds them open without ever
+// responding, so a relay handshake dialed against it blocks until its context is
+// cancelled. It returns the "rel://host:port" URL to dial.
+func stallingRelayListener(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var conns []net.Conn
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			conns = append(conns, c)
+			mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		mu.Lock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+		mu.Unlock()
+	})
+
+	return "rel://" + ln.Addr().String()
+}
+
+// TestRelayStates_DoesNotBlockOnRealHangingDial is a regression test for
 // status calls hanging behind an in-progress relay dial.
 //
 // While a relay is being dialed, its RelayTrack write-lock is held for the whole
 // dial (up to serverResponseTimeout per transport attempt, times the transport
 // fallback chain, times however many relays are being dialed at once) in openConnVia.
-//
-// RelayStates() is reached from the daemon status path via
-// peer.Status.GetFullStatus() -> GetRelayStates() -> Manager.RelayStates().
-// It takes rt.RLock() on every tracked relay. A reader lock blocks while a
-// writer holds the  lock, so a single foreign relay mid-Connect in openConnVia
-// stalls RelayStates(), and therefore `netbird status -d` hangs for the full dial timeout.
-func TestRelayStates_DoesNotBlockWhileForeignRelayConnecting(t *testing.T) {
-	m := &Manager{
-		relayClients: make(map[string]*RelayTrack),
-	}
+func TestRelayStates_DoesNotBlockOnRealHangingDial(t *testing.T) {
+	serverAddr := stallingRelayListener(t)
 
-	// Mirror openConnVia's state during a live dial: a track in the map whose
-	// write-lock is held for the duration of relayClient.Connect().
-	rt := NewRelayTrack()
-	rt.Lock()
-	m.relayClients["relay.example.com:443"] = rt
-	t.Cleanup(rt.Unlock)
+	mCtx, mCancel := context.WithCancel(context.Background())
+	t.Cleanup(mCancel)
+
+	m := NewManager(mCtx, nil, "alice", 1280)
+
+	dialDone := make(chan struct{})
+	go func() {
+		defer close(dialDone)
+		_, _ = m.openConnVia(mCtx, serverAddr, "peerKey", netip.Addr{})
+	}()
+
+	require.Eventually(t, func() bool {
+		m.relayClientsMutex.RLock()
+		defer m.relayClientsMutex.RUnlock()
+		_, ok := m.relayClients[serverAddr]
+		return ok
+	}, 5*time.Second, 5*time.Millisecond, "relay dial did not start")
 
 	done := make(chan []RelayConnState, 1)
 	go func() {
@@ -35,8 +78,17 @@ func TestRelayStates_DoesNotBlockWhileForeignRelayConnecting(t *testing.T) {
 	}()
 
 	select {
-	case <-done:
+	case states := <-done:
+		require.Empty(t, states, "a relay still being dialed carries no state and must be omitted")
 	case <-time.After(2 * time.Second):
-		t.Fatal("RelayStates() blocked on a relay track whose Connect() is in progress")
+		t.Fatal("RelayStates blocked on a foreign relay whose Connect() is in progress")
+	}
+
+	// Release the hanging dial so the goroutine can exit cleanly.
+	mCancel()
+	select {
+	case <-dialDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("openConnVia did not return after context cancellation")
 	}
 }

--- a/shared/relay/client/manager_relaystates_test.go
+++ b/shared/relay/client/manager_relaystates_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRelayStates_DoesNotBlockWhileForeignRelayConnecting is a regression test for
+// status calls hanging behind an in-progress relay dial.
+//
+// openConnVia establishes a new foreign relay like this:
+//
+//	rt = NewRelayTrack()
+//	rt.Lock()                          // track write-lock
+//	m.relayClients[serverAddress] = rt
+//	m.relayClientsMutex.Unlock()
+//	...
+//	err := relayClient.Connect(m.ctx)  // network dial, held UNDER rt.Lock()
+//	...
+//	rt.Unlock()                        // released only after Connect returns/times out
+//
+// So while a relay is being dialed, its RelayTrack write-lock is held for the whole
+// dial (up to serverResponseTimeout per transport attempt, times the transport
+// fallback chain, times however many relays are being dialed at once).
+//
+// RelayStates() — reached from the daemon status path via
+// peer.Status.GetFullStatus() -> GetRelayStates() -> Manager.RelayStates() — takes
+// rt.RLock() on every tracked relay. A reader lock blocks while a writer holds the
+// lock, so a single foreign relay mid-Connect stalls RelayStates(), and therefore
+// `netbird status -d`, for the full dial timeout. #6547 moved this off the shared
+// map lock but the per-track RLock still blocks the status path.
+//
+// This test recreates the exact in-progress-dial state (track present in the map
+// with its write-lock held) and asserts RelayStates() does not wait on it.
+func TestRelayStates_DoesNotBlockWhileForeignRelayConnecting(t *testing.T) {
+	m := &Manager{
+		relayClients: make(map[string]*RelayTrack),
+	}
+
+	// Mirror openConnVia's state during a live dial: a track in the map whose
+	// write-lock is held for the duration of relayClient.Connect().
+	rt := NewRelayTrack()
+	rt.Lock()
+	m.relayClients["relay.example.com:443"] = rt
+	// Release at the end so a (buggy) blocked RelayStates goroutine can unwind
+	// instead of leaking past the test.
+	t.Cleanup(rt.Unlock)
+
+	done := make(chan []RelayConnState, 1)
+	go func() {
+		done <- m.RelayStates()
+	}()
+
+	select {
+	case <-done:
+		// RelayStates returned without waiting for the in-progress dial. Good.
+	case <-time.After(2 * time.Second):
+		t.Fatal("RelayStates() blocked on a relay track whose Connect() is in progress " +
+			"(rt.Lock held across the dial in openConnVia); `netbird status -d` hangs for " +
+			"the relay dial timeout")
+	}
+}

--- a/shared/relay/client/manager_relaystates_test.go
+++ b/shared/relay/client/manager_relaystates_test.go
@@ -46,11 +46,8 @@ func stallingRelayListener(t *testing.T) string {
 }
 
 // TestRelayStates_DoesNotBlockOnRealHangingDial is a regression test for
-// status calls hanging behind an in-progress relay dial.
-//
-// While a relay is being dialed, its RelayTrack write-lock is held for the whole
-// dial (up to serverResponseTimeout per transport attempt, times the transport
-// fallback chain, times however many relays are being dialed at once) in openConnVia.
+// RelayStates() called by a "status -d command" hanging behind an in-progress
+// relay dial.
 func TestRelayStates_DoesNotBlockOnRealHangingDial(t *testing.T) {
 	serverAddr := stallingRelayListener(t)
 


### PR DESCRIPTION
## Describe your changes

Sync https://github.com/netbirdio/netbird/pull/6694 to main

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay connection handling so concurrent requests no longer block each other during a slow or stuck dial.
  * Prevented cleanup from removing relays that are still in the process of connecting.
  * Kept relay status lookups responsive even when one relay connection is hanging.

* **Tests**
  * Added regression coverage for stalled relay connections, cleanup behavior, and relay status queries under concurrent load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->