### PR TITLE
[client] Masquerade traffic to local route VIPs

### DIFF
--- a/client/firewall/iptables/router_linux.go
+++ b/client/firewall/iptables/router_linux.go
@@ -537,7 +537,6 @@ func (r *router) addPostroutingRules() error {
 	// First rule for outbound masquerade
 	rule1 := []string{
 		"-m", "mark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasquerade),
-		"!", "-o", "lo",
 		"-j", routingFinalNatJump,
 	}
 	if err := r.iptablesClient.Append(tableNat, chainRTNAT, rule1...); err != nil {

--- a/client/firewall/iptables/router_linux_test.go
+++ b/client/firewall/iptables/router_linux_test.go
@@ -60,6 +60,14 @@ func TestIptablesManager_RestoreOrCreateContainers(t *testing.T) {
 	require.NoError(t, err, "should be able to query the iptables %s table and %s chain", tableMangle, chainPREROUTING)
 	require.True(t, exists, "prerouting jump rule should exist")
 
+	outboundMasqueradeRule := []string{
+		"-m", "mark", "--mark", fmt.Sprintf("%#x", nbnet.PreroutingFwmarkMasquerade),
+		"-j", routingFinalNatJump,
+	}
+	exists, err = manager.iptablesClient.Exists(tableNat, chainRTNAT, outboundMasqueradeRule...)
+	require.NoError(t, err, "should be able to query the outbound masquerade rule")
+	require.True(t, exists, "outbound masquerade rule should include locally routed traffic")
+
 	pair := firewall.RouterPair{
 		ID:          "abc",
 		Source:      firewall.Network{Prefix: netip.MustParsePrefix("100.100.100.1/32")},

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -815,16 +815,6 @@ func (r *router) addPostroutingRules() {
 			Data:     binaryutil.NativeEndian.PutUint32(nbnet.PreroutingFwmarkMasquerade),
 		},
 
-		// We need to exclude the loopback interface as this changes the ebpf proxy port
-		&expr.Meta{
-			Key:      expr.MetaKeyOIFNAME,
-			Register: 1,
-		},
-		&expr.Cmp{
-			Op:       expr.CmpOpNeq,
-			Register: 1,
-			Data:     ifname("lo"),
-		},
 		&expr.Counter{},
 		&expr.Masq{},
 	}

--- a/client/firewall/nftables/router_linux_test.go
+++ b/client/firewall/nftables/router_linux_test.go
@@ -3,6 +3,7 @@
 package nftables
 
 import (
+	"bytes"
 	"encoding/binary"
 	"net/netip"
 	"os/exec"
@@ -19,6 +20,7 @@ import (
 	"github.com/netbirdio/netbird/client/firewall/test"
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/internal/acl/id"
+	nbnet "github.com/netbirdio/netbird/client/net"
 )
 
 const (
@@ -188,6 +190,42 @@ func TestNftablesManager_RemoveNatRule(t *testing.T) {
 			require.True(t, foundCounter, "static postrouting rule should remain")
 		})
 	}
+}
+
+func TestNftablesManager_OutboundMasqueradeIncludesLoopback(t *testing.T) {
+	if check() != NFTABLES {
+		t.Skip("nftables not supported on this OS")
+	}
+
+	manager, err := Create(ifaceMock, iface.DefaultMTU)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, manager.Close(nil))
+	})
+	require.NoError(t, manager.Init(nil))
+
+	rules, err := manager.router.conn.GetRules(manager.router.workTable, manager.router.chains[chainNameRoutingNat])
+	require.NoError(t, err)
+
+	mark := binaryutil.NativeEndian.PutUint32(nbnet.PreroutingFwmarkMasquerade)
+	found := false
+	for _, rule := range rules {
+		isOutbound := false
+		hasOutputInterfaceMatch := false
+		for _, expression := range rule.Exprs {
+			switch expression := expression.(type) {
+			case *expr.Cmp:
+				isOutbound = isOutbound || bytes.Equal(mark, expression.Data)
+			case *expr.Meta:
+				hasOutputInterfaceMatch = hasOutputInterfaceMatch || expression.Key == expr.MetaKeyOIFNAME
+			}
+		}
+		if isOutbound {
+			found = true
+			require.False(t, hasOutputInterfaceMatch, "outbound masquerade rule should include locally routed traffic")
+		}
+	}
+	require.True(t, found, "outbound masquerade rule should exist")
 }
 
 func TestRouter_AddRouteFiltering(t *testing.T) {


### PR DESCRIPTION
## Describe your changes
Allow marked routed traffic to reach the outbound masquerade target when Linux resolves its destination through the loopback interface. This covers same-host Keepalived and VRRP VIPs, which previously retained the remote NetBird source address because both iptables and nftables excluded all loopback-routed traffic.

The broad loopback exemption is no longer required for the eBPF WireGuard proxy because its exact loopback UDP flows are protected by the dedicated `SetupEBPFProxyNoTrack` raw-table rules.

Regression assertions cover both firewall backends.

## Issue ticket number and link
Fixes #5851

## Stack
- [x] This PR is independent

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes locally
- [x] I have added or updated tests where applicable
- [x] I have checked for breaking changes

## Documentation
- [x] Documentation is **not needed**

## Validation
- Linux amd64 cross-compilation with privileged tests for `./client/firewall/iptables`
- Linux amd64 cross-compilation with privileged tests for `./client/firewall/nftables`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786810082&installation_id=146802194&pr_number=6804&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6804&signature=95c70ebce56764b23b7802fd5ab9f9a48f4241c4f7ec6eb9a778d50d90e7d916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated outbound network address translation so loopback-originated traffic is handled correctly.
  - Aligned firewall behavior across supported packet-filtering systems for more consistent outbound routing.

- **Tests**
  - Added coverage confirming outbound masquerading rules are present and include eligible loopback traffic.
  - Improved validation of generated routing and NAT rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->