### PR TITLE
[client,relay] Coalesce relayed packets into batch frames (RFC)

### DIFF
--- a/client/iface/wgproxy/ebpf/proxy.go
+++ b/client/iface/wgproxy/ebpf/proxy.go
@@ -49,7 +49,8 @@ type WGEBPFProxy struct {
 
 	// batchRead drains several relayed packets from the local WireGuard socket
 	// with one recvmmsg and forwards them back-to-back, cutting the per-packet
-	// syscall and wakeup overhead on the hot send path. Gated by
+	// syscall and wakeup overhead on the hot send path and letting the relay
+	// client's frame coalescer (NB_RELAY_COALESCE) pack full frames. Gated by
 	// NB_RELAY_BATCH_READ; the per-packet path stays the default.
 	batchRead bool
 
@@ -219,7 +220,8 @@ func (p *WGEBPFProxy) proxyToRemote() {
 // the single proxy socket is shared by every relayed peer, recvmmsg yields each
 // packet's source address, which selects the destination turn conn. Draining
 // several packets per recvmmsg amortizes the read syscall and wakeup across the
-// batch on the hot send path.
+// batch and forwards them back-to-back so the relay client's coalescer can pack
+// full frames.
 func (p *WGEBPFProxy) proxyToRemoteBatch(pc net.PacketConn) {
 	batchConn := ipv4.NewPacketConn(pc)
 	bufSize := int(p.mtu) + bufsize.WGBufferOverhead

--- a/client/iface/wgproxy/ebpf/proxy.go
+++ b/client/iface/wgproxy/ebpf/proxy.go
@@ -104,6 +104,7 @@ func (p *WGEBPFProxy) Listen() error {
 		return err
 	}
 	p.conn = conn
+	nbnet.SizeRelaySocketBuffers(conn)
 
 	go p.proxyToRemote()
 	log.Infof("local wg proxy listening on: %d", proxyPort)

--- a/client/iface/wgproxy/ebpf/proxy.go
+++ b/client/iface/wgproxy/ebpf/proxy.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
@@ -46,9 +47,19 @@ type WGEBPFProxy struct {
 	batchConnIPv6 *ipv6.PacketConn
 	conn          transport.UDPConn
 
+	// batchRead drains several relayed packets from the local WireGuard socket
+	// with one recvmmsg and forwards them back-to-back, cutting the per-packet
+	// syscall and wakeup overhead on the hot send path. Gated by
+	// NB_RELAY_BATCH_READ; the per-packet path stays the default.
+	batchRead bool
+
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 }
+
+// batchReadSize bounds how many packets are drained from the local WireGuard
+// socket per recvmmsg when NB_RELAY_BATCH_READ is set.
+const batchReadSize = 64
 
 // NewWGEBPFProxy create new WGEBPFProxy instance
 func NewWGEBPFProxy(wgPort int, mtu uint16) *WGEBPFProxy {
@@ -117,6 +128,7 @@ func (p *WGEBPFProxy) Listen() error {
 	}
 	p.conn = conn
 	nbnet.SizeRelaySocketBuffers(conn)
+	p.batchRead = os.Getenv("NB_RELAY_BATCH_READ") == "true"
 
 	go p.proxyToRemote()
 	log.Infof("local wg proxy listening on: %d", proxyPort)
@@ -182,6 +194,14 @@ func (p *WGEBPFProxy) GetProxyPort() uint16 {
 // proxyToRemote read messages from local WireGuard interface and forward it to remote conn
 // From this go routine has only one instance.
 func (p *WGEBPFProxy) proxyToRemote() {
+	if p.batchRead {
+		if pc, ok := p.conn.(net.PacketConn); ok {
+			p.proxyToRemoteBatch(pc)
+			return
+		}
+		log.Warnf("batch read requested but proxy conn %T is not a net.PacketConn; using per-packet read", p.conn)
+	}
+
 	buf := make([]byte, p.mtu+bufsize.WGBufferOverhead)
 	for p.ctx.Err() == nil {
 		if err := p.readAndForwardPacket(buf); err != nil {
@@ -190,6 +210,61 @@ func (p *WGEBPFProxy) proxyToRemote() {
 			}
 			log.Errorf("failed to proxy packet to remote conn: %s", err)
 		}
+	}
+}
+
+// proxyToRemoteBatch drains up to batchReadSize packets from the local
+// WireGuard socket with one recvmmsg and forwards each through the same
+// per-packet, per-source-port turn lookup as the single-packet path. Because
+// the single proxy socket is shared by every relayed peer, recvmmsg yields each
+// packet's source address, which selects the destination turn conn. Draining
+// several packets per recvmmsg amortizes the read syscall and wakeup across the
+// batch on the hot send path.
+func (p *WGEBPFProxy) proxyToRemoteBatch(pc net.PacketConn) {
+	batchConn := ipv4.NewPacketConn(pc)
+	bufSize := int(p.mtu) + bufsize.WGBufferOverhead
+	msgs := make([]ipv4.Message, batchReadSize)
+	for i := range msgs {
+		msgs[i].Buffers = [][]byte{make([]byte, bufSize)}
+	}
+
+	for p.ctx.Err() == nil {
+		n, err := batchConn.ReadBatch(msgs, 0)
+		if err != nil {
+			if p.ctx.Err() != nil {
+				return
+			}
+			log.Errorf("failed to batch read UDP packets from WG: %s", err)
+			continue
+		}
+
+		for i := 0; i < n; i++ {
+			p.forwardBatchPacket(msgs[i].Buffers[0][:msgs[i].N], msgs[i].Addr)
+		}
+	}
+}
+
+// forwardBatchPacket forwards one packet read in a batch to the turn conn that
+// owns its source port, mirroring readAndForwardPacket for the single-read path.
+func (p *WGEBPFProxy) forwardBatchPacket(payload []byte, addr net.Addr) {
+	udpAddr, ok := addr.(*net.UDPAddr)
+	if !ok {
+		log.Errorf("unexpected batch read source address type %T", addr)
+		return
+	}
+
+	p.turnConnMutex.Lock()
+	conn, ok := p.turnConnStore[uint16(udpAddr.Port)]
+	p.turnConnMutex.Unlock()
+	if !ok {
+		if p.ctx.Err() == nil {
+			log.Debugf("turn conn not found by port because conn already has been closed: %d", udpAddr.Port)
+		}
+		return
+	}
+
+	if _, err := conn.Write(payload); err != nil {
+		log.Errorf("failed to forward local WG packet (%d) to remote turn conn: %s", udpAddr.Port, err)
 	}
 }
 

--- a/client/iface/wgproxy/ebpf/proxy.go
+++ b/client/iface/wgproxy/ebpf/proxy.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pion/transport/v3"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 
 	nberrors "github.com/netbirdio/netbird/client/errors"
 	"github.com/netbirdio/netbird/client/iface/bufsize"
@@ -37,7 +39,12 @@ type WGEBPFProxy struct {
 	lastUsedPort uint16
 	rawConnIPv4  net.PacketConn
 	rawConnIPv6  net.PacketConn
-	conn         transport.UDPConn
+	// batchConnIPv4/IPv6 wrap the raw sockets so the inject path can write a
+	// whole batch of packets with one sendmmsg (WriteBatch) instead of one
+	// WriteTo per packet. Non-nil whenever the matching raw socket is present.
+	batchConnIPv4 *ipv4.PacketConn
+	batchConnIPv6 *ipv6.PacketConn
+	conn          transport.UDPConn
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
@@ -70,10 +77,15 @@ func (p *WGEBPFProxy) Listen() error {
 		return err
 	}
 
+	p.batchConnIPv4 = ipv4.NewPacketConn(p.rawConnIPv4)
+
 	// Prepare IPv6 raw socket (optional)
 	p.rawConnIPv6, err = rawsocket.PrepareSenderRawSocketIPv6()
 	if err != nil {
 		log.Warnf("failed to prepare IPv6 raw socket, continuing with IPv4 only: %v", err)
+	}
+	if p.rawConnIPv6 != nil {
+		p.batchConnIPv6 = ipv6.NewPacketConn(p.rawConnIPv6)
 	}
 
 	err = p.ebpfManager.LoadWgProxy(proxyPort, p.localWGListenPort)

--- a/client/iface/wgproxy/ebpf/wrapper.go
+++ b/client/iface/wgproxy/ebpf/wrapper.go
@@ -8,15 +8,34 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"sync"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/ipv4"
 
 	"github.com/netbirdio/netbird/client/iface/bufsize"
 	"github.com/netbirdio/netbird/client/iface/wgproxy/listener"
 )
+
+// injectBatchSize bounds how many relayed packets are drained and injected into
+// the local WireGuard socket per sendmmsg. Matches wireguard-go's IdealBatchSize.
+const injectBatchSize = 128
+
+// batchReader is the optional interface a relay conn implements to hand several
+// packets over in one call (satisfied structurally by the relay client *Conn).
+type batchReader interface {
+	ReadBatch(bufs [][]byte, sizes []int) (n int, err error)
+}
+
+// batchWriteConn is the subset of x/net ipv4/ipv6 PacketConn used to write a
+// batch of packets with one sendmmsg. ipv4.Message and ipv6.Message are the same
+// underlying type, so both PacketConns satisfy this with []ipv4.Message.
+type batchWriteConn interface {
+	WriteBatch(ms []ipv4.Message, flags int) (int, error)
+}
 
 var (
 	errIPv6ConnNotAvailable = errors.New("IPv6 endpoint but rawConnIPv6 is not available")
@@ -110,6 +129,11 @@ type ProxyWrapper struct {
 	pausedCond *sync.Cond
 	isStarted  bool
 
+	// batchInject enables draining several relayed packets and injecting them
+	// with one sendmmsg. Gated by NB_RELAY_INJECT_BATCH so the per-packet path
+	// stays the default until the batch path is proven in the field.
+	batchInject bool
+
 	closeListener *listener.CloseListener
 }
 
@@ -145,6 +169,7 @@ func (p *ProxyWrapper) AddTurnConn(ctx context.Context, _ *net.UDPAddr, remoteCo
 	p.wgRelayedEndpointAddr = addr
 	p.headers = headers
 	p.rawConn = p.selectRawConn(headers)
+	p.batchInject = os.Getenv("NB_RELAY_INJECT_BATCH") == "true"
 	return nil
 }
 
@@ -254,6 +279,13 @@ func (p *ProxyWrapper) CloseConn() error {
 func (p *ProxyWrapper) proxyToLocal(ctx context.Context) {
 	defer p.wgeBPFProxy.removeTurnConn(uint16(p.wgRelayedEndpointAddr.Port))
 
+	if p.batchInject {
+		if br, ok := p.remoteConn.(batchReader); ok {
+			p.proxyToLocalBatch(ctx, br)
+			return
+		}
+	}
+
 	buf := make([]byte, p.wgeBPFProxy.mtu+bufsize.WGBufferOverhead)
 	for {
 		n, err := p.readFromRemote(ctx, buf)
@@ -276,6 +308,105 @@ func (p *ProxyWrapper) proxyToLocal(ctx context.Context) {
 			log.Errorf("failed to write out turn pkg to local conn: %v", err)
 		}
 	}
+}
+
+// proxyToLocalBatch drains up to injectBatchSize relayed packets per wake and
+// injects them into the local WireGuard socket with a single sendmmsg. Blocks
+// for the first packet, then takes whatever is already queued, so a steady flow
+// batches while a sparse one still injects each packet immediately.
+func (p *ProxyWrapper) proxyToLocalBatch(ctx context.Context, br batchReader) {
+	bufSize := int(p.wgeBPFProxy.mtu) + bufsize.WGBufferOverhead
+	bufs := make([][]byte, injectBatchSize)
+	sizes := make([]int, injectBatchSize)
+	sbs := make([]gopacket.SerializeBuffer, injectBatchSize)
+	msgs := make([]ipv4.Message, injectBatchSize)
+	for i := range bufs {
+		bufs[i] = make([]byte, bufSize)
+		sbs[i] = gopacket.NewSerializeBuffer()
+		msgs[i].Buffers = make([][]byte, 1)
+	}
+
+	for {
+		n, err := br.ReadBatch(bufs, sizes)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			p.closeListener.Notify()
+			if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
+				log.Errorf("failed to read batch from turn conn (endpoint: :%d): %s", p.wgRelayedEndpointAddr.Port, err)
+			}
+			return
+		}
+
+		p.pausedCond.L.Lock()
+		for p.paused {
+			p.pausedCond.Wait()
+		}
+		header := p.headerCurrentUsed
+		batchConn := p.selectBatchConn(header)
+		werr := p.sendBatch(header, batchConn, bufs, sizes, n, sbs, msgs)
+		p.pausedCond.L.Unlock()
+
+		if werr != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Errorf("failed to write out turn batch to local conn: %v", werr)
+		}
+	}
+}
+
+// sendBatch serializes n packets (each into its own reused buffer, since lengths
+// and checksums differ) and writes them with one or more WriteBatch calls.
+func (p *ProxyWrapper) sendBatch(header *PacketHeaders, batchConn batchWriteConn, bufs [][]byte, sizes []int, n int, sbs []gopacket.SerializeBuffer, msgs []ipv4.Message) error {
+	if batchConn == nil {
+		return errors.New("batch conn not available")
+	}
+	dstAddr := &net.IPAddr{IP: header.localHostAddr}
+	for i := 0; i < n; i++ {
+		payload := gopacket.Payload(bufs[i][:sizes[i]])
+		if err := gopacket.SerializeLayers(sbs[i], serializeOpts, header.ipH, header.udpH, payload); err != nil {
+			return fmt.Errorf("serialize layers: %w", err)
+		}
+		msgs[i].Buffers[0] = sbs[i].Bytes()
+		msgs[i].Addr = dstAddr
+		msgs[i].N = 0
+	}
+
+	var werr error
+	for off := 0; off < n; {
+		w, err := batchConn.WriteBatch(msgs[off:n], 0)
+		if err != nil {
+			werr = err
+			break
+		}
+		if w <= 0 {
+			werr = fmt.Errorf("write batch made no progress at %d/%d", off, n)
+			break
+		}
+		off += w
+	}
+
+	for i := 0; i < n; i++ {
+		if err := sbs[i].Clear(); err != nil {
+			log.Errorf("failed to clear layer buffer: %s", err)
+		}
+	}
+	return werr
+}
+
+func (p *ProxyWrapper) selectBatchConn(header *PacketHeaders) batchWriteConn {
+	if header.isIPv4 {
+		if p.wgeBPFProxy.batchConnIPv4 == nil {
+			return nil
+		}
+		return p.wgeBPFProxy.batchConnIPv4
+	}
+	if p.wgeBPFProxy.batchConnIPv6 == nil {
+		return nil
+	}
+	return p.wgeBPFProxy.batchConnIPv6
 }
 
 func (p *ProxyWrapper) readFromRemote(ctx context.Context, buf []byte) (int, error) {

--- a/client/iface/wgproxy/udp/proxy.go
+++ b/client/iface/wgproxy/udp/proxy.go
@@ -16,6 +16,7 @@ import (
 	cerrors "github.com/netbirdio/netbird/client/errors"
 	"github.com/netbirdio/netbird/client/iface/bufsize"
 	"github.com/netbirdio/netbird/client/iface/wgproxy/listener"
+	nbnet "github.com/netbirdio/netbird/client/net"
 )
 
 // WGUDPProxy proxies
@@ -63,6 +64,8 @@ func (p *WGUDPProxy) AddTurnConn(ctx context.Context, _ *net.UDPAddr, remoteConn
 		log.Errorf("failed dialing to local Wireguard port %s", err)
 		return err
 	}
+
+	nbnet.SizeRelaySocketBuffers(localConn)
 
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	p.localConn = localConn

--- a/client/iface/wgproxy/udp/proxy.go
+++ b/client/iface/wgproxy/udp/proxy.go
@@ -45,8 +45,9 @@ type WGUDPProxy struct {
 
 	// batchRead drains several packets from the local WireGuard socket with one
 	// recvmmsg and forwards them back-to-back, cutting the per-packet syscall
-	// and wakeup overhead on the hot send path. Gated by NB_RELAY_BATCH_READ;
-	// the per-packet path stays the default.
+	// and wakeup overhead on the hot send path and letting the relay client's
+	// frame coalescer (NB_RELAY_COALESCE) pack full frames. Gated by
+	// NB_RELAY_BATCH_READ; the per-packet path stays the default.
 	batchRead bool
 
 	closeListener *listener.CloseListener
@@ -265,8 +266,9 @@ func (p *WGUDPProxy) proxyToRemote(ctx context.Context) {
 // WireGuard socket with one recvmmsg and forwards each with the same per-packet
 // write toward the relay conn. It blocks for the first packet, then takes
 // whatever is already queued, so a busy flow amortizes the read syscall and
-// wakeup across several packets while a sparse flow still forwards each packet
-// immediately.
+// wakeup across several packets and reaches the relay client's coalescer
+// back-to-back to pack full frames, while a sparse flow still forwards each
+// packet immediately.
 func (p *WGUDPProxy) proxyToRemoteBatch(ctx context.Context, pc net.PacketConn) {
 	batchConn := ipv4.NewPacketConn(pc)
 	bufSize := int(p.mtu) + bufsize.WGBufferOverhead

--- a/client/iface/wgproxy/udp/proxy.go
+++ b/client/iface/wgproxy/udp/proxy.go
@@ -8,16 +8,22 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/ipv4"
 
 	cerrors "github.com/netbirdio/netbird/client/errors"
 	"github.com/netbirdio/netbird/client/iface/bufsize"
 	"github.com/netbirdio/netbird/client/iface/wgproxy/listener"
 	nbnet "github.com/netbirdio/netbird/client/net"
 )
+
+// batchReadSize bounds how many packets are drained from the local WireGuard
+// socket per recvmmsg when NB_RELAY_BATCH_READ is set.
+const batchReadSize = 64
 
 // WGUDPProxy proxies
 type WGUDPProxy struct {
@@ -36,6 +42,12 @@ type WGUDPProxy struct {
 	paused     bool
 	pausedCond *sync.Cond
 	isStarted  bool
+
+	// batchRead drains several packets from the local WireGuard socket with one
+	// recvmmsg and forwards them back-to-back, cutting the per-packet syscall
+	// and wakeup overhead on the hot send path. Gated by NB_RELAY_BATCH_READ;
+	// the per-packet path stays the default.
+	batchRead bool
 
 	closeListener *listener.CloseListener
 }
@@ -66,6 +78,8 @@ func (p *WGUDPProxy) AddTurnConn(ctx context.Context, _ *net.UDPAddr, remoteConn
 	}
 
 	nbnet.SizeRelaySocketBuffers(localConn)
+
+	p.batchRead = os.Getenv("NB_RELAY_BATCH_READ") == "true"
 
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	p.localConn = localConn
@@ -215,6 +229,14 @@ func (p *WGUDPProxy) proxyToRemote(ctx context.Context) {
 		}
 	}()
 
+	if p.batchRead {
+		if pc, ok := p.localConn.(net.PacketConn); ok {
+			p.proxyToRemoteBatch(ctx, pc)
+			return
+		}
+		log.Warnf("batch read requested but local conn %T is not a net.PacketConn; using per-packet read", p.localConn)
+	}
+
 	buf := make([]byte, p.mtu+bufsize.WGBufferOverhead)
 	for ctx.Err() == nil {
 		n, err := p.localConn.Read(buf)
@@ -235,6 +257,43 @@ func (p *WGUDPProxy) proxyToRemote(ctx context.Context) {
 
 			log.Debugf("failed to write to remote conn: %s", err)
 			return
+		}
+	}
+}
+
+// proxyToRemoteBatch drains up to batchReadSize packets from the local
+// WireGuard socket with one recvmmsg and forwards each with the same per-packet
+// write toward the relay conn. It blocks for the first packet, then takes
+// whatever is already queued, so a busy flow amortizes the read syscall and
+// wakeup across several packets while a sparse flow still forwards each packet
+// immediately.
+func (p *WGUDPProxy) proxyToRemoteBatch(ctx context.Context, pc net.PacketConn) {
+	batchConn := ipv4.NewPacketConn(pc)
+	bufSize := int(p.mtu) + bufsize.WGBufferOverhead
+	msgs := make([]ipv4.Message, batchReadSize)
+	for i := range msgs {
+		msgs[i].Buffers = [][]byte{make([]byte, bufSize)}
+	}
+
+	for ctx.Err() == nil {
+		n, err := batchConn.ReadBatch(msgs, 0)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			p.closeListener.Notify()
+			log.Debugf("failed to batch read from wg interface conn: %s", err)
+			return
+		}
+
+		for i := 0; i < n; i++ {
+			if _, err := p.remoteConn.Write(msgs[i].Buffers[0][:msgs[i].N]); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.Debugf("failed to write to remote conn: %s", err)
+				return
+			}
 		}
 	}
 }

--- a/client/net/sockbuffer.go
+++ b/client/net/sockbuffer.go
@@ -1,0 +1,68 @@
+package net
+
+import (
+	"os"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// relaySocketBufferEnv overrides, in bytes, the receive and send buffer size
+// applied to the UDP sockets that carry relayed WireGuard data. A value of "0"
+// disables the sizing entirely; an empty or invalid value uses the default.
+const relaySocketBufferEnv = "NB_WGPROXY_SOCKET_BUFFER"
+
+// defaultRelaySocketBufferSize is the receive/send buffer applied by default to
+// relayed-data UDP sockets. The OS default (typically ~208 KiB) is too small for
+// a single high-rate relayed flow: sender-side kernel drops on a full receive
+// buffer surface to the tunnelled TCP as loss and collapse its throughput.
+const defaultRelaySocketBufferSize = 7 << 20 // 7 MiB
+
+// socketBufferConn is the portable subset used for the fallback sizing path.
+type socketBufferConn interface {
+	SetReadBuffer(bytes int) error
+	SetWriteBuffer(bytes int) error
+}
+
+// relaySocketBufferSize resolves the configured buffer size from the environment.
+func relaySocketBufferSize() int {
+	v := os.Getenv(relaySocketBufferEnv)
+	if v == "" {
+		return defaultRelaySocketBufferSize
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		log.Warnf("invalid %s value %q, using default %d", relaySocketBufferEnv, v, defaultRelaySocketBufferSize)
+		return defaultRelaySocketBufferSize
+	}
+	return n
+}
+
+// SizeRelaySocketBuffers grows the receive and send buffers of a UDP socket that
+// carries relayed data. On Linux it first tries SO_RCVBUFFORCE/SO_SNDBUFFORCE,
+// which bypass net.core.rmem_max/wmem_max when the process is privileged; it
+// falls back to the portable SetReadBuffer/SetWriteBuffer (clamped by those
+// sysctls, but still above the OS default) when the forced path is unavailable.
+// Setting NB_WGPROXY_SOCKET_BUFFER to 0 disables the sizing.
+func SizeRelaySocketBuffers(conn any) {
+	size := relaySocketBufferSize()
+	if size == 0 {
+		return
+	}
+
+	if !forceSocketBuffers(conn, size) {
+		bc, ok := conn.(socketBufferConn)
+		if !ok {
+			log.Debugf("relay socket buffer sizing skipped: %T supports neither forced nor portable sizing", conn)
+			return
+		}
+		if err := bc.SetReadBuffer(size); err != nil {
+			log.Debugf("failed to set relay socket read buffer to %d: %s", size, err)
+		}
+		if err := bc.SetWriteBuffer(size); err != nil {
+			log.Debugf("failed to set relay socket write buffer to %d: %s", size, err)
+		}
+	}
+
+	logRelaySocketBuffers(conn)
+}

--- a/client/net/sockbuffer_linux.go
+++ b/client/net/sockbuffer_linux.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package net
+
+import (
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+type rawConnProvider interface {
+	SyscallConn() (syscall.RawConn, error)
+}
+
+// forceSocketBuffers sets the receive and send buffers with SO_RCVBUFFORCE /
+// SO_SNDBUFFORCE, which bypass net.core.rmem_max/wmem_max when the process holds
+// CAP_NET_ADMIN (typically when running as root). Returns true only when both
+// options were set, so the caller can fall back to the portable path otherwise.
+func forceSocketBuffers(conn any, size int) bool {
+	rc, ok := conn.(rawConnProvider)
+	if !ok {
+		return false
+	}
+	raw, err := rc.SyscallConn()
+	if err != nil {
+		log.Debugf("failed to get raw conn for forced relay socket sizing: %s", err)
+		return false
+	}
+
+	var setErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		if e := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUFFORCE, size); e != nil {
+			setErr = e
+			return
+		}
+		if e := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUFFORCE, size); e != nil {
+			setErr = e
+		}
+	})
+	if ctrlErr != nil {
+		log.Debugf("failed to control relay socket for forced sizing: %s", ctrlErr)
+		return false
+	}
+	if setErr != nil {
+		log.Debugf("forced relay socket sizing unavailable (%s); using portable sizing", setErr)
+		return false
+	}
+	return true
+}
+
+// logRelaySocketBuffers reads back the effective SO_RCVBUF/SO_SNDBUF and logs
+// them at debug level. The kernel stores roughly twice the requested value for
+// its own bookkeeping, so the reported numbers are about 2x what was asked for.
+func logRelaySocketBuffers(conn any) {
+	rc, ok := conn.(rawConnProvider)
+	if !ok {
+		return
+	}
+	raw, err := rc.SyscallConn()
+	if err != nil {
+		return
+	}
+
+	var rcv, snd int
+	if err := raw.Control(func(fd uintptr) {
+		rcv, _ = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUF)
+		snd, _ = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUF)
+	}); err != nil {
+		return
+	}
+	log.Debugf("relay socket buffers: rcvbuf=%d sndbuf=%d (kernel-reported, ~2x requested)", rcv, snd)
+}

--- a/client/net/sockbuffer_linux_test.go
+++ b/client/net/sockbuffer_linux_test.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package net
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// relaySocketBufferFloor is a lower bound on the readback SO_RCVBUF/SO_SNDBUF
+// after sizing. The kernel doubles the requested value on readback; unprivileged
+// runs are clamped to net.core.rmem_max (commonly 212992, doubling to 425984),
+// while privileged runs reach close to the configured default of 7 MiB. This
+// floor holds in both cases while still proving growth over the ~208 KiB OS
+// default.
+const relaySocketBufferFloor = 416 * 1024
+
+func getSockBuffers(t *testing.T, conn *net.UDPConn) (rcv, snd int) {
+	t.Helper()
+
+	sc, err := conn.SyscallConn()
+	require.NoError(t, err)
+
+	var ctrlErr error
+	err = sc.Control(func(fd uintptr) {
+		rcv, ctrlErr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUF)
+		if ctrlErr != nil {
+			return
+		}
+		snd, ctrlErr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUF)
+	})
+	require.NoError(t, err)
+	require.NoError(t, ctrlErr)
+	return rcv, snd
+}
+
+func TestSizeRelaySocketBuffersGrowsBuffers(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rcvBefore, sndBefore := getSockBuffers(t, conn)
+
+	SizeRelaySocketBuffers(conn)
+
+	rcvAfter, sndAfter := getSockBuffers(t, conn)
+
+	assert.GreaterOrEqual(t, rcvAfter, relaySocketBufferFloor)
+	assert.GreaterOrEqual(t, sndAfter, relaySocketBufferFloor)
+	assert.GreaterOrEqual(t, rcvAfter, rcvBefore)
+	assert.GreaterOrEqual(t, sndAfter, sndBefore)
+}
+
+func TestSizeRelaySocketBuffersEnvDisable(t *testing.T) {
+	t.Setenv(relaySocketBufferEnv, "0")
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rcvBefore, sndBefore := getSockBuffers(t, conn)
+
+	SizeRelaySocketBuffers(conn)
+
+	rcvAfter, sndAfter := getSockBuffers(t, conn)
+
+	assert.Equal(t, rcvBefore, rcvAfter)
+	assert.Equal(t, sndBefore, sndAfter)
+}

--- a/client/net/sockbuffer_others.go
+++ b/client/net/sockbuffer_others.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package net
+
+// forceSocketBuffers is a no-op on non-Linux platforms: the SO_*BUFFORCE options
+// are Linux-specific, so callers fall back to the portable SetReadBuffer/
+// SetWriteBuffer path.
+func forceSocketBuffers(_ any, _ int) bool {
+	return false
+}
+
+// logRelaySocketBuffers is a no-op on non-Linux platforms.
+func logRelaySocketBuffers(_ any) {}

--- a/client/net/sockbuffer_test.go
+++ b/client/net/sockbuffer_test.go
@@ -1,0 +1,78 @@
+package net
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelaySocketBufferSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		setEnv   bool
+		expected int
+	}{
+		{
+			name:     "unset uses default",
+			setEnv:   false,
+			expected: defaultRelaySocketBufferSize,
+		},
+		{
+			name:     "empty uses default",
+			envValue: "",
+			setEnv:   true,
+			expected: defaultRelaySocketBufferSize,
+		},
+		{
+			name:     "zero disables sizing",
+			envValue: "0",
+			setEnv:   true,
+			expected: 0,
+		},
+		{
+			name:     "explicit value is honored",
+			envValue: "1048576",
+			setEnv:   true,
+			expected: 1048576,
+		},
+		{
+			name:     "non-numeric value uses default",
+			envValue: "garbage",
+			setEnv:   true,
+			expected: defaultRelaySocketBufferSize,
+		},
+		{
+			name:     "negative value uses default",
+			envValue: "-5",
+			setEnv:   true,
+			expected: defaultRelaySocketBufferSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(relaySocketBufferEnv, tt.envValue)
+			}
+
+			assert.Equal(t, tt.expected, relaySocketBufferSize())
+		})
+	}
+}
+
+func TestSizeRelaySocketBuffersSmoke(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	assert.NotPanics(t, func() {
+		SizeRelaySocketBuffers(conn)
+	})
+
+	assert.NotPanics(t, func() {
+		SizeRelaySocketBuffers(struct{}{})
+	})
+}

--- a/relay/metrics/realy.go
+++ b/relay/metrics/realy.go
@@ -17,16 +17,17 @@ const (
 type Metrics struct {
 	metric.Meter
 
-	TransferBytesSent  metric.Int64Counter
-	TransferBytesRecv  metric.Int64Counter
-	AuthenticationTime metric.Float64Histogram
-	PeerStoreTime      metric.Float64Histogram
-	peerReconnections  metric.Int64Counter
-	peers              metric.Int64UpDownCounter
-	peerActivityChan   chan string
-	peerLastActive     map[string]time.Time
-	mutexActivity      sync.Mutex
-	ctx                context.Context
+	TransferBytesSent   metric.Int64Counter
+	TransferBytesRecv   metric.Int64Counter
+	AuthenticationTime  metric.Float64Histogram
+	PeerStoreTime       metric.Float64Histogram
+	peerReconnections   metric.Int64Counter
+	transportQueueDrops metric.Int64Counter
+	peers               metric.Int64UpDownCounter
+	peerActivityChan    chan string
+	peerLastActive      map[string]time.Time
+	mutexActivity       sync.Mutex
+	ctx                 context.Context
 }
 
 func NewMetrics(ctx context.Context, meter metric.Meter) (*Metrics, error) {
@@ -88,14 +89,22 @@ func NewMetrics(ctx context.Context, meter metric.Meter) (*Metrics, error) {
 		return nil, err
 	}
 
+	transportQueueDrops, err := meter.Int64Counter("relay_transport_queue_drops_total",
+		metric.WithDescription("Total number of relayed messages dropped because the destination peer's write queue was full"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	m := &Metrics{
-		Meter:              meter,
-		TransferBytesSent:  bytesSent,
-		TransferBytesRecv:  bytesRecv,
-		AuthenticationTime: authTime,
-		PeerStoreTime:      peerStoreTime,
-		peers:              peers,
-		peerReconnections:  peerReconnections,
+		Meter:               meter,
+		TransferBytesSent:   bytesSent,
+		TransferBytesRecv:   bytesRecv,
+		AuthenticationTime:  authTime,
+		PeerStoreTime:       peerStoreTime,
+		peers:               peers,
+		peerReconnections:   peerReconnections,
+		transportQueueDrops: transportQueueDrops,
 
 		ctx:              ctx,
 		peerActivityChan: make(chan string, 10),
@@ -149,6 +158,12 @@ func (m *Metrics) PeerDisconnected(id, transport string) {
 
 func (m *Metrics) RecordPeerReconnection() {
 	m.peerReconnections.Add(m.ctx, 1)
+}
+
+// TransportQueueDrop counts a relayed message dropped because the destination
+// peer's write queue was full.
+func (m *Metrics) TransportQueueDrop(transport string) {
+	m.transportQueueDrops.Add(m.ctx, 1, metric.WithAttributes(attribute.String("transport", transport)))
 }
 
 // PeerActivity increases the active connections

--- a/relay/server/peer.go
+++ b/relay/server/peer.go
@@ -161,7 +161,10 @@ func (p *Peer) handleMsgType(ctx context.Context, msgType messages.MsgType, hc *
 	switch msgType {
 	case messages.MsgTypeHealthCheck:
 		hc.OnHCResponse()
-	case messages.MsgTypeTransport:
+	case messages.MsgTypeTransport, messages.MsgTypeTransportBatch:
+		// A batch frame shares the transport header (dest peerID at the fixed
+		// offset); the relay only reads that header, rewrites it to the source,
+		// and forwards the payload opaque, so both types route identically.
 		p.metrics.TransferBytesRecv.Add(ctx, int64(n))
 		p.metrics.PeerActivity(p.String())
 		return p.handleTransportMsg(bufPtr, n)

--- a/relay/server/peer.go
+++ b/relay/server/peer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -19,8 +20,30 @@ import (
 const (
 	bufferSize = messages.MaxMessageSize
 
+	// msgQueueSize bounds the per-peer write queue: enough to absorb
+	// write-latency jitter of a congested destination (~2.2 MB worst case)
+	// without letting a dead peer pin unbounded memory.
+	msgQueueSize = 256
+
 	errCloseConn = "failed to close connection to peer: %s"
+
+	queueDropLogInterval = 5 * time.Second
 )
+
+// msgPool recycles read buffers whose ownership moves from a source peer's
+// read loop to a destination peer's write queue.
+var msgPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, bufferSize)
+		return &buf
+	},
+}
+
+// queuedMsg is a pooled buffer holding one relayed transport message.
+type queuedMsg struct {
+	bufPtr *[]byte
+	n      int
+}
 
 // Peer represents a peer connection
 type Peer struct {
@@ -34,6 +57,13 @@ type Peer struct {
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
+
+	// msgQueue decouples writes to this peer from the read loops of the
+	// source peers: a slow or stalled destination only fills its own queue.
+	msgQueue chan queuedMsg
+	// lastQueueDropLog (unix nanos) rate-limits the queue-overflow warning
+	// emitted by source peers forwarding to this peer.
+	lastQueueDropLog atomic.Int64
 
 	peersListener *store.Listener
 
@@ -53,6 +83,7 @@ func NewPeer(metrics *metrics.Metrics, id messages.PeerID, conn listener.Conn, s
 		notifier:  notifier,
 		ctx:       ctx,
 		ctxCancel: cancel,
+		msgQueue:  make(chan queuedMsg, msgQueueSize),
 	}
 
 	return p
@@ -77,11 +108,13 @@ func (p *Peer) Work() {
 	hc := healthcheck.NewSender(p.log)
 	go hc.StartHealthCheck(ctx)
 	go p.handleHealthcheckEvents(ctx, hc)
+	go p.writeLoop()
 
-	buf := make([]byte, bufferSize)
 	for {
-		n, err := p.conn.Read(ctx, buf)
+		bufPtr := msgPool.Get().(*[]byte)
+		n, err := p.conn.Read(ctx, *bufPtr)
 		if err != nil {
+			msgPool.Put(bufPtr)
 			if !errors.Is(err, net.ErrClosed) {
 				p.log.Errorf("failed to read message: %s", err)
 			}
@@ -89,25 +122,30 @@ func (p *Peer) Work() {
 		}
 
 		if n == 0 {
+			msgPool.Put(bufPtr)
 			p.log.Errorf("received empty message")
 			return
 		}
 
-		msg := buf[:n]
+		msg := (*bufPtr)[:n]
 
 		_, err = messages.ValidateVersion(msg)
 		if err != nil {
+			msgPool.Put(bufPtr)
 			p.log.Warnf("failed to validate protocol version: %s", err)
 			return
 		}
 
 		msgType, err := messages.DetermineClientMessageType(msg)
 		if err != nil {
+			msgPool.Put(bufPtr)
 			p.log.Errorf("failed to determine message type: %s", err)
 			return
 		}
 
-		p.handleMsgType(ctx, msgType, hc, n, msg)
+		if !p.handleMsgType(ctx, msgType, hc, n, bufPtr) {
+			msgPool.Put(bufPtr)
+		}
 	}
 }
 
@@ -115,14 +153,18 @@ func (p *Peer) ID() messages.PeerID {
 	return p.id
 }
 
-func (p *Peer) handleMsgType(ctx context.Context, msgType messages.MsgType, hc *healthcheck.Sender, n int, msg []byte) {
+// handleMsgType dispatches one inbound message. It reports whether ownership
+// of bufPtr moved to a destination peer's write queue; when false the caller
+// returns the buffer to the pool.
+func (p *Peer) handleMsgType(ctx context.Context, msgType messages.MsgType, hc *healthcheck.Sender, n int, bufPtr *[]byte) bool {
+	msg := (*bufPtr)[:n]
 	switch msgType {
 	case messages.MsgTypeHealthCheck:
 		hc.OnHCResponse()
 	case messages.MsgTypeTransport:
 		p.metrics.TransferBytesRecv.Add(ctx, int64(n))
 		p.metrics.PeerActivity(p.String())
-		p.handleTransportMsg(msg)
+		return p.handleTransportMsg(bufPtr, n)
 	case messages.MsgTypeClose:
 		p.log.Infof("peer exited gracefully")
 		if err := p.conn.Close(); err != nil {
@@ -135,6 +177,7 @@ func (p *Peer) handleMsgType(ctx context.Context, msgType messages.MsgType, hc *
 	default:
 		p.log.Warnf("received unexpected message type: %s", msgType)
 	}
+	return false
 }
 
 // Write writes data to the connection
@@ -206,32 +249,84 @@ func (p *Peer) handleHealthcheckEvents(ctx context.Context, hc *healthcheck.Send
 	}
 }
 
-func (p *Peer) handleTransportMsg(msg []byte) {
+// handleTransportMsg forwards one transport message by enqueueing it on the
+// destination peer's write queue. It reports whether ownership of bufPtr moved
+// to that queue. The enqueue never blocks: a full queue means the destination
+// is congested or gone, and stalling this read loop would stall every flow of
+// the source peer.
+func (p *Peer) handleTransportMsg(bufPtr *[]byte, n int) bool {
+	msg := (*bufPtr)[:n]
 	peerID, err := messages.UnmarshalTransportID(msg)
 	if err != nil {
 		p.log.Errorf("failed to unmarshal transport message: %s", err)
-		return
+		return false
 	}
 
 	item, ok := p.store.Peer(*peerID)
 	if !ok {
 		p.log.Debugf("peer not found: %s", peerID)
-		return
+		return false
 	}
 	dp := item.(*Peer)
 
-	err = messages.UpdateTransportMsg(msg, p.id)
-	if err != nil {
+	if err := messages.UpdateTransportMsg(msg, p.id); err != nil {
 		p.log.Errorf("failed to update transport message: %s", err)
-		return
+		return false
 	}
 
-	n, err := dp.Write(dp.ctx, msg)
-	if err != nil {
-		p.log.Errorf("failed to write transport message to: %s", dp.String())
-		return
+	select {
+	case dp.msgQueue <- queuedMsg{bufPtr: bufPtr, n: n}:
+		return true
+	default:
+		p.metrics.TransportQueueDrop(dp.conn.Protocol())
+		now := time.Now().UnixNano()
+		last := dp.lastQueueDropLog.Load()
+		if now-last >= int64(queueDropLogInterval) && dp.lastQueueDropLog.CompareAndSwap(last, now) {
+			p.log.Warnf("dropping transport message to %s: write queue full", dp.String())
+		}
+		return false
 	}
-	p.metrics.TransferBytesSent.Add(p.ctx, int64(n))
+}
+
+// writeLoop serializes relayed transport writes to this peer so a slow
+// destination only backs up its own queue, never a source's read loop.
+// Control messages (healthcheck, peer notifications, close) keep writing
+// directly, as before.
+func (p *Peer) writeLoop() {
+	defer p.drainQueue()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case m := <-p.msgQueue:
+			// Write on the conn directly, not via p.Write: holding connMu.RLock
+			// while a stalled destination blocks the write would deadlock
+			// Close(), which needs connMu.Lock to close the very conn that
+			// unblocks the write. Both conn implementations serialize
+			// concurrent writes and tolerate a concurrent Close.
+			n, err := p.conn.Write(p.ctx, (*m.bufPtr)[:m.n])
+			msgPool.Put(m.bufPtr)
+			if err != nil {
+				if !errors.Is(err, net.ErrClosed) {
+					p.log.Errorf("failed to write transport message: %s", err)
+				}
+				continue
+			}
+			p.metrics.TransferBytesSent.Add(p.ctx, int64(n))
+		}
+	}
+}
+
+// drainQueue returns queued buffers to the pool after the writer stopped.
+func (p *Peer) drainQueue() {
+	for {
+		select {
+		case m := <-p.msgQueue:
+			msgPool.Put(m.bufPtr)
+		default:
+			return
+		}
+	}
 }
 
 func (p *Peer) handleSubscribePeerState(msg []byte) {

--- a/relay/server/peer_test.go
+++ b/relay/server/peer_test.go
@@ -1,0 +1,286 @@
+package server
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+
+	"github.com/netbirdio/netbird/relay/metrics"
+	"github.com/netbirdio/netbird/relay/server/store"
+	"github.com/netbirdio/netbird/shared/relay/messages"
+)
+
+// fakeConn is a scriptable listener.Conn: reads are fed through a channel and
+// writes can be gated to simulate a slow or stalled destination.
+type fakeConn struct {
+	reads     chan []byte
+	writeGate chan struct{} // each write consumes one token; nil means open
+	writes    atomic.Int64
+	readCalls atomic.Int64
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newFakeConn(gated bool) *fakeConn {
+	fc := &fakeConn{
+		reads:  make(chan []byte, 1024),
+		closed: make(chan struct{}),
+	}
+	if gated {
+		fc.writeGate = make(chan struct{}, 1024)
+	}
+	return fc
+}
+
+func (f *fakeConn) Read(ctx context.Context, b []byte) (int, error) {
+	f.readCalls.Add(1)
+	select {
+	case msg := <-f.reads:
+		return copy(b, msg), nil
+	case <-f.closed:
+		return 0, net.ErrClosed
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+}
+
+func (f *fakeConn) Write(ctx context.Context, b []byte) (int, error) {
+	if f.writeGate != nil {
+		select {
+		case <-f.writeGate:
+		case <-f.closed:
+			return 0, net.ErrClosed
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
+	select {
+	case <-f.closed:
+		return 0, net.ErrClosed
+	default:
+	}
+	f.writes.Add(1)
+	return len(b), nil
+}
+
+func (f *fakeConn) RemoteAddr() net.Addr { return &net.TCPAddr{} }
+
+func (f *fakeConn) Close() error {
+	f.closeOnce.Do(func() { close(f.closed) })
+	return nil
+}
+
+func (f *fakeConn) Protocol() string { return "test" }
+
+func testPeerPair(t *testing.T, dstGated bool) (src, dst *Peer, srcConn, dstConn *fakeConn, cleanup func()) {
+	t.Helper()
+	m, err := metrics.NewMetrics(context.Background(), otel.Meter(""))
+	if err != nil {
+		t.Fatalf("metrics: %v", err)
+	}
+	st := store.NewStore()
+	notifier := store.NewPeerNotifier()
+
+	srcConn = newFakeConn(false)
+	dstConn = newFakeConn(dstGated)
+	src = NewPeer(m, messages.HashID("src"), srcConn, st, notifier)
+	dst = NewPeer(m, messages.HashID("dst"), dstConn, st, notifier)
+	st.AddPeer(src)
+	st.AddPeer(dst)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); src.Work() }()
+	go func() { defer wg.Done(); dst.Work() }()
+
+	cleanup = func() {
+		_ = srcConn.Close()
+		_ = dstConn.Close()
+		wg.Wait()
+	}
+	return src, dst, srcConn, dstConn, cleanup
+}
+
+func transportMsgTo(t *testing.T, dst messages.PeerID, payload []byte) []byte {
+	t.Helper()
+	msg, err := messages.MarshalTransportMsg(dst, payload)
+	if err != nil {
+		t.Fatalf("marshal transport msg: %v", err)
+	}
+	return msg
+}
+
+// TestSlowDestinationDoesNotStallSource feeds the source many messages toward
+// a destination whose writes never complete; the source read loop must keep
+// consuming.
+func TestSlowDestinationDoesNotStallSource(t *testing.T) {
+	_, _, srcConn, dstConn, cleanup := testPeerPair(t, true)
+	defer cleanup()
+
+	const total = 50
+	msg := transportMsgTo(t, messages.HashID("dst"), []byte("payload"))
+	for i := 0; i < total; i++ {
+		srcConn.reads <- msg
+	}
+
+	deadline := time.After(2 * time.Second)
+	for len(srcConn.reads) > 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("source read loop stalled, %d messages unread", len(srcConn.reads))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if w := dstConn.writes.Load(); w != 0 {
+		t.Fatalf("expected no completed writes on gated destination, got %d", w)
+	}
+}
+
+// TestQueueDeliversWhenDestinationDrains releases the destination's write gate
+// and verifies queued messages arrive.
+func TestQueueDeliversWhenDestinationDrains(t *testing.T) {
+	_, _, srcConn, dstConn, cleanup := testPeerPair(t, true)
+	defer cleanup()
+
+	const total = 20
+	msg := transportMsgTo(t, messages.HashID("dst"), []byte("payload"))
+	for i := 0; i < total; i++ {
+		srcConn.reads <- msg
+	}
+	for i := 0; i < total; i++ {
+		dstConn.writeGate <- struct{}{}
+	}
+
+	deadline := time.After(2 * time.Second)
+	for dstConn.writes.Load() < total {
+		select {
+		case <-deadline:
+			t.Fatalf("expected %d writes, got %d", total, dstConn.writes.Load())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// TestQueueOverflowDrops verifies that a full destination queue drops the
+// excess instead of blocking the source, and that the queue-sized backlog is
+// still delivered once the destination drains.
+func TestQueueOverflowDrops(t *testing.T) {
+	_, _, srcConn, dstConn, cleanup := testPeerPair(t, true)
+	defer cleanup()
+
+	const overflow = 100
+	msg := transportMsgTo(t, messages.HashID("dst"), []byte("payload"))
+	total := msgQueueSize + overflow
+	for i := 0; i < total; i++ {
+		srcConn.reads <- msg
+	}
+
+	// wait until the source consumed everything (nothing may block)
+	deadline := time.After(3 * time.Second)
+	for len(srcConn.reads) > 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("source read loop stalled, %d messages unread", len(srcConn.reads))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// open the gate fully and count what arrives
+	for i := 0; i < total; i++ {
+		dstConn.writeGate <- struct{}{}
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	got := dstConn.writes.Load()
+	// the writer may have dequeued one message before the queue filled
+	if got < msgQueueSize || got > msgQueueSize+2 {
+		t.Fatalf("expected ~%d delivered messages, got %d", msgQueueSize, got)
+	}
+}
+
+// TestConcurrentSourcesMessageIntegrity has two sources forward distinct
+// payloads to one destination; run with -race to guard the buffer handoff.
+func TestConcurrentSourcesMessageIntegrity(t *testing.T) {
+	m, err := metrics.NewMetrics(context.Background(), otel.Meter(""))
+	if err != nil {
+		t.Fatalf("metrics: %v", err)
+	}
+	st := store.NewStore()
+	notifier := store.NewPeerNotifier()
+
+	dstConn := newFakeConn(false)
+	dst := NewPeer(m, messages.HashID("dst"), dstConn, st, notifier)
+	st.AddPeer(dst)
+
+	var wg sync.WaitGroup
+	srcConns := make([]*fakeConn, 2)
+	for i := range srcConns {
+		srcConns[i] = newFakeConn(false)
+		p := NewPeer(m, messages.HashID(string(rune('a'+i))), srcConns[i], st, notifier)
+		st.AddPeer(p)
+		wg.Add(1)
+		go func() { defer wg.Done(); p.Work() }()
+	}
+	wg.Add(1)
+	go func() { defer wg.Done(); dst.Work() }()
+
+	const perSource = 500
+	msg := transportMsgTo(t, messages.HashID("dst"), []byte("payload-integrity-check"))
+	var sendWg sync.WaitGroup
+	for _, sc := range srcConns {
+		sendWg.Add(1)
+		go func(sc *fakeConn) {
+			defer sendWg.Done()
+			for i := 0; i < perSource; i++ {
+				sc.reads <- msg
+			}
+		}(sc)
+	}
+	sendWg.Wait()
+
+	deadline := time.After(5 * time.Second)
+	for dstConn.writes.Load() < 2*perSource {
+		select {
+		case <-deadline:
+			t.Fatalf("expected %d writes, got %d", 2*perSource, dstConn.writes.Load())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	for _, sc := range srcConns {
+		_ = sc.Close()
+	}
+	_ = dstConn.Close()
+	wg.Wait()
+}
+
+// TestWriterStopsOnClose closes the peer and verifies its writer goroutine
+// exits (enqueue never blocks afterwards).
+func TestWriterStopsOnClose(t *testing.T) {
+	_, dst, srcConn, _, cleanup := testPeerPair(t, true)
+	defer cleanup()
+
+	msg := transportMsgTo(t, messages.HashID("dst"), []byte("payload"))
+	srcConn.reads <- msg
+	time.Sleep(50 * time.Millisecond)
+
+	dst.Close()
+
+	// the source must still be able to forward (enqueue or drop) without blocking
+	for i := 0; i < msgQueueSize*2; i++ {
+		srcConn.reads <- msg
+	}
+	deadline := time.After(3 * time.Second)
+	for len(srcConn.reads) > 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("source read loop stalled after destination close, %d unread", len(srcConn.reads))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/shared/relay/client/bench_pipe_test.go
+++ b/shared/relay/client/bench_pipe_test.go
@@ -1,0 +1,332 @@
+//go:build devcert
+
+package client
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"runtime/pprof"
+	"strconv"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+
+	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/relay/server"
+	"github.com/netbirdio/netbird/shared/relay/auth/allow"
+)
+
+const pktSize = 1300
+
+// benchPkts returns the packet count for burst tests, overridable via
+// BENCH_PKTS to widen the measurement window for a stable CPU profile.
+func benchPkts(def int) int {
+	if v := os.Getenv("BENCH_PKTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// procCPUSeconds returns cumulative user+system CPU seconds for this process.
+// The harness runs both clients and the relay in-process, so this is the total
+// pipeline CPU; pps divided by it is a stable per-core efficiency metric for
+// A/B-ing a data-path change.
+func procCPUSeconds() float64 {
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0
+	}
+	u := time.Duration(ru.Utime.Sec)*time.Second + time.Duration(ru.Utime.Usec)*time.Microsecond
+	s := time.Duration(ru.Stime.Sec)*time.Second + time.Duration(ru.Stime.Usec)*time.Microsecond
+	return (u + s).Seconds()
+}
+
+// maybeCPUProfile starts an in-band CPU profile scoped to the measured window
+// when BENCH_CPUPROFILE names an output file. Returns a stop func.
+func maybeCPUProfile(t *testing.T) func() {
+	path := os.Getenv("BENCH_CPUPROFILE")
+	if path == "" {
+		return func() {}
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create cpu profile %q: %v", path, err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		t.Fatalf("start cpu profile: %v", err)
+	}
+	return func() {
+		pprof.StopCPUProfile()
+		_ = f.Close()
+		t.Logf("cpu profile written to %s", path)
+	}
+}
+
+// reportEfficiency prints the CPU-normalized throughput for a measured window.
+func reportEfficiency(t *testing.T, label string, rcvd int64, cpuSec float64) {
+	t.Helper()
+	if cpuSec <= 0 {
+		return
+	}
+	ppsPerCore := float64(rcvd) / cpuSec
+	mbitPerCore := float64(rcvd) * pktSize * 8 / cpuSec / 1e6
+	fmt.Printf("%s: cpu=%.2fs pps/core=%.0f Mbit/core-s=%.1f\n", label, cpuSec, ppsPerCore, mbitPerCore)
+}
+
+// benchClientA/B expose the last connected pair's clients so tests can read
+// their inbound-drop counters.
+var benchClientA, benchClientB *Client
+
+func chanDrops() int64 {
+	return benchClientA.InboundMsgDrops() + benchClientB.InboundMsgDrops()
+}
+
+func startBenchServer(t *testing.T, addr string) *server.Server {
+	t.Helper()
+	cfg := server.Config{
+		Meter:          otel.Meter(""),
+		ExposedAddress: "rel://" + addr,
+		TLSSupport:     false,
+		AuthValidator:  &allow.Auth{},
+	}
+	srv, err := server.NewServer(cfg)
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	go func() {
+		_ = srv.Listen(server.ListenerConfig{Address: addr})
+	}()
+	time.Sleep(1 * time.Second)
+	return srv
+}
+
+func connectPair(t *testing.T, serverAddr, a, b string) (net.Conn, net.Conn, func()) {
+	t.Helper()
+	ctx := context.Background()
+	ca := NewClient("rel://"+serverAddr, hmacTokenStore, a, iface.DefaultMTU)
+	if err := ca.Connect(ctx); err != nil {
+		t.Fatalf("%s connect: %v", a, err)
+	}
+	cb := NewClient("rel://"+serverAddr, hmacTokenStore, b, iface.DefaultMTU)
+	if err := cb.Connect(ctx); err != nil {
+		t.Fatalf("%s connect: %v", b, err)
+	}
+	benchClientA, benchClientB = ca, cb
+	t.Logf("transports: %s=%s %s=%s", a, ca.Transport(), b, cb.Transport())
+	connAB, err := ca.OpenConn(ctx, b)
+	if err != nil {
+		t.Fatalf("open %s->%s: %v", a, b, err)
+	}
+	connBA, err := cb.OpenConn(ctx, a)
+	if err != nil {
+		t.Fatalf("open %s->%s: %v", b, a, err)
+	}
+	// warmup: wait until full-size datagrams fit (QUIC path MTU discovery)
+	warm := make([]byte, pktSize)
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		if _, err := connAB.Write(warm); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("warmup: %d byte writes still failing after 20s", pktSize)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	// drain any warmup packets on the far side
+	time.Sleep(300 * time.Millisecond)
+	drainNonBlocking(connBA)
+	cleanup := func() {
+		_ = ca.Close()
+		_ = cb.Close()
+	}
+	return connAB, connBA, cleanup
+}
+
+// drainNonBlocking empties pending messages without blocking (uses the
+// underlying message channel via a short-lived reader goroutine).
+func drainNonBlocking(conn net.Conn) {
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, 2048)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			_ = buf
+			// rely on the outer timeout; Conn.Read blocks until a message arrives
+			if _, err := conn.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+	time.Sleep(200 * time.Millisecond)
+	close(done)
+}
+
+// drainCount reads packets until idle for idleTimeout, returns count.
+func drainCount(conn net.Conn, count *atomic.Int64, stop chan struct{}) {
+	buf := make([]byte, 2048)
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		n, err := conn.Read(buf)
+		if err != nil {
+			return
+		}
+		if n >= pktSize {
+			count.Add(1)
+		}
+	}
+}
+
+func pump(conn net.Conn, npkts int, interval time.Duration) (sent int, elapsed time.Duration) {
+	payload := make([]byte, pktSize)
+	start := time.Now()
+	var tick *time.Ticker
+	if interval > 0 {
+		tick = time.NewTicker(interval)
+		defer tick.Stop()
+	}
+	errs := 0
+	for i := 0; i < npkts; i++ {
+		binary.BigEndian.PutUint64(payload, uint64(i))
+		if _, err := conn.Write(payload); err != nil {
+			errs++
+			if errs > 100 {
+				fmt.Printf("pump aborted after %d write errors, last: %v\n", errs, err)
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		sent++
+		if tick != nil {
+			<-tick.C
+		}
+	}
+	return sent, time.Since(start)
+}
+
+func mbit(pkts int64, d time.Duration) float64 {
+	return float64(pkts) * pktSize * 8 / d.Seconds() / 1e6
+}
+
+// TestPipeBurst: one direction, send as fast as the pipeline accepts.
+func TestPipeBurst(t *testing.T) {
+	addr := "127.0.0.1:60111"
+	srv := startBenchServer(t, addr)
+	defer srv.Shutdown(context.Background())
+
+	connAB, connBA, cleanup := connectPair(t, addr, "alice", "bob")
+	defer cleanup()
+
+	drops0 := chanDrops()
+	var rcvd atomic.Int64
+	stop := make(chan struct{})
+	go drainCount(connBA, &rcvd, stop)
+
+	n := benchPkts(50000)
+	cpu0 := procCPUSeconds()
+	stopProfile := maybeCPUProfile(t)
+	sent, elapsed := pump(connAB, n, 0)
+	// wait for the tail to drain
+	last := rcvd.Load()
+	for {
+		time.Sleep(300 * time.Millisecond)
+		cur := rcvd.Load()
+		if cur == last {
+			break
+		}
+		last = cur
+	}
+	stopProfile()
+	cpuSec := procCPUSeconds() - cpu0
+	close(stop)
+	r := rcvd.Load()
+	fmt.Printf("BURST: sent=%d in %v (send-side %.1f Mbit/s, %.0f pps) rcvd=%d loss=%.2f%% chanDrops=%d recv-rate~%.1f Mbit/s\n",
+		sent, elapsed, mbit(int64(sent), elapsed), float64(sent)/elapsed.Seconds(),
+		r, 100*float64(int64(sent)-r)/float64(sent), chanDrops()-drops0, mbit(r, elapsed))
+	reportEfficiency(t, "BURST", r, cpuSec)
+}
+
+// TestPipePaced: one direction, fixed rates, find the drop onset.
+func TestPipePaced(t *testing.T) {
+	addr := "127.0.0.1:60112"
+	srv := startBenchServer(t, addr)
+	defer srv.Shutdown(context.Background())
+
+	connAB, connBA, cleanup := connectPair(t, addr, "alice", "bob")
+	defer cleanup()
+
+	var rcvd atomic.Int64
+	stop := make(chan struct{})
+	go drainCount(connBA, &rcvd, stop)
+	defer close(stop)
+
+	for _, rateMbit := range []int{25, 50, 100, 200, 400, 800} {
+		pps := float64(rateMbit) * 1e6 / 8 / pktSize
+		interval := time.Duration(float64(time.Second) / pps)
+		n := int(pps * 3) // ~3 seconds per rate
+		drops0 := chanDrops()
+		before := rcvd.Load()
+		sent, elapsed := pump(connAB, n, interval)
+		time.Sleep(500 * time.Millisecond)
+		got := rcvd.Load() - before
+		fmt.Printf("PACED %4d Mbit target: sent=%d actual=%.1f Mbit/s rcvd=%d loss=%.2f%% chanDrops=%d\n",
+			rateMbit, sent, mbit(int64(sent), elapsed), got,
+			100*float64(int64(sent)-got)/float64(sent), chanDrops()-drops0)
+	}
+}
+
+// TestPipeBidir: both directions pump simultaneously (coupling check).
+func TestPipeBidir(t *testing.T) {
+	addr := "127.0.0.1:60113"
+	srv := startBenchServer(t, addr)
+	defer srv.Shutdown(context.Background())
+
+	connAB, connBA, cleanup := connectPair(t, addr, "alice", "bob")
+	defer cleanup()
+
+	drops0 := chanDrops()
+	var rcvdA, rcvdB atomic.Int64
+	stop := make(chan struct{})
+	go drainCount(connBA, &rcvdB, stop) // bob receives from alice
+	go drainCount(connAB, &rcvdA, stop) // alice receives from bob
+
+	const n = 50000
+	type res struct {
+		sent    int
+		elapsed time.Duration
+	}
+	resCh := make(chan res, 2)
+	go func() {
+		s, e := pump(connAB, n, 0)
+		resCh <- res{s, e}
+	}()
+	go func() {
+		s, e := pump(connBA, n, 0)
+		resCh <- res{s, e}
+	}()
+	r1, r2 := <-resCh, <-resCh
+	time.Sleep(1 * time.Second)
+	close(stop)
+	fmt.Printf("BIDIR: dir1 sent=%d %.1f Mbit/s; dir2 sent=%d %.1f Mbit/s; rcvdByBob=%d rcvdByAlice=%d chanDrops=%d\n",
+		r1.sent, mbit(int64(r1.sent), r1.elapsed),
+		r2.sent, mbit(int64(r2.sent), r2.elapsed),
+		rcvdB.Load(), rcvdA.Load(), chanDrops()-drops0)
+}

--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -25,6 +25,19 @@ const (
 	bufferSize            = 8820
 	serverResponseTimeout = 8 * time.Second
 	connChannelSize       = 100
+
+	// msgChanSendTimeout bounds how long an inbound message may wait for a slot
+	// on a reliable transport before it is dropped. It must stay far below the
+	// server's healthcheck disconnect window (~45s): the wait happens on the
+	// shared read loop, which also answers healthchecks.
+	msgChanSendTimeout = time.Second
+	// msgChanDropCooldown is how long writeMsg falls back to immediate drops
+	// after a timed-out send. Without it, a receiver that stopped draining
+	// (e.g. proxy paused after a P2P takeover) would stall the shared read
+	// loop for msgChanSendTimeout per message.
+	msgChanDropCooldown = time.Second
+	// dropLogInterval rate-limits the dropped-message warning.
+	dropLogInterval = 5 * time.Second
 )
 
 var (
@@ -74,6 +87,23 @@ type connContainer struct {
 	closed      bool // flag to check if channel is closed
 	ctx         context.Context
 	cancel      context.CancelFunc
+
+	// reliable is true when the relay transport is stream-based (e.g. WS over
+	// TCP): the link itself never loses messages, so writeMsg waits bounded for
+	// a channel slot instead of dropping. Datagram transports keep dropping,
+	// matching their link semantics.
+	reliable bool
+	// drops points at the owning Client's inbound-drop counter.
+	drops *atomic.Int64
+	// pendingSends tracks in-flight blocking sends; close() waits for them
+	// before closing the messages channel. Add is guarded by msgChanLock
+	// together with the closed flag.
+	pendingSends sync.WaitGroup
+	// cooldownUntil (unix nanos) makes writeMsg drop immediately while in the
+	// future, so a stalled receiver costs one timeout per cooldown window, not
+	// one per message.
+	cooldownUntil atomic.Int64
+	lastDropLog   atomic.Int64 // unix nanos of the last drop warning
 }
 
 func newConnContainer(log *log.Entry, c *Client, peerID messages.PeerID, instanceURL *RelayAddr) *connContainer {
@@ -90,6 +120,8 @@ func newConnContainer(log *log.Entry, c *Client, peerID messages.PeerID, instanc
 		messages: msgChan,
 		ctx:      ctx,
 		cancel:   cancel,
+		reliable: c.reliableTransport,
+		drops:    &c.inboundDrops,
 	}
 
 	// bind conn to client
@@ -111,19 +143,51 @@ func (cc *connContainer) netConn() net.Conn {
 
 func (cc *connContainer) writeMsg(msg Msg) {
 	cc.msgChanLock.Lock()
-	defer cc.msgChanLock.Unlock()
-
 	if cc.closed {
+		cc.msgChanLock.Unlock()
 		msg.Free()
 		return
 	}
 
 	select {
 	case cc.messages <- msg:
+		cc.msgChanLock.Unlock()
+		return
+	default:
+	}
+
+	if !cc.reliable || time.Now().UnixNano() < cc.cooldownUntil.Load() {
+		cc.msgChanLock.Unlock()
+		cc.dropMsg(msg)
+		return
+	}
+
+	// Registering under msgChanLock while !closed guarantees close() waits for
+	// this send before closing the channel.
+	cc.pendingSends.Add(1)
+	cc.msgChanLock.Unlock()
+	defer cc.pendingSends.Done()
+
+	timer := time.NewTimer(msgChanSendTimeout)
+	defer timer.Stop()
+	select {
+	case cc.messages <- msg:
 	case <-cc.ctx.Done():
 		msg.Free()
-	default:
-		msg.Free()
+	case <-timer.C:
+		cc.cooldownUntil.Store(time.Now().Add(msgChanDropCooldown).UnixNano())
+		cc.dropMsg(msg)
+	}
+}
+
+// dropMsg frees msg, counts the drop, and warns at most once per dropLogInterval.
+func (cc *connContainer) dropMsg(msg Msg) {
+	msg.Free()
+	n := cc.drops.Add(1)
+	now := time.Now().UnixNano()
+	last := cc.lastDropLog.Load()
+	if now-last >= int64(dropLogInterval) && cc.lastDropLog.CompareAndSwap(last, now) {
+		cc.log.Warnf("dropping inbound relayed message: receiver is not draining (%d drops total)", n)
 	}
 }
 
@@ -131,15 +195,18 @@ func (cc *connContainer) close() {
 	cc.cancel()
 
 	cc.msgChanLock.Lock()
-	defer cc.msgChanLock.Unlock()
-
 	if cc.closed {
+		cc.msgChanLock.Unlock()
 		return
 	}
-
 	cc.closed = true
-	close(cc.messages)
+	cc.msgChanLock.Unlock()
 
+	// Senders blocked in writeMsg wake via cc.ctx; waiting for them before
+	// closing the channel rules out a send on the closed channel.
+	cc.pendingSends.Wait()
+
+	close(cc.messages)
 	for msg := range cc.messages {
 		msg.Free()
 	}
@@ -191,6 +258,19 @@ type Client struct {
 	// transport is the negotiated relay transport of the
 	// current connection, guarded by mu.
 	transport string
+	// reliableTransport is true when the negotiated transport is stream-based
+	// (no per-message loss, e.g. WS over TCP); guarded by mu.
+	reliableTransport bool
+	// inboundDrops counts inbound transport messages dropped because the
+	// destination connection's channel stayed full. Cumulative for the
+	// lifetime of the Client.
+	inboundDrops atomic.Int64
+}
+
+// InboundMsgDrops returns the number of inbound transport messages dropped
+// because the receiver did not drain them in time.
+func (c *Client) InboundMsgDrops() int64 {
+	return c.inboundDrops.Load()
 }
 
 // Transport returns the negotiated relay transport of the current connection,
@@ -422,6 +502,7 @@ func (c *Client) connect(ctx context.Context) (*RelayAddr, error) {
 	if tc, ok := conn.(transportConn); ok {
 		c.transport = tc.Protocol()
 	}
+	c.reliableTransport = !dialer.IsConnDatagramSized(conn)
 
 	instanceURL, err := c.handShake(ctx)
 	if err != nil {
@@ -813,6 +894,7 @@ func (c *Client) close(gracefullyExit bool) error {
 	}
 	c.serviceIsRunning = false
 	c.transport = ""
+	c.reliableTransport = false
 
 	c.muInstanceURL.Lock()
 	c.instanceURL = nil

--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/netip"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -43,6 +44,16 @@ const (
 	msgChanDropCooldown = time.Second
 	// dropLogInterval rate-limits the dropped-message warning.
 	dropLogInterval = 5 * time.Second
+
+	// coalesceMaxCount and coalesceMaxBytes bound one outbound batch frame; it is
+	// flushed when either is reached. coalesceFlushDelay bounds how long the first
+	// buffered packet of a frame waits for company, so sparse/control traffic is
+	// not delayed noticeably while a bulk flow fills frames by size.
+	coalesceMaxCount   = 24
+	coalesceMaxBytes   = bufferSize - 128
+	coalesceFlushDelay = 250 * time.Microsecond
+	// batchLenPrefixSize is the per-payload length prefix in a batch frame.
+	batchLenPrefixSize = 2
 )
 
 var (
@@ -109,6 +120,16 @@ type connContainer struct {
 	// one per message.
 	cooldownUntil atomic.Int64
 	lastDropLog   atomic.Int64 // unix nanos of the last drop warning
+
+	// coalesce accumulates outbound packets to this peer into one batch frame.
+	// All fields below are guarded by coalesceMu.
+	coalesceEnabled bool
+	coalesceMu      sync.Mutex
+	coalesceFrame   []byte // batch frame under construction (header + packed payloads)
+	coalesceCount   int
+	coalesceTimer   *time.Timer
+	// writeRelay writes a full frame to the client's current relay connection.
+	writeRelay func([]byte) (int, error)
 }
 
 func newConnContainer(log *log.Entry, c *Client, peerID messages.PeerID, instanceURL *RelayAddr) *connContainer {
@@ -120,13 +141,15 @@ func newConnContainer(log *log.Entry, c *Client, peerID messages.PeerID, instanc
 		instanceURL: instanceURL,
 	}
 	cc := &connContainer{
-		log:      log,
-		conn:     cn,
-		messages: msgChan,
-		ctx:      ctx,
-		cancel:   cancel,
-		reliable: c.reliableTransport,
-		drops:    &c.inboundDrops,
+		log:             log,
+		conn:            cn,
+		messages:        msgChan,
+		ctx:             ctx,
+		cancel:          cancel,
+		reliable:        c.reliableTransport,
+		drops:           &c.inboundDrops,
+		coalesceEnabled: c.coalesce && c.reliableTransport,
+		writeRelay:      func(b []byte) (int, error) { return c.relayConn.Write(b) },
 	}
 
 	// bind conn to client
@@ -196,7 +219,90 @@ func (cc *connContainer) dropMsg(msg Msg) {
 	}
 }
 
+// enqueueCoalesced appends payload to this peer's pending batch frame and
+// flushes when the frame is full; a short timer flushes a partial frame so
+// sparse/control traffic is not delayed. It returns len(payload) to satisfy the
+// net.Conn.Write contract, mirroring the per-packet path. payload is copied into
+// the frame, so the caller may reuse its buffer after return.
+func (cc *connContainer) enqueueCoalesced(payload []byte) (int, error) {
+	cc.coalesceMu.Lock()
+	if cc.coalesceCount == 0 {
+		cc.coalesceFrame = messages.TransportBatchHeader(cc.conn.dstID)
+	} else if len(cc.coalesceFrame)+batchLenPrefixSize+len(payload) > coalesceMaxBytes {
+		cc.flushLocked()
+		cc.coalesceFrame = messages.TransportBatchHeader(cc.conn.dstID)
+	}
+
+	frame, ok := messages.AppendBatchPayload(cc.coalesceFrame, payload)
+	if !ok {
+		// Payload too large to length-prefix: flush and send it standalone.
+		cc.flushLocked()
+		cc.coalesceMu.Unlock()
+		return cc.writeSingle(payload)
+	}
+	cc.coalesceFrame = frame
+	cc.coalesceCount++
+
+	switch {
+	case cc.coalesceCount >= coalesceMaxCount || len(cc.coalesceFrame) >= coalesceMaxBytes:
+		cc.flushLocked()
+	case cc.coalesceCount == 1:
+		cc.armFlushTimerLocked()
+	}
+	cc.coalesceMu.Unlock()
+	return len(payload), nil
+}
+
+// writeSingle sends one payload as a plain transport message (fallback path).
+func (cc *connContainer) writeSingle(payload []byte) (int, error) {
+	msg, err := messages.MarshalTransportMsg(cc.conn.dstID, payload)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := cc.writeRelay(msg); err != nil {
+		return 0, err
+	}
+	return len(payload), nil
+}
+
+// flushLocked writes the pending batch frame to the relay. Caller holds coalesceMu.
+func (cc *connContainer) flushLocked() {
+	if cc.coalesceCount == 0 {
+		return
+	}
+	frame := cc.coalesceFrame
+	cc.coalesceFrame = nil
+	cc.coalesceCount = 0
+	if cc.coalesceTimer != nil {
+		cc.coalesceTimer.Stop()
+	}
+	if _, err := cc.writeRelay(frame); err != nil {
+		cc.log.Errorf("failed to write coalesced batch frame: %s", err)
+	}
+}
+
+func (cc *connContainer) armFlushTimerLocked() {
+	if cc.coalesceTimer == nil {
+		cc.coalesceTimer = time.AfterFunc(coalesceFlushDelay, cc.timedFlush)
+		return
+	}
+	cc.coalesceTimer.Reset(coalesceFlushDelay)
+}
+
+func (cc *connContainer) timedFlush() {
+	cc.coalesceMu.Lock()
+	cc.flushLocked()
+	cc.coalesceMu.Unlock()
+}
+
 func (cc *connContainer) close() {
+	cc.coalesceMu.Lock()
+	cc.flushLocked()
+	if cc.coalesceTimer != nil {
+		cc.coalesceTimer.Stop()
+	}
+	cc.coalesceMu.Unlock()
+
 	cc.cancel()
 
 	cc.msgChanLock.Lock()
@@ -270,6 +376,11 @@ type Client struct {
 	// destination connection's channel stayed full. Cumulative for the
 	// lifetime of the Client.
 	inboundDrops atomic.Int64
+
+	// coalesce enables packing several outbound packets destined to the same
+	// peer into one MsgTypeTransportBatch frame. Gated by NB_RELAY_COALESCE and
+	// only used on reliable (stream) transports.
+	coalesce bool
 }
 
 // InboundMsgDrops returns the number of inbound transport messages dropped
@@ -317,7 +428,8 @@ func NewClientWithServerIP(serverURL string, serverIP netip.Addr, authTokenStore
 				return &buf
 			},
 		},
-		conns: make(map[messages.PeerID]*connContainer),
+		conns:    make(map[messages.PeerID]*connContainer),
+		coalesce: os.Getenv("NB_RELAY_COALESCE") == "true",
 	}
 
 	c.earlyMsgs = newEarlyMsgBuffer()
@@ -669,6 +781,8 @@ func (c *Client) handleMsg(msgType messages.MsgType, buf []byte, bufPtr *[]byte,
 		c.bufPool.Put(bufPtr)
 	case messages.MsgTypeTransport:
 		return c.handleTransportMsg(buf, bufPtr, internallyStoppedFlag)
+	case messages.MsgTypeTransportBatch:
+		return c.handleTransportBatchMsg(buf, bufPtr, internallyStoppedFlag)
 	case messages.MsgTypePeersOnline:
 		c.handlePeersOnlineMsg(buf)
 		c.bufPool.Put(bufPtr)
@@ -740,6 +854,51 @@ func (c *Client) handleTransportMsg(buf []byte, bufPtr *[]byte, internallyStoppe
 	return true
 }
 
+// handleTransportBatchMsg splits a coalesced frame into its packets and delivers
+// each as an independent Msg. Each packet is copied into its own pooled buffer so
+// ownership is per-packet (an out-of-order drop cannot free a buffer another
+// packet still aliases); the original frame buffer is returned to the pool once.
+func (c *Client) handleTransportBatchMsg(buf []byte, bufPtr *[]byte, internallyStoppedFlag *internalStopFlag) bool {
+	peerID, payloads, err := messages.UnmarshalTransportBatch(buf)
+	if err != nil {
+		if c.serviceIsRunning && !internallyStoppedFlag.isSet() {
+			c.log.Errorf("failed to parse transport batch message: %v", err)
+		}
+		c.bufPool.Put(bufPtr)
+		return true
+	}
+
+	c.mu.Lock()
+	if !c.serviceIsRunning {
+		c.mu.Unlock()
+		c.bufPool.Put(bufPtr)
+		return false
+	}
+	container, ok := c.conns[*peerID]
+	earlyBuf := c.earlyMsgs
+	c.mu.Unlock()
+
+	for _, payload := range payloads {
+		pBufPtr := c.bufPool.Get().(*[]byte)
+		n := copy(*pBufPtr, payload)
+		msg := Msg{
+			bufPool: c.bufPool,
+			bufPtr:  pBufPtr,
+			Payload: (*pBufPtr)[:n],
+		}
+		if !ok {
+			if earlyBuf == nil || !earlyBuf.put(*peerID, msg) {
+				c.bufPool.Put(pBufPtr)
+			}
+			continue
+		}
+		container.writeMsg(msg)
+	}
+
+	c.bufPool.Put(bufPtr)
+	return true
+}
+
 func (c *Client) writeTo(containerRef *connContainer, dstID messages.PeerID, payload []byte) (int, error) {
 	c.mu.Lock()
 	current, ok := c.conns[dstID]
@@ -750,6 +909,10 @@ func (c *Client) writeTo(containerRef *connContainer, dstID messages.PeerID, pay
 
 	if current != containerRef {
 		return 0, net.ErrClosed
+	}
+
+	if current.coalesceEnabled {
+		return current.enqueueCoalesced(payload)
 	}
 
 	// todo: use buffer pool instead of create new transport msg.

--- a/shared/relay/client/client.go
+++ b/shared/relay/client/client.go
@@ -24,7 +24,12 @@ import (
 const (
 	bufferSize            = 8820
 	serverResponseTimeout = 8 * time.Second
-	connChannelSize       = 100
+	// connChannelSize is the buffered-message capacity per peer connection.
+	// It must cover the bandwidth-delay product of a fast relayed path so
+	// steady-state traffic never blocks the shared read loop: at 300 Mbit/s
+	// and 50 ms RTT the in-flight data is ~1.9 MB ≈ 213 messages. Buffers
+	// come from the client's pool, so idle connections hold none.
+	connChannelSize = 512
 
 	// msgChanSendTimeout bounds how long an inbound message may wait for a slot
 	// on a reliable transport before it is dropped. It must stay far below the

--- a/shared/relay/client/conn.go
+++ b/shared/relay/client/conn.go
@@ -32,6 +32,52 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 	return n, nil
 }
 
+// BatchReader is an optional interface a net.Conn may implement to hand several
+// relayed packets to the caller in one call. The relayed data path uses it to
+// inject a whole batch into the local WireGuard socket with a single sendmmsg
+// instead of one syscall per packet.
+type BatchReader interface {
+	// ReadBatch reads up to len(bufs) packets. It blocks for the first packet,
+	// then drains any packets already queued without blocking. sizes[i] receives
+	// the length copied into bufs[i]. It returns the number of packets read; a
+	// return of (0, err) means the connection is closed.
+	ReadBatch(bufs [][]byte, sizes []int) (n int, err error)
+}
+
+// ReadBatch implements BatchReader. It preserves Conn.Read's pooled-buffer
+// contract: exactly one Msg is consumed and freed per packet returned, so it is
+// safe to interleave with Read and with connContainer.close()'s drain loop.
+func (c *Conn) ReadBatch(bufs [][]byte, sizes []int) (n int, err error) {
+	if len(bufs) == 0 {
+		return 0, nil
+	}
+
+	m, ok := <-c.messageChan
+	if !ok {
+		return 0, net.ErrClosed
+	}
+	sizes[0] = copy(bufs[0], m.Payload)
+	m.Free()
+	n = 1
+
+	for n < len(bufs) {
+		select {
+		case m, ok = <-c.messageChan:
+			if !ok {
+				// Channel closed mid-drain: return what we have; the next
+				// ReadBatch/Read observes the closed channel and errors.
+				return n, nil
+			}
+			sizes[n] = copy(bufs[n], m.Payload)
+			m.Free()
+			n++
+		default:
+			return n, nil
+		}
+	}
+	return n, nil
+}
+
 func (c *Conn) Close() error {
 	return c.closeFn(c.dstID)
 }

--- a/shared/relay/client/conn_container_test.go
+++ b/shared/relay/client/conn_container_test.go
@@ -144,6 +144,78 @@ func TestWriteMsgImmediateDropDatagram(t *testing.T) {
 	}
 }
 
+// TestReadBatchDrainsInOrder verifies Conn.ReadBatch returns queued packets in
+// FIFO order, copies each payload out, frees every Msg exactly once (no pool
+// double-free — run with -race), and reports no drops.
+func TestReadBatchDrainsInOrder(t *testing.T) {
+	cc, c := newTestContainer(t, true)
+	defer cc.close()
+
+	const total = 10
+	for i := 0; i < total; i++ {
+		bufPtr := c.bufPool.Get().(*[]byte)
+		(*bufPtr)[0] = byte(i)
+		cc.writeMsg(Msg{bufPool: c.bufPool, bufPtr: bufPtr, Payload: (*bufPtr)[:16]})
+	}
+
+	const batch = 4
+	bufs := make([][]byte, batch)
+	sizes := make([]int, batch)
+	for i := range bufs {
+		bufs[i] = make([]byte, bufferSize)
+	}
+
+	got := 0
+	for got < total {
+		n, err := cc.conn.ReadBatch(bufs, sizes)
+		if err != nil {
+			t.Fatalf("ReadBatch: %v", err)
+		}
+		if n <= 0 || n > batch {
+			t.Fatalf("ReadBatch returned n=%d, want 1..%d", n, batch)
+		}
+		for i := 0; i < n; i++ {
+			if sizes[i] != 16 {
+				t.Fatalf("sizes[%d]=%d, want 16", i, sizes[i])
+			}
+			if bufs[i][0] != byte(got) {
+				t.Fatalf("out of order: got marker %d, want %d", bufs[i][0], got)
+			}
+			got++
+		}
+	}
+	if d := c.InboundMsgDrops(); d != 0 {
+		t.Fatalf("expected 0 drops, got %d", d)
+	}
+}
+
+// TestReadBatchDrainsOnlyAvailable verifies ReadBatch blocks for the first
+// packet then returns whatever is already queued without waiting for the batch
+// to fill.
+func TestReadBatchDrainsOnlyAvailable(t *testing.T) {
+	cc, c := newTestContainer(t, true)
+	defer cc.close()
+
+	const queued = 3
+	for i := 0; i < queued; i++ {
+		cc.writeMsg(testMsg(c))
+	}
+
+	bufs := make([][]byte, 8)
+	sizes := make([]int, 8)
+	for i := range bufs {
+		bufs[i] = make([]byte, bufferSize)
+	}
+
+	n, err := cc.conn.ReadBatch(bufs, sizes)
+	if err != nil {
+		t.Fatalf("ReadBatch: %v", err)
+	}
+	if n != queued {
+		t.Fatalf("ReadBatch returned n=%d, want %d (only what was queued)", n, queued)
+	}
+}
+
 // TestCloseUnblocksPendingWriters guards against a send on the closed messages
 // channel when close() races blocked writeMsg calls. Run with -race.
 func TestCloseUnblocksPendingWriters(t *testing.T) {

--- a/shared/relay/client/conn_container_test.go
+++ b/shared/relay/client/conn_container_test.go
@@ -1,0 +1,187 @@
+package client
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/shared/relay/messages"
+)
+
+func newTestContainer(t *testing.T, reliable bool) (*connContainer, *Client) {
+	t.Helper()
+	c := &Client{
+		log:               log.WithField("relay", "test"),
+		reliableTransport: reliable,
+		bufPool: &sync.Pool{
+			New: func() any {
+				buf := make([]byte, bufferSize)
+				return &buf
+			},
+		},
+		conns: make(map[messages.PeerID]*connContainer),
+	}
+	cc := newConnContainer(c.log, c, messages.HashID("test-peer"), nil)
+	return cc, c
+}
+
+func testMsg(c *Client) Msg {
+	bufPtr := c.bufPool.Get().(*[]byte)
+	return Msg{
+		bufPool: c.bufPool,
+		bufPtr:  bufPtr,
+		Payload: (*bufPtr)[:16],
+	}
+}
+
+func fillChannel(cc *connContainer, c *Client) {
+	for i := 0; i < connChannelSize; i++ {
+		cc.writeMsg(testMsg(c))
+	}
+}
+
+func TestWriteMsgFastPathNoDrop(t *testing.T) {
+	cc, c := newTestContainer(t, true)
+	defer cc.close()
+
+	const total = connChannelSize * 5
+	received := make(chan struct{})
+	go func() {
+		buf := make([]byte, bufferSize)
+		for i := 0; i < total; i++ {
+			if _, err := cc.conn.Read(buf); err != nil {
+				return
+			}
+		}
+		close(received)
+	}()
+
+	for i := 0; i < total; i++ {
+		cc.writeMsg(testMsg(c))
+	}
+
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("receiver did not get all messages")
+	}
+	if d := c.InboundMsgDrops(); d != 0 {
+		t.Fatalf("expected 0 drops, got %d", d)
+	}
+}
+
+func TestWriteMsgBlocksThenDropsReliable(t *testing.T) {
+	cc, c := newTestContainer(t, true)
+	defer cc.close()
+
+	fillChannel(cc, c)
+
+	start := time.Now()
+	cc.writeMsg(testMsg(c))
+	elapsed := time.Since(start)
+
+	if elapsed < msgChanSendTimeout/2 || elapsed > 3*msgChanSendTimeout {
+		t.Fatalf("expected ~%v bounded block, got %v", msgChanSendTimeout, elapsed)
+	}
+	if d := c.InboundMsgDrops(); d != 1 {
+		t.Fatalf("expected 1 drop, got %d", d)
+	}
+
+	// cooldown: the next overflow drops immediately
+	start = time.Now()
+	cc.writeMsg(testMsg(c))
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("expected immediate drop during cooldown, took %v", elapsed)
+	}
+	if d := c.InboundMsgDrops(); d != 2 {
+		t.Fatalf("expected 2 drops, got %d", d)
+	}
+}
+
+func TestWriteMsgBlockedSenderReleasedByDrain(t *testing.T) {
+	cc, c := newTestContainer(t, true)
+	defer cc.close()
+
+	fillChannel(cc, c)
+
+	done := make(chan struct{})
+	go func() {
+		cc.writeMsg(testMsg(c))
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	buf := make([]byte, bufferSize)
+	if _, err := cc.conn.Read(buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(msgChanSendTimeout / 2):
+		t.Fatal("sender was not released by the drain")
+	}
+	if d := c.InboundMsgDrops(); d != 0 {
+		t.Fatalf("expected 0 drops, got %d", d)
+	}
+}
+
+func TestWriteMsgImmediateDropDatagram(t *testing.T) {
+	cc, c := newTestContainer(t, false)
+	defer cc.close()
+
+	fillChannel(cc, c)
+
+	start := time.Now()
+	cc.writeMsg(testMsg(c))
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("expected immediate drop on datagram transport, took %v", elapsed)
+	}
+	if d := c.InboundMsgDrops(); d != 1 {
+		t.Fatalf("expected 1 drop, got %d", d)
+	}
+}
+
+// TestCloseUnblocksPendingWriters guards against a send on the closed messages
+// channel when close() races blocked writeMsg calls. Run with -race.
+func TestCloseUnblocksPendingWriters(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		cc, c := newTestContainer(t, true)
+		fillChannel(cc, c)
+
+		var wg sync.WaitGroup
+		for s := 0; s < 4; s++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				cc.writeMsg(testMsg(c))
+			}()
+		}
+
+		closed := make(chan struct{})
+		go func() {
+			cc.close()
+			close(closed)
+		}()
+
+		select {
+		case <-closed:
+		case <-time.After(time.Second):
+			t.Fatal("close did not return")
+		}
+		wg.Wait()
+
+		// the reader must observe EOF via the closed channel
+		buf := make([]byte, bufferSize)
+		if _, err := cc.conn.Read(buf); err == nil {
+			// drained a leftover message; the channel still must be closed
+			for {
+				if _, err := cc.conn.Read(buf); err != nil {
+					break
+				}
+			}
+		}
+	}
+}

--- a/shared/relay/client/dialer/capability.go
+++ b/shared/relay/client/dialer/capability.go
@@ -1,5 +1,7 @@
 package dialer
 
+import "net"
+
 // DatagramSized is implemented by dialers whose connections carry each write in
 // a single datagram, so a write can be rejected when it exceeds the path's
 // datagram budget (e.g. QUIC). Transports without this capability (e.g.
@@ -14,5 +16,13 @@ type DatagramSized interface {
 // IsDatagramSized reports whether d produces datagram-sized connections.
 func IsDatagramSized(d DialeFn) bool {
 	_, ok := d.(DatagramSized)
+	return ok
+}
+
+// IsConnDatagramSized reports whether conn carries each write in a single
+// unreliable datagram, i.e. the transport provides no flow control or
+// retransmission and overflows must be dropped rather than waited out.
+func IsConnDatagramSized(conn net.Conn) bool {
+	_, ok := conn.(DatagramSized)
 	return ok
 }

--- a/shared/relay/client/dialer/quic/conn.go
+++ b/shared/relay/client/dialer/quic/conn.go
@@ -62,6 +62,10 @@ func (c *Conn) Protocol() string {
 	return Network
 }
 
+// DatagramSized marks this connection as carrying each write in a single
+// unreliable datagram. See dialer.DatagramSized.
+func (c *Conn) DatagramSized() {}
+
 func (c *Conn) RemoteAddr() net.Addr {
 	return c.session.RemoteAddr()
 }

--- a/shared/relay/client/dialer/quic/quic.go
+++ b/shared/relay/client/dialer/quic/quic.go
@@ -61,6 +61,10 @@ func (d Dialer) Dial(ctx context.Context, address, serverName string) (net.Conn,
 	if err != nil {
 		return nil, fmt.Errorf("listen udp: %w", err)
 	}
+	// quic.Dial takes ownership of this socket but leaves its buffers at the OS
+	// default; size it so a busy relay path does not drop datagrams on a full
+	// kernel buffer.
+	nbnet.SizeRelaySocketBuffers(udpConn)
 
 	udpAddr, err := net.ResolveUDPAddr("udp", quicURL)
 	if err != nil {

--- a/shared/relay/client/manager.go
+++ b/shared/relay/client/manager.go
@@ -55,6 +55,9 @@ type RelayConnState struct {
 	URL string
 	// Transport is the negotiated transport, empty if not connected.
 	Transport string
+	// InboundMsgDrops counts inbound relayed messages dropped because the
+	// receiver did not drain them in time.
+	InboundMsgDrops int64
 	// Err is set when the relay is not connected.
 	Err error
 }
@@ -554,5 +557,5 @@ func relayConnState(c *Client) RelayConnState {
 	if err != nil {
 		return RelayConnState{URL: c.connectionURL, Err: err}
 	}
-	return RelayConnState{URL: addr, Transport: c.Transport()}
+	return RelayConnState{URL: addr, Transport: c.Transport(), InboundMsgDrops: c.InboundMsgDrops()}
 }

--- a/shared/relay/messages/message.go
+++ b/shared/relay/messages/message.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 )
@@ -30,6 +31,12 @@ const (
 	MsgTypePeersOnline          = 10
 	MsgTypePeersWentOffline     = 11
 
+	// MsgTypeTransportBatch carries several packets destined to the same peer in
+	// one frame, so one WS/TLS record + one TCP syscall replaces one per packet.
+	// It shares the transport header (dest peerID at offsetTransportID), so the
+	// relay routes it via the same opaque forward path as MsgTypeTransport.
+	MsgTypeTransportBatch = 12
+
 	// base size of the message
 	sizeOfVersionByte = 1
 	sizeOfMsgType     = 1
@@ -50,6 +57,10 @@ const (
 	headerSizeTransport      = peerIDSize
 	offsetTransportID        = sizeOfProtoHeader
 	headerTotalSizeTransport = sizeOfProtoHeader + headerSizeTransport
+
+	// transport batch: header is identical to transport, followed by repeated
+	// [uint16 length][payload] entries.
+	sizeOfBatchLenPrefix = 2
 )
 
 var (
@@ -75,6 +86,8 @@ func (m MsgType) String() string {
 		return "auth response"
 	case MsgTypeTransport:
 		return "transport"
+	case MsgTypeTransportBatch:
+		return "transport batch"
 	case MsgTypeClose:
 		return "close"
 	case MsgTypeHealthCheck:
@@ -116,6 +129,7 @@ func DetermineClientMessageType(msg []byte) (MsgType, error) {
 		MsgTypeHello,
 		MsgTypeAuth,
 		MsgTypeTransport,
+		MsgTypeTransportBatch,
 		MsgTypeClose,
 		MsgTypeHealthCheck,
 		MsgTypeSubscribePeerState,
@@ -138,6 +152,7 @@ func DetermineServerMessageType(msg []byte) (MsgType, error) {
 		MsgTypeHelloResponse,
 		MsgTypeAuthResponse,
 		MsgTypeTransport,
+		MsgTypeTransportBatch,
 		MsgTypeClose,
 		MsgTypeHealthCheck,
 		MsgTypePeersOnline,
@@ -304,6 +319,58 @@ func UnmarshalTransportMsg(buf []byte) (*PeerID, []byte, error) {
 	var peerID PeerID
 	copy(peerID[:], buf[offsetTransportID:offsetEnd])
 	return &peerID, buf[headerTotalSizeTransport:], nil
+}
+
+// TransportBatchHeader returns a fresh batch frame containing only the header
+// (version, MsgTypeTransportBatch, dest peerID). Callers append packed payloads
+// with AppendBatchPayload. The header matches the transport header, so the relay
+// routes the frame through the same opaque forward path.
+func TransportBatchHeader(peerID PeerID) []byte {
+	h := make([]byte, headerTotalSizeTransport, MaxMessageSize)
+	h[0] = byte(CurrentProtocolVersion)
+	h[1] = byte(MsgTypeTransportBatch)
+	copy(h[offsetTransportID:], peerID[:])
+	return h
+}
+
+// AppendBatchPayload appends a [uint16 length][payload] entry to a batch frame
+// and returns the extended frame. It reports whether the payload fits a uint16
+// length (WireGuard packets always do); an oversized payload is not appended.
+func AppendBatchPayload(frame, payload []byte) ([]byte, bool) {
+	if len(payload) > 0xFFFF {
+		return frame, false
+	}
+	var lp [sizeOfBatchLenPrefix]byte
+	binary.BigEndian.PutUint16(lp[:], uint16(len(payload)))
+	frame = append(frame, lp[:]...)
+	return append(frame, payload...), true
+}
+
+// UnmarshalTransportBatch extracts the peerID and each packed payload from a
+// batch frame. The returned payload slices alias buf.
+func UnmarshalTransportBatch(buf []byte) (*PeerID, [][]byte, error) {
+	if len(buf) < headerTotalSizeTransport {
+		return nil, nil, ErrInvalidMessageLength
+	}
+
+	const offsetEnd = offsetTransportID + peerIDSize
+	var peerID PeerID
+	copy(peerID[:], buf[offsetTransportID:offsetEnd])
+
+	var payloads [][]byte
+	for off := headerTotalSizeTransport; off < len(buf); {
+		if off+sizeOfBatchLenPrefix > len(buf) {
+			return nil, nil, ErrInvalidMessageLength
+		}
+		l := int(binary.BigEndian.Uint16(buf[off:]))
+		off += sizeOfBatchLenPrefix
+		if off+l > len(buf) {
+			return nil, nil, ErrInvalidMessageLength
+		}
+		payloads = append(payloads, buf[off:off+l])
+		off += l
+	}
+	return &peerID, payloads, nil
 }
 
 // UnmarshalTransportID extracts the peerID from the transport message.

--- a/shared/relay/messages/message_test.go
+++ b/shared/relay/messages/message_test.go
@@ -119,6 +119,60 @@ func TestMarshalTransportMsg(t *testing.T) {
 	}
 }
 
+func TestMarshalTransportBatch(t *testing.T) {
+	peerID := HashID("abdFAaBcawquEiCMzAabYosuUaGLtSNhKxz+")
+	payloads := [][]byte{
+		[]byte("first"),
+		[]byte(""),
+		[]byte("a slightly longer third payload"),
+	}
+
+	frame := TransportBatchHeader(peerID)
+	for _, p := range payloads {
+		var ok bool
+		frame, ok = AppendBatchPayload(frame, p)
+		if !ok {
+			t.Fatalf("AppendBatchPayload rejected payload of len %d", len(p))
+		}
+	}
+
+	// The batch frame must route like a transport frame on both sides.
+	if mt, err := DetermineClientMessageType(frame); err != nil || mt != MsgTypeTransportBatch {
+		t.Fatalf("client msg type = %v (err %v), want %d", mt, err, MsgTypeTransportBatch)
+	}
+	if mt, err := DetermineServerMessageType(frame); err != nil || mt != MsgTypeTransportBatch {
+		t.Fatalf("server msg type = %v (err %v), want %d", mt, err, MsgTypeTransportBatch)
+	}
+	// The dest peerID lives at the transport offset, so the relay's opaque
+	// UnmarshalTransportID/UpdateTransportMsg work unchanged.
+	if id, err := UnmarshalTransportID(frame); err != nil || id.String() != peerID.String() {
+		t.Fatalf("UnmarshalTransportID = %v (err %v), want %s", id, err, peerID)
+	}
+
+	id, got, err := UnmarshalTransportBatch(frame)
+	if err != nil {
+		t.Fatalf("UnmarshalTransportBatch: %v", err)
+	}
+	if id.String() != peerID.String() {
+		t.Errorf("peerID = %s, want %s", id, peerID)
+	}
+	if len(got) != len(payloads) {
+		t.Fatalf("got %d payloads, want %d", len(got), len(payloads))
+	}
+	for i := range payloads {
+		if string(got[i]) != string(payloads[i]) {
+			t.Errorf("payload %d = %q, want %q", i, got[i], payloads[i])
+		}
+	}
+
+	// A truncated frame (length prefix promises more than is present) must error,
+	// not panic or over-read.
+	truncated := frame[:len(frame)-3]
+	if _, _, err := UnmarshalTransportBatch(truncated); err == nil {
+		t.Errorf("expected error on truncated batch frame")
+	}
+}
+
 func TestMarshalHealthcheck(t *testing.T) {
 	msg := MarshalHealthcheck()
 


### PR DESCRIPTION
## Describe your changes

**Draft / RFC** — this is the one slice of the #6021 throughput work that extends the relay wire protocol, so we'd like design guidance before polishing it (questions at the bottom). Stacked on #6775 (which stacks on #6774).

**What it does:** adds `MsgTypeTransportBatch`, a frame that packs several packets destined to the same peer as repeated `[uint16 length][payload]` entries after the normal transport header. The header layout deliberately matches a plain transport message, so the relay server rewrites only the destination peer ID and forwards the whole frame **opaquely** — no per-packet parsing on the server's hot path. The client packs opportunistically: whatever is already queued gets coalesced up to `MaxMessageSize`, so it adds no latency under light load and packs full frames exactly when it matters. Opt-in via `NB_RELAY_COALESCE` (off by default).

Coalescing only engages on stream transports (WebSocket). QUIC datagrams are capped by path MTU, so they can't carry multi-packet frames — one more reason WS wins on relayed throughput once buffers are sized.

Measured effect (same setup as #6774: two 1 Gbit Linux hosts, ~5 ms RTT, single iperf3 flow, cubic, stock sysctls, receiver-side Mbit/s, WS transport):

| | up | down |
|---|---|---|
| #6774 + batch I/O | 227 | 184 |
| + this PR | 288 | ~180 |

Cumulative vs stock 0.74.2: 97.6 → 288 Mbit/s single-flow (~3×), with zero retransmissions on the tunnelled TCP.

**Why draft — the compatibility question.** A batch frame must be understood by **both** the relay server (it accepts the type) and the **receiving peer** (frames are forwarded opaquely, so the receiver unpacks them). The protocol currently has no capability negotiation: the version byte is hard-validated to 1 everywhere, and `AuthResponse` carries only the server address. As-is, the feature is safe purely because it's opt-in — an operator enables it once the relay and all participating peers run a supporting version. That's workable for self-hosted fleets but not a general answer. Options we see:

1. **Keep it operator-coordinated** (this PR as-is): env-gated everywhere, documented constraint. Simplest; no handshake change.
2. **Protocol version bump to 2.** The relay learns each client's version at auth time; it forwards batch frames opaquely to v2 receivers and unpacks them into single transport messages for v1 receivers; senders enable coalescing only when the relay advertises v2. Backward-compatible in both directions, but old relays reject a v2 auth outright, so new clients need a one-shot fallback reconnect at v1, and the relay grows an unpack path for mixed fleets.
3. **Explicit capability flag** in the handshake (new field or message) rather than overloading the version byte.

Which direction would you take? We'll rework the PR accordingly.

## Issue ticket number and link

#6021

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first). — discussion anchor: #6021; this PR is a draft specifically to have that design discussion.

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Draft under design discussion; `NB_RELAY_COALESCE` is an opt-in experimental gate. Docs to be added once the negotiation design is settled.