### PR TITLE
[management] Ensure reverse proxy target IDs auto-increment

### DIFF
--- a/management/internals/modules/reverseproxy/service/service.go
+++ b/management/internals/modules/reverseproxy/service/service.go
@@ -114,7 +114,7 @@ type MiddlewareConfig struct {
 }
 
 type Target struct {
-	ID            uint          `gorm:"primaryKey" json:"-"`
+	ID            uint          `gorm:"primaryKey;autoIncrement" json:"-"`
 	AccountID     string        `gorm:"index:idx_target_account;not null" json:"-"`
 	ServiceID     string        `gorm:"index:idx_service_targets;not null" json:"-"`
 	Path          *string       `json:"path,omitempty"`

--- a/management/server/store/sql_store_test.go
+++ b/management/server/store/sql_store_test.go
@@ -384,8 +384,11 @@ func TestSqlite_DeleteAccount(t *testing.T) {
 		},
 	}
 
+	// Saving the account persists the reverse-proxy target through GORM's
+	// association handling, so verify the database-generated key is returned.
 	err = store.SaveAccount(context.Background(), account)
 	require.NoError(t, err)
+	require.NotZero(t, account.Services[0].Targets[0].ID, "saved service targets should receive a database ID")
 
 	if len(store.GetAllAccounts(context.Background())) != 1 {
 		t.Errorf("expecting 1 Accounts to be stored after SaveAccount()")


### PR DESCRIPTION
## Describe your changes
Explicitly mark reverse-proxy target IDs as auto-incrementing in the GORM model. Add a regression assertion that a saved reverse-proxy target receives a database-generated ID.

## Issue ticket number and link
Fixes #6007

## Stack
- [x] This PR is independent

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes locally
- [x] I have added or updated tests where applicable
- [x] I have checked for breaking changes

## Documentation
- [x] Documentation is **not needed**

## Validation
- `go test ./management/server/store ./management/internals/modules/reverseproxy/service -run ^`
- Full multi-database test requires Docker, which was unavailable locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reverse-proxy service targets now receive unique database identifiers automatically when saved.
  - Improved persistence reliability for reverse-proxy configurations, helping ensure saved targets can be referenced and managed consistently.

- **Tests**
  - Added coverage to verify that saved targets receive valid identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->