### PR TITLE
[client] Scope conntrack cancellation per run

### DIFF
--- a/client/internal/netflow/conntrack/conntrack.go
+++ b/client/internal/netflow/conntrack/conntrack.go
@@ -3,6 +3,7 @@
 package conntrack
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"net/netip"
@@ -37,14 +38,18 @@ type ConnTrack struct {
 	flowLogger nftypes.FlowLogger
 	iface      nftypes.IFaceMapper
 
-	conn listener
-	mux  sync.Mutex
+	mux sync.Mutex
+	run *conntrackRun
 
 	dial           func() (listener, error)
 	instanceID     uuid.UUID
-	started        bool
-	done           chan struct{}
 	sysctlModified bool
+}
+
+type conntrackRun struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	conn   listener
 }
 
 // DialFunc is a constructor for netlink conntrack connections.
@@ -71,7 +76,6 @@ func New(flowLogger nftypes.FlowLogger, iface nftypes.IFaceMapper, opts ...Optio
 		iface:      iface,
 		instanceID: uuid.New(),
 		dial:       defaultDial,
-		done:       make(chan struct{}, 1),
 	}
 	for _, opt := range opts {
 		opt(ct)
@@ -84,7 +88,7 @@ func (c *ConnTrack) Start(enableCounters bool) error {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	if c.started {
+	if c.run != nil {
 		return nil
 	}
 
@@ -99,8 +103,6 @@ func (c *ConnTrack) Start(enableCounters bool) error {
 		c.RestoreAccounting()
 		return fmt.Errorf("dial conntrack: %w", err)
 	}
-	c.conn = conn
-
 	events := make(chan nfct.Event, defaultChannelSize)
 	errChan, err := conn.Listen(events, 1, []netfilter.NetlinkGroup{
 		netfilter.GroupCTNew,
@@ -108,37 +110,42 @@ func (c *ConnTrack) Start(enableCounters bool) error {
 	})
 
 	if err != nil {
-		if err := c.conn.Close(); err != nil {
+		if err := conn.Close(); err != nil {
 			log.Errorf("Error closing conntrack connection: %v", err)
 		}
-		c.conn = nil
 		c.RestoreAccounting()
 		return fmt.Errorf("start conntrack listener: %w", err)
 	}
 
-	// Drain any stale stop signal from a previous cycle.
-	select {
-	case <-c.done:
-	default:
+	ctx, cancel := context.WithCancel(context.Background())
+	run := &conntrackRun{
+		ctx:    ctx,
+		cancel: cancel,
+		conn:   conn,
 	}
+	c.run = run
 
-	c.started = true
-
-	go c.receiverRoutine(events, errChan)
+	go c.receiverRoutine(run, events, errChan)
 
 	return nil
 }
 
-func (c *ConnTrack) receiverRoutine(events chan nfct.Event, errChan chan error) {
+func (c *ConnTrack) receiverRoutine(run *conntrackRun, events chan nfct.Event, errChan chan error) {
 	for {
 		select {
 		case event := <-events:
-			c.handleEvent(event)
-		case err := <-errChan:
-			if events, errChan = c.handleListenerError(err); events == nil {
+			if run.ctx.Err() != nil {
 				return
 			}
-		case <-c.done:
+			c.handleEvent(event)
+		case err := <-errChan:
+			if run.ctx.Err() != nil {
+				return
+			}
+			if events, errChan = c.handleListenerError(run, err); events == nil {
+				return
+			}
+		case <-run.ctx.Done():
 			return
 		}
 	}
@@ -146,27 +153,35 @@ func (c *ConnTrack) receiverRoutine(events chan nfct.Event, errChan chan error) 
 
 // handleListenerError closes the failed connection and attempts to reconnect.
 // Returns new channels on success, or nil if shutdown was requested.
-func (c *ConnTrack) handleListenerError(err error) (chan nfct.Event, chan error) {
+func (c *ConnTrack) handleListenerError(run *conntrackRun, err error) (chan nfct.Event, chan error) {
 	log.Warnf("conntrack event listener failed: %v", err)
-	c.closeConn()
-	return c.reconnect()
+	if !c.closeRunConn(run) {
+		return nil, nil
+	}
+	return c.reconnect(run)
 }
 
-func (c *ConnTrack) closeConn() {
+func (c *ConnTrack) closeRunConn(run *conntrackRun) bool {
 	c.mux.Lock()
-	defer c.mux.Unlock()
+	if c.run != run {
+		c.mux.Unlock()
+		return false
+	}
+	conn := run.conn
+	run.conn = nil
+	c.mux.Unlock()
 
-	if c.conn != nil {
-		if err := c.conn.Close(); err != nil {
+	if conn != nil {
+		if err := conn.Close(); err != nil {
 			log.Debugf("close conntrack connection: %v", err)
 		}
-		c.conn = nil
 	}
+	return true
 }
 
 // reconnect attempts to re-establish the conntrack netlink listener with exponential backoff.
 // Returns new channels on success, or nil if shutdown was requested.
-func (c *ConnTrack) reconnect() (chan nfct.Event, chan error) {
+func (c *ConnTrack) reconnect(run *conntrackRun) (chan nfct.Event, chan error) {
 	bo := &backoff.ExponentialBackOff{
 		InitialInterval:     reconnectInitInterval,
 		RandomizationFactor: reconnectRandomization,
@@ -181,19 +196,24 @@ func (c *ConnTrack) reconnect() (chan nfct.Event, chan error) {
 		delay := bo.NextBackOff()
 		log.Infof("reconnecting conntrack listener in %s", delay)
 
+		timer := time.NewTimer(delay)
 		select {
-		case <-c.done:
-			c.mux.Lock()
-			c.started = false
-			c.mux.Unlock()
+		case <-run.ctx.Done():
+			timer.Stop()
 			return nil, nil
-		case <-time.After(delay):
+		case <-timer.C:
 		}
 
 		conn, err := c.dial()
 		if err != nil {
 			log.Warnf("reconnect conntrack dial: %v", err)
 			continue
+		}
+		if run.ctx.Err() != nil {
+			if closeErr := conn.Close(); closeErr != nil {
+				log.Debugf("close conntrack connection: %v", closeErr)
+			}
+			return nil, nil
 		}
 
 		events := make(chan nfct.Event, defaultChannelSize)
@@ -210,15 +230,14 @@ func (c *ConnTrack) reconnect() (chan nfct.Event, chan error) {
 		}
 
 		c.mux.Lock()
-		if !c.started {
-			// Stop() ran while we were reconnecting.
+		if c.run != run || run.ctx.Err() != nil {
 			c.mux.Unlock()
 			if closeErr := conn.Close(); closeErr != nil {
 				log.Debugf("close conntrack connection: %v", closeErr)
 			}
 			return nil, nil
 		}
-		c.conn = conn
+		run.conn = conn
 		c.mux.Unlock()
 
 		log.Infof("conntrack listener reconnected successfully")
@@ -229,61 +248,47 @@ func (c *ConnTrack) reconnect() (chan nfct.Event, chan error) {
 
 // Stop stops the connection tracking. This method is idempotent.
 func (c *ConnTrack) Stop() {
-	c.mux.Lock()
-	defer c.mux.Unlock()
-
-	if !c.started {
+	conn := c.stopRun()
+	if conn == nil {
 		return
 	}
 
 	log.Info("Stopping conntrack event listening")
-
-	select {
-	case c.done <- struct{}{}:
-	default:
+	if err := conn.Close(); err != nil {
+		log.Errorf("Error closing conntrack connection: %v", err)
 	}
-
-	if c.conn != nil {
-		if err := c.conn.Close(); err != nil {
-			log.Errorf("Error closing conntrack connection: %v", err)
-		}
-		c.conn = nil
-	}
-
-	c.started = false
-
-	c.RestoreAccounting()
 }
 
 // Close stops listening for events and cleans up resources
 func (c *ConnTrack) Close() error {
-	c.mux.Lock()
-	defer c.mux.Unlock()
-
-	if !c.started {
+	conn := c.stopRun()
+	if conn == nil {
 		return nil
 	}
 
-	select {
-	case c.done <- struct{}{}:
-	default:
-	}
-
-	c.started = false
-
-	var closeErr error
-	if c.conn != nil {
-		closeErr = c.conn.Close()
-		c.conn = nil
-	}
-
-	c.RestoreAccounting()
-
-	if closeErr != nil {
-		return fmt.Errorf("close conntrack: %w", closeErr)
+	if err := conn.Close(); err != nil {
+		return fmt.Errorf("close conntrack: %w", err)
 	}
 
 	return nil
+}
+
+func (c *ConnTrack) stopRun() listener {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if c.run == nil {
+		return nil
+	}
+
+	run := c.run
+	c.run = nil
+	run.cancel()
+	conn := run.conn
+	run.conn = nil
+
+	c.RestoreAccounting()
+	return conn
 }
 
 // handleEvent processes incoming conntrack events

--- a/client/internal/netflow/conntrack/conntrack_test.go
+++ b/client/internal/netflow/conntrack/conntrack_test.go
@@ -205,6 +205,7 @@ func TestStopStartWhilePreviousReconnectDialInFlight(t *testing.T) {
 	current := newMockListener()
 	dialStarted := make(chan struct{})
 	dialProceed := make(chan struct{})
+	unexpectedDial := make(chan struct{}, 1)
 	callCount := atomic.Int32{}
 
 	ct := New(nil, nil, WithDialer(func() (listener, error) {
@@ -218,7 +219,7 @@ func TestStopStartWhilePreviousReconnectDialInFlight(t *testing.T) {
 		case 3:
 			return current, nil
 		default:
-			t.Fatal("unexpected conntrack dial")
+			unexpectedDial <- struct{}{}
 			return nil, assert.AnError
 		}
 	}))
@@ -252,6 +253,11 @@ func TestStopStartWhilePreviousReconnectDialInFlight(t *testing.T) {
 	assert.Same(t, current, ct.run.conn)
 	ct.mux.Unlock()
 	assert.False(t, current.closed.Load(), "current run connection should remain open")
+	select {
+	case <-unexpectedDial:
+		t.Error("unexpected conntrack dial")
+	default:
+	}
 
 	ct.Stop()
 	assert.True(t, current.closed.Load(), "current run connection should close on Stop")

--- a/client/internal/netflow/conntrack/conntrack_test.go
+++ b/client/internal/netflow/conntrack/conntrack_test.go
@@ -101,8 +101,7 @@ func TestStopDuringReconnectBackoff(t *testing.T) {
 	ct.Stop()
 
 	ct.mux.Lock()
-	assert.False(t, ct.started, "started should be false after Stop")
-	assert.Nil(t, ct.conn, "conn should be nil after Stop")
+	assert.Nil(t, ct.run, "run should be nil after Stop")
 	ct.mux.Unlock()
 }
 
@@ -140,7 +139,7 @@ func TestStopRaceWithReconnectDial(t *testing.T) {
 	// Stop while dial is in progress (conn is nil at this point).
 	ct.Stop()
 
-	// Let the dial complete. reconnect should detect started==false and close the new conn.
+	// Let the dial complete. reconnect should detect that its run stopped and close the new conn.
 	close(dialProceed)
 
 	// The second connection should be closed (not leaked).
@@ -151,8 +150,7 @@ func TestStopRaceWithReconnectDial(t *testing.T) {
 	}
 
 	ct.mux.Lock()
-	assert.False(t, ct.started)
-	assert.Nil(t, ct.conn)
+	assert.Nil(t, ct.run)
 	ct.mux.Unlock()
 }
 
@@ -197,9 +195,66 @@ func TestCloseRaceWithReconnectDial(t *testing.T) {
 	}
 
 	ct.mux.Lock()
-	assert.False(t, ct.started)
-	assert.Nil(t, ct.conn)
+	assert.Nil(t, ct.run)
 	ct.mux.Unlock()
+}
+
+func TestStopStartWhilePreviousReconnectDialInFlight(t *testing.T) {
+	first := newMockListener()
+	stale := newMockListener()
+	current := newMockListener()
+	dialStarted := make(chan struct{})
+	dialProceed := make(chan struct{})
+	callCount := atomic.Int32{}
+
+	ct := New(nil, nil, WithDialer(func() (listener, error) {
+		switch callCount.Add(1) {
+		case 1:
+			return first, nil
+		case 2:
+			close(dialStarted)
+			<-dialProceed
+			return stale, nil
+		case 3:
+			return current, nil
+		default:
+			t.Fatal("unexpected conntrack dial")
+			return nil, assert.AnError
+		}
+	}))
+
+	require.NoError(t, ct.Start(false))
+	first.errChan <- assert.AnError
+
+	select {
+	case <-dialStarted:
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for reconnect dial")
+	}
+
+	ct.Stop()
+	require.NoError(t, ct.Start(false))
+
+	ct.mux.Lock()
+	require.NotNil(t, ct.run)
+	assert.Same(t, current, ct.run.conn)
+	ct.mux.Unlock()
+
+	close(dialProceed)
+	select {
+	case <-stale.closedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stale reconnect connection was not closed")
+	}
+
+	ct.mux.Lock()
+	require.NotNil(t, ct.run)
+	assert.Same(t, current, ct.run.conn)
+	ct.mux.Unlock()
+	assert.False(t, current.closed.Load(), "current run connection should remain open")
+
+	ct.Stop()
+	assert.True(t, current.closed.Load(), "current run connection should close on Stop")
 }
 
 func TestStartIsIdempotent(t *testing.T) {


### PR DESCRIPTION
## Describe your changes
Replace the conntrack listener’s shared stop channel and global connection state with a per-run context and listener owner.

A stopped listener can remain inside reconnect dial or listen after `Stop` returns. Previously, a following `Start` could consume the shared stop signal and set `started` again, allowing the stale reconnect to replace or close the new listener. Reconnect publication and cleanup now verify the originating run identity, so stale work can only close its own candidate connection.

The regression test reproduces a stopped run completing its reconnect dial after a replacement run has started and verifies that the replacement remains current and open.

## Issue ticket number and link
Fixes #5887

## Stack
- [x] This PR is independent

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes locally
- [x] I have added or updated tests where applicable
- [x] I have checked for breaking changes

## Documentation
- [x] Documentation is **not needed**

## Validation
- Linux amd64 test-binary compilation for `./client/internal/netflow/conntrack`
- `GOOS=linux GOARCH=amd64 go vet ./client/internal/netflow/conntrack`
- `git diff --check`

The Linux-only tests could not be executed on the local macOS host.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786811331&installation_id=146802194&pr_number=6807&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6807&signature=56a5f957f51a0a85cf5a0aea85b42d5e10baf873f1d224922c289ec274d1498f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection tracking lifecycle with per-run cancellation to ensure listeners stop cleanly.
  * Refined reconnection flow to avoid stale reconnect attempts affecting newly started runs.
  * Updated Stop/Close behavior so in-flight reconnects are promptly canceled and associated connections are cleaned up.

* **Tests**
  * Enhanced conntrack reconnection/stop concurrency coverage to assert run lifecycle changes during races.
  * Added a race-focused test for stop/restart while a reconnect dial is in flight, verifying the stale connection is closed and the active run remains correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->