### PR TITLE
[client] Preserve firewall authorization in connection marks

### DIFF
--- a/client/firewall/iptables/acl_linux.go
+++ b/client/firewall/iptables/acl_linux.go
@@ -98,7 +98,7 @@ func (m *aclManager) AddPeerFiltering(
 	mangleSpecs = append(mangleSpecs,
 		"-i", m.wgIface.Name(),
 		"-m", "addrtype", "--dst-type", "LOCAL",
-		"-j", "MARK", "--set-xmark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkRedirected),
+		"-j", "CONNMARK", "--set-mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkRedirected),
 	)
 
 	specs = append(specs, "-j", actionToStr(action))
@@ -386,7 +386,8 @@ func (m *aclManager) seedInitialEntries() {
 	m.appendToEntries(mangleFwdKey, []string{
 		"-i", m.wgIface.Name(),
 		"-m", "conntrack", "--ctstate", "DNAT",
-		"-m", "mark", "!", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkRedirected),
+		"-m", "connmark", "!", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkRedirected),
+		"-m", "connmark", "!", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasquerade),
 		"-j", "DROP",
 	})
 }
@@ -394,7 +395,7 @@ func (m *aclManager) seedInitialEntries() {
 func (m *aclManager) seedInitialOptionalEntries() {
 	m.optionalEntries["FORWARD"] = []entry{
 		{
-			spec:     []string{"-m", "mark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkRedirected), "-j", "ACCEPT"},
+			spec:     []string{"-m", "connmark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkRedirected), "-j", "ACCEPT"},
 			position: 2,
 		},
 	}

--- a/client/firewall/iptables/acl_linux_test.go
+++ b/client/firewall/iptables/acl_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux && !android
+
+package iptables
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
+	nbnet "github.com/netbirdio/netbird/client/net"
+)
+
+type aclTestIface struct{}
+
+func (aclTestIface) Name() string            { return "wt0" }
+func (aclTestIface) Address() wgaddr.Address { return wgaddr.Address{} }
+
+func TestSeedInitialEntriesUsesConnectionMarkForRedirectedTraffic(t *testing.T) {
+	m := &aclManager{entries: make(map[string][][]string), optionalEntries: make(map[string][]entry)}
+	m.wgIface = aclTestIface{}
+
+	m.seedInitialEntries()
+	m.seedInitialOptionalEntries()
+
+	mark := fmt.Sprintf("%#x", nbnet.PreroutingFwmarkRedirected)
+	routeMark := fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasquerade)
+	assert.Contains(t, m.entries[mangleFwdKey], []string{
+		"-i", "wt0", "-m", "conntrack", "--ctstate", "DNAT",
+		"-m", "connmark", "!", "--mark", mark,
+		"-m", "connmark", "!", "--mark", routeMark, "-j", "DROP",
+	})
+	assert.Equal(t, []string{"-m", "connmark", "--mark", mark, "-j", "ACCEPT"}, m.optionalEntries["FORWARD"][0].spec)
+}

--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"maps"
 	"net/netip"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -537,7 +536,7 @@ func (r *router) cleanupDataPlaneMark() error {
 func (r *router) addPostroutingRules() error {
 	// First rule for outbound masquerade
 	rule1 := []string{
-		"-m", "mark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasquerade),
+		"-m", "connmark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasquerade),
 		"!", "-o", "lo",
 		"-j", routingFinalNatJump,
 	}
@@ -548,7 +547,7 @@ func (r *router) addPostroutingRules() error {
 
 	// Second rule for return traffic masquerade
 	rule2 := []string{
-		"-m", "mark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasqueradeReturn),
+		"-m", "connmark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasqueradeReturn),
 		"-o", r.wgIface.Name(),
 		"-j", routingFinalNatJump,
 	}
@@ -663,7 +662,6 @@ func (r *router) cleanJumpRules() error {
 
 func (r *router) addNatRule(pair firewall.RouterPair) error {
 	ruleKey := firewall.GenKey(firewall.NatFormat, pair)
-	connmarkRuleKey := ruleKey + "-connmark"
 
 	if _, exists := r.rules[ruleKey]; exists {
 		if err := r.removeNatRule(pair); err != nil {
@@ -697,10 +695,8 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 	rule = append(rule, sourceExp...)
 	rule = append(rule, destExp...)
 	rule = append(rule,
-		"-j", "MARK", "--set-mark", fmt.Sprintf("%#x", markValue),
+		"-j", "CONNMARK", "--set-mark", fmt.Sprintf("%#x", markValue),
 	)
-	connmarkRule := slices.Clone(rule[:len(rule)-4])
-	connmarkRule = append(connmarkRule, "-j", "CONNMARK", "--set-mark", fmt.Sprintf("%#x", markValue))
 
 	// Ensure nat rules come first, so the mark can be overwritten.
 	// Currently overwritten by the dst-type LOCAL rules for redirected traffic.
@@ -708,13 +704,8 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 		// TODO: rollback ipset counter
 		return fmt.Errorf("error while adding marking rule for %s: %v", pair.Destination, err)
 	}
-	if err := r.iptablesClient.Insert(tableMangle, chainRTPRE, 2, connmarkRule...); err != nil {
-		_ = r.iptablesClient.DeleteIfExists(tableMangle, chainRTPRE, rule...)
-		return fmt.Errorf("error while adding connection marking rule for %s: %v", pair.Destination, err)
-	}
 
 	r.rules[ruleKey] = rule
-	r.rules[connmarkRuleKey] = connmarkRule
 
 	r.updateState()
 	return nil
@@ -722,7 +713,6 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 
 func (r *router) removeNatRule(pair firewall.RouterPair) error {
 	ruleKey := firewall.GenKey(firewall.NatFormat, pair)
-	connmarkRuleKey := ruleKey + "-connmark"
 
 	if rule, exists := r.rules[ruleKey]; exists {
 		if err := r.iptablesClient.DeleteIfExists(tableMangle, chainRTPRE, rule...); err != nil {
@@ -735,12 +725,6 @@ func (r *router) removeNatRule(pair firewall.RouterPair) error {
 		}
 	} else {
 		log.Debugf("marking rule %s not found", ruleKey)
-	}
-	if rule, exists := r.rules[connmarkRuleKey]; exists {
-		if err := r.iptablesClient.DeleteIfExists(tableMangle, chainRTPRE, rule...); err != nil {
-			return fmt.Errorf("error while removing connection marking rule for %s: %v", pair.Destination, err)
-		}
-		delete(r.rules, connmarkRuleKey)
 	}
 
 	r.updateState()

--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -662,12 +663,12 @@ func (r *router) cleanJumpRules() error {
 
 func (r *router) addNatRule(pair firewall.RouterPair) error {
 	ruleKey := firewall.GenKey(firewall.NatFormat, pair)
+	connmarkRuleKey := ruleKey + "-connmark"
 
-	if rule, exists := r.rules[ruleKey]; exists {
-		if err := r.iptablesClient.DeleteIfExists(tableMangle, chainRTPRE, rule...); err != nil {
-			return fmt.Errorf("error while removing existing marking rule for %s: %v", pair.Destination, err)
+	if _, exists := r.rules[ruleKey]; exists {
+		if err := r.removeNatRule(pair); err != nil {
+			return err
 		}
-		delete(r.rules, ruleKey)
 	}
 
 	markValue := nbnet.PreroutingFwmarkMasquerade
@@ -698,6 +699,8 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 	rule = append(rule,
 		"-j", "MARK", "--set-mark", fmt.Sprintf("%#x", markValue),
 	)
+	connmarkRule := slices.Clone(rule[:len(rule)-4])
+	connmarkRule = append(connmarkRule, "-j", "CONNMARK", "--set-mark", fmt.Sprintf("%#x", markValue))
 
 	// Ensure nat rules come first, so the mark can be overwritten.
 	// Currently overwritten by the dst-type LOCAL rules for redirected traffic.
@@ -705,8 +708,13 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 		// TODO: rollback ipset counter
 		return fmt.Errorf("error while adding marking rule for %s: %v", pair.Destination, err)
 	}
+	if err := r.iptablesClient.Insert(tableMangle, chainRTPRE, 2, connmarkRule...); err != nil {
+		_ = r.iptablesClient.DeleteIfExists(tableMangle, chainRTPRE, rule...)
+		return fmt.Errorf("error while adding connection marking rule for %s: %v", pair.Destination, err)
+	}
 
 	r.rules[ruleKey] = rule
+	r.rules[connmarkRuleKey] = connmarkRule
 
 	r.updateState()
 	return nil
@@ -714,6 +722,7 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 
 func (r *router) removeNatRule(pair firewall.RouterPair) error {
 	ruleKey := firewall.GenKey(firewall.NatFormat, pair)
+	connmarkRuleKey := ruleKey + "-connmark"
 
 	if rule, exists := r.rules[ruleKey]; exists {
 		if err := r.iptablesClient.DeleteIfExists(tableMangle, chainRTPRE, rule...); err != nil {
@@ -726,6 +735,12 @@ func (r *router) removeNatRule(pair firewall.RouterPair) error {
 		}
 	} else {
 		log.Debugf("marking rule %s not found", ruleKey)
+	}
+	if rule, exists := r.rules[connmarkRuleKey]; exists {
+		if err := r.iptablesClient.DeleteIfExists(tableMangle, chainRTPRE, rule...); err != nil {
+			return fmt.Errorf("error while removing connection marking rule for %s: %v", pair.Destination, err)
+		}
+		delete(r.rules, connmarkRuleKey)
 	}
 
 	r.updateState()

--- a/client/firewall/iptables/router_linux_test.go
+++ b/client/firewall/iptables/router_linux_test.go
@@ -59,6 +59,16 @@ func TestIptablesManager_RestoreOrCreateContainers(t *testing.T) {
 	exists, err = manager.iptablesClient.Exists(tableMangle, chainPREROUTING, "-j", chainRTPRE)
 	require.NoError(t, err, "should be able to query the iptables %s table and %s chain", tableMangle, chainPREROUTING)
 	require.True(t, exists, "prerouting jump rule should exist")
+	require.Equal(t, []string{
+		"-m", "connmark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasquerade),
+		"!", "-o", "lo",
+		"-j", routingFinalNatJump,
+	}, manager.rules["static-nat-outbound"])
+	require.Equal(t, []string{
+		"-m", "connmark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasqueradeReturn),
+		"-o", ifaceMock.Name(),
+		"-j", routingFinalNatJump,
+	}, manager.rules["static-nat-return"])
 
 	pair := firewall.RouterPair{
 		ID:          "abc",
@@ -102,7 +112,7 @@ func TestIptablesManager_AddNatRule(t *testing.T) {
 				"--ctstate", "NEW",
 				"-s", testCase.InputPair.Source.String(),
 				"-d", testCase.InputPair.Destination.String(),
-				"-j", "MARK", "--set-mark",
+				"-j", "CONNMARK", "--set-mark",
 				fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasquerade),
 			}
 
@@ -113,7 +123,6 @@ func TestIptablesManager_AddNatRule(t *testing.T) {
 				foundRule, found := manager.rules[natRuleKey]
 				require.True(t, found, "marking rule should exist in the map")
 				require.Equal(t, markingRule, foundRule, "stored marking rule should match")
-				require.Contains(t, manager.rules, natRuleKey+"-connmark", "connection marking rule should exist in the map")
 			} else {
 				require.False(t, exists, "marking rule should not be created")
 				_, found := manager.rules[natRuleKey]
@@ -129,7 +138,7 @@ func TestIptablesManager_AddNatRule(t *testing.T) {
 				"--ctstate", "NEW",
 				"-s", inversePair.Source.String(),
 				"-d", inversePair.Destination.String(),
-				"-j", "MARK", "--set-mark",
+				"-j", "CONNMARK", "--set-mark",
 				fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasqueradeReturn),
 			}
 
@@ -140,7 +149,6 @@ func TestIptablesManager_AddNatRule(t *testing.T) {
 				foundRule, found := manager.rules[inverseRuleKey]
 				require.True(t, found, "inverse marking rule should exist in the map")
 				require.Equal(t, inverseMarkingRule, foundRule, "stored inverse marking rule should match")
-				require.Contains(t, manager.rules, inverseRuleKey+"-connmark", "inverse connection marking rule should exist in the map")
 			} else {
 				require.False(t, exists, "inverse marking rule should not be created")
 				_, found := manager.rules[inverseRuleKey]
@@ -179,7 +187,7 @@ func TestIptablesManager_RemoveNatRule(t *testing.T) {
 				"--ctstate", "NEW",
 				"-s", testCase.InputPair.Source.String(),
 				"-d", testCase.InputPair.Destination.String(),
-				"-j", "MARK", "--set-mark",
+				"-j", "CONNMARK", "--set-mark",
 				fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasquerade),
 			}
 
@@ -189,7 +197,6 @@ func TestIptablesManager_RemoveNatRule(t *testing.T) {
 
 			_, found := manager.rules[natRuleKey]
 			require.False(t, found, "marking rule should not exist in the manager map")
-			require.NotContains(t, manager.rules, natRuleKey+"-connmark", "connection marking rule should not exist in the manager map")
 
 			// Check inverse rule removal
 			inversePair := firewall.GetInversePair(testCase.InputPair)
@@ -200,7 +207,7 @@ func TestIptablesManager_RemoveNatRule(t *testing.T) {
 				"--ctstate", "NEW",
 				"-s", inversePair.Source.String(),
 				"-d", inversePair.Destination.String(),
-				"-j", "MARK", "--set-mark",
+				"-j", "CONNMARK", "--set-mark",
 				fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasqueradeReturn),
 			}
 
@@ -210,7 +217,6 @@ func TestIptablesManager_RemoveNatRule(t *testing.T) {
 
 			_, found = manager.rules[inverseRuleKey]
 			require.False(t, found, "inverse marking rule should not exist in the map")
-			require.NotContains(t, manager.rules, inverseRuleKey+"-connmark", "inverse connection marking rule should not exist in the map")
 		})
 	}
 }

--- a/client/firewall/iptables/router_linux_test.go
+++ b/client/firewall/iptables/router_linux_test.go
@@ -113,6 +113,7 @@ func TestIptablesManager_AddNatRule(t *testing.T) {
 				foundRule, found := manager.rules[natRuleKey]
 				require.True(t, found, "marking rule should exist in the map")
 				require.Equal(t, markingRule, foundRule, "stored marking rule should match")
+				require.Contains(t, manager.rules, natRuleKey+"-connmark", "connection marking rule should exist in the map")
 			} else {
 				require.False(t, exists, "marking rule should not be created")
 				_, found := manager.rules[natRuleKey]
@@ -139,6 +140,7 @@ func TestIptablesManager_AddNatRule(t *testing.T) {
 				foundRule, found := manager.rules[inverseRuleKey]
 				require.True(t, found, "inverse marking rule should exist in the map")
 				require.Equal(t, inverseMarkingRule, foundRule, "stored inverse marking rule should match")
+				require.Contains(t, manager.rules, inverseRuleKey+"-connmark", "inverse connection marking rule should exist in the map")
 			} else {
 				require.False(t, exists, "inverse marking rule should not be created")
 				_, found := manager.rules[inverseRuleKey]
@@ -187,6 +189,7 @@ func TestIptablesManager_RemoveNatRule(t *testing.T) {
 
 			_, found := manager.rules[natRuleKey]
 			require.False(t, found, "marking rule should not exist in the manager map")
+			require.NotContains(t, manager.rules, natRuleKey+"-connmark", "connection marking rule should not exist in the manager map")
 
 			// Check inverse rule removal
 			inversePair := firewall.GetInversePair(testCase.InputPair)
@@ -207,6 +210,7 @@ func TestIptablesManager_RemoveNatRule(t *testing.T) {
 
 			_, found = manager.rules[inverseRuleKey]
 			require.False(t, found, "inverse marking rule should not exist in the map")
+			require.NotContains(t, manager.rules, inverseRuleKey+"-connmark", "inverse connection marking rule should not exist in the map")
 		})
 	}
 }

--- a/client/firewall/nftables/acl_linux.go
+++ b/client/firewall/nftables/acl_linux.go
@@ -388,8 +388,8 @@ func (m *AclManager) createPreroutingRule(expressions []expr.Any, userData []byt
 			Register: 1,
 			Data:     binaryutil.NativeEndian.PutUint32(nbnet.PreroutingFwmarkRedirected),
 		},
-		&expr.Meta{
-			Key:            expr.MetaKeyMARK,
+		&expr.Ct{
+			Key:            expr.CtKeyMARK,
 			Register:       1,
 			SourceRegister: true,
 		},
@@ -477,8 +477,8 @@ func (m *AclManager) addFwmarkToForward(chainFwFilter *nftables.Chain) {
 		Table: m.workTable,
 		Chain: chainFwFilter,
 		Exprs: []expr.Any{
-			&expr.Meta{
-				Key:      expr.MetaKeyMARK,
+			&expr.Ct{
+				Key:      expr.CtKeyMARK,
 				Register: 1,
 			},
 			&expr.Cmp{
@@ -702,7 +702,6 @@ func ifname(n string) []byte {
 	return b
 }
 
-
 // ipToBytes converts net.IP to the correct byte length for the address family.
 func ipToBytes(ip net.IP, af addrFamily) []byte {
 	if af.addrLen == 4 {
@@ -710,4 +709,3 @@ func ipToBytes(ip net.IP, af addrFamily) []byte {
 	}
 	return ip.To16()
 }
-

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -778,6 +778,11 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 			SourceRegister: true,
 			Register:       1,
 		},
+		&expr.Ct{
+			Key:            expr.CtKeyMARK,
+			SourceRegister: true,
+			Register:       1,
+		},
 	)
 
 	ruleKey := firewall.GenKey(firewall.PreroutingFormat, pair)

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -773,11 +773,6 @@ func (r *router) addNatRule(pair firewall.RouterPair) error {
 			Register: 1,
 			Data:     binaryutil.NativeEndian.PutUint32(markValue),
 		},
-		&expr.Meta{
-			Key:            expr.MetaKeyMARK,
-			SourceRegister: true,
-			Register:       1,
-		},
 		&expr.Ct{
 			Key:            expr.CtKeyMARK,
 			SourceRegister: true,
@@ -810,8 +805,8 @@ func (r *router) addPostroutingRules() {
 	// First masquerade rule for traffic coming in from WireGuard interface
 	exprs := []expr.Any{
 		// Match on the first fwmark
-		&expr.Meta{
-			Key:      expr.MetaKeyMARK,
+		&expr.Ct{
+			Key:      expr.CtKeyMARK,
 			Register: 1,
 		},
 		&expr.Cmp{
@@ -843,8 +838,8 @@ func (r *router) addPostroutingRules() {
 	// Second masquerade rule for traffic going out through WireGuard interface
 	exprs2 := []expr.Any{
 		// Match on the second fwmark
-		&expr.Meta{
-			Key:      expr.MetaKeyMARK,
+		&expr.Ct{
+			Key:      expr.CtKeyMARK,
 			Register: 1,
 		},
 		&expr.Cmp{

--- a/client/firewall/nftables/router_linux_test.go
+++ b/client/firewall/nftables/router_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/netbirdio/netbird/client/firewall/test"
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/internal/acl/id"
+	nbnet "github.com/netbirdio/netbird/client/net"
 )
 
 const (
@@ -110,6 +111,16 @@ func TestNftablesManager_AddNatRule(t *testing.T) {
 							if len(rule.UserData) > 0 && string(rule.UserData) == natRuleKey {
 								// Compare expressions up to the mark setting expressions
 								require.ElementsMatchf(t, rule.Exprs[:len(testingExpression)], testingExpression, "prerouting nat rule elements should match")
+								hasConnectionMarkWrite := false
+								for _, expression := range rule.Exprs {
+									switch expression := expression.(type) {
+									case *expr.Meta:
+										require.False(t, expression.SourceRegister && expression.Key == expr.MetaKeyMARK, "NAT rule should not write a packet mark")
+									case *expr.Ct:
+										hasConnectionMarkWrite = hasConnectionMarkWrite || expression.SourceRegister && expression.Key == expr.CtKeyMARK
+									}
+								}
+								require.True(t, hasConnectionMarkWrite, "NAT rule should write the connection mark")
 								found = 1
 							}
 						}
@@ -187,6 +198,47 @@ func TestNftablesManager_RemoveNatRule(t *testing.T) {
 			}
 			require.True(t, foundCounter, "static postrouting rule should remain")
 		})
+	}
+}
+
+func TestNftablesManager_PostroutingMatchesConnectionMarks(t *testing.T) {
+	if check() != NFTABLES {
+		t.Skip("nftables not supported on this OS")
+	}
+
+	manager, err := Create(ifaceMock, iface.DefaultMTU)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, manager.Close(nil))
+	})
+	require.NoError(t, manager.Init(nil))
+
+	rules, err := manager.router.conn.GetRules(manager.router.workTable, manager.router.chains[chainNameRoutingNat])
+	require.NoError(t, err)
+
+	marks := map[uint32]bool{
+		nbnet.PreroutingFwmarkMasquerade:       false,
+		nbnet.PreroutingFwmarkMasqueradeReturn: false,
+	}
+	for _, rule := range rules {
+		usesConnectionMark := false
+		for _, expression := range rule.Exprs {
+			if ct, ok := expression.(*expr.Ct); ok && ct.Key == expr.CtKeyMARK {
+				usesConnectionMark = true
+			}
+			cmp, ok := expression.(*expr.Cmp)
+			if !ok || !usesConnectionMark || len(cmp.Data) != 4 {
+				continue
+			}
+			mark := binaryutil.NativeEndian.Uint32(cmp.Data)
+			if _, ok := marks[mark]; ok {
+				marks[mark] = true
+			}
+		}
+	}
+
+	for mark, found := range marks {
+		require.Truef(t, found, "postrouting rule should match connection mark %#x", mark)
 	}
 }
 

--- a/client/internal/netflow/conntrack/conntrack.go
+++ b/client/internal/netflow/conntrack/conntrack.go
@@ -418,9 +418,9 @@ func (c *ConnTrack) getFlowID(conntrackID uint32) uuid.UUID {
 
 func (c *ConnTrack) inferDirection(mark uint32, srcIP, dstIP netip.Addr) nftypes.Direction {
 	switch mark {
-	case nbnet.DataPlaneMarkIn:
+	case nbnet.DataPlaneMarkIn, nbnet.PreroutingFwmarkRedirected, nbnet.PreroutingFwmarkMasquerade:
 		return nftypes.Ingress
-	case nbnet.DataPlaneMarkOut:
+	case nbnet.DataPlaneMarkOut, nbnet.PreroutingFwmarkMasqueradeReturn:
 		return nftypes.Egress
 	}
 

--- a/client/internal/netflow/conntrack/conntrack_test.go
+++ b/client/internal/netflow/conntrack/conntrack_test.go
@@ -3,6 +3,7 @@
 package conntrack
 
 import (
+	"net/netip"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -11,6 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 	nfct "github.com/ti-mo/conntrack"
 	"github.com/ti-mo/netfilter"
+
+	nftypes "github.com/netbirdio/netbird/client/internal/netflow/types"
+	nbnet "github.com/netbirdio/netbird/client/net"
 )
 
 type mockListener struct {
@@ -221,4 +225,12 @@ func TestStartIsIdempotent(t *testing.T) {
 	assert.Equal(t, int32(1), callCount.Load(), "dial should only be called once")
 
 	ct.Stop()
+}
+
+func TestInferDirectionForFirewallConnectionMarks(t *testing.T) {
+	ct := &ConnTrack{}
+
+	assert.Equal(t, nftypes.Ingress, ct.inferDirection(nbnet.PreroutingFwmarkRedirected, netip.Addr{}, netip.Addr{}))
+	assert.Equal(t, nftypes.Ingress, ct.inferDirection(nbnet.PreroutingFwmarkMasquerade, netip.Addr{}, netip.Addr{}))
+	assert.Equal(t, nftypes.Egress, ct.inferDirection(nbnet.PreroutingFwmarkMasqueradeReturn, netip.Addr{}, netip.Addr{}))
 }


### PR DESCRIPTION
## Describe your changes
Persist NetBird firewall authorization and routed-network marks in conntrack instead of relying on mutable per-packet marks. The DNAT guard now checks connection marks, so kube-router, kube-proxy, and other netfilter consumers can modify packet marks without causing authorized traffic to be dropped.

Both iptables and nftables backends are updated. Routed marks remain classified correctly by netflow.

## Issue ticket number and link
Fixes #6022

## Stack
- [x] This PR is independent

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes locally
- [x] I have added or updated tests where applicable
- [x] I have checked for breaking changes

## Documentation
- [x] Documentation is **not needed**

## Validation
- Cross-compiled Linux test binaries for `./client/firewall/iptables`
- Cross-compiled Linux test binaries for `./client/firewall/nftables`
- Cross-compiled Linux test binaries for `./client/internal/netflow/conntrack`
- `git diff --check`

Runtime netfilter tests require a Linux environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786808434&installation_id=146802194&pr_number=6802&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6802&signature=9712e419e1e17cb5d6a34ad77c961ff3629293f35137fc42a143fa54931b1fa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firewall rule behavior for redirected, masqueraded, and return traffic by switching NAT/ACL handling to use connection (conntrack) marks consistently.
  * Strengthened DNAT guard logic to drop incorrectly marked redirected traffic.
  * Improved NetFlow direction detection for firewall-managed connections based on these connection marks.
* **Tests**
  * Added/updated Linux-focused tests to verify connection-mark-based rule generation and NAT matching/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->