### PR TITLE
fix: last_seen api peers

### DIFF
--- a/management/server/http/handlers/peers/peers_handler.go
+++ b/management/server/http/handlers/peers/peers_handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+	"time"
 
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
@@ -557,7 +558,7 @@ func peerToAccessiblePeer(peer *nbpeer.Peer, dnsDomain string) api.AccessiblePee
 		Id:          peer.ID,
 		Ip:          peer.IP.String(),
 		Ipv6:        peerIPv6String(peer),
-		LastSeen:    peer.Status.LastSeen,
+		LastSeen:    peerLastSeen(peer),
 		Name:        peer.Name,
 		Os:          peer.Meta.OS,
 		UserId:      peer.UserID,
@@ -578,7 +579,7 @@ func toSinglePeerResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dnsD
 		Ipv6:                        peerIPv6String(peer),
 		ConnectionIp:                peer.Location.ConnectionIP.String(),
 		Connected:                   peer.Status.Connected,
-		LastSeen:                    peer.Status.LastSeen,
+		LastSeen:                    peerLastSeen(peer),
 		Os:                          fmt.Sprintf("%s %s", peer.Meta.OS, osVersion),
 		KernelVersion:               peer.Meta.KernelVersion,
 		GeonameId:                   int(peer.Location.GeoNameID),
@@ -633,7 +634,7 @@ func toPeerListItemResponse(peer *nbpeer.Peer, groupsInfo []api.GroupMinimum, dn
 		Ipv6:                        peerIPv6String(peer),
 		ConnectionIp:                peer.Location.ConnectionIP.String(),
 		Connected:                   peer.Status.Connected,
-		LastSeen:                    peer.Status.LastSeen,
+		LastSeen:                    peerLastSeen(peer),
 		Os:                          fmt.Sprintf("%s %s", peer.Meta.OS, osVersion),
 		KernelVersion:               peer.Meta.KernelVersion,
 		GeonameId:                   int(peer.Location.GeoNameID),
@@ -714,4 +715,17 @@ func peerIPv6String(peer *nbpeer.Peer) *string {
 	}
 	s := peer.IPv6.String()
 	return &s
+}
+
+// peerLastSeen returns the value to expose as last_seen for a peer.
+// Connected peers are reported as seen right now; disconnected peers keep
+// the stored last_seen timestamp (the moment they went offline).
+func peerLastSeen(peer *nbpeer.Peer) time.Time {
+	if peer.Status != nil && peer.Status.Connected {
+		return time.Now().UTC()
+	}
+	if peer.Status != nil {
+		return peer.Status.LastSeen
+	}
+	return time.Time{}
 }

--- a/management/server/http/handlers/peers/peers_handler_test.go
+++ b/management/server/http/handlers/peers/peers_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"strings"
 	"testing"
 	"time"
 
@@ -361,6 +362,128 @@ func TestGetPeers(t *testing.T) {
 			assert.Equal(t, tc.expectedPeer.SSHEnabled, got.SshEnabled)
 			assert.Equal(t, tc.expectedPeer.Status.Connected, got.Connected)
 			assert.Equal(t, tc.expectedPeer.Meta.SystemSerialNumber, got.SerialNumber)
+		})
+	}
+}
+
+func TestPeerLastSeenInResponse(t *testing.T) {
+	connectedLastSeen := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	disconnectedLastSeen := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
+
+	connectedPeer := &nbpeer.Peer{
+		ID:     "connected-peer",
+		Key:    "key1",
+		IP:     netip.MustParseAddr("100.64.0.1"),
+		Status: &nbpeer.PeerStatus{Connected: true, LastSeen: connectedLastSeen},
+		Name:   "connected",
+		Meta:   nbpeer.PeerSystemMeta{Hostname: "connected"},
+	}
+	disconnectedPeer := &nbpeer.Peer{
+		ID:     "disconnected-peer",
+		Key:    "key2",
+		IP:     netip.MustParseAddr("100.64.0.2"),
+		Status: &nbpeer.PeerStatus{Connected: false, LastSeen: disconnectedLastSeen},
+		Name:   "disconnected",
+		UserID: regularUser,
+		Meta:   nbpeer.PeerSystemMeta{Hostname: "disconnected"},
+	}
+
+	p := initTestMetaData(t, connectedPeer, disconnectedPeer)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/api/peers", p.GetAllPeers).Methods("GET")
+	router.HandleFunc("/api/peers/{peerId}", p.HandlePeer).Methods("GET")
+	router.HandleFunc("/api/peers/{peerId}/accessible-peers", p.GetAccessiblePeers).Methods("GET")
+
+	tt := []struct {
+		name              string
+		path              string
+		userID            string
+		expectedID        string
+		expectedConnected bool
+		expectedLastSeen  time.Time
+	}{
+		{
+			name:              "list connected peer",
+			path:              "/api/peers",
+			userID:            adminUser,
+			expectedID:        connectedPeer.ID,
+			expectedConnected: true,
+			expectedLastSeen:  time.Now().UTC(),
+		},
+		{
+			name:              "list disconnected peer",
+			path:              "/api/peers",
+			userID:            adminUser,
+			expectedID:        disconnectedPeer.ID,
+			expectedConnected: false,
+			expectedLastSeen:  disconnectedLastSeen,
+		},
+		{
+			name:              "single connected peer",
+			path:              "/api/peers/" + connectedPeer.ID,
+			userID:            adminUser,
+			expectedID:        connectedPeer.ID,
+			expectedConnected: true,
+			expectedLastSeen:  time.Now().UTC(),
+		},
+		{
+			name:              "accessible connected peer",
+			path:              fmt.Sprintf("/api/peers/%s/accessible-peers", disconnectedPeer.ID),
+			userID:            regularUser,
+			expectedID:        connectedPeer.ID,
+			expectedConnected: true,
+			expectedLastSeen:  time.Now().UTC(),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req = nbcontext.SetUserAuthInRequest(req, auth.UserAuth{
+				UserId:    tc.userID,
+				Domain:    "hotmail.com",
+				AccountId: "test_id",
+			})
+			router.ServeHTTP(recorder, req)
+			require.Equal(t, http.StatusOK, recorder.Code)
+
+			var lastSeen time.Time
+			switch {
+			case tc.path == "/api/peers":
+				var resp []*api.PeerBatch
+				require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+
+				var found bool
+				for _, peer := range resp {
+					if peer.Id == tc.expectedID {
+						found = true
+						assert.Equal(t, tc.expectedConnected, peer.Connected)
+						lastSeen = peer.LastSeen
+						break
+					}
+				}
+				require.True(t, found, "expected peer %s not found in list", tc.expectedID)
+			case strings.HasSuffix(tc.path, "/accessible-peers"):
+				var resp []api.AccessiblePeer
+				require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+				require.Len(t, resp, 1)
+				assert.Equal(t, tc.expectedID, resp[0].Id)
+				lastSeen = resp[0].LastSeen
+			default:
+				var resp api.Peer
+				require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+				assert.Equal(t, tc.expectedID, resp.Id)
+				assert.Equal(t, tc.expectedConnected, resp.Connected)
+				lastSeen = resp.LastSeen
+			}
+
+			if tc.expectedConnected {
+				assert.WithinDuration(t, time.Now().UTC(), lastSeen, time.Second)
+			} else {
+				assert.Equal(t, tc.expectedLastSeen, lastSeen)
+			}
 		})
 	}
 }

--- a/shared/management/http/api/openapi.yml
+++ b/shared/management/http/api/openapi.yml
@@ -832,7 +832,9 @@ components:
               type: boolean
               example: true
             last_seen:
-              description: Last time peer connected to Netbird's management service
+              description: |
+                Last time peer connected to Netbird's management service.
+                For connected peers this value reflects the current request time.
               type: string
               format: date-time
               example: "2023-05-05T10:05:26.420578Z"
@@ -1070,7 +1072,9 @@ components:
               type: boolean
               example: true
             last_seen:
-              description: Last time peer connected to Netbird's management service
+              description: |
+                Last time peer connected to Netbird's management service.
+                For connected peers this value reflects the current request time.
               type: string
               format: date-time
               example: "2023-05-05T10:05:26.420578Z"

--- a/shared/management/http/api/types.gen.go
+++ b/shared/management/http/api/types.gen.go
@@ -1579,7 +1579,8 @@ type AccessiblePeer struct {
 	// Ipv6 Peer's IPv6 overlay address
 	Ipv6 *string `json:"ipv6,omitempty"`
 
-	// LastSeen Last time peer connected to Netbird's management service
+	// LastSeen Last time peer connected to Netbird's management service.
+	// For connected peers this value reflects the current request time.
 	LastSeen time.Time `json:"last_seen"`
 
 	// Name Peer's hostname
@@ -4004,7 +4005,8 @@ type Peer struct {
 	// LastLogin Last time this peer performed log in (authentication). E.g., user authenticated.
 	LastLogin time.Time `json:"last_login"`
 
-	// LastSeen Last time peer connected to Netbird's management service
+	// LastSeen Last time peer connected to Netbird's management service.
+	// For connected peers this value reflects the current request time.
 	LastSeen   time.Time       `json:"last_seen"`
 	LocalFlags *PeerLocalFlags `json:"local_flags,omitempty"`
 
@@ -4098,7 +4100,8 @@ type PeerBatch struct {
 	// LastLogin Last time this peer performed log in (authentication). E.g., user authenticated.
 	LastLogin time.Time `json:"last_login"`
 
-	// LastSeen Last time peer connected to Netbird's management service
+	// LastSeen Last time peer connected to Netbird's management service.
+	// For connected peers this value reflects the current request time.
 	LastSeen   time.Time       `json:"last_seen"`
 	LocalFlags *PeerLocalFlags `json:"local_flags,omitempty"`
 


### PR DESCRIPTION
## Describe your changes

Fixes the `/api/peers` `last_seen` field so it reflects the current request time for connected peers, instead of freezing at the peer's connection-start timestamp.

Since commit `97bc1eebd` introduced session-token fencing for peer status updates, `peer_status.last_seen` is written by the database only on connect/disconnect. While a peer stays connected on a long-lived gRPC Sync stream, the stored `last_seen` no longer gets refreshed. This change restores the expected API behavior at the HTTP presentation layer without altering the underlying fencing logic or adding database writes on the hot sync-stream path.

Changes:
- Added `peerLastSeen()` helper in `management/server/http/handlers/peers/peers_handler.go` that returns `time.Now().UTC()` for connected peers and the stored `LastSeen` for disconnected peers.
- Applied the helper to `toSinglePeerResponse`, `toPeerListItemResponse`, and `peerToAccessiblePeer`.
- Updated the `last_seen` descriptions in `shared/management/http/api/openapi.yml` for `Peer`, `PeerBatch` (via `Peer`), and `AccessiblePeer`.
- Regenerated `shared/management/http/api/types.gen.go` with `oapi-codegen@v2.7.1`.
- Added `TestPeerLastSeenInResponse` covering list, single-peer, and accessible-peers endpoints.

## Issue ticket number and link

Fixes https://github.com/netbirdio/netbird/issues/5139

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Peer responses now report the current time as `last_seen` for connected peers.
  * Disconnected peers continue to show their most recently recorded timestamp.
  * Updated behavior consistently across peer list, detail, and accessible-peer views.

* **Documentation**
  * Clarified `last_seen` behavior in the API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->