### PR TITLE
[client] Preserve user autostart setting across Windows NSIS upgrades

### DIFF
--- a/client/installer.nsis
+++ b/client/installer.nsis
@@ -299,14 +299,14 @@ ExecWait '"$INSTDIR\${MAIN_APP_EXE}" service uninstall'
 DetailPrint "Terminating Netbird UI process..."
 ExecWait `taskkill /im ${UI_APP_EXE}.exe /f`
 
-; Remove autostart registry entries
-DetailPrint "Removing autostart registry entries if they exist..."
-; Legacy machine-wide entry written by older installers.
+; Remove the legacy machine-wide autostart entry older installers wrote.
+; The per-user HKCU\...\Run value is owned by the UI's Wails toggle and is
+; left untouched here: the NSIS upgrade path runs this uninstaller before
+; reinstalling, so deleting it would wipe the user's launch-on-login choice
+; on every update. A leftover entry after a genuine uninstall is harmless --
+; Windows ignores Run values whose target executable no longer exists.
+DetailPrint "Removing legacy machine-wide autostart entry if present..."
 DeleteRegValue HKLM "${AUTOSTART_REG_KEY}" "${APP_NAME}"
-; Per-user entry the UI toggle writes via Wails (value name is the lowercase
-; app-name slug). Uninstall removes the app, so drop it too.
-DeleteRegValue HKCU "${AUTOSTART_REG_KEY}" "${APP_NAME}"
-DeleteRegValue HKCU "${AUTOSTART_REG_KEY}" "netbird"
 
 ; Handle data deletion based on checkbox
 DetailPrint "Checking if user requested data deletion..."


### PR DESCRIPTION
## Describe your changes

Fixes a pre-existing bug where every Windows EXE (NSIS) auto-update silently
wiped the user's launch-on-login setting.

The NSIS upgrade path (`client/installer.nsis` `.onInit`) runs the previous
version's uninstaller before reinstalling. That uninstaller deleted the
per-user `HKCU\...\CurrentVersion\Run` value that the UI's Wails autostart
toggle owns, so an upgrade removed the user's autostart choice on every update.

This stops deleting the HKCU value on uninstall. A leftover entry after a
genuine uninstall is harmless — Windows ignores `Run` values whose target
executable no longer exists, and a reinstall re-establishes it. The legacy
machine-wide `HKLM` entry that older installers wrote is still cleaned up.

This is groundwork for the upcoming autostart-default-on change, which keeps
the autostart decision entirely in the signed GUI (no installer/updater Run-key
writes).

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal Windows installer fix with no user-facing surface beyond the setting
now being preserved as expected.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved upgrade and uninstall behavior for autostart settings.
  - Legacy machine-wide autostart entries are now removed as expected.
  - Per-user autostart preferences are preserved, preventing uninstall or upgrade actions from unexpectedly disabling settings configured through the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->