### PR TITLE
[management] add logs to ephemeral delete

### DIFF
--- a/management/internals/modules/peers/ephemeral/manager/ephemeral.go
+++ b/management/internals/modules/peers/ephemeral/manager/ephemeral.go
@@ -215,7 +215,7 @@ func (e *EphemeralManager) cleanup(ctx context.Context) {
 	}
 
 	for accountID, peerIDs := range peerIDsPerAccount {
-		log.WithContext(ctx).Tracef("cleanup: deleting %d ephemeral peers for account %s", len(peerIDs), accountID)
+		log.WithContext(ctx).Debugf("cleanup: deleting %d ephemeral peers for account %s: %s", len(peerIDs), accountID, peerIDs)
 		err := e.peersManager.DeletePeers(ctx, accountID, peerIDs, activity.SystemInitiator, true)
 		if err != nil {
 			log.WithContext(ctx).Errorf("failed to delete ephemeral peers: %s", err)

--- a/management/internals/modules/peers/manager.go
+++ b/management/internals/modules/peers/manager.go
@@ -184,6 +184,8 @@ func (m *managerImpl) DeletePeers(ctx context.Context, accountID string, peerIDs
 				return err
 			}
 
+			log.WithContext(ctx).Debugf("DeletePeers: deleted peer %s", peerID)
+
 			if !(peer.ProxyMeta.Embedded || peer.Meta.KernelVersion == "wasm") {
 				eventsToStore = append(eventsToStore, func() {
 					m.accountManager.StoreEvent(ctx, userID, peer.ID, accountID, activity.PeerRemovedByUser, peer.EventMeta(dnsDomain))

--- a/management/internals/shared/grpc/token_mgr.go
+++ b/management/internals/shared/grpc/token_mgr.go
@@ -161,6 +161,8 @@ func (m *TimeBasedAuthSecretsManager) SetupRefresh(ctx context.Context, accountI
 		m.turnCancelMap[peerID] = turnCancel
 		go m.refreshTURNTokens(ctx, accountID, peerID, turnCancel)
 		log.WithContext(ctx).Debugf("starting TURN refresh for %s", peerID)
+	} else {
+		log.WithContext(ctx).Debugf("no TURN configuration, skipping TURN refresh for %s", peerID)
 	}
 
 	if m.relayCfg != nil {
@@ -168,6 +170,8 @@ func (m *TimeBasedAuthSecretsManager) SetupRefresh(ctx context.Context, accountI
 		m.relayCancelMap[peerID] = relayCancel
 		go m.refreshRelayTokens(ctx, accountID, peerID, relayCancel)
 		log.WithContext(ctx).Tracef("starting relay refresh for %s", peerID)
+	} else {
+		log.WithContext(ctx).Tracef("no relay configuration, skipping relay refresh for %s", peerID)
 	}
 }
 

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -106,10 +106,12 @@ func (am *DefaultAccountManager) MarkPeerConnected(ctx context.Context, peerPubK
 	}
 	if !updated {
 		am.metrics.AccountManagerMetrics().CountPeerStatusUpdate(telemetry.PeerStatusConnect, telemetry.PeerStatusStale)
-		log.WithContext(ctx).Tracef("peer %s already has a newer session in store, skipping connect", peer.ID)
+		log.WithContext(ctx).Debugf("peer %s already has a newer session in store, skipping connect", peer.ID)
 		return nil
 	}
 	am.metrics.AccountManagerMetrics().CountPeerStatusUpdate(telemetry.PeerStatusConnect, telemetry.PeerStatusApplied)
+
+	log.WithContext(ctx).Debugf("mark peer %s connected", peer.ID)
 
 	if err = am.schedulePeerExpirations(ctx, accountID, peer); err != nil {
 		return err
@@ -180,11 +182,13 @@ func (am *DefaultAccountManager) MarkPeerDisconnected(ctx context.Context, peerP
 	}
 	if !updated {
 		am.metrics.AccountManagerMetrics().CountPeerStatusUpdate(telemetry.PeerStatusDisconnect, telemetry.PeerStatusStale)
-		log.WithContext(ctx).Tracef("peer %s session token mismatch on disconnect (token=%d), skipping",
+		log.WithContext(ctx).Debugf("peer %s session token mismatch on disconnect (token=%d), skipping",
 			peer.ID, sessionStartedAt)
 		return nil
 	}
 	am.metrics.AccountManagerMetrics().CountPeerStatusUpdate(telemetry.PeerStatusDisconnect, telemetry.PeerStatusApplied)
+
+	log.WithContext(ctx).Debugf("mark peer %s disconnected", peer.ID)
 
 	// Symmetric with MarkPeerConnected: when an embedded proxy peer goes
 	// offline, refresh the peers that had synthesized records pointing at


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Logging Improvements**
  * Added more detailed debug logging when cleaning up ephemeral peers, including the specific peer IDs being deleted.
  * Added debug log output after each peer is successfully deleted.
  * Improved debug-level diagnostics for stale session and token-mismatch early exits during peer connect/disconnect handling.
  * Added explicit logs when TURN/relay refresh steps are skipped due to missing or disabled configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->