### PR TITLE
[client] Evaluate IP fragments against firewall ACLs

### DIFF
--- a/client/firewall/uspfilter/filter.go
+++ b/client/firewall/uspfilter/filter.go
@@ -121,6 +121,7 @@ type Manager struct {
 	udpTracker     *conntrack.UDPTracker
 	icmpTracker    *conntrack.ICMPTracker
 	tcpTracker     *conntrack.TCPTracker
+	fragments      *fragmentTracker
 	forwarder      atomic.Pointer[forwarder.Forwarder]
 	pendingCapture atomic.Pointer[forwarder.PacketCapture]
 	logger         *nblog.Logger
@@ -181,6 +182,41 @@ func (d *decoder) decodePacket(data []byte) error {
 	default:
 		return fmt.Errorf("unknown IP version %d", version)
 	}
+}
+
+// decodeTransport decodes the transport header of a first fragment (which
+// gopacket leaves undecoded) into the decoder and appends its layer type to
+// decoded, so the ACL pipeline can evaluate it like a normal packet. It returns
+// false if the protocol is unsupported or the header is truncated.
+func (d *decoder) decodeTransport(proto layers.IPProtocol, payload []byte) bool {
+	var l4 gopacket.DecodingLayer
+	var layerType gopacket.LayerType
+	var minLen int
+	switch proto {
+	case layers.IPProtocolTCP:
+		l4, layerType, minLen = &d.tcp, layers.LayerTypeTCP, 20
+	case layers.IPProtocolUDP:
+		l4, layerType, minLen = &d.udp, layers.LayerTypeUDP, 8
+	case layers.IPProtocolICMPv4:
+		l4, layerType, minLen = &d.icmp4, layers.LayerTypeICMPv4, 8
+	case layers.IPProtocolICMPv6:
+		l4, layerType, minLen = &d.icmp6, layers.LayerTypeICMPv6, 8
+	default:
+		return false
+	}
+
+	// Reject a fragment too small to hold the full transport header before
+	// decoding: it can't be ACL-evaluated (tiny-fragment attack), and skipping
+	// the decode avoids gopacket allocating an error on the drop path.
+	if len(payload) < minLen {
+		return false
+	}
+
+	if err := l4.DecodeFromBytes(payload, gopacket.NilDecodeFeedback); err != nil {
+		return false
+	}
+	d.decoded = append(d.decoded, layerType)
+	return true
 }
 
 // Create userspace firewall manager constructor
@@ -286,6 +322,8 @@ func create(iface common.IFaceMapper, nativeFirewall firewall.Manager, disableSe
 	if err := m.localipmanager.UpdateLocalIPs(iface); err != nil {
 		return nil, fmt.Errorf("update local IPs: %w", err)
 	}
+	m.fragments = newFragmentTracker(m.logger)
+
 	if disableConntrack {
 		log.Info("conntrack is disabled")
 	} else {
@@ -299,6 +337,7 @@ func create(iface common.IFaceMapper, nativeFirewall firewall.Manager, disableSe
 		}
 	}
 	if err := iface.SetFilter(m); err != nil {
+		m.fragments.Close()
 		return nil, fmt.Errorf("set filter: %w", err)
 	}
 	return m, nil
@@ -694,6 +733,10 @@ func (m *Manager) resetState() {
 		m.tcpTracker.Close()
 	}
 
+	if m.fragments != nil {
+		m.fragments.Close()
+	}
+
 	if fwder := m.forwarder.Load(); fwder != nil {
 		fwder.SetCapture(nil)
 		fwder.Stop()
@@ -1046,19 +1089,20 @@ func (m *Manager) filterInbound(packetData []byte, size int) bool {
 		return true
 	}
 
-	// TODO: pass fragments of routed packets to forwarder
+	// gopacket does not decode the transport header of any IP fragment, so
+	// fragments take a dedicated path: the first fragment's header is decoded
+	// and ACL-evaluated here, and the remaining fragments inherit its verdict.
 	if fragment {
-		if m.logger.Enabled(nblog.LevelTrace) {
-			if d.decoded[0] == layers.LayerTypeIPv4 {
-				m.logger.Trace4("packet is a fragment: src=%v dst=%v id=%v flags=%v",
-					srcIP, dstIP, d.ip4.Id, d.ip4.Flags)
-			} else {
-				m.logger.Trace2("packet is an IPv6 fragment: src=%v dst=%v", srcIP, dstIP)
-			}
-		}
-		return false
+		return m.filterInboundFragment(d, srcIP, dstIP, size)
 	}
 
+	return m.filterInboundDecoded(d, srcIP, dstIP, packetData, size)
+}
+
+// filterInboundDecoded runs the ACL, DNAT and conntrack pipeline on a fully
+// decoded (non-fragment) inbound packet. It returns true if the packet should
+// be dropped.
+func (m *Manager) filterInboundDecoded(d *decoder, srcIP, dstIP netip.Addr, packetData []byte, size int) bool {
 	// TODO: optimize port DNAT by caching matched rules in conntrack
 	if translated := m.translateInboundPortDNAT(packetData, d, srcIP, dstIP); translated {
 		// Re-decode after port DNAT translation to update port information
@@ -1089,33 +1133,226 @@ func (m *Manager) filterInbound(packetData []byte, size int) bool {
 	return m.handleRoutedTraffic(d, srcIP, dstIP, packetData, size)
 }
 
+// fragmentMeta holds the reassembly identity and layout of an IP fragment,
+// extracted uniformly for IPv4 and IPv6.
+type fragmentMeta struct {
+	key fragmentKey
+	// offset is the fragment offset in 8-byte units (zero for the first
+	// fragment).
+	offset uint16
+	// moreFragments is the More Fragments bit. A first fragment with it unset is
+	// an IPv6 atomic fragment (a complete datagram, RFC 6946): it has no trailing
+	// fragments to inherit a verdict, so it must not be recorded.
+	moreFragments bool
+	proto         layers.IPProtocol
+	// l4payload is the fragmentable payload of this fragment. For the first
+	// fragment it starts with the transport header.
+	l4payload []byte
+	// headerEndOctets is the first fragment's payload length in 8-byte units:
+	// the smallest offset a trailing fragment may start at without overlapping
+	// the inspected transport header.
+	headerEndOctets uint16
+}
+
+// fragmentMetadata extracts the fragment identity and layout from a decoded IP
+// fragment. It returns false for fragments it can't interpret (e.g. an IPv6
+// fragment header shorter than 8 bytes), which are then dropped.
+func fragmentMetadata(d *decoder, srcIP, dstIP netip.Addr) (fragmentMeta, bool) {
+	switch d.decoded[0] {
+	case layers.LayerTypeIPv4:
+		payload := d.ip4.Payload
+		return fragmentMeta{
+			key:             fragmentKey{srcIP: srcIP, dstIP: dstIP, id: uint32(d.ip4.Id), proto: uint8(d.ip4.Protocol)},
+			offset:          d.ip4.FragOffset,
+			moreFragments:   d.ip4.Flags&layers.IPv4MoreFragments != 0,
+			proto:           d.ip4.Protocol,
+			l4payload:       payload,
+			headerEndOctets: octets(len(payload)),
+		}, true
+
+	case layers.LayerTypeIPv6:
+		// IPv6 fragment extension header: 8 bytes, followed by the fragmentable
+		// payload. Layout: next header (1), reserved (1), offset+flags (2), id (4).
+		payload := d.ip6.Payload
+		if len(payload) < 8 {
+			return fragmentMeta{}, false
+		}
+		nextHeader := layers.IPProtocol(payload[0])
+		offsetFlags := binary.BigEndian.Uint16(payload[2:4])
+		id := binary.BigEndian.Uint32(payload[4:8])
+		l4 := payload[8:]
+		return fragmentMeta{
+			key:             fragmentKey{srcIP: srcIP, dstIP: dstIP, id: id, proto: uint8(nextHeader)},
+			offset:          offsetFlags >> 3,
+			moreFragments:   offsetFlags&1 != 0,
+			proto:           nextHeader,
+			l4payload:       l4,
+			headerEndOctets: octets(len(l4)),
+		}, true
+
+	default:
+		return fragmentMeta{}, false
+	}
+}
+
+// octets rounds a byte length up to whole 8-byte units, the granularity of the
+// IP fragment offset field.
+func octets(nbytes int) uint16 {
+	return uint16((nbytes + 7) / 8)
+}
+
+// filterInboundFragment decides the fate of an IP fragment. gopacket stops
+// decoding at the network layer for every fragment, so the first fragment's
+// transport header is decoded and ACL-evaluated here and its verdict recorded;
+// the remaining (headerless) fragments inherit that verdict. Anything that
+// cannot be tied to an allowed, non-overlapping first fragment is dropped.
+func (m *Manager) filterInboundFragment(d *decoder, srcIP, dstIP netip.Addr, size int) bool {
+	meta, ok := fragmentMetadata(d, srcIP, dstIP)
+	if !ok {
+		if m.logger.Enabled(nblog.LevelTrace) {
+			m.logger.Trace2("dropping unsupported fragment: src=%v dst=%v", srcIP, dstIP)
+		}
+		return true
+	}
+
+	if meta.offset != 0 {
+		return m.filterTrailingFragment(meta, srcIP, dstIP)
+	}
+
+	// A new first fragment supersedes any recorded verdict for this datagram, so
+	// a re-sent or overlapping offset-zero fragment can't inherit the old one.
+	m.fragments.poison(meta.key)
+
+	// First fragment: decode its transport header so the ACL can evaluate it. A
+	// decode failure means the fragment is too small to hold the full transport
+	// header (RFC 1858 §3 tiny-fragment attack); it can't be evaluated, so drop it.
+	if !d.decodeTransport(meta.proto, meta.l4payload) {
+		if m.logger.Enabled(nblog.LevelTrace) {
+			m.logger.Trace3("dropping first fragment without full L4 header: src=%v dst=%v id=%v",
+				srcIP, dstIP, meta.key.id)
+		}
+		return true
+	}
+
+	return m.filterFirstFragment(d, meta, srcIP, dstIP, size)
+}
+
+// filterTrailingFragment applies a recorded first-fragment verdict to a
+// non-first fragment.
+func (m *Manager) filterTrailingFragment(meta fragmentMeta, srcIP, dstIP netip.Addr) bool {
+	switch m.fragments.verdict(meta.key, meta.offset) {
+	case fragmentAllow:
+		return false
+	case fragmentOverlap:
+		if m.logger.Enabled(nblog.LevelTrace) {
+			m.logger.Trace3("dropping overlapping fragment rewriting inspected header: src=%v dst=%v id=%v",
+				srcIP, dstIP, meta.key.id)
+		}
+		return true
+	default:
+		if m.logger.Enabled(nblog.LevelTrace) {
+			m.logger.Trace3("dropping fragment with no allowed first fragment: src=%v dst=%v id=%v",
+				srcIP, dstIP, meta.key.id)
+		}
+		return true
+	}
+}
+
+// filterFirstFragment runs the verdict part of the inbound pipeline on a first
+// fragment with its transport header decoded. It mirrors filterInboundDecoded
+// but skips DNAT (port rewriting on fragments is unsupported) and forwarder
+// injection (fragments are left to the stack to reassemble, not forwarded).
+// Allowed fragments have their verdict recorded so the datagram's trailing
+// fragments inherit it.
+func (m *Manager) filterFirstFragment(d *decoder, meta fragmentMeta, srcIP, dstIP netip.Addr, size int) bool {
+	if m.stateful && m.isValidTrackedConnection(d, srcIP, dstIP, size) {
+		m.recordFirstFragment(meta)
+		return false
+	}
+
+	if m.localipmanager.IsLocalIP(dstIP) {
+		ruleID, blocked := m.peerACLsBlock(srcIP, d, nil)
+		if blocked {
+			m.storeDropFlow("Dropping local first fragment (ACL denied): rule_id=%s proto=%v src=%s:%d dst=%s:%d",
+				d, srcIP, dstIP, ruleID, size)
+			return true
+		}
+		m.trackInbound(d, srcIP, dstIP, ruleID, size)
+		m.recordFirstFragment(meta)
+		return false
+	}
+
+	if !m.routingEnabled.Load() {
+		if m.logger.Enabled(nblog.LevelTrace) {
+			m.logger.Trace2("Dropping routed fragment (routing disabled): src=%s dst=%s", srcIP, dstIP)
+		}
+		return true
+	}
+	if m.nativeRouter.Load() {
+		m.trackInbound(d, srcIP, dstIP, nil, size)
+		m.recordFirstFragment(meta)
+		return false
+	}
+
+	// TODO: pass fragments of routed packets to the forwarder; until then
+	// allowed routed fragments go to the native stack.
+	srcPort, dstPort := getPortsFromPacket(d)
+	ruleID, pass := m.routeACLsPass(srcIP, dstIP, d.decoded[1], srcPort, dstPort)
+	if !pass {
+		m.storeDropFlow("Dropping routed first fragment (ACL denied): rule_id=%s proto=%v src=%s:%d dst=%s:%d",
+			d, srcIP, dstIP, ruleID, size)
+		return true
+	}
+
+	m.recordFirstFragment(meta)
+	return false
+}
+
+// recordFirstFragment caches an allowed first fragment's verdict for its
+// trailing fragments to inherit. Atomic fragments (no More Fragments bit) are
+// complete datagrams with no trailing fragments, so they are not cached and
+// cannot exhaust the verdict table.
+func (m *Manager) recordFirstFragment(meta fragmentMeta) {
+	if !meta.moreFragments {
+		return
+	}
+	m.fragments.recordAllowed(meta.key, meta.headerEndOctets)
+}
+
+// storeDropFlow logs and records a netflow drop event for an inbound packet
+// denied by the ACLs. msg is the trace format taking rule id, protocol, source
+// and destination.
+func (m *Manager) storeDropFlow(msg string, d *decoder, srcIP, dstIP netip.Addr, ruleID []byte, size int) {
+	pnum := getProtocolFromPacket(d)
+	srcPort, dstPort := getPortsFromPacket(d)
+
+	if m.logger.Enabled(nblog.LevelTrace) {
+		m.logger.Trace6(msg, ruleID, pnum, srcIP, srcPort, dstIP, dstPort)
+	}
+
+	m.flowLogger.StoreEvent(nftypes.EventFields{
+		FlowID:     uuid.New(),
+		Type:       nftypes.TypeDrop,
+		RuleID:     ruleID,
+		Direction:  nftypes.Ingress,
+		Protocol:   pnum,
+		SourceIP:   srcIP,
+		DestIP:     dstIP,
+		SourcePort: srcPort,
+		DestPort:   dstPort,
+		// TODO: icmp type/code
+		RxPackets: 1,
+		RxBytes:   uint64(size),
+	})
+}
+
 // handleLocalTraffic handles local traffic.
 // If it returns true, the packet should be dropped.
 func (m *Manager) handleLocalTraffic(d *decoder, srcIP, dstIP netip.Addr, packetData []byte, size int) bool {
 	ruleID, blocked := m.peerACLsBlock(srcIP, d, packetData)
 	if blocked {
-		pnum := getProtocolFromPacket(d)
-		srcPort, dstPort := getPortsFromPacket(d)
-
-		if m.logger.Enabled(nblog.LevelTrace) {
-			m.logger.Trace6("Dropping local packet (ACL denied): rule_id=%s proto=%v src=%s:%d dst=%s:%d",
-				ruleID, pnum, srcIP, srcPort, dstIP, dstPort)
-		}
-
-		m.flowLogger.StoreEvent(nftypes.EventFields{
-			FlowID:     uuid.New(),
-			Type:       nftypes.TypeDrop,
-			RuleID:     ruleID,
-			Direction:  nftypes.Ingress,
-			Protocol:   pnum,
-			SourceIP:   srcIP,
-			DestIP:     dstIP,
-			SourcePort: srcPort,
-			DestPort:   dstPort,
-			// TODO: icmp type/code
-			RxPackets: 1,
-			RxBytes:   uint64(size),
-		})
+		m.storeDropFlow("Dropping local packet (ACL denied): rule_id=%s proto=%v src=%s:%d dst=%s:%d",
+			d, srcIP, dstIP, ruleID, size)
 		return true
 	}
 
@@ -1168,27 +1405,8 @@ func (m *Manager) handleRoutedTraffic(d *decoder, srcIP, dstIP netip.Addr, packe
 
 	ruleID, pass := m.routeACLsPass(srcIP, dstIP, protoLayer, srcPort, dstPort)
 	if !pass {
-		proto := getProtocolFromPacket(d)
-
-		if m.logger.Enabled(nblog.LevelTrace) {
-			m.logger.Trace6("Dropping routed packet (ACL denied): rule_id=%s proto=%v src=%s:%d dst=%s:%d",
-				ruleID, proto, srcIP, srcPort, dstIP, dstPort)
-		}
-
-		m.flowLogger.StoreEvent(nftypes.EventFields{
-			FlowID:     uuid.New(),
-			Type:       nftypes.TypeDrop,
-			RuleID:     ruleID,
-			Direction:  nftypes.Ingress,
-			Protocol:   proto,
-			SourceIP:   srcIP,
-			DestIP:     dstIP,
-			SourcePort: srcPort,
-			DestPort:   dstPort,
-			// TODO: icmp type/code
-			RxPackets: 1,
-			RxBytes:   uint64(size),
-		})
+		m.storeDropFlow("Dropping routed packet (ACL denied): rule_id=%s proto=%v src=%s:%d dst=%s:%d",
+			d, srcIP, dstIP, ruleID, size)
 		return true
 	}
 

--- a/client/firewall/uspfilter/fragment.go
+++ b/client/firewall/uspfilter/fragment.go
@@ -1,0 +1,204 @@
+package uspfilter
+
+import (
+	"context"
+	"net/netip"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	nblog "github.com/netbirdio/netbird/client/firewall/uspfilter/log"
+)
+
+const (
+	// defaultFragmentTimeout bounds how long a first-fragment verdict is kept
+	// while the remaining fragments arrive. It mirrors the Linux IP reassembly
+	// timeout (net.ipv4.ipfrag_time).
+	defaultFragmentTimeout = 30 * time.Second
+	// fragmentCleanupInterval is how often expired verdicts are purged.
+	fragmentCleanupInterval = 10 * time.Second
+	// defaultMaxFragmentEntries caps the number of concurrently tracked
+	// fragmented datagrams. The table stays bounded because each datagram is a
+	// single small entry regardless of how many fragments it is split into, and
+	// the 13-bit IPv4 fragment-offset field limits any datagram to 64 KiB.
+	defaultMaxFragmentEntries = 16384
+
+	// EnvFragmentMaxEntries overrides defaultMaxFragmentEntries.
+	EnvFragmentMaxEntries = "NB_FRAGMENT_MAX_ENTRIES"
+)
+
+// fragmentVerdict is the decision for a trailing (headerless) fragment.
+type fragmentVerdict int
+
+const (
+	// fragmentDeny drops the fragment: no allowed first fragment is on record.
+	fragmentDeny fragmentVerdict = iota
+	// fragmentAllow passes the fragment: it belongs to an allowed datagram and
+	// does not overlap the already-inspected transport header.
+	fragmentAllow
+	// fragmentOverlap drops the fragment and poisons its datagram: it overlaps
+	// the transport header the ACL inspected (RFC 1858 §4, RFC 3128; RFC 5722
+	// requires discarding the whole datagram on overlap for IPv6).
+	fragmentOverlap
+)
+
+// fragmentKey identifies a fragmented datagram. It matches the RFC 791 / RFC
+// 8200 reassembly key: source, destination, protocol and identification. The id
+// is 32-bit to hold both the IPv4 (16-bit) and IPv6 (32-bit) identification.
+type fragmentKey struct {
+	srcIP netip.Addr
+	dstIP netip.Addr
+	id    uint32
+	proto uint8
+}
+
+// fragmentEntry records the verdict of an allowed first fragment.
+type fragmentEntry struct {
+	// headerEndOctets is the offset, in 8-byte units, at which the first
+	// fragment's payload ended. A trailing fragment starting before this
+	// overlaps bytes the ACL already inspected and is rejected.
+	headerEndOctets uint16
+	// recordedAt is when the first fragment was accepted. The verdict expires a
+	// fixed timeout later and is not refreshed, mirroring the kernel reassembly
+	// timer so a trailing-fragment flood can't keep a datagram alive.
+	recordedAt time.Time
+}
+
+// fragmentTracker records the ACL verdict of a datagram's first fragment so the
+// remaining fragments, which carry no L4 header, can inherit the decision
+// without reassembling the datagram. Only allowed first fragments are stored;
+// anything that cannot be tied to an allowed, non-overlapping first fragment is
+// dropped (fail closed).
+type fragmentTracker struct {
+	logger  *nblog.Logger
+	mutex   sync.Mutex
+	entries map[fragmentKey]fragmentEntry
+	timeout time.Duration
+	// maxEntries caps the table; atCapacity dedups the capacity warning until
+	// the table drains below the cap again.
+	maxEntries    int
+	atCapacity    bool
+	cleanupTicker *time.Ticker
+	cancel        context.CancelFunc
+}
+
+func newFragmentTracker(logger *nblog.Logger) *fragmentTracker {
+	ctx, cancel := context.WithCancel(context.Background())
+	t := &fragmentTracker{
+		logger:        logger,
+		entries:       make(map[fragmentKey]fragmentEntry),
+		timeout:       defaultFragmentTimeout,
+		maxEntries:    fragmentMaxEntries(logger),
+		cleanupTicker: time.NewTicker(fragmentCleanupInterval),
+		cancel:        cancel,
+	}
+	go t.cleanupRoutine(ctx)
+	return t
+}
+
+func fragmentMaxEntries(logger *nblog.Logger) int {
+	v := os.Getenv(EnvFragmentMaxEntries)
+	if v == "" {
+		return defaultMaxFragmentEntries
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		logger.Warn2("invalid %s=%q, using default", EnvFragmentMaxEntries, v)
+		return defaultMaxFragmentEntries
+	}
+	return n
+}
+
+// recordAllowed stores the verdict of an allowed first fragment. headerEndOctets
+// is the first fragment's payload length in 8-byte units. When the table is full
+// the record is dropped, which fails closed: the datagram's trailing fragments
+// will be denied.
+func (t *fragmentTracker) recordAllowed(key fragmentKey, headerEndOctets uint16) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	if t.entries == nil {
+		return
+	}
+	if _, ok := t.entries[key]; !ok && len(t.entries) >= t.maxEntries {
+		if !t.atCapacity {
+			t.atCapacity = true
+			t.logger.Warn2("fragment verdict table at capacity (%d/%d): trailing fragments of new datagrams will be dropped",
+				len(t.entries), t.maxEntries)
+		}
+		return
+	}
+	t.entries[key] = fragmentEntry{
+		headerEndOctets: headerEndOctets,
+		recordedAt:      time.Now(),
+	}
+}
+
+// poison drops any recorded verdict for a datagram, so its later fragments are
+// denied until a new allowed first fragment is recorded. Called on every
+// offset-zero fragment to defeat offset-zero overlap rewrites (RFC 3128).
+func (t *fragmentTracker) poison(key fragmentKey) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	delete(t.entries, key)
+}
+
+// verdict decides the fate of a trailing fragment at fragOffsetOctets (the IPv4
+// fragment offset, in 8-byte units). A fragment overlapping the inspected
+// header poisons the datagram: the entry is removed so all further fragments of
+// that datagram are denied too.
+func (t *fragmentTracker) verdict(key fragmentKey, fragOffsetOctets uint16) fragmentVerdict {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	entry, ok := t.entries[key]
+	if !ok {
+		return fragmentDeny
+	}
+	if time.Since(entry.recordedAt) > t.timeout {
+		delete(t.entries, key)
+		return fragmentDeny
+	}
+	if fragOffsetOctets < entry.headerEndOctets {
+		delete(t.entries, key)
+		return fragmentOverlap
+	}
+	return fragmentAllow
+}
+
+func (t *fragmentTracker) cleanupRoutine(ctx context.Context) {
+	defer t.cleanupTicker.Stop()
+	for {
+		select {
+		case <-t.cleanupTicker.C:
+			t.cleanup()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (t *fragmentTracker) cleanup() {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	for key, entry := range t.entries {
+		if time.Since(entry.recordedAt) > t.timeout {
+			delete(t.entries, key)
+		}
+	}
+
+	if len(t.entries) < t.maxEntries {
+		t.atCapacity = false
+	}
+}
+
+// Close stops the cleanup routine and releases resources.
+func (t *fragmentTracker) Close() {
+	t.cancel()
+
+	t.mutex.Lock()
+	t.entries = nil
+	t.mutex.Unlock()
+}

--- a/client/firewall/uspfilter/fragment_bench_test.go
+++ b/client/firewall/uspfilter/fragment_bench_test.go
@@ -1,0 +1,115 @@
+package uspfilter
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// benchFilterInbound drives filterInbound over a fixed packet in a tight loop.
+// Packets are built once, outside the timed region, so the benchmark measures
+// only pipeline cost, which is what an attacker can amplify.
+func benchFilterInbound(b *testing.B, pkt []byte) {
+	b.Helper()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(pkt)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m := benchManager
+		m.filterInbound(pkt, len(pkt))
+	}
+}
+
+// benchManager is a package-level manager reused across fragment benchmarks so
+// setup cost stays out of the timed region.
+var benchManager *Manager
+
+func setupBenchManager(b *testing.B) *Manager {
+	b.Helper()
+	m := newFragmentTestManager(b)
+	allowUDP(b, m, 8080)
+	// Disable conntrack so the allowed-first-fragment path measures transport
+	// decode + ACL every iteration instead of matching the connection tracked
+	// on the first iteration.
+	m.stateful = false
+	benchManager = m
+	return m
+}
+
+// BenchmarkInbound_NormalPacket is the baseline: a full, non-fragmented UDP
+// packet that passes the ACL. Fragment paths should stay comparable to this.
+func BenchmarkInbound_NormalPacket(b *testing.B) {
+	setupBenchManager(b)
+	pkt := normalUDPPacket(b, 8080, 32)
+	benchFilterInbound(b, pkt)
+}
+
+// BenchmarkInbound_FirstFragmentAllowed measures the first-fragment path:
+// transport decode + ACL evaluation + verdict record.
+func BenchmarkInbound_FirstFragmentAllowed(b *testing.B) {
+	setupBenchManager(b)
+	pkt := firstFragmentUDP(b, 0x2000, 8080, 32)
+	benchFilterInbound(b, pkt)
+}
+
+// BenchmarkInbound_TrailingFragmentAllowed measures the common trailing-fragment
+// path: a single map lookup after the first fragment is on record.
+func BenchmarkInbound_TrailingFragmentAllowed(b *testing.B) {
+	m := setupBenchManager(b)
+	first := firstFragmentUDP(b, 0x3000, 8080, 32)
+	m.filterInbound(first, len(first))
+	pkt := trailingFragment(b, 0x3000, 5, false, 24)
+	benchFilterInbound(b, pkt)
+}
+
+// BenchmarkInbound_TrailingFragmentNoFirst is the primary DoS vector: an
+// attacker floods trailing fragments with no first fragment on record. Each is
+// a map miss and must be cheap.
+func BenchmarkInbound_TrailingFragmentNoFirst(b *testing.B) {
+	setupBenchManager(b)
+	pkt := trailingFragment(b, 0x4000, 185, false, 40)
+	benchFilterInbound(b, pkt)
+}
+
+// BenchmarkInbound_TinyFirstFragment measures the tiny-fragment drop path: a
+// first fragment too small to decode a transport header.
+func BenchmarkInbound_TinyFirstFragment(b *testing.B) {
+	setupBenchManager(b)
+	pkt := trailingFragment(b, 0x5000, 0, true, 4)
+	benchFilterInbound(b, pkt)
+}
+
+// BenchmarkInbound_TrailingFragmentDistinctIDs is the worst case for the
+// verdict table: an attacker varies the datagram id on every packet so no first
+// fragment ever matches. Verdict lookups always miss and nothing is recorded,
+// so the table cannot grow. Each iteration rewrites the id field in place.
+func BenchmarkInbound_TrailingFragmentDistinctIDs(b *testing.B) {
+	setupBenchManager(b)
+	pkt := trailingFragment(b, 0x6000, 185, false, 40)
+	m := benchManager
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(pkt)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// IPv4 identification field is at bytes 4:6.
+		binary.BigEndian.PutUint16(pkt[4:6], uint16(i))
+		m.filterInbound(pkt, len(pkt))
+	}
+}
+
+// BenchmarkInbound_FirstFragmentDistinctIDs measures sustained first-fragment
+// pressure with distinct ids: transport decode + ACL + verdict insert until the
+// table caps, exercising the map growth and capacity guard.
+func BenchmarkInbound_FirstFragmentDistinctIDs(b *testing.B) {
+	setupBenchManager(b)
+	pkt := firstFragmentUDP(b, 0x7000, 8080, 32)
+	m := benchManager
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(pkt)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		binary.BigEndian.PutUint16(pkt[4:6], uint16(i))
+		m.filterInbound(pkt, len(pkt))
+	}
+}

--- a/client/firewall/uspfilter/fragment_test.go
+++ b/client/firewall/uspfilter/fragment_test.go
@@ -1,0 +1,554 @@
+package uspfilter
+
+import (
+	"encoding/binary"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	fw "github.com/netbirdio/netbird/client/firewall/manager"
+	nbiface "github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
+)
+
+const (
+	fragTestSrc   = "100.10.0.1"
+	fragTestDst   = "100.10.0.100"
+	fragTestSrcV6 = "fd00::1"
+	fragTestDstV6 = "fd00::100"
+)
+
+func newFragmentTestManager(tb testing.TB) *Manager {
+	tb.Helper()
+
+	ifaceMock := &IFaceMock{
+		SetFilterFunc: func(device.PacketFilter) error { return nil },
+		AddressFunc: func() wgaddr.Address {
+			return wgaddr.Address{
+				IP:      netip.MustParseAddr(fragTestDst),
+				Network: netip.MustParsePrefix("100.10.0.0/16"),
+				IPv6:    netip.MustParseAddr(fragTestDstV6),
+				IPv6Net: netip.MustParsePrefix("fd00::/64"),
+			}
+		},
+	}
+
+	m, err := Create(ifaceMock, false, flowLogger, nbiface.DefaultMTU)
+	require.NoError(tb, err)
+	require.NoError(tb, m.UpdateLocalIPs())
+	tb.Cleanup(func() { require.NoError(tb, m.Close(nil)) })
+	return m
+}
+
+// firstFragmentUDPTo builds the first fragment of a fragmented UDP datagram to
+// the given destination: it carries the full UDP header plus payloadLen bytes
+// of data, with the More Fragments flag set and offset zero.
+func firstFragmentUDPTo(tb testing.TB, dst string, id uint16, dstPort uint16, payloadLen int) []byte {
+	tb.Helper()
+
+	ip := &layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Id:       id,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    net.ParseIP(fragTestSrc),
+		DstIP:    net.ParseIP(dst),
+		Flags:    layers.IPv4MoreFragments,
+	}
+	udp := &layers.UDP{SrcPort: 40000, DstPort: layers.UDPPort(dstPort)}
+	require.NoError(tb, udp.SetNetworkLayerForChecksum(ip))
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	require.NoError(tb, gopacket.SerializeLayers(buf, opts, ip, udp, gopacket.Payload(make([]byte, payloadLen))))
+	return buf.Bytes()
+}
+
+func firstFragmentUDP(tb testing.TB, id uint16, dstPort uint16, payloadLen int) []byte {
+	tb.Helper()
+	return firstFragmentUDPTo(tb, fragTestDst, id, dstPort, payloadLen)
+}
+
+// firstFragmentTCP builds the first fragment of a fragmented TCP datagram: the
+// full 20-byte TCP header plus 12 bytes of data, with the More Fragments flag
+// set and offset zero.
+func firstFragmentTCP(tb testing.TB, id uint16, dstPort uint16) []byte {
+	tb.Helper()
+
+	ip := &layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Id:       id,
+		Protocol: layers.IPProtocolTCP,
+		SrcIP:    net.ParseIP(fragTestSrc),
+		DstIP:    net.ParseIP(fragTestDst),
+		Flags:    layers.IPv4MoreFragments,
+	}
+	tcp := &layers.TCP{SrcPort: 40000, DstPort: layers.TCPPort(dstPort), SYN: true, Window: 64240}
+	require.NoError(tb, tcp.SetNetworkLayerForChecksum(ip))
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	require.NoError(tb, gopacket.SerializeLayers(buf, opts, ip, tcp, gopacket.Payload(make([]byte, 12))))
+	return buf.Bytes()
+}
+
+// trailingFragmentTo builds a non-first fragment to the given destination: an
+// IPv4 header at the given fragment offset (in 8-byte units) carrying raw
+// payload and no L4 header.
+func trailingFragmentTo(tb testing.TB, dst string, proto layers.IPProtocol, id uint16, fragOffsetOctets uint16, moreFragments bool, payloadLen int) []byte {
+	tb.Helper()
+
+	ip := &layers.IPv4{
+		Version:    4,
+		TTL:        64,
+		Id:         id,
+		Protocol:   proto,
+		SrcIP:      net.ParseIP(fragTestSrc),
+		DstIP:      net.ParseIP(dst),
+		FragOffset: fragOffsetOctets,
+	}
+	if moreFragments {
+		ip.Flags = layers.IPv4MoreFragments
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true}
+	require.NoError(tb, gopacket.SerializeLayers(buf, opts, ip, gopacket.Payload(make([]byte, payloadLen))))
+	return buf.Bytes()
+}
+
+func trailingFragment(tb testing.TB, id uint16, fragOffsetOctets uint16, moreFragments bool, payloadLen int) []byte {
+	tb.Helper()
+	return trailingFragmentTo(tb, fragTestDst, layers.IPProtocolUDP, id, fragOffsetOctets, moreFragments, payloadLen)
+}
+
+// outboundUDPPacket builds a complete outbound UDP packet from the local
+// address, used to establish conntrack state for reply-direction tests.
+func outboundUDPPacket(tb testing.TB, srcPort, dstPort uint16) []byte {
+	tb.Helper()
+
+	ip := &layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Id:       1,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    net.ParseIP(fragTestDst),
+		DstIP:    net.ParseIP(fragTestSrc),
+	}
+	udp := &layers.UDP{SrcPort: layers.UDPPort(srcPort), DstPort: layers.UDPPort(dstPort)}
+	require.NoError(tb, udp.SetNetworkLayerForChecksum(ip))
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	require.NoError(tb, gopacket.SerializeLayers(buf, opts, ip, udp, gopacket.Payload(make([]byte, 16))))
+	return buf.Bytes()
+}
+
+// normalUDPPacket builds a complete, non-fragmented UDP packet for baseline
+// comparisons against the fragment paths.
+func normalUDPPacket(tb testing.TB, dstPort uint16, payloadLen int) []byte {
+	tb.Helper()
+
+	ip := &layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Id:       1,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    net.ParseIP(fragTestSrc),
+		DstIP:    net.ParseIP(fragTestDst),
+	}
+	udp := &layers.UDP{SrcPort: 40000, DstPort: layers.UDPPort(dstPort)}
+	require.NoError(tb, udp.SetNetworkLayerForChecksum(ip))
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true, FixLengths: true}
+	require.NoError(tb, gopacket.SerializeLayers(buf, opts, ip, udp, gopacket.Payload(make([]byte, payloadLen))))
+	return buf.Bytes()
+}
+
+func allowUDP(tb testing.TB, m *Manager, dstPort uint16) {
+	tb.Helper()
+	_, err := m.AddPeerFiltering(nil, net.ParseIP(fragTestSrc), fw.ProtocolUDP, nil,
+		&fw.Port{Values: []uint16{dstPort}}, fw.ActionAccept, "")
+	require.NoError(tb, err)
+}
+
+// TestFragment_TrailingWithoutFirstDropped is the core bypass repro: a trailing
+// fragment with no allowed first fragment on record must be dropped. Before the
+// fix, filterInbound returned false (allow) for any fragment.
+func TestFragment_TrailingWithoutFirstDropped(t *testing.T) {
+	m := newFragmentTestManager(t)
+
+	frag := trailingFragment(t, 0x1234, 185, false, 40)
+	require.True(t, m.filterInbound(frag, len(frag)),
+		"trailing fragment without an allowed first fragment must be dropped")
+}
+
+// TestFragment_AllowedFirstPassesTrailing verifies that once a first fragment
+// passes the ACL, its trailing fragments inherit the allow verdict.
+func TestFragment_AllowedFirstPassesTrailing(t *testing.T) {
+	m := newFragmentTestManager(t)
+	allowUDP(t, m, 8080)
+
+	// First fragment: UDP header (8) + 32 payload = 40 octets -> headerEnd = 5.
+	first := firstFragmentUDP(t, 0x2222, 8080, 32)
+	require.False(t, m.filterInbound(first, len(first)),
+		"allowed first fragment should pass and be recorded")
+
+	trailing := trailingFragment(t, 0x2222, 5, false, 24)
+	require.False(t, m.filterInbound(trailing, len(trailing)),
+		"trailing fragment of an allowed datagram should pass")
+}
+
+// TestFragment_DeniedFirstDropsTrailing verifies that a first fragment blocked
+// by the ACL leaves no verdict, so its trailing fragments are dropped.
+func TestFragment_DeniedFirstDropsTrailing(t *testing.T) {
+	m := newFragmentTestManager(t)
+	// No accept rule: local traffic defaults to deny.
+
+	first := firstFragmentUDP(t, 0x3333, 9999, 32)
+	require.True(t, m.filterInbound(first, len(first)),
+		"first fragment to a blocked port should be dropped by the ACL")
+
+	trailing := trailingFragment(t, 0x3333, 5, false, 24)
+	require.True(t, m.filterInbound(trailing, len(trailing)),
+		"trailing fragment of a denied datagram must be dropped")
+}
+
+// TestFragment_OverlappingHeaderDropped covers the RFC 1858 §4 / RFC 3128
+// overlapping-fragment rewrite: a trailing fragment starting inside the range
+// the ACL already inspected is dropped and poisons the datagram. TCP is used so
+// the overlap lands on real header bytes (the flags at byte 13).
+func TestFragment_OverlappingHeaderDropped(t *testing.T) {
+	m := newFragmentTestManager(t)
+	_, err := m.AddPeerFiltering(nil, net.ParseIP(fragTestSrc), fw.ProtocolTCP, nil,
+		&fw.Port{Values: []uint16{8080}}, fw.ActionAccept, "")
+	require.NoError(t, err)
+
+	// First fragment: TCP header (20) + 12 data = 32 bytes -> headerEnd = 4 octets.
+	first := firstFragmentTCP(t, 0x4444, 8080)
+	require.False(t, m.filterInbound(first, len(first)))
+
+	// Overlapping fragment at offset 1 (byte 8) falls inside the inspected TCP
+	// header, so it could rewrite the flags or port on reassembly.
+	overlap := trailingFragmentTo(t, fragTestDst, layers.IPProtocolTCP, 0x4444, 1, true, 32)
+	require.True(t, m.filterInbound(overlap, len(overlap)),
+		"fragment overlapping the inspected header must be dropped")
+
+	// The datagram is now poisoned: a later, non-overlapping fragment is also
+	// dropped because the verdict was removed.
+	later := trailingFragmentTo(t, fragTestDst, layers.IPProtocolTCP, 0x4444, 4, false, 24)
+	require.True(t, m.filterInbound(later, len(later)),
+		"fragments after an overlap must be dropped (datagram poisoned)")
+}
+
+// TestFragment_OffsetZeroOverlapPoisons covers the RFC 3128 offset-zero rewrite:
+// an allowed first fragment followed by a denied offset-zero fragment for the
+// same datagram must not leave the earlier allow verdict in place.
+func TestFragment_OffsetZeroOverlapPoisons(t *testing.T) {
+	m := newFragmentTestManager(t)
+	allowUDP(t, m, 8080)
+
+	allowed := firstFragmentUDP(t, 0x5A5A, 8080, 32)
+	require.False(t, m.filterInbound(allowed, len(allowed)),
+		"allowed first fragment should pass and be recorded")
+
+	// A second offset-zero fragment to a denied port supersedes the datagram's
+	// verdict; it is dropped and must not leave the allow in place.
+	denied := firstFragmentUDP(t, 0x5A5A, 9999, 32)
+	require.True(t, m.filterInbound(denied, len(denied)),
+		"denied offset-zero fragment must be dropped")
+
+	trailing := trailingFragment(t, 0x5A5A, 5, false, 24)
+	require.True(t, m.filterInbound(trailing, len(trailing)),
+		"trailing fragment must be denied after the datagram was poisoned")
+}
+
+// TestFragment_TinyFirstDropped covers the tiny-fragment attack: a first
+// fragment too small to contain the full transport header can't be
+// ACL-evaluated and must be dropped.
+func TestFragment_TinyFirstDropped(t *testing.T) {
+	m := newFragmentTestManager(t)
+	allowUDP(t, m, 8080)
+
+	// IPv4 header + 4 raw bytes, MF set, offset 0: too small for the 8-byte UDP
+	// header, so it decodes to L3 only.
+	tiny := trailingFragment(t, 0x5555, 0, true, 4)
+	require.True(t, m.filterInbound(tiny, len(tiny)),
+		"tiny first fragment without a full L4 header must be dropped")
+}
+
+// TestFragment_TCPFirstFragment verifies the TCP arm of the transport decode: a
+// first fragment carrying the full 20-byte TCP header is ACL-evaluated and its
+// trailing fragments inherit the verdict.
+func TestFragment_TCPFirstFragment(t *testing.T) {
+	m := newFragmentTestManager(t)
+	_, err := m.AddPeerFiltering(nil, net.ParseIP(fragTestSrc), fw.ProtocolTCP, nil,
+		&fw.Port{Values: []uint16{8080}}, fw.ActionAccept, "")
+	require.NoError(t, err)
+
+	// TCP header (20) + 12 data = 32 bytes -> headerEnd = 4 octets.
+	first := firstFragmentTCP(t, 0x6666, 8080)
+	require.False(t, m.filterInbound(first, len(first)),
+		"allowed TCP first fragment should pass and be recorded")
+
+	trailing := trailingFragmentTo(t, fragTestDst, layers.IPProtocolTCP, 0x6666, 4, false, 24)
+	require.False(t, m.filterInbound(trailing, len(trailing)),
+		"trailing fragment of an allowed TCP datagram should pass")
+}
+
+// TestFragment_TCPTinyFirstDropped verifies the TCP minimum header length: 12
+// bytes would satisfy a UDP header but falls short of the 20-byte TCP header.
+func TestFragment_TCPTinyFirstDropped(t *testing.T) {
+	m := newFragmentTestManager(t)
+	_, err := m.AddPeerFiltering(nil, net.ParseIP(fragTestSrc), fw.ProtocolTCP, nil,
+		&fw.Port{Values: []uint16{8080}}, fw.ActionAccept, "")
+	require.NoError(t, err)
+
+	tiny := trailingFragmentTo(t, fragTestDst, layers.IPProtocolTCP, 0x7777, 0, true, 12)
+	require.True(t, m.filterInbound(tiny, len(tiny)),
+		"first fragment shorter than the TCP header must be dropped")
+}
+
+// TestFragment_ConntrackAllowsFirstFragment verifies the conntrack branch: reply
+// fragments of an outbound-established UDP flow pass without any inbound rule.
+func TestFragment_ConntrackAllowsFirstFragment(t *testing.T) {
+	m := newFragmentTestManager(t)
+
+	out := outboundUDPPacket(t, 12345, 40000)
+	require.False(t, m.filterOutbound(out, len(out)))
+
+	first := firstFragmentUDP(t, 0x8888, 12345, 32)
+	require.False(t, m.filterInbound(first, len(first)),
+		"reply first fragment should pass via conntrack")
+
+	trailing := trailingFragment(t, 0x8888, 5, false, 24)
+	require.False(t, m.filterInbound(trailing, len(trailing)),
+		"trailing fragment of a tracked flow should pass")
+}
+
+// TestFragment_RoutingDisabledDropsFragment verifies routed first fragments are
+// dropped when routing is disabled.
+func TestFragment_RoutingDisabledDropsFragment(t *testing.T) {
+	m := newFragmentTestManager(t)
+	m.routingEnabled.Store(false)
+
+	first := firstFragmentUDPTo(t, "198.51.100.10", 0x9999, 8080, 32)
+	require.True(t, m.filterInbound(first, len(first)),
+		"routed first fragment must be dropped when routing is disabled")
+}
+
+// TestFragment_RouteACL verifies the route-ACL branch: fragments to a non-local
+// destination follow the route rules, allowed datagrams pass their trailing
+// fragments and denied ones don't.
+func TestFragment_RouteACL(t *testing.T) {
+	m := newFragmentTestManager(t)
+	m.routingEnabled.Store(true)
+	m.nativeRouter.Store(false)
+
+	_, err := m.AddRouteFiltering(
+		[]byte("rt-1"),
+		[]netip.Prefix{netip.MustParsePrefix("100.10.0.0/16")},
+		fw.Network{Prefix: netip.MustParsePrefix("198.51.100.0/24")},
+		fw.ProtocolUDP,
+		nil,
+		&fw.Port{Values: []uint16{8080}},
+		fw.ActionAccept,
+	)
+	require.NoError(t, err)
+
+	first := firstFragmentUDPTo(t, "198.51.100.10", 0xAAAA, 8080, 32)
+	require.False(t, m.filterInbound(first, len(first)),
+		"route-ACL-allowed first fragment should pass")
+	trailing := trailingFragmentTo(t, "198.51.100.10", layers.IPProtocolUDP, 0xAAAA, 5, false, 24)
+	require.False(t, m.filterInbound(trailing, len(trailing)),
+		"trailing fragment of an allowed routed datagram should pass")
+
+	denied := firstFragmentUDPTo(t, "198.51.100.10", 0xBBBB, 9999, 32)
+	require.True(t, m.filterInbound(denied, len(denied)),
+		"route-ACL-denied first fragment must be dropped")
+	deniedTrailing := trailingFragmentTo(t, "198.51.100.10", layers.IPProtocolUDP, 0xBBBB, 5, false, 24)
+	require.True(t, m.filterInbound(deniedTrailing, len(deniedTrailing)),
+		"trailing fragment of a denied routed datagram must be dropped")
+}
+
+// TestFragment_ExpiredVerdictDropsTrailing verifies a verdict older than the
+// tracker timeout no longer admits trailing fragments.
+func TestFragment_ExpiredVerdictDropsTrailing(t *testing.T) {
+	m := newFragmentTestManager(t)
+	allowUDP(t, m, 8080)
+
+	first := firstFragmentUDP(t, 0xCCCC, 8080, 32)
+	require.False(t, m.filterInbound(first, len(first)))
+
+	m.fragments.mutex.Lock()
+	for key, entry := range m.fragments.entries {
+		entry.recordedAt = time.Now().Add(-defaultFragmentTimeout - time.Second)
+		m.fragments.entries[key] = entry
+	}
+	m.fragments.mutex.Unlock()
+
+	trailing := trailingFragment(t, 0xCCCC, 5, false, 24)
+	require.True(t, m.filterInbound(trailing, len(trailing)),
+		"trailing fragment after verdict expiry must be dropped")
+}
+
+// TestFragment_CapacityFailsClosed verifies the table cap: at capacity, new
+// datagram verdicts are not recorded (their trailing fragments are dropped)
+// while already-recorded datagrams keep working.
+func TestFragment_CapacityFailsClosed(t *testing.T) {
+	m := newFragmentTestManager(t)
+	allowUDP(t, m, 8080)
+
+	m.fragments.mutex.Lock()
+	m.fragments.maxEntries = 1
+	m.fragments.mutex.Unlock()
+
+	first1 := firstFragmentUDP(t, 0x0101, 8080, 32)
+	require.False(t, m.filterInbound(first1, len(first1)))
+
+	first2 := firstFragmentUDP(t, 0x0202, 8080, 32)
+	require.False(t, m.filterInbound(first2, len(first2)),
+		"first fragment itself still passes at capacity")
+
+	trailing2 := trailingFragment(t, 0x0202, 5, false, 24)
+	require.True(t, m.filterInbound(trailing2, len(trailing2)),
+		"trailing fragment of an unrecorded datagram must be dropped at capacity")
+
+	trailing1 := trailingFragment(t, 0x0101, 5, false, 24)
+	require.False(t, m.filterInbound(trailing1, len(trailing1)),
+		"already-recorded datagram should keep passing at capacity")
+}
+
+// v6FragmentHeader builds the 8-byte IPv6 fragment extension header for the
+// given inner protocol, offset (8-byte units), More Fragments bit and id.
+func v6FragmentHeader(proto layers.IPProtocol, offsetOctets uint16, moreFragments bool, id uint32) []byte {
+	offsetFlags := offsetOctets << 3
+	if moreFragments {
+		offsetFlags |= 1
+	}
+	hdr := make([]byte, 8)
+	hdr[0] = uint8(proto)
+	binary.BigEndian.PutUint16(hdr[2:4], offsetFlags)
+	binary.BigEndian.PutUint32(hdr[4:8], id)
+	return hdr
+}
+
+func v6UDPHeader(dstPort uint16, dataLen int) []byte {
+	hdr := make([]byte, 8)
+	binary.BigEndian.PutUint16(hdr[0:2], 40000)
+	binary.BigEndian.PutUint16(hdr[2:4], dstPort)
+	binary.BigEndian.PutUint16(hdr[4:6], uint16(8+dataLen))
+	return hdr
+}
+
+// firstFragmentUDPv6 builds the first fragment of a fragmented IPv6 UDP
+// datagram: fragment header (offset 0, More Fragments set) + full UDP header +
+// data.
+func firstFragmentUDPv6(tb testing.TB, id uint32, dstPort uint16, dataLen int) []byte {
+	tb.Helper()
+	return fragmentUDPv6(tb, id, dstPort, dataLen, true)
+}
+
+// fragmentUDPv6 builds an offset-zero IPv6 UDP fragment. With moreFragments
+// false it is an atomic fragment (a complete datagram, RFC 6946).
+func fragmentUDPv6(tb testing.TB, id uint32, dstPort uint16, dataLen int, moreFragments bool) []byte {
+	tb.Helper()
+
+	ip := &layers.IPv6{
+		Version:    6,
+		NextHeader: layers.IPProtocolIPv6Fragment,
+		HopLimit:   64,
+		SrcIP:      net.ParseIP(fragTestSrcV6),
+		DstIP:      net.ParseIP(fragTestDstV6),
+	}
+	payload := append(v6FragmentHeader(layers.IPProtocolUDP, 0, moreFragments, id), v6UDPHeader(dstPort, dataLen)...)
+	payload = append(payload, make([]byte, dataLen)...)
+
+	buf := gopacket.NewSerializeBuffer()
+	require.NoError(tb, gopacket.SerializeLayers(buf, gopacket.SerializeOptions{FixLengths: true}, ip, gopacket.Payload(payload)))
+	return buf.Bytes()
+}
+
+// trailingFragmentV6 builds a non-first IPv6 fragment: fragment header at the
+// given offset carrying raw data and no transport header.
+func trailingFragmentV6(tb testing.TB, id uint32, offsetOctets uint16, moreFragments bool, dataLen int) []byte {
+	tb.Helper()
+
+	ip := &layers.IPv6{
+		Version:    6,
+		NextHeader: layers.IPProtocolIPv6Fragment,
+		HopLimit:   64,
+		SrcIP:      net.ParseIP(fragTestSrcV6),
+		DstIP:      net.ParseIP(fragTestDstV6),
+	}
+	payload := append(v6FragmentHeader(layers.IPProtocolUDP, offsetOctets, moreFragments, id), make([]byte, dataLen)...)
+
+	buf := gopacket.NewSerializeBuffer()
+	require.NoError(tb, gopacket.SerializeLayers(buf, gopacket.SerializeOptions{FixLengths: true}, ip, gopacket.Payload(payload)))
+	return buf.Bytes()
+}
+
+// TestFragmentV6_TrailingWithoutFirstDropped verifies the IPv6 bypass is closed:
+// a trailing fragment with no allowed first fragment is dropped.
+func TestFragmentV6_TrailingWithoutFirstDropped(t *testing.T) {
+	m := newFragmentTestManager(t)
+
+	frag := trailingFragmentV6(t, 0xAABBCCDD, 100, false, 40)
+	require.True(t, m.filterInbound(frag, len(frag)),
+		"IPv6 trailing fragment without an allowed first fragment must be dropped")
+}
+
+// TestFragmentV6_AllowedFirstPassesTrailing verifies IPv6 fragments are
+// evaluated like IPv4: an allowed first fragment lets its trailing fragments
+// through.
+func TestFragmentV6_AllowedFirstPassesTrailing(t *testing.T) {
+	m := newFragmentTestManager(t)
+	_, err := m.AddPeerFiltering(nil, net.ParseIP(fragTestSrcV6), fw.ProtocolUDP, nil,
+		&fw.Port{Values: []uint16{8080}}, fw.ActionAccept, "")
+	require.NoError(t, err)
+
+	// First fragment: UDP header (8) + 32 data = 40 octets -> headerEnd = 5.
+	first := firstFragmentUDPv6(t, 0xAABBCCDD, 8080, 32)
+	require.False(t, m.filterInbound(first, len(first)),
+		"allowed IPv6 first fragment should pass and be recorded")
+
+	trailing := trailingFragmentV6(t, 0xAABBCCDD, 5, false, 24)
+	require.False(t, m.filterInbound(trailing, len(trailing)),
+		"trailing fragment of an allowed IPv6 datagram should pass")
+}
+
+// TestFragmentV6_AtomicNotCached verifies an IPv6 atomic fragment (fragment
+// header with offset 0 and no More Fragments, a complete datagram per RFC 6946)
+// is evaluated but not recorded, so a flood of allowed atomic fragments can't
+// exhaust the verdict table.
+func TestFragmentV6_AtomicNotCached(t *testing.T) {
+	m := newFragmentTestManager(t)
+	_, err := m.AddPeerFiltering(nil, net.ParseIP(fragTestSrcV6), fw.ProtocolUDP, nil,
+		&fw.Port{Values: []uint16{8080}}, fw.ActionAccept, "")
+	require.NoError(t, err)
+
+	atomic := fragmentUDPv6(t, 0xA70301C, 8080, 16, false)
+	require.False(t, m.filterInbound(atomic, len(atomic)),
+		"allowed IPv6 atomic fragment should pass")
+
+	m.fragments.mutex.Lock()
+	n := len(m.fragments.entries)
+	m.fragments.mutex.Unlock()
+	require.Zero(t, n, "atomic fragment must not create a verdict entry")
+
+	// A genuine fragmented datagram (More Fragments set) is still recorded.
+	first := fragmentUDPv6(t, 0xBEEF, 8080, 32, true)
+	require.False(t, m.filterInbound(first, len(first)))
+	m.fragments.mutex.Lock()
+	n = len(m.fragments.entries)
+	m.fragments.mutex.Unlock()
+	require.Equal(t, 1, n, "genuine first fragment must record a verdict")
+}


### PR DESCRIPTION
## Describe your changes

The userspace firewall passed every IP fragment through without ACL evaluation, because gopacket does not decode the transport header of a fragment (not even the first one). This makes fragments follow the same ACL path as whole packets.

- Decode and ACL-evaluate the first fragment of a datagram (IPv4 and IPv6) and record its verdict, keyed by the reassembly tuple (source, destination, protocol, identification).
- Trailing fragments inherit the recorded verdict; a fragment with no allowed first fragment on record is dropped (fail closed). Downstream reassembly by the kernel/netstack is unchanged.
- Drop first fragments too small to hold the full transport header, and drop fragments that overlap the already-inspected header (RFC 1858 / RFC 3128; RFC 5722 for IPv6).
- Bound the verdict table with a TTL and a cap (`NB_FRAGMENT_MAX_ENTRIES`, default 16384), failing closed at capacity.
- Emit netflow drop events for denied first fragments, matching non-fragmented packets.

Added unit tests and benchmarks for the fragment paths (v4/v6, tiny-fragment, overlap, conntrack, routed, TTL, capacity); the attacker-amplifiable paths stay zero-allocation and at or below the normal-packet baseline.

## Issue ticket number and link

## Stack

- `0.74.7-branch` - :warning: No PR associated with branch <!-- branch-stack -->
  - \#6781 :point\_left:

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal firewall packet-handling behavior; no user-facing configuration beyond the optional `NB_FRAGMENT_MAX_ENTRIES` tuning env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure handling for fragmented IPv4 and IPv6 traffic.
  - Fragmented packets are now evaluated consistently against inbound and routed firewall rules.
  - Allowed first fragments permit matching trailing fragments, while unknown, expired, overlapping, or unsupported fragments are blocked.
  - Added fail-closed safeguards when fragment tracking capacity is reached.
- **Bug Fixes**
  - Improved firewall drop logging and flow reporting for denied fragmented traffic.
- **Tests**
  - Added comprehensive coverage and performance benchmarks for fragmented packet scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
