### PR TITLE
[management] build routes for peer cache on network map components

### DIFF
--- a/management/server/types/networkmap_components.go
+++ b/management/server/types/networkmap_components.go
@@ -42,6 +42,13 @@ type NetworkMapComponents struct {
 	PostureFailedPeers map[string]map[string]struct{}
 
 	RouterPeers map[string]*nbpeer.Peer
+
+	routesByPeerIdx map[string][]routeIndexEntry
+}
+
+type routeIndexEntry struct {
+	route    *route.Route
+	viaGroup bool
 }
 
 type AccountSettingsInfo struct {
@@ -530,6 +537,27 @@ func (c *NetworkMapComponents) getRoutingPeerRoutes(peerID string) (enabledRoute
 		disabledRoutes = append(disabledRoutes, r)
 	}
 
+	for _, entry := range c.routesByPeer()[peerID] {
+		if entry.viaGroup {
+			newPeerRoute := entry.route.Copy()
+			newPeerRoute.Peer = peerID
+			newPeerRoute.PeerGroups = nil
+			newPeerRoute.ID = route.ID(string(entry.route.ID) + ":" + peerID)
+			takeRoute(newPeerRoute)
+			continue
+		}
+		takeRoute(entry.route.Copy())
+	}
+
+	return enabledRoutes, disabledRoutes
+}
+
+func (c *NetworkMapComponents) routesByPeer() map[string][]routeIndexEntry {
+	if c.routesByPeerIdx != nil {
+		return c.routesByPeerIdx
+	}
+
+	idx := make(map[string][]routeIndexEntry)
 	for _, r := range c.Routes {
 		for _, groupID := range r.PeerGroups {
 			group := c.GetGroupInfo(groupID)
@@ -537,24 +565,16 @@ func (c *NetworkMapComponents) getRoutingPeerRoutes(peerID string) (enabledRoute
 				continue
 			}
 			for _, id := range group.Peers {
-				if id != peerID {
-					continue
-				}
-
-				newPeerRoute := r.Copy()
-				newPeerRoute.Peer = id
-				newPeerRoute.PeerGroups = nil
-				newPeerRoute.ID = route.ID(string(r.ID) + ":" + id)
-				takeRoute(newPeerRoute)
-				break
+				idx[id] = append(idx[id], routeIndexEntry{route: r, viaGroup: true})
 			}
 		}
-		if r.Peer == peerID {
-			takeRoute(r.Copy())
+		if r.Peer != "" {
+			idx[r.Peer] = append(idx[r.Peer], routeIndexEntry{route: r})
 		}
 	}
 
-	return enabledRoutes, disabledRoutes
+	c.routesByPeerIdx = idx
+	return idx
 }
 
 func (c *NetworkMapComponents) filterRoutesByGroups(routes []*route.Route, groupListMap LookupMap) []*route.Route {

--- a/management/server/types/networkmap_components.go
+++ b/management/server/types/networkmap_components.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/netbirdio/netbird/client/ssh/auth"
@@ -43,7 +44,8 @@ type NetworkMapComponents struct {
 
 	RouterPeers map[string]*nbpeer.Peer
 
-	routesByPeerIdx map[string][]routeIndexEntry
+	routesByPeerOnce sync.Once
+	routesByPeerIdx  map[string][]routeIndexEntry
 }
 
 type routeIndexEntry struct {
@@ -540,7 +542,6 @@ func (c *NetworkMapComponents) getRoutingPeerRoutes(peerID string) (enabledRoute
 	for _, entry := range c.routesByPeer()[peerID] {
 		if entry.viaGroup {
 			newPeerRoute := entry.route.Copy()
-			newPeerRoute.Peer = peerID
 			newPeerRoute.PeerGroups = nil
 			newPeerRoute.ID = route.ID(string(entry.route.ID) + ":" + peerID)
 			takeRoute(newPeerRoute)
@@ -553,28 +554,26 @@ func (c *NetworkMapComponents) getRoutingPeerRoutes(peerID string) (enabledRoute
 }
 
 func (c *NetworkMapComponents) routesByPeer() map[string][]routeIndexEntry {
-	if c.routesByPeerIdx != nil {
-		return c.routesByPeerIdx
-	}
-
-	idx := make(map[string][]routeIndexEntry)
-	for _, r := range c.Routes {
-		for _, groupID := range r.PeerGroups {
-			group := c.GetGroupInfo(groupID)
-			if group == nil {
-				continue
+	c.routesByPeerOnce.Do(func() {
+		idx := make(map[string][]routeIndexEntry)
+		for _, r := range c.Routes {
+			for _, groupID := range r.PeerGroups {
+				group := c.GetGroupInfo(groupID)
+				if group == nil {
+					continue
+				}
+				for _, id := range group.Peers {
+					idx[id] = append(idx[id], routeIndexEntry{route: r, viaGroup: true})
+				}
 			}
-			for _, id := range group.Peers {
-				idx[id] = append(idx[id], routeIndexEntry{route: r, viaGroup: true})
+			if r.Peer != "" {
+				idx[r.Peer] = append(idx[r.Peer], routeIndexEntry{route: r})
 			}
 		}
-		if r.Peer != "" {
-			idx[r.Peer] = append(idx[r.Peer], routeIndexEntry{route: r})
-		}
-	}
+		c.routesByPeerIdx = idx
+	})
 
-	c.routesByPeerIdx = idx
-	return idx
+	return c.routesByPeerIdx
 }
 
 func (c *NetworkMapComponents) filterRoutesByGroups(routes []*route.Route, groupListMap LookupMap) []*route.Route {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved network map route lookup efficiency by caching routing candidates per peer, avoiding repeated scans of all routes.
  * Enhanced peer-group handling by generating peer-specific routing entries: routes now correctly reflect the target peer and use updated, peer-scoped route identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->