### PR TITLE
[management] enable pprof via env var

### DIFF
--- a/management/main.go
+++ b/management/main.go
@@ -1,19 +1,12 @@
 package main
 
 import (
-	"log"
-	"net/http"
-	// nolint:gosec
-	_ "net/http/pprof"
 	"os"
 
 	"github.com/netbirdio/netbird/management/cmd"
 )
 
 func main() {
-	go func() {
-		log.Println(http.ListenAndServe("localhost:6060", nil))
-	}()
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/management/main.go
+++ b/management/main.go
@@ -1,12 +1,24 @@
 package main
 
 import (
+	"net/http"
+	// nolint:gosec
+	_ "net/http/pprof"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/netbirdio/netbird/management/cmd"
 )
 
 func main() {
+	if pprofAddr := os.Getenv("NB_PPROF_ADDR"); pprofAddr != "" {
+		log.Infof("pprof enabled, listening on: %s", pprofAddr)
+		go func() {
+			log.Println(http.ListenAndServe(pprofAddr, nil))
+		}()
+	}
+
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/854


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP profiling is no longer enabled by default.
  * Profiling now starts only when a valid `NB_PPROF_ADDR` environment variable is configured.

* **Chores**
  * Added startup logging to indicate the configured profiling address when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->