### PR TITLE
[client] Bind netstack SOCKS5 proxy to 127.0.0.1 by default

### DIFF
--- a/client/iface/netstack/env.go
+++ b/client/iface/netstack/env.go
@@ -3,7 +3,6 @@
 package netstack
 
 import (
-	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -36,7 +35,7 @@ func IsEnabled() bool {
 }
 
 func ListenAddr() string {
-	return fmt.Sprintf("%s:%d", listenHost(), listenPort())
+	return net.JoinHostPort(listenHost(), strconv.Itoa(listenPort()))
 }
 
 // listenHost returns the host/IP the SOCKS5 proxy binds to. It defaults to

--- a/client/iface/netstack/env.go
+++ b/client/iface/netstack/env.go
@@ -4,13 +4,31 @@ package netstack
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
 )
 
-const EnvUseNetstackMode = "NB_USE_NETSTACK_MODE"
+const (
+	EnvUseNetstackMode = "NB_USE_NETSTACK_MODE"
+
+	// EnvSocks5ListenerPort overrides the port the SOCKS5 proxy listens on.
+	EnvSocks5ListenerPort = "NB_SOCKS5_LISTENER_PORT"
+
+	// EnvSocks5ListenerAddress overrides the host/IP the SOCKS5 proxy binds to.
+	// The proxy is a bridge for local host applications into the userspace
+	// WireGuard netstack, so it binds to loopback by default. Override this only
+	// when the proxy must be reachable from other hosts (e.g. a container
+	// gateway); doing so exposes an unauthenticated SOCKS5 proxy on that
+	// address.
+	EnvSocks5ListenerAddress = "NB_SOCKS5_LISTENER_ADDRESS"
+
+	// defaultSocks5Host is the loopback address the SOCKS5 proxy binds to unless
+	// overridden via EnvSocks5ListenerAddress.
+	defaultSocks5Host = "127.0.0.1"
+)
 
 // IsEnabled todo: move these function to cmd layer
 func IsEnabled() bool {
@@ -18,24 +36,40 @@ func IsEnabled() bool {
 }
 
 func ListenAddr() string {
-	sPort := os.Getenv("NB_SOCKS5_LISTENER_PORT")
+	return fmt.Sprintf("%s:%d", listenHost(), listenPort())
+}
+
+// listenHost returns the host/IP the SOCKS5 proxy binds to. It defaults to
+// loopback and only honors EnvSocks5ListenerAddress when it holds a valid IP.
+func listenHost() string {
+	addr := os.Getenv(EnvSocks5ListenerAddress)
+	if addr == "" {
+		return defaultSocks5Host
+	}
+	if net.ParseIP(addr) == nil {
+		log.Warnf("invalid socks5 listener address %q, falling back to default: %s", addr, defaultSocks5Host)
+		return defaultSocks5Host
+	}
+	return addr
+}
+
+// listenPort returns the port the SOCKS5 proxy binds to, defaulting to
+// DefaultSocks5Port when EnvSocks5ListenerPort is unset or invalid.
+func listenPort() int {
+	sPort := os.Getenv(EnvSocks5ListenerPort)
 	if sPort == "" {
-		return listenAddr(DefaultSocks5Port)
+		return DefaultSocks5Port
 	}
 
 	port, err := strconv.Atoi(sPort)
 	if err != nil {
 		log.Warnf("invalid socks5 listener port, unable to convert it to int, falling back to default: %d", DefaultSocks5Port)
-		return listenAddr(DefaultSocks5Port)
+		return DefaultSocks5Port
 	}
 	if port < 1 || port > 65535 {
 		log.Warnf("invalid socks5 listener port, it should be in the range 1-65535, falling back to default: %d", DefaultSocks5Port)
-		return listenAddr(DefaultSocks5Port)
+		return DefaultSocks5Port
 	}
 
-	return listenAddr(port)
-}
-
-func listenAddr(port int) string {
-	return fmt.Sprintf("0.0.0.0:%d", port)
+	return port
 }

--- a/client/iface/netstack/env_test.go
+++ b/client/iface/netstack/env_test.go
@@ -3,14 +3,15 @@
 package netstack
 
 import (
-	"fmt"
+	"net"
+	"strconv"
 	"testing"
 )
 
 func TestListenAddr_DefaultsToLoopback(t *testing.T) {
 	// No env overrides: must bind loopback, never all interfaces.
 	got := ListenAddr()
-	want := fmt.Sprintf("127.0.0.1:%d", DefaultSocks5Port)
+	want := net.JoinHostPort("127.0.0.1", strconv.Itoa(DefaultSocks5Port))
 	if got != want {
 		t.Fatalf("ListenAddr() = %q, want %q", got, want)
 	}
@@ -24,13 +25,14 @@ func TestListenAddr_AddressOverride(t *testing.T) {
 	}{
 		{name: "valid override honored", env: "0.0.0.0", want: "0.0.0.0"},
 		{name: "valid specific ip honored", env: "10.0.0.5", want: "10.0.0.5"},
+		{name: "ipv6 loopback bracketed", env: "::1", want: "::1"},
 		{name: "invalid falls back to loopback", env: "not-an-ip", want: "127.0.0.1"},
 		{name: "empty falls back to loopback", env: "", want: "127.0.0.1"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(EnvSocks5ListenerAddress, tc.env)
-			want := fmt.Sprintf("%s:%d", tc.want, DefaultSocks5Port)
+			want := net.JoinHostPort(tc.want, strconv.Itoa(DefaultSocks5Port))
 			if got := ListenAddr(); got != want {
 				t.Fatalf("ListenAddr() = %q, want %q", got, want)
 			}
@@ -52,7 +54,7 @@ func TestListenAddr_PortOverride(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(EnvSocks5ListenerPort, tc.env)
-			want := fmt.Sprintf("127.0.0.1:%d", tc.want)
+			want := net.JoinHostPort("127.0.0.1", strconv.Itoa(tc.want))
 			if got := ListenAddr(); got != want {
 				t.Fatalf("ListenAddr() = %q, want %q", got, want)
 			}

--- a/client/iface/netstack/env_test.go
+++ b/client/iface/netstack/env_test.go
@@ -1,0 +1,61 @@
+//go:build !js
+
+package netstack
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestListenAddr_DefaultsToLoopback(t *testing.T) {
+	// No env overrides: must bind loopback, never all interfaces.
+	got := ListenAddr()
+	want := fmt.Sprintf("127.0.0.1:%d", DefaultSocks5Port)
+	if got != want {
+		t.Fatalf("ListenAddr() = %q, want %q", got, want)
+	}
+}
+
+func TestListenAddr_AddressOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{name: "valid override honored", env: "0.0.0.0", want: "0.0.0.0"},
+		{name: "valid specific ip honored", env: "10.0.0.5", want: "10.0.0.5"},
+		{name: "invalid falls back to loopback", env: "not-an-ip", want: "127.0.0.1"},
+		{name: "empty falls back to loopback", env: "", want: "127.0.0.1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvSocks5ListenerAddress, tc.env)
+			want := fmt.Sprintf("%s:%d", tc.want, DefaultSocks5Port)
+			if got := ListenAddr(); got != want {
+				t.Fatalf("ListenAddr() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestListenAddr_PortOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{name: "valid port honored", env: "1081", want: 1081},
+		{name: "non-numeric falls back", env: "abc", want: DefaultSocks5Port},
+		{name: "out of range falls back", env: "70000", want: DefaultSocks5Port},
+		{name: "zero falls back", env: "0", want: DefaultSocks5Port},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvSocks5ListenerPort, tc.env)
+			want := fmt.Sprintf("127.0.0.1:%d", tc.want)
+			if got := ListenAddr(); got != want {
+				t.Fatalf("ListenAddr() = %q, want %q", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes

In netstack mode the SOCKS5 proxy bridges local host applications into the
userspace WireGuard stack (`client/iface/netstack/proxy.go`), so it only needs
to be reachable from the same machine. It was binding to `0.0.0.0`, making an
unauthenticated proxy reachable from the network — any host able to reach the
port could relay traffic through the client into its NetBird overlay.

Bind to `127.0.0.1` by default. Add `NB_SOCKS5_LISTENER_ADDRESS` to override the
bind host for the rare case the proxy must be reachable from other hosts (e.g. a
container gateway); it is validated as an IP and falls back to loopback.
`ListenAddr` is split into `listenHost`/`listenPort` helpers, with tests.

Behavior change: setups that relied on reaching the netstack SOCKS5 proxy from
another host must now set `NB_SOCKS5_LISTENER_ADDRESS=0.0.0.0` explicitly.

## Issue ticket number and link

Internal security hardening of the netstack SOCKS5 listener bind address
([client/iface/netstack/env.go](https://github.com/netbirdio/netbird/blob/main/client/iface/netstack/env.go)).

## Stack

- `0.74.7-branch` - :warning: No PR associated with branch <!-- branch-stack -->
  - \#6812 :point\_left:

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)

Paste the PR link from <https://github.com/netbirdio/docs> here:

<https://github.com/netbirdio/docs/pull/860>

<!-- codesmith:footer -->

***

<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786872199&installation_id=146802194&pr_number=6812&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6812&signature=6e78df77b784915baee9647b555483a8f7550a604d5393edcc501dd8f58b1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a> <sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration options for the SOCKS5 listener’s bind address and port.
  - SOCKS5 now defaults to listening only on the local machine for improved security.
  - Valid address and port overrides are supported, with safe defaults used for invalid values.

- **Tests**
  - Added coverage for default settings and valid or invalid address and port configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
