### PR TITLE
[management] use IP-octetless DNS name for ephemeral nodes if available

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -844,7 +844,7 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, accountID, setupKe
 		}
 
 		var freeLabel string
-		if ephemeral || attempt > 1 {
+		if attempt > 1 {
 			freeLabel, err = getPeerIPDNSLabel(freeIP, peer.Meta.Hostname)
 			if err != nil {
 				return nil, nil, nil, false, fmt.Errorf("failed to get free DNS label: %w", err)


### PR DESCRIPTION
## Describe your changes

We have an environment with lots of ephemeral peers; eg. autoscaled kube nodes. Sometimes, though, an administrator might need to connect to one of those via ssh; in that situation, it's much easier if the same hostname that is visible elsewhere (eg. kubectl get node) "just works", rather than having to discover the ephemeral peer name via `netbird status -d|grep`.

## Issue ticket number and link

Fixes: https://github.com/netbirdio/netbird/issues/5043

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [X] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [X] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

I don't think ephemeral peers are documented to use suffixed DNS names currently, and it would be strange to me if anyone was relying on this behavior.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS label selection when adding ephemeral peers.
  * Ephemeral peers now use the parsed hostname on the initial allocation attempt and fall back to an IP-derived label only when retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->