### PR TITLE
[client] Size relay data-path socket buffers for throughput

### DIFF
--- a/client/iface/wgproxy/ebpf/proxy.go
+++ b/client/iface/wgproxy/ebpf/proxy.go
@@ -104,6 +104,7 @@ func (p *WGEBPFProxy) Listen() error {
 		return err
 	}
 	p.conn = conn
+	nbnet.SizeRelaySocketBuffers(conn)
 
 	go p.proxyToRemote()
 	log.Infof("local wg proxy listening on: %d", proxyPort)

--- a/client/iface/wgproxy/udp/proxy.go
+++ b/client/iface/wgproxy/udp/proxy.go
@@ -16,6 +16,7 @@ import (
 	cerrors "github.com/netbirdio/netbird/client/errors"
 	"github.com/netbirdio/netbird/client/iface/bufsize"
 	"github.com/netbirdio/netbird/client/iface/wgproxy/listener"
+	nbnet "github.com/netbirdio/netbird/client/net"
 )
 
 // WGUDPProxy proxies
@@ -63,6 +64,8 @@ func (p *WGUDPProxy) AddTurnConn(ctx context.Context, _ *net.UDPAddr, remoteConn
 		log.Errorf("failed dialing to local Wireguard port %s", err)
 		return err
 	}
+
+	nbnet.SizeRelaySocketBuffers(localConn)
 
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	p.localConn = localConn

--- a/client/iface/wgproxy/udp/proxy.go
+++ b/client/iface/wgproxy/udp/proxy.go
@@ -16,6 +16,7 @@ import (
 	cerrors "github.com/netbirdio/netbird/client/errors"
 	"github.com/netbirdio/netbird/client/iface/bufsize"
 	"github.com/netbirdio/netbird/client/iface/wgproxy/listener"
+	nbnet "github.com/netbirdio/netbird/client/net"
 )
 
 // WGUDPProxy proxies
@@ -63,6 +64,8 @@ func (p *WGUDPProxy) AddRelayedConn(ctx context.Context, _ *net.UDPAddr, remoteC
 		log.Errorf("failed dialing to local Wireguard port %s", err)
 		return err
 	}
+
+	nbnet.SizeRelaySocketBuffers(localConn)
 
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	p.localConn = localConn

--- a/client/net/sockbuffer.go
+++ b/client/net/sockbuffer.go
@@ -1,0 +1,68 @@
+package net
+
+import (
+	"os"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// relaySocketBufferEnv overrides, in bytes, the receive and send buffer size
+// applied to the UDP sockets that carry relayed WireGuard data. A value of "0"
+// disables the sizing entirely; an empty or invalid value uses the default.
+const relaySocketBufferEnv = "NB_WGPROXY_SOCKET_BUFFER"
+
+// defaultRelaySocketBufferSize is the receive/send buffer applied by default to
+// relayed-data UDP sockets. The OS default (typically ~208 KiB) is too small for
+// a single high-rate relayed flow: sender-side kernel drops on a full receive
+// buffer surface to the tunnelled TCP as loss and collapse its throughput.
+const defaultRelaySocketBufferSize = 7 << 20 // 7 MiB
+
+// socketBufferConn is the portable subset used for the fallback sizing path.
+type socketBufferConn interface {
+	SetReadBuffer(bytes int) error
+	SetWriteBuffer(bytes int) error
+}
+
+// relaySocketBufferSize resolves the configured buffer size from the environment.
+func relaySocketBufferSize() int {
+	v := os.Getenv(relaySocketBufferEnv)
+	if v == "" {
+		return defaultRelaySocketBufferSize
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		log.Warnf("invalid %s value %q, using default %d", relaySocketBufferEnv, v, defaultRelaySocketBufferSize)
+		return defaultRelaySocketBufferSize
+	}
+	return n
+}
+
+// SizeRelaySocketBuffers grows the receive and send buffers of a UDP socket that
+// carries relayed data. On Linux it first tries SO_RCVBUFFORCE/SO_SNDBUFFORCE,
+// which bypass net.core.rmem_max/wmem_max when the process is privileged; it
+// falls back to the portable SetReadBuffer/SetWriteBuffer (clamped by those
+// sysctls, but still above the OS default) when the forced path is unavailable.
+// Setting NB_WGPROXY_SOCKET_BUFFER to 0 disables the sizing.
+func SizeRelaySocketBuffers(conn any) {
+	size := relaySocketBufferSize()
+	if size == 0 {
+		return
+	}
+
+	if !forceSocketBuffers(conn, size) {
+		bc, ok := conn.(socketBufferConn)
+		if !ok {
+			log.Debugf("relay socket buffer sizing skipped: %T supports neither forced nor portable sizing", conn)
+			return
+		}
+		if err := bc.SetReadBuffer(size); err != nil {
+			log.Debugf("failed to set relay socket read buffer to %d: %s", size, err)
+		}
+		if err := bc.SetWriteBuffer(size); err != nil {
+			log.Debugf("failed to set relay socket write buffer to %d: %s", size, err)
+		}
+	}
+
+	logRelaySocketBuffers(conn)
+}

--- a/client/net/sockbuffer.go
+++ b/client/net/sockbuffer.go
@@ -29,7 +29,7 @@ func relaySocketBufferSize() int {
 	if v == "" {
 		return defaultRelaySocketBufferSize
 	}
-	n, err := strconv.Atoi(v)
+	n, err := strconv.ParseInt(v, 10, 64)
 	if err != nil || n < 0 {
 		log.Warnf("invalid %s value %q, using default %d", relaySocketBufferEnv, v, defaultRelaySocketBufferSize)
 		return defaultRelaySocketBufferSize
@@ -38,7 +38,7 @@ func relaySocketBufferSize() int {
 		log.Warnf("%s value %d exceeds the kernel limit, using %d", relaySocketBufferEnv, n, maxRelaySocketBufferSize)
 		return maxRelaySocketBufferSize
 	}
-	return n
+	return int(n)
 }
 
 // SizeRelaySocketBuffers grows the receive and send buffers of a UDP socket that carries

--- a/client/net/sockbuffer.go
+++ b/client/net/sockbuffer.go
@@ -1,15 +1,16 @@
 package net
 
 import (
+	"math"
 	"os"
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
 )
 
-// relaySocketBufferEnv overrides, in bytes, the receive and send buffer size
-// applied to the UDP sockets that carry relayed WireGuard data. A value of "0"
-// disables the sizing entirely; an empty or invalid value uses the default.
+// relaySocketBufferEnv sets, in bytes, the size that the receive and send buffers of
+// the UDP sockets carrying relayed WireGuard data are grown to. Buffers already at least
+// that large are left alone. "0" disables the sizing; empty or invalid uses the default.
 const relaySocketBufferEnv = "NB_WGPROXY_SOCKET_BUFFER"
 
 // defaultRelaySocketBufferSize is the receive/send buffer applied by default to
@@ -18,11 +19,9 @@ const relaySocketBufferEnv = "NB_WGPROXY_SOCKET_BUFFER"
 // buffer surface to the tunnelled TCP as loss and collapse its throughput.
 const defaultRelaySocketBufferSize = 7 << 20 // 7 MiB
 
-// socketBufferConn is the portable subset used for the fallback sizing path.
-type socketBufferConn interface {
-	SetReadBuffer(bytes int) error
-	SetWriteBuffer(bytes int) error
-}
+// maxRelaySocketBufferSize is the largest size the kernel accepts before doubling it, and
+// keeps the value within the int32 that setsockopt takes.
+const maxRelaySocketBufferSize = math.MaxInt32 / 2
 
 // relaySocketBufferSize resolves the configured buffer size from the environment.
 func relaySocketBufferSize() int {
@@ -35,34 +34,23 @@ func relaySocketBufferSize() int {
 		log.Warnf("invalid %s value %q, using default %d", relaySocketBufferEnv, v, defaultRelaySocketBufferSize)
 		return defaultRelaySocketBufferSize
 	}
+	if n > maxRelaySocketBufferSize {
+		log.Warnf("%s value %d exceeds the kernel limit, using %d", relaySocketBufferEnv, n, maxRelaySocketBufferSize)
+		return maxRelaySocketBufferSize
+	}
 	return n
 }
 
-// SizeRelaySocketBuffers grows the receive and send buffers of a UDP socket that
-// carries relayed data. On Linux it first tries SO_RCVBUFFORCE/SO_SNDBUFFORCE,
-// which bypass net.core.rmem_max/wmem_max when the process is privileged; it
-// falls back to the portable SetReadBuffer/SetWriteBuffer (clamped by those
-// sysctls, but still above the OS default) when the forced path is unavailable.
-// Setting NB_WGPROXY_SOCKET_BUFFER to 0 disables the sizing.
+// SizeRelaySocketBuffers grows the receive and send buffers of a UDP socket that carries
+// relayed WireGuard data to the size set by NB_WGPROXY_SOCKET_BUFFER (7 MiB by default),
+// and never shrinks a buffer that is already larger. Setting the variable to 0 disables
+// the sizing. Only the Linux kernel-mode WireGuard proxies own such a socket, so this
+// does nothing on other platforms.
 func SizeRelaySocketBuffers(conn any) {
 	size := relaySocketBufferSize()
 	if size == 0 {
 		return
 	}
 
-	if !forceSocketBuffers(conn, size) {
-		bc, ok := conn.(socketBufferConn)
-		if !ok {
-			log.Debugf("relay socket buffer sizing skipped: %T supports neither forced nor portable sizing", conn)
-			return
-		}
-		if err := bc.SetReadBuffer(size); err != nil {
-			log.Debugf("failed to set relay socket read buffer to %d: %s", size, err)
-		}
-		if err := bc.SetWriteBuffer(size); err != nil {
-			log.Debugf("failed to set relay socket write buffer to %d: %s", size, err)
-		}
-	}
-
-	logRelaySocketBuffers(conn)
+	growSocketBuffers(conn, size)
 }

--- a/client/net/sockbuffer_linux.go
+++ b/client/net/sockbuffer_linux.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package net
+
+import (
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+type rawConnProvider interface {
+	SyscallConn() (syscall.RawConn, error)
+}
+
+// forceSocketBuffers sets the receive and send buffers with SO_RCVBUFFORCE /
+// SO_SNDBUFFORCE, which bypass net.core.rmem_max/wmem_max when the process holds
+// CAP_NET_ADMIN (typically when running as root). Returns true only when both
+// options were set, so the caller can fall back to the portable path otherwise.
+func forceSocketBuffers(conn any, size int) bool {
+	rc, ok := conn.(rawConnProvider)
+	if !ok {
+		return false
+	}
+	raw, err := rc.SyscallConn()
+	if err != nil {
+		log.Debugf("failed to get raw conn for forced relay socket sizing: %s", err)
+		return false
+	}
+
+	var setErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		if e := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUFFORCE, size); e != nil {
+			setErr = e
+			return
+		}
+		if e := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUFFORCE, size); e != nil {
+			setErr = e
+		}
+	})
+	if ctrlErr != nil {
+		log.Debugf("failed to control relay socket for forced sizing: %s", ctrlErr)
+		return false
+	}
+	if setErr != nil {
+		log.Debugf("forced relay socket sizing unavailable (%s); using portable sizing", setErr)
+		return false
+	}
+	return true
+}
+
+// logRelaySocketBuffers reads back the effective SO_RCVBUF/SO_SNDBUF and logs
+// them at debug level. The kernel stores roughly twice the requested value for
+// its own bookkeeping, so the reported numbers are about 2x what was asked for.
+func logRelaySocketBuffers(conn any) {
+	rc, ok := conn.(rawConnProvider)
+	if !ok {
+		return
+	}
+	raw, err := rc.SyscallConn()
+	if err != nil {
+		return
+	}
+
+	var rcv, snd int
+	if err := raw.Control(func(fd uintptr) {
+		rcv, _ = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUF)
+		snd, _ = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUF)
+	}); err != nil {
+		return
+	}
+	log.Debugf("relay socket buffers: rcvbuf=%d sndbuf=%d (kernel-reported, ~2x requested)", rcv, snd)
+}

--- a/client/net/sockbuffer_linux.go
+++ b/client/net/sockbuffer_linux.go
@@ -13,61 +13,71 @@ type rawConnProvider interface {
 	SyscallConn() (syscall.RawConn, error)
 }
 
-// forceSocketBuffers sets the receive and send buffers with SO_RCVBUFFORCE /
-// SO_SNDBUFFORCE, which bypass net.core.rmem_max/wmem_max when the process holds
-// CAP_NET_ADMIN (typically when running as root). Returns true only when both
-// options were set, so the caller can fall back to the portable path otherwise.
-func forceSocketBuffers(conn any, size int) bool {
+func growSocketBuffers(conn any, size int) {
 	rc, ok := conn.(rawConnProvider)
 	if !ok {
-		return false
+		log.Debugf("relay socket buffer sizing skipped: %T has no raw connection", conn)
+		return
 	}
 	raw, err := rc.SyscallConn()
 	if err != nil {
-		log.Debugf("failed to get raw conn for forced relay socket sizing: %s", err)
-		return false
+		log.Debugf("relay socket buffer sizing skipped: get raw conn: %v", err)
+		return
 	}
 
-	var setErr error
-	ctrlErr := raw.Control(func(fd uintptr) {
-		if e := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUFFORCE, size); e != nil {
-			setErr = e
-			return
-		}
-		if e := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUFFORCE, size); e != nil {
-			setErr = e
-		}
-	})
-	if ctrlErr != nil {
-		log.Debugf("failed to control relay socket for forced sizing: %s", ctrlErr)
-		return false
-	}
-	if setErr != nil {
-		log.Debugf("forced relay socket sizing unavailable (%s); using portable sizing", setErr)
-		return false
-	}
-	return true
+	growSocketBuffer(raw, "receive", unix.SO_RCVBUF, unix.SO_RCVBUFFORCE, size)
+	growSocketBuffer(raw, "send", unix.SO_SNDBUF, unix.SO_SNDBUFFORCE, size)
 }
 
-// logRelaySocketBuffers reads back the effective SO_RCVBUF/SO_SNDBUF and logs
-// them at debug level. The kernel stores roughly twice the requested value for
-// its own bookkeeping, so the reported numbers are about 2x what was asked for.
-func logRelaySocketBuffers(conn any) {
-	rc, ok := conn.(rawConnProvider)
-	if !ok {
+// growSocketBuffer raises one buffer to size unless it is already at least that large.
+// The forced option goes first because it ignores rmem_max/wmem_max. The unforced
+// fallback is capped by them, so it only shrinks a buffer already above twice that cap.
+func growSocketBuffer(raw syscall.RawConn, name string, opt, forceOpt, size int) {
+	before, err := getSockoptInt(raw, opt)
+	if err != nil {
+		log.Debugf("relay socket %s buffer sizing skipped: read current size: %v", name, err)
 		return
 	}
-	raw, err := rc.SyscallConn()
-	if err != nil {
+	// The kernel doubles a requested size for its own overhead and reports the doubled
+	// value, but reports an untouched socket's default as is.
+	if before >= 2*size {
+		log.Debugf("relay socket %s buffer already %d bytes, keeping it", name, before)
 		return
 	}
 
-	var rcv, snd int
-	if err := raw.Control(func(fd uintptr) {
-		rcv, _ = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUF)
-		snd, _ = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUF)
-	}); err != nil {
+	if err := setSockoptInt(raw, forceOpt, size); err != nil {
+		log.Debugf("forced relay socket %s buffer sizing unavailable: %v", name, err)
+		if err := setSockoptInt(raw, opt, size); err != nil {
+			log.Debugf("failed to set relay socket %s buffer to %d bytes: %v", name, size, err)
+			return
+		}
+	}
+
+	after, err := getSockoptInt(raw, opt)
+	if err != nil {
+		log.Debugf("failed to read back relay socket %s buffer: %v", name, err)
 		return
 	}
-	log.Debugf("relay socket buffers: rcvbuf=%d sndbuf=%d (kernel-reported, ~2x requested)", rcv, snd)
+	log.Debugf("relay socket %s buffer set from %d to %d bytes (kernel-reported)", name, before, after)
+}
+
+func getSockoptInt(raw syscall.RawConn, opt int) (int, error) {
+	var value int
+	var sockErr error
+	if err := raw.Control(func(fd uintptr) {
+		value, sockErr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, opt)
+	}); err != nil {
+		return 0, err
+	}
+	return value, sockErr
+}
+
+func setSockoptInt(raw syscall.RawConn, opt, value int) error {
+	var sockErr error
+	if err := raw.Control(func(fd uintptr) {
+		sockErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, opt, value)
+	}); err != nil {
+		return err
+	}
+	return sockErr
 }

--- a/client/net/sockbuffer_linux_test.go
+++ b/client/net/sockbuffer_linux_test.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package net
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// relaySocketBufferFloor is a lower bound on the readback SO_RCVBUF/SO_SNDBUF
+// after sizing. The kernel doubles the requested value on readback; unprivileged
+// runs are clamped to net.core.rmem_max (commonly 212992, doubling to 425984),
+// while privileged runs reach close to the configured default of 7 MiB. This
+// floor holds in both cases while still proving growth over the ~208 KiB OS
+// default.
+const relaySocketBufferFloor = 416 * 1024
+
+func getSockBuffers(t *testing.T, conn *net.UDPConn) (rcv, snd int) {
+	t.Helper()
+
+	sc, err := conn.SyscallConn()
+	require.NoError(t, err)
+
+	var ctrlErr error
+	err = sc.Control(func(fd uintptr) {
+		rcv, ctrlErr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUF)
+		if ctrlErr != nil {
+			return
+		}
+		snd, ctrlErr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUF)
+	})
+	require.NoError(t, err)
+	require.NoError(t, ctrlErr)
+	return rcv, snd
+}
+
+func TestSizeRelaySocketBuffersGrowsBuffers(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rcvBefore, sndBefore := getSockBuffers(t, conn)
+
+	SizeRelaySocketBuffers(conn)
+
+	rcvAfter, sndAfter := getSockBuffers(t, conn)
+
+	assert.GreaterOrEqual(t, rcvAfter, relaySocketBufferFloor)
+	assert.GreaterOrEqual(t, sndAfter, relaySocketBufferFloor)
+	assert.GreaterOrEqual(t, rcvAfter, rcvBefore)
+	assert.GreaterOrEqual(t, sndAfter, sndBefore)
+}
+
+func TestSizeRelaySocketBuffersEnvDisable(t *testing.T) {
+	t.Setenv(relaySocketBufferEnv, "0")
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rcvBefore, sndBefore := getSockBuffers(t, conn)
+
+	SizeRelaySocketBuffers(conn)
+
+	rcvAfter, sndAfter := getSockBuffers(t, conn)
+
+	assert.Equal(t, rcvBefore, rcvAfter)
+	assert.Equal(t, sndBefore, sndAfter)
+}

--- a/client/net/sockbuffer_linux_test.go
+++ b/client/net/sockbuffer_linux_test.go
@@ -38,7 +38,43 @@ func getSockBuffers(t *testing.T, conn *net.UDPConn) (rcv, snd int) {
 	return rcv, snd
 }
 
+// setSockBuffers applies size with the unforced SO_RCVBUF/SO_SNDBUF, which works without
+// privilege while size stays under rmem_max/wmem_max, and returns the kernel readback.
+func setSockBuffers(t *testing.T, conn *net.UDPConn, size int) (rcv, snd int) {
+	t.Helper()
+
+	sc, err := conn.SyscallConn()
+	require.NoError(t, err)
+
+	var ctrlErr error
+	err = sc.Control(func(fd uintptr) {
+		ctrlErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUF, size)
+		if ctrlErr != nil {
+			return
+		}
+		ctrlErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUF, size)
+	})
+	require.NoError(t, err)
+	require.NoError(t, ctrlErr)
+
+	rcv, snd = getSockBuffers(t, conn)
+	require.Equal(t, 2*size, rcv, "precondition: receive buffer readback is doubled")
+	require.Equal(t, 2*size, snd, "precondition: send buffer readback is doubled")
+	return rcv, snd
+}
+
+func listenLoopbackUDP(t *testing.T) *net.UDPConn {
+	t.Helper()
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
 func TestSizeRelaySocketBuffersGrowsBuffers(t *testing.T) {
+	unsetRelaySocketBufferEnv(t)
+
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
 	require.NoError(t, err)
 	defer conn.Close()
@@ -70,4 +106,51 @@ func TestSizeRelaySocketBuffersEnvDisable(t *testing.T) {
 
 	assert.Equal(t, rcvBefore, rcvAfter)
 	assert.Equal(t, sndBefore, sndAfter)
+}
+
+func TestSizeRelaySocketBuffersNeverShrinks(t *testing.T) {
+	// A 65536 request reads back as 131072. Asking for 32768 afterwards would read back
+	// as 65536, so applying it would halve buffers that are already larger.
+	t.Setenv(relaySocketBufferEnv, "32768")
+
+	conn := listenLoopbackUDP(t)
+	rcvBefore, sndBefore := setSockBuffers(t, conn, 65536)
+
+	SizeRelaySocketBuffers(conn)
+
+	rcvAfter, sndAfter := getSockBuffers(t, conn)
+	assert.Equal(t, rcvBefore, rcvAfter, "receive buffer must not shrink")
+	assert.Equal(t, sndBefore, sndAfter, "send buffer must not shrink")
+}
+
+func TestSizeRelaySocketBuffersOversizedValue(t *testing.T) {
+	// 1<<32 truncates to 0 in setsockopt's int32 argument, and the kernel turns 0 into its
+	// minimum buffer. On 32-bit platforms Atoi rejects the value and the default applies,
+	// which must not shrink either.
+	t.Setenv(relaySocketBufferEnv, "4294967296")
+
+	conn := listenLoopbackUDP(t)
+	rcvBefore, sndBefore := setSockBuffers(t, conn, 65536)
+
+	SizeRelaySocketBuffers(conn)
+
+	rcvAfter, sndAfter := getSockBuffers(t, conn)
+	assert.GreaterOrEqual(t, rcvAfter, rcvBefore, "receive buffer must not shrink")
+	assert.GreaterOrEqual(t, sndAfter, sndBefore, "send buffer must not shrink")
+}
+
+func TestSizeRelaySocketBuffersComparesKernelUnits(t *testing.T) {
+	// The buffers read back 131072. A 98304 request is below that as a raw number but reads
+	// back as 196608 once applied, so it still grows them. Comparing the readback against
+	// the unscaled request would wrongly skip it.
+	t.Setenv(relaySocketBufferEnv, "98304")
+
+	conn := listenLoopbackUDP(t)
+	setSockBuffers(t, conn, 65536)
+
+	SizeRelaySocketBuffers(conn)
+
+	rcvAfter, sndAfter := getSockBuffers(t, conn)
+	assert.Equal(t, 2*98304, rcvAfter, "receive buffer should reach the requested size")
+	assert.Equal(t, 2*98304, sndAfter, "send buffer should reach the requested size")
 }

--- a/client/net/sockbuffer_linux_test.go
+++ b/client/net/sockbuffer_linux_test.go
@@ -124,9 +124,9 @@ func TestSizeRelaySocketBuffersNeverShrinks(t *testing.T) {
 }
 
 func TestSizeRelaySocketBuffersOversizedValue(t *testing.T) {
-	// 1<<32 truncates to 0 in setsockopt's int32 argument, and the kernel turns 0 into its
-	// minimum buffer. On 32-bit platforms Atoi rejects the value and the default applies,
-	// which must not shrink either.
+	// Unclamped, 1<<32 would truncate to 0 in setsockopt's int32 argument and the kernel
+	// would apply its minimum buffer. The clamped value must not shrink the buffers either;
+	// unprivileged, rmem_max caps the result, so only growth is asserted here.
 	t.Setenv(relaySocketBufferEnv, "4294967296")
 
 	conn := listenLoopbackUDP(t)

--- a/client/net/sockbuffer_others.go
+++ b/client/net/sockbuffer_others.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package net
+
+// forceSocketBuffers is a no-op on non-Linux platforms: the SO_*BUFFORCE options
+// are Linux-specific, so callers fall back to the portable SetReadBuffer/
+// SetWriteBuffer path.
+func forceSocketBuffers(_ any, _ int) bool {
+	return false
+}
+
+// logRelaySocketBuffers is a no-op on non-Linux platforms.
+func logRelaySocketBuffers(_ any) {}

--- a/client/net/sockbuffer_others.go
+++ b/client/net/sockbuffer_others.go
@@ -2,12 +2,6 @@
 
 package net
 
-// forceSocketBuffers is a no-op on non-Linux platforms: the SO_*BUFFORCE options
-// are Linux-specific, so callers fall back to the portable SetReadBuffer/
-// SetWriteBuffer path.
-func forceSocketBuffers(_ any, _ int) bool {
-	return false
-}
-
-// logRelaySocketBuffers is a no-op on non-Linux platforms.
-func logRelaySocketBuffers(_ any) {}
+// growSocketBuffers does nothing: only the Linux kernel-mode WireGuard proxies own a UDP
+// socket on the relayed data path.
+func growSocketBuffers(_ any, _ int) {}

--- a/client/net/sockbuffer_test.go
+++ b/client/net/sockbuffer_test.go
@@ -1,0 +1,78 @@
+package net
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelaySocketBufferSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		setEnv   bool
+		expected int
+	}{
+		{
+			name:     "unset uses default",
+			setEnv:   false,
+			expected: defaultRelaySocketBufferSize,
+		},
+		{
+			name:     "empty uses default",
+			envValue: "",
+			setEnv:   true,
+			expected: defaultRelaySocketBufferSize,
+		},
+		{
+			name:     "zero disables sizing",
+			envValue: "0",
+			setEnv:   true,
+			expected: 0,
+		},
+		{
+			name:     "explicit value is honored",
+			envValue: "1048576",
+			setEnv:   true,
+			expected: 1048576,
+		},
+		{
+			name:     "non-numeric value uses default",
+			envValue: "garbage",
+			setEnv:   true,
+			expected: defaultRelaySocketBufferSize,
+		},
+		{
+			name:     "negative value uses default",
+			envValue: "-5",
+			setEnv:   true,
+			expected: defaultRelaySocketBufferSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(relaySocketBufferEnv, tt.envValue)
+			}
+
+			assert.Equal(t, tt.expected, relaySocketBufferSize())
+		})
+	}
+}
+
+func TestSizeRelaySocketBuffersSmoke(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	assert.NotPanics(t, func() {
+		SizeRelaySocketBuffers(conn)
+	})
+
+	assert.NotPanics(t, func() {
+		SizeRelaySocketBuffers(struct{}{})
+	})
+}

--- a/client/net/sockbuffer_test.go
+++ b/client/net/sockbuffer_test.go
@@ -1,12 +1,22 @@
 package net
 
 import (
+	"math"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// unsetRelaySocketBufferEnv clears the variable for the rest of the test and restores
+// any ambient value afterwards.
+func unsetRelaySocketBufferEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(relaySocketBufferEnv, "")
+	require.NoError(t, os.Unsetenv(relaySocketBufferEnv))
+}
 
 func TestRelaySocketBufferSize(t *testing.T) {
 	tests := []struct {
@@ -50,15 +60,23 @@ func TestRelaySocketBufferSize(t *testing.T) {
 			setEnv:   true,
 			expected: defaultRelaySocketBufferSize,
 		},
+		{
+			name:     "value above the kernel cap is clamped",
+			envValue: "2000000000",
+			setEnv:   true,
+			expected: math.MaxInt32 / 2,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnv {
 				t.Setenv(relaySocketBufferEnv, tt.envValue)
+			} else {
+				unsetRelaySocketBufferEnv(t)
 			}
 
-			assert.Equal(t, tt.expected, relaySocketBufferSize())
+			assert.Equal(t, tt.expected, relaySocketBufferSize(), "resolved buffer size")
 		})
 	}
 }

--- a/client/net/sockbuffer_test.go
+++ b/client/net/sockbuffer_test.go
@@ -66,6 +66,12 @@ func TestRelaySocketBufferSize(t *testing.T) {
 			setEnv:   true,
 			expected: math.MaxInt32 / 2,
 		},
+		{
+			name:     "value wider than 32 bits is clamped",
+			envValue: "4294967296",
+			setEnv:   true,
+			expected: math.MaxInt32 / 2,
+		},
 	}
 
 	for _, tt := range tests {

--- a/shared/relay/client/dialer/quic/quic.go
+++ b/shared/relay/client/dialer/quic/quic.go
@@ -61,6 +61,10 @@ func (d Dialer) Dial(ctx context.Context, address, serverName string) (net.Conn,
 	if err != nil {
 		return nil, fmt.Errorf("listen udp: %w", err)
 	}
+	// quic.Dial takes ownership of this socket but leaves its buffers at the OS
+	// default; size it so a busy relay path does not drop datagrams on a full
+	// kernel buffer.
+	nbnet.SizeRelaySocketBuffers(udpConn)
 
 	udpAddr, err := net.ResolveUDPAddr("udp", quicURL)
 	if err != nil {


### PR DESCRIPTION
## Describe your changes

The UDP sockets that carry relayed WireGuard data are never sized, so they run at the OS default (`net.core.rmem_default`, typically ~208 KiB). A single fast relayed flow overruns the sending peer's local WG proxy socket: the kernel drops packets, the tunnelled TCP interprets that as path loss, and its congestion window collapses.

A repo-wide grep for `SO_RCVBUF|SO_SNDBUF|SetReadBuffer|SetWriteBuffer` finds exactly one call site in the tree — `client/internal/routemanager/systemops/systemops_unix.go:185`, the netlink route socket. Nothing on the data path:

- `client/iface/wgproxy/udp/proxy.go` — the UDP proxy's local socket, used with kernel WireGuard when eBPF is unavailable
- `client/iface/wgproxy/ebpf/proxy.go` — the eBPF proxy's local socket

Both exist only on Linux with kernel WireGuard. Userspace, netstack and non-Linux clients hand relayed packets to an in-memory bind and have no such socket.

This PR grows the receive and send buffers of both sockets to 7 MiB by default. Each buffer is read back first and left alone when it is already at least the target. Neither the default nor `NB_WGPROXY_SOCKET_BUFFER` (in bytes; `0` disables) can shrink a buffer. `SO_RCVBUFFORCE`/`SO_SNDBUFFORCE` are tried first because `net.core.rmem_max`/`wmem_max` do not cap them. Without `CAP_NET_ADMIN` in the initial user namespace (e.g. in an unprivileged container), sizing falls back to plain `SO_RCVBUF`/`SO_SNDBUF`, which those sysctls do cap.

The QUIC relay dialer is deliberately left alone: quic-go sizes that socket itself, including an `SO_RCVBUFFORCE` attempt on Linux (`sys_conn_buffers.go`), so a call there would be redundant. An earlier revision of this PR touched it; that hunk has been removed.

Measured 2026-07 on **0.74.2** — two 1 Gbit Linux hosts, ~5 ms RTT via a dedicated relay VPS running the stock relay image, single `iperf3` flow, cubic, stock sysctls, receiver-side Mbit/s:

| | up | down |
|---|---|---|
| stock 0.74.2 | 97.6 | 96.5 |
| with this change | 180 | 150 |

Retransmissions on the tunnelled TCP drop from hundreds per 30 s run to zero. The change is client-only and wire-compatible: no relay or server change, no configuration needed.

**Caveat on the numbers:** I no longer have that lab, so they have not been re-measured on 0.77.x. The cause is unchanged on `main` (citations above). The branch merges cleanly into current `main`. Verification covered:

- `go test ./client/net/...` with and without `CAP_NET_ADMIN`, on amd64 and 386
- golangci-lint for linux, darwin and windows
- cross-builds of `client/net` for arm64, darwin, windows, freebsd and android, plus the js/wasm client

It has not been re-benchmarked on hardware.

Memory note: `SO_RCVBUF`/`SO_SNDBUF` set a limit, not an allocation. Memory is only consumed while packets are queued, so the worst case is reached only under sustained overload, which is exactly when the headroom is needed. That worst case is 14 MiB each way per proxy socket, in kernel accounting that already includes `sk_buff` overhead.

## Issue ticket number and link

#6021, and [discussion #7401](https://github.com/netbirdio/netbird/discussions/7401) — opened to get the diagnosis validated under the current discussion-first flow.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

Leaving that last box unticked deliberately: this predates the current ticket-first policy, and #6021 is a community report the team never triaged, so it is not an agreed ticket. The linked discussion is the request for that agreement. If you would rather the code waited on validation, say so and I will close this and reopen it once there is a ticket — I would just rather you had something concrete to look at while deciding.

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

The behavior change is invisible to operators: buffers are grown automatically and never shrunk. `NB_WGPROXY_SOCKET_BUFFER` only exists to pick a different target, or `0` to keep the OS default, and nobody is expected to set it. Happy to document the variable if you would prefer it surfaced.

### Docs PR URL (required if "docs added" is checked)

N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Relay and proxy UDP connections now automatically grow socket buffers when needed, supporting high-throughput traffic.
  * Existing buffer capacity is preserved, and oversized configuration values are handled safely.
  * Buffer sizing can remain disabled through configuration and behaves consistently across supported platforms.

* **Tests**
  * Added coverage for buffer growth, configuration handling, platform behavior, oversized values, and protection against unintended shrinking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->