### PR TITLE
[proxy] enforce model allowlist for URL-routed providers (Bedrock/Vertex)

### DIFF
--- a/e2e/agentnetwork/chat_test.go
+++ b/e2e/agentnetwork/chat_test.go
@@ -91,7 +91,7 @@ func availableProviders() []providerCase {
 		if region == "" {
 			region = "us-east-1"
 		}
-		ps = append(ps, providerCase{name: "bedrock", catalogID: "bedrock_api", upstream: "https://bedrock-runtime." + region + ".amazonaws.com", apiKey: k, model: "us.anthropic.claude-haiku-4-5", kind: harness.WireMessages})
+		ps = append(ps, providerCase{name: "bedrock", catalogID: "bedrock_api", upstream: "https://bedrock-runtime." + region + ".amazonaws.com", apiKey: k, model: "us.anthropic.claude-haiku-4-5", kind: harness.WireBedrock})
 	}
 	return ps
 }
@@ -224,9 +224,12 @@ func TestProvidersMatrix(t *testing.T) {
 				var c int
 				var b string
 				var cerr error
-				if pc.kind == harness.WireVertex {
+				switch pc.kind {
+				case harness.WireVertex:
 					c, b, cerr = cl.Vertex(ctx, settings.Endpoint, proxyIP, pc.project, pc.region, pc.model, "Reply with exactly: pong", sessionID)
-				} else {
+				case harness.WireBedrock:
+					c, b, cerr = cl.Bedrock(ctx, settings.Endpoint, proxyIP, pc.model, "Reply with exactly: pong", sessionID)
+				default:
 					c, b, cerr = cl.Chat(ctx, settings.Endpoint, proxyIP, pc.kind, pc.model, "Reply with exactly: pong", sessionID)
 				}
 				if cerr == nil {

--- a/e2e/agentnetwork/guardrail_test.go
+++ b/e2e/agentnetwork/guardrail_test.go
@@ -1,0 +1,168 @@
+//go:build e2e
+
+package agentnetwork
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/e2e/harness"
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+// catalogModel returns the normalized catalog id the proxy stamps for a
+// path-routed provider's configured model — the form the guardrail allowlist is
+// compared against (region prefix / @version stripped).
+func catalogModel(pc providerCase) string {
+	switch pc.kind {
+	case harness.WireBedrock:
+		return strings.TrimPrefix(pc.model, "us.")
+	case harness.WireVertex:
+		return strings.SplitN(pc.model, "@", 2)[0]
+	default:
+		return pc.model
+	}
+}
+
+// disallowedModel returns a valid-shaped model id for the provider that is NOT
+// the configured/allowed one, so the guardrail must reject it before the
+// request ever reaches the upstream.
+func disallowedModel(pc providerCase) string {
+	switch pc.kind {
+	case harness.WireBedrock:
+		return "us.anthropic.claude-opus-4-8"
+	case harness.WireVertex:
+		return "claude-opus-4-8@20250101"
+	default:
+		return "unlisted-model"
+	}
+}
+
+// sendModel drives one request for the given model through the provider's native
+// wire shape and returns the HTTP status.
+func sendModel(ctx context.Context, t *testing.T, cl *harness.Client, endpoint, proxyIP string, pc providerCase, model string) int {
+	t.Helper()
+	var code int
+	var err error
+	switch pc.kind {
+	case harness.WireBedrock:
+		code, _, err = cl.Bedrock(ctx, endpoint, proxyIP, model, "Reply with exactly: pong", "")
+	case harness.WireVertex:
+		code, _, err = cl.Vertex(ctx, endpoint, proxyIP, pc.project, pc.region, model, "Reply with exactly: pong", "")
+	default:
+		code, _, err = cl.Chat(ctx, endpoint, proxyIP, pc.kind, model, "Reply with exactly: pong", "")
+	}
+	require.NoError(t, err, "request must reach the proxy for %s", pc.name)
+	return code
+}
+
+// TestModelAllowlistEnforced provisions a Model Allowlist guardrail limiting each
+// path-routed provider (Bedrock, Vertex) to its configured model, then drives
+// requests over the tunnel: the allowed model returns 200 while a model outside
+// the allowlist is denied 403 by the guardrail before it reaches the upstream.
+// This is the coverage missing for #6751 — the model for these providers travels
+// in the URL path, and the allowlist must be enforced there.
+func TestModelAllowlistEnforced(t *testing.T) {
+	var providers []providerCase
+	for _, pc := range availableProviders() {
+		if pc.kind == harness.WireBedrock || pc.kind == harness.WireVertex {
+			providers = append(providers, pc)
+		}
+	}
+	if len(providers) == 0 {
+		t.Skip("no path-routed provider keys set (AWS_BEARER_TOKEN_BEDROCK / GOOGLE_VERTEX_*); source ~/.llm-keys")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	grp, err := srv.API().Groups.Create(ctx, api.PostApiGroupsJSONRequestBody{Name: "e2e-allowlist"})
+	require.NoError(t, err, "create group")
+	t.Cleanup(func() { _ = srv.API().Groups.Delete(context.Background(), grp.Id) })
+
+	ephemeral := false
+	sk, err := srv.API().SetupKeys.Create(ctx, api.PostApiSetupKeysJSONRequestBody{
+		Name:       "e2e-allowlist-client",
+		Type:       "reusable",
+		ExpiresIn:  86400,
+		UsageLimit: 0,
+		AutoGroups: []string{grp.Id},
+		Ephemeral:  &ephemeral,
+	})
+	require.NoError(t, err, "mint setup key")
+
+	// Providers with their configured (allowed) models; the first bootstraps the cluster.
+	ids := make([]string, 0, len(providers))
+	allowed := make([]string, 0, len(providers))
+	for i, pc := range providers {
+		req := providerRequest(pc)
+		if i == 0 {
+			req.BootstrapCluster = ptr(harness.AgentNetworkCluster)
+		}
+		prov, perr := srv.CreateProvider(ctx, req)
+		require.NoError(t, perr, "create provider %s", pc.name)
+		id := prov.Id
+		ids = append(ids, id)
+		allowed = append(allowed, catalogModel(pc))
+		t.Cleanup(func() { _ = srv.DeleteProvider(context.Background(), id) })
+	}
+
+	// Guardrail allowlisting exactly the configured models.
+	var gr api.AgentNetworkGuardrailRequest
+	gr.Name = "e2e-allowlist"
+	gr.Checks.ModelAllowlist.Enabled = true
+	gr.Checks.ModelAllowlist.Models = allowed
+	guard, err := srv.CreateGuardrail(ctx, gr)
+	require.NoError(t, err, "create guardrail")
+	t.Cleanup(func() { _ = srv.DeleteGuardrail(context.Background(), guard.Id) })
+
+	enabled := true
+	pol, err := srv.CreatePolicy(ctx, api.AgentNetworkPolicyRequest{
+		Name:                   "e2e-allowlist",
+		Enabled:                &enabled,
+		SourceGroups:           []string{grp.Id},
+		DestinationProviderIds: ids,
+		GuardrailIds:           &[]string{guard.Id},
+	})
+	require.NoError(t, err, "create policy")
+	t.Cleanup(func() { _ = srv.DeletePolicy(context.Background(), pol.Id) })
+
+	settings, err := srv.GetSettings(ctx)
+	require.NoError(t, err, "read settings for endpoint")
+	require.NotEmpty(t, settings.Endpoint, "agent-network endpoint must be assigned")
+
+	proxyToken, err := srv.CreateProxyTokenCLI(ctx, "e2e-proxy-allowlist")
+	require.NoError(t, err, "mint proxy token via CLI")
+	px, err := harness.StartProxy(ctx, srv, proxyToken)
+	require.NoError(t, err, "start proxy")
+	t.Cleanup(func() { _ = px.Terminate(context.Background()) })
+
+	cl, err := harness.StartClient(ctx, srv, sk.Key)
+	require.NoError(t, err, "start client")
+	t.Cleanup(func() { _ = cl.Terminate(context.Background()) })
+
+	require.NoError(t, cl.WaitConnected(ctx, 90*time.Second), "client must connect to management")
+	if err := cl.WaitProxyPeer(ctx, 180*time.Second); err != nil {
+		t.Fatalf("client did not see the proxy peer: %v\n=== proxy logs ===\n%s", err, px.Logs(context.Background()))
+	}
+	proxyIP, err := cl.ResolveProxyIP(ctx, settings.Endpoint)
+	require.NoError(t, err, "resolve agent-network endpoint to proxy IP")
+
+	for _, pc := range providers {
+		pc := pc
+		t.Run(pc.name, func(t *testing.T) {
+			// The admin's allowlisted model is served end to end.
+			assert.Equal(t, 200, sendModel(ctx, t, cl, settings.Endpoint, proxyIP, pc, pc.model),
+				"allowlisted model must be permitted for %s", pc.name)
+			// A model outside the allowlist is rejected by the guardrail (before
+			// the upstream), regardless of whether it is a real catalog model.
+			assert.Equal(t, 403, sendModel(ctx, t, cl, settings.Endpoint, proxyIP, pc, disallowedModel(pc)),
+				"model outside the allowlist must be denied for %s", pc.name)
+		})
+	}
+}

--- a/e2e/harness/agentnetwork.go
+++ b/e2e/harness/agentnetwork.go
@@ -107,6 +107,17 @@ func (c *Combined) DeletePolicy(ctx context.Context, id string) error {
 	return anDelete(ctx, c, "/api/agent-network/policies/"+id)
 }
 
+// CreateGuardrail creates an agent-network guardrail (e.g. a model allowlist)
+// that can then be attached to a policy via its GuardrailIds.
+func (c *Combined) CreateGuardrail(ctx context.Context, req api.AgentNetworkGuardrailRequest) (api.AgentNetworkGuardrail, error) {
+	return anRequest[api.AgentNetworkGuardrail](ctx, c, http.MethodPost, "/api/agent-network/guardrails", req)
+}
+
+// DeleteGuardrail removes a guardrail by id.
+func (c *Combined) DeleteGuardrail(ctx context.Context, id string) error {
+	return anDelete(ctx, c, "/api/agent-network/guardrails/"+id)
+}
+
 // GetSettings returns the account's agent-network settings row. It exists only
 // after the first provider create bootstraps it.
 func (c *Combined) GetSettings(ctx context.Context) (api.AgentNetworkSettings, error) {

--- a/e2e/harness/client.go
+++ b/e2e/harness/client.go
@@ -194,6 +194,11 @@ const (
 	// WireVertex is the Anthropic-on-Vertex rawPredict shape: the client posts
 	// the full Vertex model path and the proxy mints the SA OAuth token.
 	WireVertex = "vertex"
+	// WireBedrock is the native AWS Bedrock InvokeModel shape: the model id
+	// travels in the URL path (/model/{id}/invoke), not the body, so the proxy
+	// routes by path. This is what a Bedrock SDK client sends and the shape the
+	// model-allowlist guardrail must enforce.
+	WireBedrock = "bedrock"
 )
 
 // Chat issues a chat-completion POST to the agent-network endpoint over the
@@ -223,6 +228,17 @@ func (cl *Client) Chat(ctx context.Context, endpoint, proxyIP, kind, model, prom
 func (cl *Client) Vertex(ctx context.Context, endpoint, proxyIP, project, region, model, prompt, sessionID string) (int, string, error) {
 	path := fmt.Sprintf("/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:rawPredict", project, region, model)
 	body := fmt.Sprintf(`{"anthropic_version":"vertex-2023-10-16","max_tokens":64,"messages":[{"role":"user","content":%q}]}`, prompt)
+	return cl.post(ctx, endpoint, proxyIP, path, body, withSessionID(nil, sessionID))
+}
+
+// Bedrock issues a native AWS Bedrock InvokeModel POST over the tunnel. The
+// model id is carried in the request path (/model/{id}/invoke), so the proxy
+// routes by path; the body uses the bedrock anthropic_version rather than a
+// model field. A non-empty sessionID is sent as the universal x-session-id
+// header the proxy records.
+func (cl *Client) Bedrock(ctx context.Context, endpoint, proxyIP, model, prompt, sessionID string) (int, string, error) {
+	path := "/model/" + model + "/invoke"
+	body := fmt.Sprintf(`{"anthropic_version":"bedrock-2023-05-31","max_tokens":64,"messages":[{"role":"user","content":%q}]}`, prompt)
 	return cl.post(ctx, endpoint, proxyIP, path, body, withSessionID(nil, sessionID))
 }
 

--- a/proxy/internal/middleware/builtin/llm_guardrail/middleware.go
+++ b/proxy/internal/middleware/builtin/llm_guardrail/middleware.go
@@ -25,6 +25,14 @@ const (
 	denyCodeModel    = "llm_policy.model_blocked"
 	denyReasonModel  = "model_blocked"
 	denyMessageModel = "model is not in the policy allowlist"
+	// Deny reason used when an allowlist is configured but the request model
+	// could not be determined. URL/path-routed providers (AWS Bedrock, Google
+	// Vertex, ...) carry the model outside the JSON body, so a request shape the
+	// parser does not recognise reaches the guardrail with no model. Such a
+	// request must be denied (fail closed), never waved through.
+	denyCodeModelUnknown    = "llm_policy.model_unknown"
+	denyReasonModelUnknown  = "model_unknown"
+	denyMessageModelUnknown = "request model could not be determined for the policy allowlist"
 )
 
 // Middleware enforces the model allowlist and optionally captures the
@@ -108,23 +116,37 @@ func (m *Middleware) evaluateAllowlist(model string, modelPresent bool) *middlew
 	if len(m.cfg.ModelAllowlist) == 0 {
 		return nil
 	}
-	if !modelPresent {
-		return nil
+	// Fail closed: with an allowlist configured, a request whose model the
+	// upstream parser could not extract (absent or empty) must be denied rather
+	// than allowed. This is what enforces the allowlist for URL/path-routed
+	// providers (Bedrock, Vertex, ...) whose model lives outside the JSON body.
+	if !modelPresent || normaliseModel(model) == "" {
+		return denyModel("", denyCodeModelUnknown, denyMessageModelUnknown, denyReasonModelUnknown)
 	}
 	if m.modelInAllowlist(model) {
 		return nil
+	}
+	return denyModel(model, denyCodeModel, denyMessageModel, denyReasonModel)
+}
+
+// denyModel builds a 403 deny Output for a model-allowlist rejection. model is
+// included in the details only when non-empty.
+func denyModel(model, code, message, reason string) *middleware.Output {
+	details := map[string]string{}
+	if model != "" {
+		details["model"] = model
 	}
 	return &middleware.Output{
 		Decision:   middleware.DecisionDeny,
 		DenyStatus: 403,
 		DenyReason: &middleware.DenyReason{
-			Code:    denyCodeModel,
-			Message: denyMessageModel,
-			Details: map[string]string{"model": model},
+			Code:    code,
+			Message: message,
+			Details: details,
 		},
 		Metadata: []middleware.KV{
 			{Key: middleware.KeyLLMPolicyDecision, Value: "deny"},
-			{Key: middleware.KeyLLMPolicyReason, Value: denyReasonModel},
+			{Key: middleware.KeyLLMPolicyReason, Value: reason},
 		},
 	}
 }

--- a/proxy/internal/middleware/builtin/llm_guardrail/middleware_test.go
+++ b/proxy/internal/middleware/builtin/llm_guardrail/middleware_test.go
@@ -102,13 +102,44 @@ func TestAllowlistCaseInsensitive(t *testing.T) {
 	}
 }
 
-func TestAllowlistMissingModelKeyAllows(t *testing.T) {
+func TestAllowlistMissingModelKeyDenies(t *testing.T) {
+	// Fail closed: with an allowlist configured, a request whose model the
+	// parser could not extract (URL/path-routed providers such as Bedrock or
+	// Vertex whose shape wasn't recognised) must be denied, not allowed.
 	mw := New(Config{ModelAllowlist: []string{"gpt-4o"}})
 	out, err := mw.Invoke(context.Background(), newInput())
 	require.NoError(t, err)
-	assert.Equal(t, middleware.DecisionAllow, out.Decision, "missing model key must allow even with non-empty allowlist")
+	require.NotNil(t, out)
+	assert.Equal(t, middleware.DecisionDeny, out.Decision, "absent model must be denied when an allowlist is set")
+	assert.Equal(t, 403, out.DenyStatus, "deny status must be 403")
+	require.NotNil(t, out.DenyReason, "deny reason must be populated")
+	assert.Equal(t, "llm_policy.model_unknown", out.DenyReason.Code, "deny code must be model_unknown")
 	dec, _ := metaValue(t, out.Metadata, middleware.KeyLLMPolicyDecision)
-	assert.Equal(t, "allow", dec, "decision must be allow when model key is absent")
+	assert.Equal(t, "deny", dec, "decision must be deny when model key is absent")
+	reason, _ := metaValue(t, out.Metadata, middleware.KeyLLMPolicyReason)
+	assert.Equal(t, "model_unknown", reason, "reason metadata must be model_unknown")
+}
+
+func TestAllowlistEmptyModelValueDenies(t *testing.T) {
+	// A present-but-empty model is as undeterminable as an absent one.
+	mw := New(Config{ModelAllowlist: []string{"gpt-4o"}})
+	out, err := mw.Invoke(context.Background(), newInput(
+		middleware.KV{Key: middleware.KeyLLMModel, Value: "   "},
+	))
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, middleware.DecisionDeny, out.Decision, "empty model must be denied when an allowlist is set")
+	require.NotNil(t, out.DenyReason, "deny reason must be populated")
+	assert.Equal(t, "llm_policy.model_unknown", out.DenyReason.Code, "deny code must be model_unknown")
+}
+
+func TestAllowlistEmptyListAllowsMissingModel(t *testing.T) {
+	// Without an allowlist there is nothing to enforce, so a missing model is
+	// still allowed — the fail-closed rule only applies when a list is set.
+	mw := New(Config{})
+	out, err := mw.Invoke(context.Background(), newInput())
+	require.NoError(t, err)
+	assert.Equal(t, middleware.DecisionAllow, out.Decision, "no allowlist must allow even without a model")
 }
 
 func TestPromptCaptureDisabledEmitsNoPrompt(t *testing.T) {

--- a/proxy/internal/middleware/builtin/llm_request_parser/guardrail_allowlist_test.go
+++ b/proxy/internal/middleware/builtin/llm_request_parser/guardrail_allowlist_test.go
@@ -1,0 +1,106 @@
+package llm_request_parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/proxy/internal/middleware"
+	"github.com/netbirdio/netbird/proxy/internal/middleware/builtin/llm_guardrail"
+)
+
+// runParserGuardrail runs the request parser then the model-allowlist guardrail
+// in SlotOnRequest order, threading the parser's metadata into the guardrail the
+// same way the real chain does. It returns the guardrail decision so tests can
+// assert allowlist enforcement for URL/path-routed providers end to end.
+func runParserGuardrail(t *testing.T, url string, body []byte, allowlist []string) *middleware.Output {
+	t.Helper()
+	parser := newMiddleware(t)
+	parsed, err := parser.Invoke(context.Background(), &middleware.Input{
+		Slot: middleware.SlotOnRequest,
+		URL:  url,
+		Body: body,
+	})
+	require.NoError(t, err, "parser must not error")
+
+	guard := llm_guardrail.New(llm_guardrail.Config{ModelAllowlist: allowlist})
+	out, err := guard.Invoke(context.Background(), &middleware.Input{
+		Slot:     middleware.SlotOnRequest,
+		Metadata: parsed.Metadata,
+	})
+	require.NoError(t, err, "guardrail must not error")
+	require.NotNil(t, out, "guardrail must return an output")
+	return out
+}
+
+// TestModelAllowlist_URLRoutedProviders validates that the model allowlist is
+// enforced for providers whose model travels in the URL path (AWS Bedrock,
+// Google Vertex) rather than the JSON body. The "unknown action" case is the
+// regression guard for #6751: a Bedrock request shape the parser cannot map to a
+// model must fail closed under an allowlist instead of bypassing it.
+func TestModelAllowlist_URLRoutedProviders(t *testing.T) {
+	const bedrockBody = `{"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":"hi"}]}`
+	const vertexBody = `{"anthropic_version":"vertex-2023-10-16","messages":[{"role":"user","content":"hi"}]}`
+
+	tests := []struct {
+		name      string
+		url       string
+		body      string
+		allowlist []string
+		decision  middleware.Decision
+		denyCode  string
+	}{
+		{
+			name:      "bedrock allowed model passes",
+			url:       "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-haiku-4-5-v1:0/invoke",
+			body:      bedrockBody,
+			allowlist: []string{"anthropic.claude-haiku-4-5"},
+			decision:  middleware.DecisionAllow,
+		},
+		{
+			name:      "bedrock disallowed model denied",
+			url:       "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-opus-4-8-v1:0/invoke",
+			body:      bedrockBody,
+			allowlist: []string{"anthropic.claude-haiku-4-5"},
+			decision:  middleware.DecisionDeny,
+			denyCode:  "llm_policy.model_blocked",
+		},
+		{
+			name:      "bedrock unknown action fails closed",
+			url:       "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-opus-4-8-v1:0/some-future-action",
+			body:      bedrockBody,
+			allowlist: []string{"anthropic.claude-haiku-4-5"},
+			decision:  middleware.DecisionDeny,
+			denyCode:  "llm_policy.model_unknown",
+		},
+		{
+			name:      "vertex disallowed model denied",
+			url:       "/v1/projects/p/locations/global/publishers/anthropic/models/claude-opus-4-8@20250101:rawPredict",
+			body:      vertexBody,
+			allowlist: []string{"claude-haiku-4-5"},
+			decision:  middleware.DecisionDeny,
+			denyCode:  "llm_policy.model_blocked",
+		},
+		{
+			name:      "vertex allowed model passes",
+			url:       "/v1/projects/p/locations/global/publishers/anthropic/models/claude-haiku-4-5@20250101:rawPredict",
+			body:      vertexBody,
+			allowlist: []string{"claude-haiku-4-5"},
+			decision:  middleware.DecisionAllow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := runParserGuardrail(t, tt.url, []byte(tt.body), tt.allowlist)
+			assert.Equal(t, tt.decision, out.Decision, "unexpected decision for %s", tt.name)
+			if tt.decision == middleware.DecisionDeny {
+				require.NotNil(t, out.DenyReason, "deny reason must be set for %s", tt.name)
+				assert.Equal(t, 403, out.DenyStatus, "deny status must be 403 for %s", tt.name)
+				assert.Equal(t, tt.denyCode, out.DenyReason.Code, "deny code for %s", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes

The Agent Network policy Guardrail "Model Allowlist" was not enforced for providers whose model travels in the URL/path rather than the JSON body — most visibly AWS Bedrock (reported in netbirdio/netbird#6751), and the same class applies to Google Vertex.

Root cause: the `llm_guardrail` allowlist check **failed open**. `evaluateAllowlist` returned allow whenever the request model was absent from the metadata bag (`middleware.go`, `if !modelPresent { return nil }`). The model is stamped upstream by `llm_request_parser`; for body-routed providers (OpenAI/Anthropic) it comes from the JSON body, but for path-routed providers the model is recovered only when the request matches a recognized path shape (Bedrock `/model/{id}/{invoke|converse|...}`, Vertex `/v1/projects/.../publishers/.../models/...`). Any shape the parser did not recognize reached the guardrail with no model and was allowed regardless of the allowlist.

Fix (provider-agnostic): **fail closed**. When an allowlist is configured and the model cannot be determined (absent or empty), the request is denied `403` with a distinct `llm_policy.model_unknown` reason. This closes the bypass for Bedrock, Vertex, and any future URL-routed provider in one place. When no allowlist is configured, behavior is unchanged.

The model allowlist is enforced solely in the proxy `llm_guardrail`; management's `CheckLLMPolicyLimits` handles only token/budget caps, so no management change is required.

## Issue ticket number and link

<https://github.com/netbirdio/netbird/discussions/6751>

## Stack

- \#6726 <!-- branch-stack -->
  - \#6764 :point\_left:

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Bug fix that restores the documented allowlist behavior; no user-facing surface changes.

### Docs PR URL (required if "docs added" is checked)

Paste the PR link from <https://github.com/netbirdio/docs> here:

<https://github.com/netbirdio/docs/pull/>\_\_

## Tests

- `llm_guardrail`: absent/empty model under a configured allowlist now denies (`model_unknown`); empty allowlist still allows a missing model (fail-closed only applies when a list is set); existing allow/deny/case-insensitive cases retained.
- `llm_request_parser`: new parser→guardrail integration test drives real **Bedrock** (`/model/{id}/invoke`) and **Vertex** (`/v1/projects/.../models/...`) URL shapes and asserts allowed→200, disallowed→403 (`model_blocked`), and an unrecognized Bedrock action→403 (`model_unknown`, the #6751 regression guard).

Note: a full through-tunnel e2e for the allowlist is intentionally deferred — the agent-network e2e (`WaitProxyPeer`) is currently red on `main`/`0.74.x` for an unrelated lazy-connection reason; it will be added once that harness gate is fixed.
