### PR TITLE
[infrastructure] add internal health-check fallback for proxy readiness

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -292,10 +292,10 @@ wait_management_proxy() {
     if curl -sk -f -o /dev/null "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN/oauth2/.well-known/openid-configuration" 2>/dev/null; then
       break
     fi
-    # Fallback: check the container directly so the script
-    # completes even when hairpin NAT prevents the host from
-    # reaching its own external DNS name.
-    if curl -sk -f -o /dev/null "http://netbird-server:80/oauth2/.well-known/openid-configuration" 2>/dev/null; then
+    # Fallback: use --resolve to bypass DNS and connect to local
+    # Traefik directly. Works even when hairpin NAT prevents the
+    # host from reaching its own external IP via the domain name.
+    if curl -sk -f -o /dev/null --resolve "${NETBIRD_DOMAIN}:${NETBIRD_PORT}:127.0.0.1" "${NETBIRD_HTTP_PROTOCOL}://${NETBIRD_DOMAIN}/oauth2/.well-known/openid-configuration" 2>/dev/null; then
       break
     fi
     if [[ $counter -eq 60 ]]; then

--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -292,6 +292,12 @@ wait_management_proxy() {
     if curl -sk -f -o /dev/null "$NETBIRD_HTTP_PROTOCOL://$NETBIRD_DOMAIN/oauth2/.well-known/openid-configuration" 2>/dev/null; then
       break
     fi
+    # Fallback: check the container directly so the script
+    # completes even when hairpin NAT prevents the host from
+    # reaching its own external DNS name.
+    if curl -sk -f -o /dev/null "http://netbird-server:80/oauth2/.well-known/openid-configuration" 2>/dev/null; then
+      break
+    fi
     if [[ $counter -eq 60 ]]; then
       echo ""
       echo "Taking too long. Checking logs..."


### PR DESCRIPTION
**Problem**
`wait_management_proxy` in `getting-started.sh` only checks the embedded IdP endpoint via external DNS. When hairpin NAT is not configured, the host cannot reach its own external DNS name, causing the script to hang and `proxy.env` to be left unpopulated. This results in `netbird-proxy` crashing with `invalid domain format: ""`.

**Solution**
Add a fallback health check via the Docker container name (`netbird-server:80`) so the script completes even when hairpin NAT prevents external DNS loopback.

**Documentation**
- [x] Documentation is **not needed**

**Test**
`bash -n infrastructure_files/getting-started.sh`

Fixes #5892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup reliability by adding a fallback readiness check: if the proxy-based readiness endpoint can’t be reached, the system retries by attempting a direct connection to the local host using the configured port, completing initialization once successful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->