### PR TITLE
[client] Bring the connection up in Go after SSO login

### DIFF
--- a/client/ui/frontend/src/lib/connection.ts
+++ b/client/ui/frontend/src/lib/connection.ts
@@ -51,7 +51,14 @@ async function runSsoLogin(
     if (uri) await openBrowserLoginUri(uri);
 
     const cancelPromise = buildSsoCancelPromise(state, signal);
-    const waitPromise = Connection.WaitSSOLogin({ userCode: result.userCode, hostname: "" });
+    // Combine wait + up in Go so the connection comes up the moment SSO
+    // completes. During SSO the tray window is hidden and the webview is
+    // suspended, so a frontend-driven Up (a promise continuation) would not
+    // fire until the user woke the window (e.g. hovering the tray icon).
+    const waitPromise = Connection.WaitSSOLoginAndUp(
+        { userCode: result.userCode, hostname: "" },
+        { profileName: "", username: "" },
+    );
 
     try {
         await Promise.race([waitPromise, cancelPromise]);
@@ -89,13 +96,13 @@ export async function startConnection(onSettled?: () => void, signal?: AbortSign
         if (signal?.aborted) state.cancelled = true;
 
         if (!state.cancelled && result.needsSsoLogin) {
+            // runSsoLogin brings the connection up in Go once SSO completes.
             await runSsoLogin(result, state, signal);
-        }
-
-        if (!state.cancelled && signal?.aborted) state.cancelled = true;
-
-        if (!state.cancelled) {
-            await Connection.Up({ profileName: "", username: "" });
+        } else {
+            if (!state.cancelled && signal?.aborted) state.cancelled = true;
+            if (!state.cancelled) {
+                await Connection.Up({ profileName: "", username: "" });
+            }
         }
     } catch (e) {
         WindowManager.CloseBrowserLogin().catch(console.error);

--- a/client/ui/services/connection.go
+++ b/client/ui/services/connection.go
@@ -162,6 +162,27 @@ func (s *Connection) Up(ctx context.Context, p UpParams) error {
 	return nil
 }
 
+// WaitSSOLoginAndUp blocks until the SSO login completes and then brings the
+// connection up, both from the Go side. Keeping the post-login Up here rather
+// than as a frontend continuation is deliberate: during SSO the tray window is
+// hidden and the webview is suspended (macOS App Nap / hidden-window timer
+// throttling), so a frontend-driven Up would not run until the user woke the
+// window (e.g. by hovering the tray icon). Doing it in Go connects the moment
+// the daemon reports SSO success. Returns the authenticated user's email.
+func (s *Connection) WaitSSOLoginAndUp(ctx context.Context, wait WaitSSOParams, up UpParams) (string, error) {
+	email, err := s.WaitSSOLogin(ctx, wait)
+	if err != nil {
+		return "", err
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if err := s.Up(ctx, up); err != nil {
+		return "", err
+	}
+	return email, nil
+}
+
 func (s *Connection) Down(ctx context.Context) error {
 	cli, err := s.conn.Client()
 	if err != nil {

--- a/client/ui/services/connection.go
+++ b/client/ui/services/connection.go
@@ -35,7 +35,7 @@ type LoginResult struct {
 	VerificationURIComplete string `json:"verificationUriComplete"`
 }
 
-// WaitSSOParams are the inputs to WaitSSOLogin.
+// WaitSSOParams are the inputs to waitSSOLogin.
 type WaitSSOParams struct {
 	UserCode string `json:"userCode"`
 	Hostname string `json:"hostname"`
@@ -125,23 +125,6 @@ func (s *Connection) Login(ctx context.Context, p LoginParams) (LoginResult, err
 	}, nil
 }
 
-func (s *Connection) WaitSSOLogin(ctx context.Context, p WaitSSOParams) (string, error) {
-	cli, err := s.conn.Client()
-	if err != nil {
-		return "", err
-	}
-	log.Infof("waiting for SSO login to complete")
-	resp, err := cli.WaitSSOLogin(ctx, &proto.WaitSSOLoginRequest{
-		UserCode: p.UserCode,
-		Hostname: p.Hostname,
-	})
-	if err != nil {
-		return "", s.classifyDaemonError(err)
-	}
-	log.Infof("SSO login completed, daemon reported success")
-	return resp.GetEmail(), nil
-}
-
 func (s *Connection) Up(ctx context.Context, p UpParams) error {
 	cli, err := s.conn.Client()
 	if err != nil {
@@ -170,7 +153,7 @@ func (s *Connection) Up(ctx context.Context, p UpParams) error {
 // window (e.g. by hovering the tray icon). Doing it in Go connects the moment
 // the daemon reports SSO success. Returns the authenticated user's email.
 func (s *Connection) WaitSSOLoginAndUp(ctx context.Context, wait WaitSSOParams, up UpParams) (string, error) {
-	email, err := s.WaitSSOLogin(ctx, wait)
+	email, err := s.waitSSOLogin(ctx, wait)
 	if err != nil {
 		return "", err
 	}
@@ -240,6 +223,26 @@ func (s *Connection) Logout(ctx context.Context, p LogoutParams) error {
 	}
 
 	return nil
+}
+
+// waitSSOLogin blocks until the daemon reports the SSO login result and returns
+// the authenticated user's email. It is unexported because the frontend drives
+// SSO through the exported WaitSSOLoginAndUp.
+func (s *Connection) waitSSOLogin(ctx context.Context, p WaitSSOParams) (string, error) {
+	cli, err := s.conn.Client()
+	if err != nil {
+		return "", err
+	}
+	log.Infof("waiting for SSO login to complete")
+	resp, err := cli.WaitSSOLogin(ctx, &proto.WaitSSOLoginRequest{
+		UserCode: p.UserCode,
+		Hostname: p.Hostname,
+	})
+	if err != nil {
+		return "", s.classifyDaemonError(err)
+	}
+	log.Infof("SSO login completed, daemon reported success")
+	return resp.GetEmail(), nil
 }
 
 // classifyDaemonError maps a gRPC error to a localised ClientError.


### PR DESCRIPTION
## Describe your changes

Fixes the GUI client sometimes not connecting for a long time after SSO login —
until the user interacts with the app (e.g. hovering the tray icon).

**Root cause:** the login flow orchestrates `Login → WaitSSOLogin → Up` in the
frontend (`client/ui/frontend/src/lib/connection.ts`). `WaitSSOLogin` blocks in
the daemon while the user completes SSO in the external browser. During that
time the tray window is hidden and the webview is suspended (macOS App Nap /
Windows hidden-window timer throttling), so the promise continuation that
issues `Up` doesn't run until the webview resumes — which only happens on user
interaction. This is exactly the stall `client/ui/frontend/src/lib/stallwatch.ts`
was added to detect in #6717 ("the WaitSSOLogin → Up handoff"); that PR added
detection only.

**Fix:** move the handoff off the webview's critical path. A new Go method
`Connection.WaitSSOLoginAndUp` performs `WaitSSOLogin` and then `Up` entirely in
Go, so the daemon connects the moment SSO completes, independent of webview
state. The frontend calls this single method on the SSO path and no longer
issues its own `Up`; the non-SSO (token) path is unchanged. Cancellation still
works via the bound call's context cancel, and the method re-checks `ctx.Err()`
before `Up`. The UI catches up via the status subscription when the window
wakes.

- `client/ui/services/connection.go`: add `WaitSSOLoginAndUp`
- `client/ui/frontend/src/lib/connection.ts`: use it on the SSO path; drop the
  separate frontend `Up` there

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

Note: this adds a UI-service method consumed only by the bundled desktop
frontend (not a public/gRPC/CLI surface). No behavior change outside the GUI
login path. Hard to cover with an automated test — it is webview-suspension
timing behind an external SSO round-trip; verified by manual repro (log in,
leave the tray window hidden, confirm the tunnel comes up without interaction).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal desktop-client login fix with no user-facing configuration or API
surface.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streamlined connection flow that waits for SSO authentication to complete before bringing the connection online.
  * After success, the authenticated email address is returned as part of the connection process.
* **Bug Fixes**
  * Improved handling of canceled requests by ensuring interruption is detected after SSO completes.
  * Authentication and connection failures now surface as clearer, more consistent errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->