### PR TITLE
[client] fix flaky test around event aggregation

### DIFF
--- a/client/internal/netflow/store/event_aggregation_test.go
+++ b/client/internal/netflow/store/event_aggregation_test.go
@@ -175,7 +175,9 @@ func TestFlowAggregationOfUnknownProtocols(t *testing.T) {
 }
 
 func TestResetAggregationWindow(t *testing.T) {
-	store := NewAggregatingMemoryStore()
+	now := time.Now()
+	nowFunc := func() time.Time { return now }
+	store := NewAggregatingMemoryStoreWithTimeFunc(nowFunc)
 	store.StoreEvent(&types.Event{
 		ID:        uuid.New(),
 		Timestamp: time.Now(),
@@ -198,6 +200,7 @@ func TestResetAggregationWindow(t *testing.T) {
 		},
 	})
 
+	now = now.Add(1 * time.Second)
 	reset := store.ResetAggregationWindow()
 	previousEvents, ok := reset.(*AggregatingMemory)
 	assert.True(t, ok)

--- a/client/internal/netflow/store/memory.go
+++ b/client/internal/netflow/store/memory.go
@@ -29,6 +29,7 @@ type AggregatingMemory struct {
 	WindowStart time.Time
 	WindowEnd   time.Time
 	rnd         *v2.PCG
+	nowFunc     func() time.Time
 }
 
 func (m *Memory) StoreEvent(event *types.Event) {
@@ -62,7 +63,12 @@ func (m *Memory) DeleteEvents(ids []uuid.UUID) {
 }
 
 func NewAggregatingMemoryStore() *AggregatingMemory {
-	return &AggregatingMemory{WindowStart: time.Now(), Memory: Memory{events: make(map[uuid.UUID]*types.Event)}, rnd: v2.NewPCG(rand.Uint64(), rand.Uint64())}
+	return NewAggregatingMemoryStoreWithTimeFunc(defaultNowFunc)
+}
+
+// used in tests when deterministic (less random) time intervals are required
+func NewAggregatingMemoryStoreWithTimeFunc(nowFunc func() time.Time) *AggregatingMemory {
+	return &AggregatingMemory{WindowStart: nowFunc(), Memory: Memory{events: make(map[uuid.UUID]*types.Event)}, nowFunc: nowFunc, rnd: v2.NewPCG(rand.Uint64(), rand.Uint64())}
 }
 
 func (am *AggregatingMemory) ResetAggregationWindow() types.FlowEventAggregator {
@@ -151,4 +157,8 @@ func (am *AggregatingMemory) GetAggregatedEvents() []*types.Event {
 	}
 
 	return slices.Collect(maps.Values(aggregated)) // could return an iterator instead here
+}
+
+func defaultNowFunc() time.Time {
+	return time.Now()
 }

--- a/client/internal/netflow/store/memory.go
+++ b/client/internal/netflow/store/memory.go
@@ -75,7 +75,7 @@ func (am *AggregatingMemory) ResetAggregationWindow() types.FlowEventAggregator 
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
-	now := time.Now()
+	now := am.nowFunc()
 	toret := AggregatingMemory{WindowStart: am.WindowStart, WindowEnd: now, Memory: Memory{events: am.events}, rnd: v2.NewPCG(rand.Uint64(), rand.Uint64())}
 
 	am.events = make(map[uuid.UUID]*types.Event)


### PR DESCRIPTION
## Describe your changes
Use deterministic time interval in an event aggregation test to avoid false negative around time check.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aggregation window reset behavior to use consistent, controllable time sources, ensuring timing-based resets work reliably.
* **Tests**
  * Updated aggregation window tests to control time rather than relying on real-time, reducing flaky, timing-dependent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->