### PR TITLE
[client, relay] Increase early-message buffer cap to 10000 to avoid dropping relayed handshakes

### DIFF
--- a/shared/relay/client/early_msg_buffer.go
+++ b/shared/relay/client/early_msg_buffer.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	earlyMsgTTL      = 5 * time.Second
-	earlyMsgCapacity = 1000
+	earlyMsgCapacity = 10000
 )
 
 // earlyMsgBuffer buffers transport messages that arrive before the corresponding


### PR DESCRIPTION
## Describe your changes

Bump `earlyMsgCapacity` from 1000 to 10000 in
[`shared/relay/client/early_msg_buffer.go`](https://github.com/netbirdio/netbird/blob/8f64173574eebc51198ec1c805095b01c3259dba/shared/relay/client/early_msg_buffer.go#L13).

On a relay reconnect the server replays each peer's first WireGuard
handshake before the local side has finished calling `OpenConn`, so those
transport messages land in the early-message buffer. The buffer holds one
entry per peer and `put()` rejects new peers once it hits the cap. Increasing to 10K allows for serving up to 10K different peers handshakes before to push back and require future reattempts.

## Issue ticket number and link

No public GitHub issue. Fixes a hardcoded buffer cap that drops relayed
handshakes at scale, found during the client-reliability benchmark. Code:
https://github.com/netbirdio/netbird/blob/8f64173574eebc51198ec1c805095b01c3259dba/shared/relay/client/early_msg_buffer.go#L13

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal relay client buffer constant. No public API, config, or CLI
change; observable behavior is unchanged except that more peers' early
handshakes survive a reconnect at scale.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the number of early messages that can be buffered, helping preserve more incoming messages during initial connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->