### PR TITLE
[client] Fix DNS probe listener impossible panic on unparseable local address

### DIFF
--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -292,7 +292,7 @@ func (s *serviceViaListener) generateFreePort() (uint16, error) {
 		return customPort, nil
 	}
 
-	probeListener, err := net.ListenUDP("udp", &net.UDPAddr{})
+	probeListener, err := net.ListenUDP("udp4", &net.UDPAddr{})
 	if err != nil {
 		log.Debugf("failed to bind random port for DNS: %s", err)
 		return 0, err

--- a/client/internal/dns/service_listener.go
+++ b/client/internal/dns/service_listener.go
@@ -292,18 +292,16 @@ func (s *serviceViaListener) generateFreePort() (uint16, error) {
 		return customPort, nil
 	}
 
-	udpAddr := net.UDPAddrFromAddrPort(netip.MustParseAddrPort("0.0.0.0:0"))
-	probeListener, err := net.ListenUDP("udp", udpAddr)
+	probeListener, err := net.ListenUDP("udp", &net.UDPAddr{})
 	if err != nil {
 		log.Debugf("failed to bind random port for DNS: %s", err)
 		return 0, err
 	}
 
-	addrPort := netip.MustParseAddrPort(probeListener.LocalAddr().String()) // might panic if address is incorrect
-	err = probeListener.Close()
-	if err != nil {
+	port := uint16(probeListener.LocalAddr().(*net.UDPAddr).Port)
+	if err = probeListener.Close(); err != nil {
 		log.Debugf("failed to free up DNS port: %s", err)
 		return 0, err
 	}
-	return addrPort.Port(), nil
+	return port, nil
 }


### PR DESCRIPTION
generateFreePort used netip.MustParseAddrPort on the OS-produced LocalAddr().String(), which panics on address strings that don't parse. Eliminate the parsing entirely by reading the port from the concrete *net.UDPAddr that net.ListenUDP returns, and construct the bind address directly. The probe listener is bound with udp4 so only an IPv4 wildcard address is ever used.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when selecting an ephemeral UDP port.
  * Avoided potential failures when determining the assigned port.
  * Preserved existing error handling and diagnostic logging for listener operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->