### PR TITLE
[relay] Handle QUIC connections concurrently to prevent handshake head-of-line blocking

### DIFF
--- a/relay/server/listener/quic/listener.go
+++ b/relay/server/listener/quic/listener.go
@@ -51,7 +51,10 @@ func (l *Listener) Listen(acceptFn func(conn relaylistener.Conn)) error {
 
 		log.Infof("QUIC client connected from: %s", session.RemoteAddr())
 		conn := NewConn(session)
-		acceptFn(conn)
+		// Run the accept handler (which performs the pre-auth handshake) in its
+		// own goroutine so a slow or stalled handshake cannot block accepting
+		// further connections.
+		go acceptFn(conn)
 	}
 }
 


### PR DESCRIPTION
## Describe your changes

The QUIC listener's accept loop ran the per-connection accept handler (which performs the pre-authentication handshake) synchronously, so a single slow or stalled handshake blocked the listener from accepting any further connections. This dispatches the handler in its own goroutine so connections are handled concurrently, matching the WebSocket listener's behavior.

- Handle incoming QUIC connections concurrently so one slow handshake can't block others

The per-connection handshake stays bounded by the existing handshake timeout.

## Issue ticket number and link

## Stack

- `0.74.7-branch` - :warning: No PR associated with branch <!-- branch-stack -->
  - \#6784 :point\_left:

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal concurrency change to the relay QUIC listener with no user-facing behavior.

### Docs PR URL (required if "docs added" is checked)

Paste the PR link from <https://github.com/netbirdio/docs> here:

<https://github.com/netbirdio/docs/pull/>\_\_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved QUIC connection handling so slow or stalled handshakes no longer block the acceptance of new connections.
  - Maintained existing connection acceptance and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
