### PR TITLE
[proxy, client] Include system events in status conversion

### DIFF
--- a/client/internal/debug/debug.go
+++ b/client/internal/debug/debug.go
@@ -480,7 +480,6 @@ func (g *BundleGenerator) addStatus() error {
 
 		fullStatus := g.statusRecorder.GetFullStatus()
 		protoFullStatus := nbstatus.ToProtoFullStatus(fullStatus)
-		protoFullStatus.Events = g.statusRecorder.GetEventHistory()
 		overview := nbstatus.ConvertToStatusOutputOverview(protoFullStatus, nbstatus.ConvertOptions{
 			Anonymize:     g.anonymize,
 			ProfileName:   profName,

--- a/client/status/status.go
+++ b/client/status/status.go
@@ -746,6 +746,8 @@ func ToProtoFullStatus(fullStatus peer.FullStatus) *proto.FullStatus {
 		pbFullStatus.DnsServers = append(pbFullStatus.DnsServers, pbDnsState)
 	}
 
+	pbFullStatus.Events = fullStatus.Events
+
 	return &pbFullStatus
 }
 


### PR DESCRIPTION
## Describe your changes

The embedded netbird clients used by the reverse proxy did not surface system events in their status output. `ToProtoFullStatus` converted every status field except the events list, so the proxy's per-account debug status endpoint always rendered an empty "Events:" section.

- Copy system events in `ToProtoFullStatus` so consumers of the conversion get them
- Drop the now-redundant explicit events assignment in the debug bundle generator, which previously worked around the gap

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal debug status output only; no user-facing docs affected.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Debug status bundles now preserve event history consistently.
  * Status output now correctly includes recorded events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->