### PR TITLE
[management] add groups to default OIDC scopes for generic providers

### DIFF
--- a/idp/dex/config.go
+++ b/idp/dex/config.go
@@ -270,11 +270,13 @@ func applyOIDCDefaults(connType string, config map[string]interface{}) map[strin
 	for k, v := range config {
 		augmented[k] = v
 	}
-	setDefault(augmented, "scopes", []string{"openid", "profile", "email", "groups"})
+	setDefault(augmented, "scopes", []string{"openid", "profile", "email"})
 	setDefault(augmented, "insecureEnableGroups", true)
 	setDefault(augmented, "insecureSkipEmailVerified", true)
 
 	switch connType {
+	case "oidc":
+		augmented["scopes"] = []string{"openid", "profile", "email", "groups"}
 	case "zitadel":
 		setDefault(augmented, "getUserInfo", true)
 	case "entra":

--- a/idp/dex/config.go
+++ b/idp/dex/config.go
@@ -270,7 +270,7 @@ func applyOIDCDefaults(connType string, config map[string]interface{}) map[strin
 	for k, v := range config {
 		augmented[k] = v
 	}
-	setDefault(augmented, "scopes", []string{"openid", "profile", "email"})
+	setDefault(augmented, "scopes", []string{"openid", "profile", "email", "groups"})
 	setDefault(augmented, "insecureEnableGroups", true)
 	setDefault(augmented, "insecureSkipEmailVerified", true)
 

--- a/idp/dex/connector.go
+++ b/idp/dex/connector.go
@@ -222,7 +222,7 @@ func buildOIDCConnectorConfig(cfg *ConnectorConfig, redirectURI string) ([]byte,
 		"clientID":             cfg.ClientID,
 		"clientSecret":         cfg.ClientSecret,
 		"redirectURI":          redirectURI,
-		"scopes":               []string{"openid", "profile", "email"},
+		"scopes":               []string{"openid", "profile", "email", "groups"},
 		"insecureEnableGroups": true,
 		//some providers don't return email verified, so we need to skip it if not present (e.g., Entra, Okta, Duo)
 		"insecureSkipEmailVerified": true,

--- a/idp/dex/connector.go
+++ b/idp/dex/connector.go
@@ -222,12 +222,14 @@ func buildOIDCConnectorConfig(cfg *ConnectorConfig, redirectURI string) ([]byte,
 		"clientID":             cfg.ClientID,
 		"clientSecret":         cfg.ClientSecret,
 		"redirectURI":          redirectURI,
-		"scopes":               []string{"openid", "profile", "email", "groups"},
+		"scopes":               []string{"openid", "profile", "email"},
 		"insecureEnableGroups": true,
 		//some providers don't return email verified, so we need to skip it if not present (e.g., Entra, Okta, Duo)
 		"insecureSkipEmailVerified": true,
 	}
 	switch cfg.Type {
+	case "oidc":
+		oidcConfig["scopes"] = []string{"openid", "profile", "email", "groups"}
 	case "zitadel":
 		oidcConfig["getUserInfo"] = true
 	case "entra":

--- a/idp/dex/connector_test.go
+++ b/idp/dex/connector_test.go
@@ -46,6 +46,16 @@ func TestBuildOIDCConnectorConfig_EntraSetsUserIDKey(t *testing.T) {
 
 	assert.Equal(t, "oid", m["userIDKey"], "entra connectors must default userIDKey to oid")
 	assert.Equal(t, map[string]any{"email": "preferred_username"}, m["claimMapping"])
+	assert.Equal(t, []any{"openid", "profile", "email"}, m["scopes"])
+}
+
+func TestBuildOIDCConnectorConfig_GenericIncludesGroupsScope(t *testing.T) {
+	data, err := buildOIDCConnectorConfig(&ConnectorConfig{Type: "oidc"}, "https://example.com/oauth2/callback")
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.Equal(t, []any{"openid", "profile", "email", "groups"}, m["scopes"])
 }
 
 func TestBuildOIDCConnectorConfig_NonEntraDoesNotSetUserIDKey(t *testing.T) {


### PR DESCRIPTION
## Description

Generic OIDC providers defaulted scopes to `openid profile email`, omitting `groups`. This prevented JWT group sync and group information from flowing through from the upstream IdP. Other providers like okta and pocketid already included `groups` in their default scopes.

## Changes

- Added `groups` to default OIDC scopes in `idp/dex/connector.go` (buildOIDCConnectorConfig)
- Added `groups` to default OIDC scopes in `idp/dex/config.go` (augmentConnectorConfig)

## Documentation

- [x] Documentation is **not needed** for this change (scope default change, no user-facing config impact)

Fixes #5673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC connectors using the generic `oidc` type now request group information by default (via the `groups` scope), in addition to `openid`, `profile`, and `email`.

* **Bug Fixes**
  * Ensures `groups` scope is consistently included for generic OIDC configuration, rather than only for certain provider-specific connector types.

* **Tests**
  * Added/updated coverage to verify the OIDC `scopes` behavior for both generic `oidc` and provider-specific cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->