### PR TITLE
[management] deduplicate JWT group claims

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -136,6 +136,17 @@ func isUniqueConstraintError(err error) bool {
 // Returns a bool indicating if there are changes in the JWT group membership, the updated user AutoGroups,
 // newly groups to create and an error if any occurred.
 func (am *DefaultAccountManager) getJWTGroupsChanges(user *types.User, groups []*types.Group, groupNames []string) (bool, []string, []*types.Group, error) {
+	uniqueGroupNames := make([]string, 0, len(groupNames))
+	seenGroupNames := make(map[string]struct{}, len(groupNames))
+	for _, name := range groupNames {
+		if _, seen := seenGroupNames[name]; seen {
+			continue
+		}
+		seenGroupNames[name] = struct{}{}
+		uniqueGroupNames = append(uniqueGroupNames, name)
+	}
+	groupNames = uniqueGroupNames
+
 	existedGroupsByName := make(map[string]*types.Group)
 	for _, group := range groups {
 		existedGroupsByName[group.Name] = group

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -680,7 +680,7 @@ func TestDefaultAccountManager_SyncUserJWTGroups(t *testing.T) {
 		Domain:         domain,
 		UserId:         userId,
 		DomainCategory: "test-category",
-		Groups:         []string{"group1", "group2"},
+		Groups:         []string{"group1", "group2", "group1", "group2"},
 	}
 	t.Run("JWT groups disabled", func(t *testing.T) {
 		err := manager.SyncUserJWTGroups(context.Background(), claims)
@@ -723,6 +723,7 @@ func TestDefaultAccountManager_SyncUserJWTGroups(t *testing.T) {
 		require.True(t, ok, "group2 should be added to the account")
 		require.Equal(t, g2.Name, "group2", "group2 name should match")
 		require.Equal(t, g2.Issued, types.GroupIssuedJWT, "group2 issued should match")
+		require.ElementsMatch(t, []string{g1.ID, g2.ID}, account.Users[userId].AutoGroups, "JWT groups should only be assigned once")
 	})
 	t.Run("local embedded-Dex user is skipped", func(t *testing.T) {
 		initAccount.Settings.JWTGroupsEnabled = true


### PR DESCRIPTION
## Description

JWT group claims can contain repeated names when multiple identity-provider mappings emit the same group. The synchronization path preserved those duplicates, creating multiple JWT groups with the same name and assigning every generated group ID to the user.

This deduplicates claimed group names before calculating membership changes while preserving their original order and case.

## Changes

- Deduplicate JWT group names at the synchronization boundary
- Extend the existing JWT group sync test with repeated claim values
- Verify both group records and user memberships remain unique

## Testing

- `go test ./management/server -run '^TestDefaultAccountManager_SyncUserJWTGroups$' -count=1`
- `go test ./management/server/util -count=1`
- `go build ./management/...`
- `go vet ./management/server ./management/server/util`

Fixes #6618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate group assignments when incoming group claims contain repeated entries.
  * Group synchronization now produces only unique auto-group memberships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->