### PR TITLE
[client] deprecate non-functional admin URL flag

### DIFF
--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -148,7 +148,8 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&daemonAddr, "daemon-addr", defaultDaemonAddr, "Daemon service address to serve CLI requests [unix|tcp]://[path|host:port]")
 	rootCmd.PersistentFlags().StringVarP(&managementURL, "management-url", "m", "", fmt.Sprintf("Management Service URL [http|https]://[host]:[port] (default \"%s\")", profilemanager.DefaultManagementURL))
-	rootCmd.PersistentFlags().StringVar(&adminURL, "admin-url", "", fmt.Sprintf("Admin Panel URL [http|https]://[host]:[port] (default \"%s\")", profilemanager.DefaultAdminURL))
+	rootCmd.PersistentFlags().StringVar(&adminURL, "admin-url", "", fmt.Sprintf("(DEPRECATED) Admin Panel URL [http|https]://[host]:[port] (default \"%s\") - This flag is no longer functional", profilemanager.DefaultAdminURL))
+	_ = rootCmd.PersistentFlags().MarkDeprecated("admin-url", "the admin-url flag is no longer functional and will be removed in a future version")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "sets NetBird log level")
 	rootCmd.PersistentFlags().StringSliceVar(&logFiles, "log-file", []string{defaultLogFile}, "sets NetBird log paths written to simultaneously. If `console` is specified the log will be output to stdout. If `syslog` is specified the log will be sent to syslog daemon. You can pass the flag multiple times or separate entries by `,` character")
 	rootCmd.PersistentFlags().StringVarP(&setupKey, "setup-key", "k", "", "Setup key obtained from the Management Service Dashboard (used to register peer)")

--- a/client/cmd/root_test.go
+++ b/client/cmd/root_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/internal/profilemanager"
 )
 
 func TestInitCommands(t *testing.T) {
@@ -36,6 +37,36 @@ func TestInitCommands(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func TestAdminURLFlagDeprecated(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("admin-url")
+	if flag == nil {
+		t.Fatal("admin-url flag not found")
+	}
+
+	expectedUsage := fmt.Sprintf("(DEPRECATED) Admin Panel URL [http|https]://[host]:[port] (default \"%s\") - This flag is no longer functional", profilemanager.DefaultAdminURL)
+	if flag.Usage != expectedUsage {
+		t.Fatalf("expected admin-url usage %q, got %q", expectedUsage, flag.Usage)
+	}
+
+	expectedDeprecation := "the admin-url flag is no longer functional and will be removed in a future version"
+	if flag.Deprecated != expectedDeprecation {
+		t.Fatalf("expected admin-url deprecation message %q, got %q", expectedDeprecation, flag.Deprecated)
+	}
+}
+
+func TestSetupSetConfigReqIgnoresAdminURL(t *testing.T) {
+	previousAdminURL := adminURL
+	adminURL = "https://admin.example.com"
+	t.Cleanup(func() {
+		adminURL = previousAdminURL
+	})
+
+	req := setupSetConfigReq(nil, upCmd, "profile", "user")
+	if req.AdminURL != "" {
+		t.Fatalf("expected deprecated admin-url to be ignored, got %q", req.AdminURL)
 	}
 }
 

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -384,7 +384,6 @@ func setupSetConfigReq(customDNSAddressConverted []byte, cmd *cobra.Command, pro
 	req.Username = username
 
 	req.ManagementUrl = managementURL
-	req.AdminURL = adminURL
 	req.NatExternalIPs = natExternalIPs
 	req.CustomDNSAddress = customDNSAddressConverted
 	req.ExtraIFaceBlacklist = extraIFaceBlackList


### PR DESCRIPTION
## Description

PR #4218 deprecated the `--admin-url` flag and stopped applying its value, but the long-running profiles work in PR #3980 restored the old behavior when it merged shortly afterward.

This restores the intended deprecation behavior.

## Changes

- Mark `--admin-url` as deprecated and describe it as non-functional
- Stop forwarding its value in `SetConfigRequest`
- Add regression tests for the flag metadata and ignored configuration value

## Testing

- `TMPDIR=/tmp/netbird-tests go test ./client/cmd -count=1`
- `go test ./client/internal/profilemanager -count=1`
- `go vet ./client/cmd ./client/internal/profilemanager`
- `go build -o /tmp/netbird-tests/netbird ./client`

Fixes #4486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecated the `--admin-url` CLI option and clarified that it is no longer functional.
  * Daemon configuration now ignores values supplied through the deprecated admin URL option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->