### PR TITLE
Additional relay support.

### DIFF
--- a/combined/cmd/config.go
+++ b/combined/cmd/config.go
@@ -29,7 +29,8 @@ import (
 // Architecture:
 //   - Management: Always runs locally (this IS the management server)
 //   - Signal: Runs locally by default; disabled if server.signalUri is set
-//   - Relay: Runs locally by default; disabled if server.relays is set
+//   - Relay: Runs locally by default; server.additionalRelays adds more relay
+//     addresses, while server.relays disables the local relay and replaces them
 //   - STUN: Runs locally on port 3478 by default; disabled if server.stuns is set
 //
 // All user-facing settings are under "server". The relay/signal/management
@@ -58,6 +59,9 @@ type ServerConfig struct {
 	StunPorts      []int  `yaml:"stunPorts"`      // STUN ports (empty to disable local STUN)
 	AuthSecret     string `yaml:"authSecret"`     // Shared secret for relay authentication
 	DataDir        string `yaml:"dataDir"`        // Data directory for all services
+
+	// Additional relay addresses advertised alongside the local relay
+	AdditionalRelays []string `yaml:"additionalRelays"`
 
 	// External service overrides (simplified mode)
 	// When these are set, the corresponding local service is NOT started
@@ -273,6 +277,8 @@ func parseExposedAddress(exposedAddress string) (protocol, hostname, hostPort st
 // ApplySimplifiedDefaults populates internal relay/signal/management configs from server settings.
 // Management is always enabled. Signal, Relay, and STUN are enabled unless external
 // overrides are configured (server.signalUri, server.relays, server.stuns).
+// server.additionalRelays does not override the local relay; its addresses are
+// advertised to clients in addition to the auto-configured local relay address.
 func (c *CombinedConfig) ApplySimplifiedDefaults() {
 	if !c.hasRequiredSettings() {
 		return
@@ -395,10 +401,9 @@ func (c *CombinedConfig) autoConfigureClientSettings(exposedProto, exposedHost, 
 		// Use external relay config from server
 		c.Management.Relays = c.Server.Relays
 	} else if len(c.Management.Relays.Addresses) == 0 {
-		// Auto-configure local relay
-		c.Management.Relays.Addresses = []string{
-			fmt.Sprintf("%s://%s", relayProto, exposedHostPort),
-		}
+		// Auto-configure the local relay, then advertise any additional relays.
+		localRelay := fmt.Sprintf("%s://%s", relayProto, exposedHostPort)
+		c.Management.Relays.Addresses = append([]string{localRelay}, c.Server.AdditionalRelays...)
 	}
 	if c.Management.Relays.Secret == "" {
 		c.Management.Relays.Secret = c.Server.AuthSecret

--- a/combined/cmd/config_test.go
+++ b/combined/cmd/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestApplySimplifiedDefaultsWithAdditionalRelays(t *testing.T) {
@@ -30,9 +32,7 @@ func TestApplySimplifiedDefaultsWithAdditionalRelays(t *testing.T) {
 		"rels://relay-eu.example.com:443",
 		"rels://relay-us.example.com:443",
 	}
-	if !reflect.DeepEqual(cfg.Management.Relays.Addresses, wantAddresses) {
-		t.Fatalf("relay addresses = %v, want %v", cfg.Management.Relays.Addresses, wantAddresses)
-	}
+	assert.ElementsMatch(t, wantAddresses, cfg.Management.Relays.Addresses)
 	if cfg.Management.Relays.Secret != cfg.Server.AuthSecret {
 		t.Fatalf("relay secret = %q, want server auth secret", cfg.Management.Relays.Secret)
 	}
@@ -72,9 +72,7 @@ func TestApplySimplifiedDefaultsWithRelayOverrideIgnoresAdditionalRelays(t *test
 
 	cfg.ApplySimplifiedDefaults()
 
-	if !reflect.DeepEqual(cfg.Management.Relays.Addresses, cfg.Server.Relays.Addresses) {
-		t.Fatalf("management relay addresses = %v, want %v", cfg.Management.Relays.Addresses, cfg.Server.Relays.Addresses)
-	}
+	assert.ElementsMatch(t, cfg.Server.Relays.Addresses, cfg.Management.Relays.Addresses)
 }
 
 func TestAdditionalRelaysStillRequireLocalRelaySecret(t *testing.T) {
@@ -111,7 +109,5 @@ func TestLoadConfigParsesAdditionalRelays(t *testing.T) {
 		"rels://relay-eu.example.com:443",
 		"rels://relay-us.example.com:443",
 	}
-	if !reflect.DeepEqual(cfg.Management.Relays.Addresses, wantAddresses) {
-		t.Fatalf("relay addresses = %v, want %v", cfg.Management.Relays.Addresses, wantAddresses)
-	}
+	assert.ElementsMatch(t, wantAddresses, cfg.Management.Relays.Addresses)
 }

--- a/combined/cmd/config_test.go
+++ b/combined/cmd/config_test.go
@@ -60,6 +60,23 @@ func TestApplySimplifiedDefaultsWithRelayOverride(t *testing.T) {
 	}
 }
 
+func TestApplySimplifiedDefaultsWithRelayOverrideIgnoresAdditionalRelays(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Server.ExposedAddress = "https://netbird.example.com:443"
+	cfg.Server.Relays = RelaysConfig{
+		Addresses: []string{"rels://relay.example.com:443"},
+	}
+	cfg.Server.AdditionalRelays = []string{
+		"rels://additional-relay.example.com:443",
+	}
+
+	cfg.ApplySimplifiedDefaults()
+
+	if !reflect.DeepEqual(cfg.Management.Relays.Addresses, cfg.Server.Relays.Addresses) {
+		t.Fatalf("management relay addresses = %v, want %v", cfg.Management.Relays.Addresses, cfg.Server.Relays.Addresses)
+	}
+}
+
 func TestAdditionalRelaysStillRequireLocalRelaySecret(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Server.ExposedAddress = "https://netbird.example.com:443"

--- a/combined/cmd/config_test.go
+++ b/combined/cmd/config_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestApplySimplifiedDefaultsWithAdditionalRelays(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Server.ExposedAddress = "https://netbird.example.com:443"
+	cfg.Server.AuthSecret = "shared-relay-secret"
+	cfg.Server.AdditionalRelays = []string{
+		"rels://relay-eu.example.com:443",
+		"rels://relay-us.example.com:443",
+	}
+
+	cfg.ApplySimplifiedDefaults()
+
+	if !cfg.Relay.Enabled {
+		t.Fatal("local relay should remain enabled when additional relays are configured")
+	}
+	if !cfg.Relay.Stun.Enabled {
+		t.Fatal("local STUN should remain enabled when additional relays are configured")
+	}
+
+	wantAddresses := []string{
+		"rels://netbird.example.com:443",
+		"rels://relay-eu.example.com:443",
+		"rels://relay-us.example.com:443",
+	}
+	if !reflect.DeepEqual(cfg.Management.Relays.Addresses, wantAddresses) {
+		t.Fatalf("relay addresses = %v, want %v", cfg.Management.Relays.Addresses, wantAddresses)
+	}
+	if cfg.Management.Relays.Secret != cfg.Server.AuthSecret {
+		t.Fatalf("relay secret = %q, want server auth secret", cfg.Management.Relays.Secret)
+	}
+}
+
+func TestApplySimplifiedDefaultsWithRelayOverride(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Server.ExposedAddress = "https://netbird.example.com:443"
+	cfg.Server.Relays = RelaysConfig{
+		Addresses:      []string{"rels://relay.example.com:443"},
+		CredentialsTTL: "24h",
+		Secret:         "external-relay-secret",
+	}
+
+	cfg.ApplySimplifiedDefaults()
+
+	if cfg.Relay.Enabled {
+		t.Fatal("local relay should remain disabled when server.relays overrides it")
+	}
+	if cfg.Relay.Stun.Enabled {
+		t.Fatal("local STUN should remain disabled with the relay override")
+	}
+	if !reflect.DeepEqual(cfg.Management.Relays, cfg.Server.Relays) {
+		t.Fatalf("management relay config = %+v, want %+v", cfg.Management.Relays, cfg.Server.Relays)
+	}
+}
+
+func TestAdditionalRelaysStillRequireLocalRelaySecret(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Server.ExposedAddress = "https://netbird.example.com:443"
+	cfg.Server.AuthSecret = ""
+	cfg.Server.AdditionalRelays = []string{"rels://relay.example.com:443"}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() should require server.authSecret because the local relay is enabled")
+	}
+}
+
+func TestLoadConfigParsesAdditionalRelays(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	configData := []byte(`server:
+  exposedAddress: "https://netbird.example.com:443"
+  authSecret: "shared-relay-secret"
+  additionalRelays:
+    - "rels://relay-eu.example.com:443"
+    - "rels://relay-us.example.com:443"
+`)
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatalf("write test config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	wantAddresses := []string{
+		"rels://netbird.example.com:443",
+		"rels://relay-eu.example.com:443",
+		"rels://relay-us.example.com:443",
+	}
+	if !reflect.DeepEqual(cfg.Management.Relays.Addresses, wantAddresses) {
+		t.Fatalf("relay addresses = %v, want %v", cfg.Management.Relays.Addresses, wantAddresses)
+	}
+}

--- a/combined/config.yaml.example
+++ b/combined/config.yaml.example
@@ -8,7 +8,8 @@
 # Architecture:
 #   - Management: Always runs locally (this IS the management server)
 #   - Signal: Local by default; set 'signalUri' to use external (disables local)
-#   - Relay: Local by default; set 'relays' to use external (disables local)
+#   - Relay: Local by default; set 'additionalRelays' to advertise more relays,
+#     or set 'relays' to replace the local relay with external relays
 #   - STUN: Local on port 3478 by default; set 'stuns' to use external instead
 
 server:
@@ -50,6 +51,12 @@ server:
 
   # Data directory for all services
   dataDir: "/var/lib/netbird/"
+
+  # Additional relay servers - keeps the local relay and advertises these too.
+  # The additional relay servers must use the same authSecret as this server.
+  # additionalRelays:
+  #   - "rels://relay-eu.example.com:443"
+  #   - "rels://relay-us.example.com:443"
 
   # ============================================================================
   # External Service Overrides (optional)

--- a/combined/config.yaml.example
+++ b/combined/config.yaml.example
@@ -52,7 +52,7 @@ server:
   # Data directory for all services
   dataDir: "/var/lib/netbird/"
 
-  # Additional relay servers - keeps the local relay and advertises these too.
+  # Additional relay servers - keeps the local relay and advertises these too (ignored if relays.addresses is set).
   # The additional relay servers must use the same authSecret as this server.
   # additionalRelays:
   #   - "rels://relay-eu.example.com:443"


### PR DESCRIPTION
## Describe your changes

Add `server.additionalRelays` support to the combined server so operators can
advertise external relay servers without disabling the embedded relay and STUN
service.

The automatically generated embedded relay address remains first in the relay
list, followed by the configured additional relay addresses. The existing
`server.relays` replacement behavior is unchanged and continues to take
precedence when configured.

This change also:

- documents the new setting in `combined/config.yaml.example`;
- verifies that the embedded relay and STUN service remain enabled;
- verifies relay address ordering and shared-secret configuration;
- verifies that the existing `server.relays` override behavior is preserved;
- verifies YAML loading and local relay secret validation.

The focused unit tests, race detector, `go vet`, and golangci-lint pass. The
configuration was also tested end-to-end with a combined server, two external
relays, and independent NetBird peers, including active-relay failover.

## Issue ticket number and link

Closes https://github.com/netbirdio/netbird/issues/5351

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
https://github.com/netbirdio/docs/pull/847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for advertising extra relays via `additionalRelays` while keeping the embedded/local relay enabled.
  * Client relay auto-configuration now includes the auto-detected local relay address followed by any configured `additionalRelays`.
* **Documentation**
  * Clarified the difference between `additionalRelays` (augment) and `relays` (replace), including authSecret behavior and configuration examples.
* **Bug Fixes**
  * Ensured relay configuration/validation requires the relay auth secret even when only `additionalRelays` are configured.
  * Confirmed that setting `relays` overrides `additionalRelays` (no augmentation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->