### PR TITLE
[misc] fix dex approval template field name

### DIFF
--- a/idp/dex/web/templates/approval.html
+++ b/idp/dex/web/templates/approval.html
@@ -5,7 +5,7 @@
     <p class="nb-subheading">{{ .Client }} wants to access your account</p>
 
     <form method="post">
-        <input type="hidden" name="req" value="{{ .ReqID }}"/>
+        <input type="hidden" name="req" value="{{ .AuthReqID }}"/>
         <input type="hidden" name="approval" value="approve"/>
         <button type="submit" class="nb-btn">
             Allow Access
@@ -15,7 +15,7 @@
     <div class="nb-divider"></div>
 
     <form method="post">
-        <input type="hidden" name="req" value="{{ .ReqID }}"/>
+        <input type="hidden" name="req" value="{{ .AuthReqID }}"/>
         <input type="hidden" name="approval" value="rejected"/>
         <button type="submit" class="nb-btn-connector" style="margin-bottom:0">
             Deny Access


### PR DESCRIPTION
## Description

The embedded Dex approval template used `.ReqID` but the correct template field is `.AuthReqID`. This caused the OAuth consent form to render with an empty hidden input, breaking the authorization flow for third-party OIDC clients using the combined server.

## Changes

- Changed `.ReqID` to `.AuthReqID` in `idp/dex/web/templates/approval.html` (2 occurrences)

## Documentation

- [x] Documentation is **not needed** for this change (template fix)

Fixes #5746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed approval and rejection actions to submit the correct authentication request identifier, ensuring access decisions are processed reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->