### PR TITLE
[client] Restore residual state in foreground mode before login

### DIFF
--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -333,9 +333,9 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, setupKey string,
 		return fmt.Errorf("read config file %s: %v", configFilePath, err)
 	}
 
-	// Mirror runInForegroundMode: recover residual state from a previous
-	// unclean shutdown and enable advanced routing before dialing
-	// management, so leftover routing rules can't break the login.
+	// Mirror runInForegroundMode: recover residual state (DNS, firewall,
+	// ssh config, legacy routing) from a previous unclean shutdown and
+	// enable advanced routing before dialing management.
 	if err := server.RestoreResidualState(ctx, profilemanager.NewServiceManager(configFilePath).GetStatePath()); err != nil {
 		log.Warnf("failed to restore residual state: %v", err)
 	}

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -17,7 +17,9 @@ import (
 	"github.com/netbirdio/netbird/client/internal"
 	"github.com/netbirdio/netbird/client/internal/auth"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
+	nbnet "github.com/netbirdio/netbird/client/net"
 	"github.com/netbirdio/netbird/client/proto"
+	"github.com/netbirdio/netbird/client/server"
 	"github.com/netbirdio/netbird/client/system"
 	"github.com/netbirdio/netbird/util"
 )
@@ -330,6 +332,14 @@ func doForegroundLogin(ctx context.Context, cmd *cobra.Command, setupKey string,
 	if err != nil {
 		return fmt.Errorf("read config file %s: %v", configFilePath, err)
 	}
+
+	// Mirror runInForegroundMode: recover residual state from a previous
+	// unclean shutdown and enable advanced routing before dialing
+	// management, so leftover routing rules can't break the login.
+	if err := server.RestoreResidualState(ctx, profilemanager.NewServiceManager(configFilePath).GetStatePath()); err != nil {
+		log.Warnf("failed to restore residual state: %v", err)
+	}
+	nbnet.Init()
 
 	err = foregroundLogin(ctx, cmd, config, setupKey, activeProf.ID)
 	if err != nil {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -22,6 +22,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
+	nbnet "github.com/netbirdio/netbird/client/net"
 	"github.com/netbirdio/netbird/client/server"
 	"github.com/netbirdio/netbird/client/system"
 	"github.com/netbirdio/netbird/shared/management/domain"
@@ -240,6 +241,11 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *pr
 	if err := server.RestoreResidualState(ctx, profilemanager.NewServiceManager(configPath).GetStatePath()); err != nil {
 		log.Warnf("failed to restore residual state: %v", err)
 	}
+
+	// Enable advanced routing (as the daemon does on startup) so the
+	// management dial bypasses a leftover fwmark rule instead of being
+	// shunted into a stale routing table.
+	nbnet.Init()
 
 	err = foregroundLogin(ctx, cmd, config, providedSetupKey, activeProf.ID)
 	if err != nil {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -22,6 +22,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
+	"github.com/netbirdio/netbird/client/server"
 	"github.com/netbirdio/netbird/client/system"
 	"github.com/netbirdio/netbird/shared/management/domain"
 	"github.com/netbirdio/netbird/util"
@@ -228,6 +229,17 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *pr
 	}
 
 	_, _ = profilemanager.UpdateOldManagementURL(ctx, config, configFilePath)
+
+	// Restore residual state left by a previous run that did not shut down
+	// cleanly, mirroring what the daemon does before connecting. Without this,
+	// leftover routing rules can shunt the management connection into a stale
+	// routing table and every subsequent login times out. Foreground mode is
+	// particularly exposed in containers: a crashed container restarts inside
+	// the same (pod) network namespace, so the stale rules survive while the
+	// process state does not.
+	if err := server.RestoreResidualState(ctx, profilemanager.NewServiceManager(configPath).GetStatePath()); err != nil {
+		log.Warnf("failed to restore residual state: %v", err)
+	}
 
 	err = foregroundLogin(ctx, cmd, config, providedSetupKey, activeProf.ID)
 	if err != nil {

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -232,12 +232,14 @@ func runInForegroundMode(ctx context.Context, cmd *cobra.Command, activeProf *pr
 	_, _ = profilemanager.UpdateOldManagementURL(ctx, config, configFilePath)
 
 	// Restore residual state left by a previous run that did not shut down
-	// cleanly, mirroring what the daemon does before connecting. Without this,
-	// leftover routing rules can shunt the management connection into a stale
-	// routing table and every subsequent login times out. Foreground mode is
-	// particularly exposed in containers: a crashed container restarts inside
-	// the same (pod) network namespace, so the stale rules survive while the
-	// process state does not.
+	// cleanly, mirroring what the daemon does before connecting: it recovers
+	// DNS config (a stale resolv.conf takeover can make the management
+	// hostname unresolvable), firewall rules, ssh config and legacy routing.
+	// Route cleanup itself happens at engine start; nbnet.Init() below lets
+	// the management dial bypass a leftover fwmark rule until then.
+	// Foreground mode is particularly exposed in containers: a crashed
+	// container restarts inside the same (pod) network namespace, so stale
+	// state survives while the process does not.
 	if err := server.RestoreResidualState(ctx, profilemanager.NewServiceManager(configPath).GetStatePath()); err != nil {
 		log.Warnf("failed to restore residual state: %v", err)
 	}

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -181,7 +181,7 @@ func (s *Server) Start() error {
 		log.Warnf("failed to redirect stderr: %v", err)
 	}
 
-	if err := restoreResidualState(s.rootCtx, s.profileManager.GetStatePath()); err != nil {
+	if err := RestoreResidualState(s.rootCtx, s.profileManager.GetStatePath()); err != nil {
 		log.Warnf(errRestoreResidualState, err)
 	}
 
@@ -551,7 +551,7 @@ func (s *Server) Login(callerCtx context.Context, msg *proto.LoginRequest) (*pro
 	s.actCancel = cancel
 	s.mutex.Unlock()
 
-	if err := restoreResidualState(s.rootCtx, s.profileManager.GetStatePath()); err != nil {
+	if err := RestoreResidualState(s.rootCtx, s.profileManager.GetStatePath()); err != nil {
 		log.Warnf(errRestoreResidualState, err)
 	}
 
@@ -858,7 +858,7 @@ func (s *Server) Up(callerCtx context.Context, msg *proto.UpRequest) (*proto.UpR
 
 		return s.waitForUp(callerCtx)
 	}
-	if err := restoreResidualState(callerCtx, s.profileManager.GetStatePath()); err != nil {
+	if err := RestoreResidualState(callerCtx, s.profileManager.GetStatePath()); err != nil {
 		log.Warnf(errRestoreResidualState, err)
 	}
 

--- a/client/server/state.go
+++ b/client/server/state.go
@@ -46,7 +46,7 @@ func (s *Server) CleanState(ctx context.Context, req *proto.CleanStateRequest) (
 
 	if req.All {
 		// Reuse existing cleanup logic for all states
-		if err := restoreResidualState(ctx, statePath); err != nil {
+		if err := RestoreResidualState(ctx, statePath); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to clean all states: %v", err)
 		}
 
@@ -113,9 +113,9 @@ func (s *Server) DeleteState(ctx context.Context, req *proto.DeleteStateRequest)
 	}, nil
 }
 
-// restoreResidualState checks if the client was not shut down in a clean way and restores residual if required.
+// RestoreResidualState checks if the client was not shut down in a clean way and restores residual if required.
 // Otherwise, we might not be able to connect to the management server to retrieve new config.
-func restoreResidualState(ctx context.Context, statePath string) error {
+func RestoreResidualState(ctx context.Context, statePath string) error {
 	if statePath == "" {
 		return nil
 	}


### PR DESCRIPTION
## Describe your changes

`netbird up --foreground-mode` goes straight to `foregroundLogin` without the residual-state recovery the daemon performs — `restoreResidualState` is called at three points in `client/server` before touching management, with a comment describing exactly why: *"Otherwise, we might not be able to connect to the management server to retrieve new config."* The foreground path never calls it.

If a previous run did not shut down cleanly (crash/kill — deferred cleanup never runs), leftover routing policy from `SetupRouting` (e.g. the `not fwmark → NetbirdVPNTableID` rule) can shunt the management connection into a stale routing table whose default route points at a dead `wt0`, and every subsequent login times out.

**Foreground mode is particularly exposed in containers** (its primary use): a crashed container restarts inside the same pod network namespace, so the stale rules survive while the process state does not. Observed in the field: a netbird router container crash-looped ~99 times over 8 hours on

```
Error: foreground login failed: ... dial tcp <mgmt-ip>:443: i/o timeout
```

while other pods in the same namespace reached the same management endpoint fine — only deleting the pod (fresh netns) recovered it. Daemon-mode installs never hit this, which is likely why it hasn't been reported.

**Fix:** export `RestoreResidualState` and call it in `runInForegroundMode` before `foregroundLogin`, mirroring the daemon's behaviour (warn and continue on error).

`go build ./client/...` and `go vet` clean; `client/server` tests pass (`client/cmd`'s `TestRemoveStaleUnixSocket*` failures are pre-existing on `main` in my environment, unchanged by this PR).

## Issue ticket number and link

None — field incident described above; happy to open an issue if preferred.

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Documentation is not needed: this fixes an internal crash-recovery omission — foreground mode now performs the same residual-state cleanup the daemon already does. No user-facing behaviour, flags, API, or configuration change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved residual state restoration during foreground startup and foreground login, ensuring consistent routing behavior.
  * Residual-state restore errors now warn without interrupting the ongoing start or login flow.
  * Residual-state cleanup now consistently performs restore/persist steps to keep residual handling accurate.
  * Foreground flows now initialize networking earlier so routing is available when login proceeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->