### PR TITLE
[infrastructure] fix signal service port mapping for gRPC

### DIFF
--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -158,7 +158,7 @@ jobs:
           grep NETBIRD_MGMT_API_ENDPOINT docker-compose.yml | grep "$CI_NETBIRD_DOMAIN:33073"
           grep AUTH_REDIRECT_URI docker-compose.yml | grep $CI_NETBIRD_AUTH_REDIRECT_URI
           grep AUTH_SILENT_REDIRECT_URI docker-compose.yml | egrep 'AUTH_SILENT_REDIRECT_URI=$'
-          grep $CI_NETBIRD_SIGNAL_PORT docker-compose.yml | grep ':80'
+          grep $CI_NETBIRD_SIGNAL_PORT docker-compose.yml | grep ':10000'
           grep LETSENCRYPT_DOMAIN docker-compose.yml | egrep 'LETSENCRYPT_DOMAIN=$'
           grep NETBIRD_TOKEN_SOURCE docker-compose.yml | grep $CI_NETBIRD_TOKEN_SOURCE
           grep AuthUserIDClaim management.json | grep $CI_NETBIRD_AUTH_USER_ID_CLAIM

--- a/infrastructure_files/configure.sh
+++ b/infrastructure_files/configure.sh
@@ -178,7 +178,7 @@ if [[ "$NETBIRD_DISABLE_LETSENCRYPT" == "true" ]]; then
   echo "- $NETBIRD_DASHBOARD_ENDPOINT -http-> dashboard:80"
   echo "- $NETBIRD_MGMT_API_ENDPOINT/api -http-> management:$NETBIRD_MGMT_API_PORT"
   echo "- $NETBIRD_MGMT_API_ENDPOINT/management.ManagementService/ -grpc-> management:$NETBIRD_MGMT_API_PORT"
-  echo "- $NETBIRD_SIGNAL_ENDPOINT/signalexchange.SignalExchange/ -grpc-> signal:80"
+  echo "- $NETBIRD_SIGNAL_ENDPOINT/signalexchange.SignalExchange/ -grpc-> signal:10000"
   echo "- $NETBIRD_RELAY_ENDPOINT/ -http-> relay:33080"
   echo "You most likely also have to change NETBIRD_MGMT_API_ENDPOINT in base.setup.env and port-mappings in docker-compose.yml.tmpl and rerun this script."
   echo " The target of the forwards depends on your setup. Beware of the gRPC protocol instead of http for management and signal!"

--- a/infrastructure_files/docker-compose.yml.tmpl
+++ b/infrastructure_files/docker-compose.yml.tmpl
@@ -46,7 +46,7 @@ services:
       - $SIGNAL_VOLUMENAME:/var/lib/netbird
       - $LETSENCRYPT_VOLUMENAME:/etc/letsencrypt:ro
     ports:
-      - $NETBIRD_SIGNAL_PORT:80
+      - $NETBIRD_SIGNAL_PORT:10000
   #      # port and command for Let's Encrypt validation
   #      - 443:443
   #    command: ["--letsencrypt-domain", "$NETBIRD_LETSENCRYPT_DOMAIN", "--log-file", "console"]


### PR DESCRIPTION
## Description

The Docker Compose template mapped the signal service's external port to internal port 80, but the signal gRPC backward compatibility server runs on port 10000. This caused clients to see Signal as Disconnected when using custom TLS certificates.

## Changes

- Changed docker-compose.yml.tmpl signal port mapping from `$NETBIRD_SIGNAL_PORT:80` to `$NETBIRD_SIGNAL_PORT:10000`

## Documentation

- [x] Documentation is **not needed** for this change (infrastructure template fix)

Fixes #4762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Signal service container port mapping to use internal port **10000** instead of **80**, ensuring gRPC traffic is routed correctly.
  * Adjusted the deployment/configuration checks to verify the Signal port mapping now matches **10000**, improving connectivity consistency for configured environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->