### PR TITLE
[management] fix duplicate operationId in OpenAPI spec

### DIFF
--- a/shared/management/http/api/openapi.yml
+++ b/shared/management/http/api/openapi.yml
@@ -10490,7 +10490,7 @@ paths:
         - EDR Intune Integrations
       summary: Delete EDR Intune Integration
       description: Deletes an EDR Intune Integration by its ID.
-      operationId: deleteIntegration
+      operationId: deleteEDRIntuneIntegration
       responses:
         '200':
           description: Integration deleted successfully. Returns an empty object.
@@ -12574,7 +12574,7 @@ paths:
         - Event Streaming Integrations
       summary: Delete Event Streaming Integration
       description: Deletes an event streaming integration by its ID.
-      operationId: deleteIntegration
+      operationId: deleteEventStreamingIntegration
       responses:
         '200':
           description: Integration deleted successfully. Returns an empty object.


### PR DESCRIPTION
## Description

The OpenAPI spec had two endpoints using the same `operationId: deleteIntegration`, which prevents strict code generators from producing client SDKs.

Renamed the conflicting operationIds to be descriptive and unique.

## Changes

- `DELETE /api/integrations/edr/intune` -> `deleteEDRIntuneIntegration`
- `DELETE /api/event-streaming/{id}` -> `deleteEventStreamingIntegration`

All other `delete*` operationIds verified unique with no further duplicates.

## Documentation

- [x] Documentation is **not needed** for this change (spec fix, no user-facing docs impact)

Fixes #5436