### PR TITLE
[infrastructure] preserve generated netbird network name

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -881,6 +881,7 @@ volumes:
 
 networks:
   netbird:
+    name: netbird
     driver: bridge
     ipam:
       config:
@@ -1015,7 +1016,7 @@ EOF
 
 render_docker_compose_traefik() {
   local network_name="${TRAEFIK_EXTERNAL_NETWORK:-netbird}"
-  local network_config=""
+  local network_config="    name: netbird"
   if [[ -n "$TRAEFIK_EXTERNAL_NETWORK" ]]; then
     network_config="    external: true"
   fi
@@ -1100,13 +1101,15 @@ render_docker_compose_exposed_ports() {
   local bind_addr=$(get_bind_address)
   local networks="[netbird]"
   local networks_config="networks:
-  netbird:"
+  netbird:
+    name: netbird"
 
   # If an external network is specified, add it and include in service networks
   if [[ -n "$EXTERNAL_PROXY_NETWORK" ]]; then
     networks="[netbird, $EXTERNAL_PROXY_NETWORK]"
     networks_config="networks:
   netbird:
+    name: netbird
   $EXTERNAL_PROXY_NETWORK:
     external: true"
   fi


### PR DESCRIPTION
**Problem**
`getting-started.sh` can generate a Compose network named `netbird_netbird` because Docker Compose prefixes the project name. Built-in Traefik labels expect the Docker network to be named `netbird`, which causes startup warnings and can prevent the stack from becoming ready.

**Solution**
Set `name: netbird` on internally-created `netbird` networks in the generated compose output. External user-provided proxy networks remain external and unchanged.

**Documentation**
- [x] Documentation is **not needed**

This fixes generated infrastructure output without changing user-facing setup steps.

**Test**
`bash -n infrastructure_files/getting-started.sh`
`git diff --check`

Fixes #5793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker Compose configurations now consistently assign the expected `netbird` network name across supported deployment setups.
  * Improved networking consistency when using built-in or external proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->