### PR TITLE
[management] Exclude disconnected peers from DNS records

### DIFF
--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -317,10 +317,12 @@ func initTestDNSAccount(t *testing.T, am *DefaultAccountManager) (*types.Account
 		return nil, err
 	}
 
-	_, err = account.FindPeerByPubKey(peer2.Key)
+	peer2, err = account.FindPeerByPubKey(peer2.Key)
 	if err != nil {
 		return nil, err
 	}
+	peer1.Status.Connected = true
+	peer2.Status.Connected = true
 
 	newGroup1 := &types.Group{
 		ID:    dnsGroup1ID,
@@ -356,6 +358,12 @@ func initTestDNSAccount(t *testing.T, am *DefaultAccountManager) (*types.Account
 
 	err = am.Store.SaveAccount(context.Background(), account)
 	if err != nil {
+		return nil, err
+	}
+	if err = am.Store.SavePeerStatus(context.Background(), account.Id, peer1.ID, *peer1.Status); err != nil {
+		return nil, err
+	}
+	if err = am.Store.SavePeerStatus(context.Background(), account.Id, peer2.ID, *peer2.Status); err != nil {
 		return nil, err
 	}
 

--- a/management/server/types/account_components.go
+++ b/management/server/types/account_components.go
@@ -553,6 +553,9 @@ func filterDNSRecordsByPeers(records []nbdns.SimpleRecord, peers map[string]*nbp
 		if peer == nil {
 			continue
 		}
+		if peer.Status == nil || !peer.Status.Connected {
+			continue
+		}
 		peerIPs[peer.IP.String()] = struct{}{}
 		if includeIPv6 && peer.IPv6.IsValid() {
 			peerIPs[peer.IPv6.String()] = struct{}{}

--- a/management/server/types/account_components_test.go
+++ b/management/server/types/account_components_test.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	nbdns "github.com/netbirdio/netbird/dns"
+	nbpeer "github.com/netbirdio/netbird/management/server/peer"
+)
+
+func TestFilterDNSRecordsByPeersExcludesDisconnectedPeers(t *testing.T) {
+	connected := &nbpeer.Peer{
+		IP:     netip.MustParseAddr("100.64.0.1"),
+		Status: &nbpeer.PeerStatus{Connected: true, LastSeen: time.Now()},
+	}
+	disconnected := &nbpeer.Peer{
+		IP:     netip.MustParseAddr("100.64.0.2"),
+		Status: &nbpeer.PeerStatus{Connected: false, LastSeen: time.Now()},
+	}
+	records := []nbdns.SimpleRecord{
+		{Name: "connected.example", RData: connected.IP.String()},
+		{Name: "disconnected.example", RData: disconnected.IP.String()},
+	}
+
+	got := filterDNSRecordsByPeers(records, map[string]*nbpeer.Peer{
+		"connected":    connected,
+		"disconnected": disconnected,
+	}, false)
+
+	assert.Equal(t, []nbdns.SimpleRecord{records[0]}, got)
+}


### PR DESCRIPTION
## Describe your changes
Exclude disconnected or uninitialized peers when building DNS records for a network map. This prevents DNS routes from continuing to advertise stale addresses after ephemeral routing peers are replaced.

## Issue ticket number and link
Fixes #3976

## Stack
- [x] This PR is independent

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes locally
- [x] I have added or updated tests where applicable
- [x] I have checked for breaking changes

## Documentation
- [x] Documentation is **not needed**

## Validation
- `go test ./management/server/types -count=1`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786729376&installation_id=146802194&pr_number=6788&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6788&signature=8f4bcfc55f3328674273fe8328150bfe76aa7747efe15b56b83040927c587688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DNS record filtering now ignores peers that aren’t currently connected, so only reachable peer addresses are considered.

* **Tests**
  * Added a unit test to confirm disconnected peers are excluded from filtered DNS results.
  * Updated DNS test setup to ensure peer connectivity status is persisted before DNS-related assertions run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->