### PR TITLE
[management] fix: prevent group deletion when referenced by service access_groups

### DIFF
--- a/management/server/group.go
+++ b/management/server/group.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	nbdns "github.com/netbirdio/netbird/dns"
+	"github.com/netbirdio/netbird/management/internals/modules/reverseproxy/service"
 	"github.com/netbirdio/netbird/management/server/activity"
 	"github.com/netbirdio/netbird/management/server/affectedpeers"
 	routerTypes "github.com/netbirdio/netbird/management/server/networks/routers/types"
@@ -734,6 +735,10 @@ func validateDeleteGroup(ctx context.Context, transaction store.Store, group *ty
 		return &GroupLinkError{"network router", linkedRouter.ID}
 	}
 
+	if isLinked, linkedService := isGroupLinkedToService(ctx, transaction, group.AccountID, group.ID); isLinked {
+		return &GroupLinkError{"service", linkedService.Name}
+	}
+
 	return checkGroupLinkedToSettings(ctx, transaction, group)
 }
 
@@ -862,6 +867,23 @@ func isGroupLinkedToNetworkRouter(ctx context.Context, transaction store.Store, 
 			return true, router
 		}
 	}
+	return false, nil
+}
+
+// isGroupLinkedToService checks if a group is linked to any reverse proxy service in the account.
+func isGroupLinkedToService(ctx context.Context, transaction store.Store, accountID string, groupID string) (bool, *service.Service) {
+	services, err := transaction.GetAccountServices(ctx, store.LockingStrengthNone, accountID)
+	if err != nil {
+		log.WithContext(ctx).Errorf("error retrieving services while checking group linkage: %v", err)
+		return false, nil
+	}
+
+	for _, svc := range services {
+		if slices.Contains(svc.AccessGroups, groupID) {
+			return true, svc
+		}
+	}
+
 	return false, nil
 }
 

--- a/management/server/group_test.go
+++ b/management/server/group_test.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	nbdns "github.com/netbirdio/netbird/dns"
+	"github.com/netbirdio/netbird/management/internals/modules/reverseproxy/service"
 	"github.com/netbirdio/netbird/management/server/groups"
 	"github.com/netbirdio/netbird/management/server/networks"
 	"github.com/netbirdio/netbird/management/server/networks/resources"
@@ -124,6 +125,11 @@ func TestDefaultAccountManager_DeleteGroup(t *testing.T) {
 			"integration",
 			"grp-for-integration",
 			"only service users with admin power can delete integration group",
+		},
+		{
+			"service",
+			"grp-for-service",
+			"service",
 		},
 	}
 
@@ -406,6 +412,14 @@ func initTestGroupAccount(am *DefaultAccountManager) (*DefaultAccountManager, *t
 		Peers:     make([]string, 0),
 	}
 
+	groupForService := &types.Group{
+		ID:        "grp-for-service",
+		AccountID: "account-id",
+		Name:      "Group for service",
+		Issued:    types.GroupIssuedAPI,
+		Peers:     make([]string, 0),
+	}
+
 	routeResource := &route.Route{
 		ID:     "example route",
 		Groups: []string{groupForRoute.ID},
@@ -441,6 +455,14 @@ func initTestGroupAccount(am *DefaultAccountManager) (*DefaultAccountManager, *t
 		Id:         "example user",
 		AutoGroups: []string{groupForUsers.ID},
 	}
+
+	svc := &service.Service{
+		ID:           "example service",
+		AccountID:    "account-id",
+		Name:         "example service",
+		AccessGroups: []string{groupForService.ID},
+	}
+
 	account := newAccountWithId(context.Background(), accountID, groupAdminUserID, domain, "", "", false)
 	account.Routes[routeResource.ID] = routeResource
 	account.Routes[routePeerGroupResource.ID] = routePeerGroupResource
@@ -448,6 +470,7 @@ func initTestGroupAccount(am *DefaultAccountManager) (*DefaultAccountManager, *t
 	account.Policies = append(account.Policies, policy)
 	account.SetupKeys[setupKey.Id] = setupKey
 	account.Users[user.Id] = user
+	account.Services = append(account.Services, svc)
 
 	err := am.Store.SaveAccount(context.Background(), account)
 	if err != nil {
@@ -461,6 +484,7 @@ func initTestGroupAccount(am *DefaultAccountManager) (*DefaultAccountManager, *t
 	_ = am.CreateGroup(context.Background(), accountID, groupAdminUserID, groupForSetupKeys)
 	_ = am.CreateGroup(context.Background(), accountID, groupAdminUserID, groupForUsers)
 	_ = am.CreateGroup(context.Background(), accountID, groupAdminUserID, groupForIntegration)
+	_ = am.CreateGroup(context.Background(), accountID, groupAdminUserID, groupForService)
 
 	acc, err := am.Store.GetAccount(context.Background(), account.Id)
 	if err != nil {


### PR DESCRIPTION
## Description

Groups can be deleted even when referenced in a private service's `AccessGroups` field, which orphans the group reference and compromises service access control.

Added `isGroupLinkedToService` check to `validateDeleteGroup`, consistent with existing checks for routes, policies, setup keys, and users.

## Changes

- **group.go**: Added `isGroupLinkedToService()` helper and its call in `validateDeleteGroup()`, following the exact same pattern as the existing 6 `isGroupLinkedTo*` functions
- **group_test.go**: Added `groupForService` + a service with `AccessGroups` to the test setup, and a `"service"` test case

## Verification

- `go build ./management/server/` — clean
- `go vet ./management/server/` — clean
- `go test -run "TestDefaultAccountManager_DeleteGroup" ./management/server/ -v` — **9/9 PASS** (8 existing + 1 new)

Fixes #6637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deletion of groups that are still linked to reverse proxy services.
  * Deletion validation now identifies the linked service when a group cannot be removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->