### PR TITLE
[client] stop retrying invalid setup keys

### DIFF
--- a/client/internal/auth/auth.go
+++ b/client/internal/auth/auth.go
@@ -213,11 +213,11 @@ func (a *Auth) Login(ctx context.Context, setupKey string, jwtToken string) (err
 				if setupKey != "" && jwtToken == "" && isPeerLoginExpired(err) {
 					err = errSetupKeyOnSSOExpiredPeer
 				}
-				isAuthError = isPermissionDenied(err)
+				isAuthError = isAuthenticationError(err)
 				return err
 			}
 		} else if err != nil {
-			isAuthError = isPermissionDenied(err)
+			isAuthError = isAuthenticationError(err)
 			return err
 		}
 
@@ -470,7 +470,7 @@ func (a *Auth) withRetry(ctx context.Context, operation func(client *mgm.GrpcCli
 }
 
 // isAuthenticationError checks if the error is an authentication-related error that should not be retried.
-// Returns true if the error is InvalidArgument or PermissionDenied, indicating that retrying won't help.
+// Returns true if retrying won't help without changing credentials or setup key.
 func isAuthenticationError(err error) bool {
 	if err == nil {
 		return false
@@ -479,7 +479,9 @@ func isAuthenticationError(err error) bool {
 	if !ok {
 		return false
 	}
-	return s.Code() == codes.InvalidArgument || s.Code() == codes.PermissionDenied
+	return s.Code() == codes.InvalidArgument ||
+		s.Code() == codes.PermissionDenied ||
+		s.Code() == codes.NotFound
 }
 
 // isPermissionDenied checks if the error is a PermissionDenied error.

--- a/client/internal/auth/auth.go
+++ b/client/internal/auth/auth.go
@@ -481,6 +481,7 @@ func isAuthenticationError(err error) bool {
 	}
 	return s.Code() == codes.InvalidArgument ||
 		s.Code() == codes.PermissionDenied ||
+		s.Code() == codes.Unauthenticated ||
 		s.Code() == codes.NotFound
 }
 

--- a/client/internal/auth/auth_test.go
+++ b/client/internal/auth/auth_test.go
@@ -78,3 +78,55 @@ func TestErrSetupKeyOnSSOExpiredPeer(t *testing.T) {
 		}
 	}
 }
+
+func TestIsAuthenticationError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("network read: connection reset"),
+			want: false,
+		},
+		{
+			name: "invalid argument",
+			err:  status.Error(codes.InvalidArgument, "invalid setup-key"),
+			want: true,
+		},
+		{
+			name: "permission denied",
+			err:  status.Error(codes.PermissionDenied, "no peer auth method provided"),
+			want: true,
+		},
+		{
+			name: "not found",
+			err:  status.Error(codes.NotFound, "setup key is invalid"),
+			want: true,
+		},
+		{
+			name: "deadline exceeded",
+			err:  status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+			want: false,
+		},
+		{
+			name: "unavailable",
+			err:  status.Error(codes.Unavailable, "connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAuthenticationError(tc.err); got != tc.want {
+				t.Fatalf("isAuthenticationError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/client/internal/auth/auth_test.go
+++ b/client/internal/auth/auth_test.go
@@ -106,6 +106,11 @@ func TestIsAuthenticationError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "unauthenticated",
+			err:  status.Error(codes.Unauthenticated, "peer is not registered"),
+			want: true,
+		},
+		{
 			name: "not found",
 			err:  status.Error(codes.NotFound, "setup key is invalid"),
 			want: true,


### PR DESCRIPTION
**Problem**
`netbird up --setup-key` can hang in the daemon retry loop when management returns a permanent auth/setup-key error such as `NotFound` for an invalid setup key. The retry loop already treated some auth failures as permanent, but not all relevant management auth statuses.

**Solution**
Classify `NotFound` and `Unauthenticated` as permanent authentication/setup-key errors. This lets invalid setup keys and unusable credentials fail fast while keeping connection errors like `DeadlineExceeded` and `Unavailable` retryable.

**Documentation**
- [x] Documentation is **not needed**

This only changes retry classification for an existing error path.

**Test**
`go test ./client/internal/auth ./client/server`

Fixes #5715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling during login by expanding which authentication-related responses stop retrying, including “not found” and other common auth/status failures.
* **Tests**
  * Added unit test coverage to verify authentication error classification across expected gRPC status codes and non-gRPC errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->