### PR TITLE
[client] lazyconn: preserve routed prefixes on idle→wake to fix subnet black-hole

### DIFF
--- a/client/internal/lazyconn/manager/manager.go
+++ b/client/internal/lazyconn/manager/manager.go
@@ -2,6 +2,8 @@ package manager
 
 import (
 	"context"
+	"net/netip"
+	"sort"
 	"sync"
 	"time"
 
@@ -55,7 +57,15 @@ type Manager struct {
 	// If any peer in the same HA group is active, all peers in that group should prevent going idle
 	peerToHAGroups map[string][]route.HAUniqueID // peer ID -> HA groups they belong to
 	haGroupToPeers map[route.HAUniqueID][]string // HA group -> peer IDs in the group
-	routesMu       sync.RWMutex
+	// peerToRoutePrefixes holds the routed subnets each routing peer serves
+	// (from the management route sync via UpdateRouteHAMap). The activity
+	// listener installs a peer's wake endpoint via WgInterface.UpdatePeer,
+	// and WireGuard only routes a destination to that endpoint when it falls
+	// inside the peer's AllowedIPs. Merging these routed prefixes into the
+	// lazy PeerConfig.AllowedIPs ensures traffic to a routed subnet wakes the
+	// idle routing peer instead of being black-holed.
+	peerToRoutePrefixes map[string][]netip.Prefix // peer ID -> routed prefixes from route sync
+	routesMu            sync.RWMutex
 }
 
 // NewManager creates a new lazy connection manager
@@ -73,6 +83,7 @@ func NewManager(config Config, engineCtx context.Context, peerStore *peerstore.S
 		activityManager:      activity.NewManager(wgIface),
 		peerToHAGroups:       make(map[string][]route.HAUniqueID),
 		haGroupToPeers:       make(map[route.HAUniqueID][]string),
+		peerToRoutePrefixes:  make(map[string][]netip.Prefix),
 	}
 
 	if wgIface.IsUserspaceBind() {
@@ -84,20 +95,47 @@ func NewManager(config Config, engineCtx context.Context, peerStore *peerstore.S
 	return m
 }
 
-// UpdateRouteHAMap updates the HA group mappings for routes
-// This should be called when route configuration changes
+// UpdateRouteHAMap updates the HA group mappings for routes.
+// This should be called when route configuration changes.
+//
+// It also rebuilds peerToRoutePrefixes: the routed subnets each routing
+// peer serves are captured so the activity listener can wake the peer on
+// traffic into those subnets. The prefix capture runs for every route,
+// including single-peer (non-HA) routes that the HA-group builder skips,
+// because a lone routing peer still needs its subnet to trigger a wakeup.
+//
+// The captured prefixes are merged into a peer's AllowedIPs only at listener
+// arm time (see armActivityListener), never written back into the stored
+// PeerConfig. Keeping the stored base pristine (overlay-only) ensures a later
+// route change or removal drops the stale prefix instead of accumulating it,
+// which would otherwise let an idle routing peer re-claim a subnet that has
+// since moved to another HA peer.
 func (m *Manager) UpdateRouteHAMap(haMap route.HAMap) {
 	m.routesMu.Lock()
 	defer m.routesMu.Unlock()
 
 	clear(m.peerToHAGroups)
 	clear(m.haGroupToPeers)
+	clear(m.peerToRoutePrefixes)
+
+	routePrefixes := make(map[string]map[netip.Prefix]struct{})
 
 	for haUniqueID, routes := range haMap {
 		var peers []string
 
 		peerSet := make(map[string]bool)
 		for _, r := range routes {
+			if r == nil {
+				continue
+			}
+
+			if prefix, ok := routePrefixForLazyPeer(r); ok {
+				if routePrefixes[r.Peer] == nil {
+					routePrefixes[r.Peer] = make(map[netip.Prefix]struct{})
+				}
+				routePrefixes[r.Peer][prefix] = struct{}{}
+			}
+
 			if !peerSet[r.Peer] {
 				peerSet[r.Peer] = true
 				peers = append(peers, r.Peer)
@@ -115,7 +153,71 @@ func (m *Manager) UpdateRouteHAMap(haMap route.HAMap) {
 		}
 	}
 
-	log.Debugf("updated route HA mappings: %d HA groups, %d peers with routes", len(m.haGroupToPeers), len(m.peerToHAGroups))
+	for peerID, prefixes := range routePrefixes {
+		m.peerToRoutePrefixes[peerID] = sortedPrefixes(prefixes)
+	}
+
+	log.Debugf("updated route HA mappings: %d HA groups, %d peers with routes, %d peers with route prefixes",
+		len(m.haGroupToPeers), len(m.peerToHAGroups), len(m.peerToRoutePrefixes))
+}
+
+// routePrefixForLazyPeer returns the masked network prefix of a static
+// (non-dynamic) route so it can be merged into the routing peer's
+// AllowedIPs. Dynamic (domain) routes and invalid networks are skipped:
+// they have no fixed subnet the client can pre-install for wakeups.
+func routePrefixForLazyPeer(r *route.Route) (netip.Prefix, bool) {
+	if r.IsDynamic() || !r.Network.IsValid() {
+		return netip.Prefix{}, false
+	}
+	return r.Network.Masked(), true
+}
+
+// sortedPrefixes returns the set's prefixes in a deterministic order (by
+// address, then prefix length) so AllowedIPs assembly is stable.
+func sortedPrefixes(prefixes map[netip.Prefix]struct{}) []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(prefixes))
+	for prefix := range prefixes {
+		out = append(out, prefix)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if cmp := out[i].Addr().Compare(out[j].Addr()); cmp != 0 {
+			return cmp < 0
+		}
+		return out[i].Bits() < out[j].Bits()
+	})
+	return out
+}
+
+// allowedIPsForPeer merges the peer's base AllowedIPs (overlay /32 from the
+// WireGuard config) with its currently routed prefixes (from the route sync).
+// The result is the AllowedIPs the activity listener installs via UpdatePeer
+// so WireGuard routes both overlay- and subnet-bound traffic to the peer's
+// wake endpoint. It is idempotent (masked deduplication) and always computed
+// from the pristine base, so a route change is reflected on the next arm
+// without stale prefixes lingering.
+func (m *Manager) allowedIPsForPeer(peerID string, base []netip.Prefix) []netip.Prefix {
+	m.routesMu.RLock()
+	defer m.routesMu.RUnlock()
+
+	set := make(map[netip.Prefix]struct{}, len(base)+len(m.peerToRoutePrefixes[peerID]))
+	for _, prefix := range base {
+		set[prefix.Masked()] = struct{}{}
+	}
+	for _, prefix := range m.peerToRoutePrefixes[peerID] {
+		set[prefix.Masked()] = struct{}{}
+	}
+	return sortedPrefixes(set)
+}
+
+// armActivityListener starts the activity listener for a peer, merging its
+// routed prefixes into the wake endpoint's AllowedIPs at arm time. The stored
+// PeerConfig is left untouched (pristine overlay-only base): the merge is
+// applied to a copy so successive arms always reflect the current routes and
+// never accumulate stale prefixes.
+func (m *Manager) armActivityListener(peerCfg lazyconn.PeerConfig) error {
+	armCfg := peerCfg
+	armCfg.AllowedIPs = m.allowedIPsForPeer(peerCfg.PublicKey, peerCfg.AllowedIPs)
+	return m.activityManager.MonitorPeerActivity(armCfg)
 }
 
 // Start starts the manager and listens for peer activity and inactivity events
@@ -201,7 +303,10 @@ func (m *Manager) AddPeer(peerCfg lazyconn.PeerConfig) (bool, error) {
 		return false, nil
 	}
 
-	if err := m.activityManager.MonitorPeerActivity(peerCfg); err != nil {
+	// Arm the activity listener with routed subnets merged into the wake
+	// endpoint's AllowedIPs. The stored PeerConfig keeps its pristine
+	// overlay-only base (see armActivityListener).
+	if err := m.armActivityListener(peerCfg); err != nil {
 		return false, err
 	}
 
@@ -288,7 +393,7 @@ func (m *Manager) DeactivatePeer(peerID peerid.ConnID) {
 
 	m.inactivityManager.RemovePeer(mp.peerCfg.PublicKey)
 
-	if err := m.activityManager.MonitorPeerActivity(*mp.peerCfg); err != nil {
+	if err := m.armActivityListener(*mp.peerCfg); err != nil {
 		mp.peerCfg.Log.Errorf("failed to create activity monitor: %v", err)
 		return
 	}
@@ -444,6 +549,12 @@ func (m *Manager) removePeer(peerID string) {
 	m.activityManager.RemovePeer(cfg.Log, cfg.PeerConnID)
 	delete(m.managedPeers, peerID)
 	delete(m.managedPeersByConnID, cfg.PeerConnID)
+
+	// Drop routed-prefix bookkeeping to avoid a map leak. Lock ordering:
+	// managedPeersMu (held by callers) -> routesMu.
+	m.routesMu.Lock()
+	delete(m.peerToRoutePrefixes, peerID)
+	m.routesMu.Unlock()
 }
 
 func (m *Manager) close() {
@@ -459,6 +570,7 @@ func (m *Manager) close() {
 	m.routesMu.Lock()
 	m.peerToHAGroups = make(map[string][]route.HAUniqueID)
 	m.haGroupToPeers = make(map[route.HAUniqueID][]string)
+	m.peerToRoutePrefixes = make(map[string][]netip.Prefix)
 	m.routesMu.Unlock()
 
 	log.Infof("lazy connection manager closed")
@@ -577,7 +689,7 @@ func (m *Manager) onPeerInactivityTimedOut(peerIDs map[string]struct{}) {
 
 		mp.peerCfg.Log.Infof("start activity monitor")
 
-		if err := m.activityManager.MonitorPeerActivity(*mp.peerCfg); err != nil {
+		if err := m.armActivityListener(*mp.peerCfg); err != nil {
 			mp.peerCfg.Log.Errorf("failed to create activity monitor: %v", err)
 			continue
 		}

--- a/client/internal/lazyconn/manager/manager_routewake_test.go
+++ b/client/internal/lazyconn/manager/manager_routewake_test.go
@@ -1,0 +1,281 @@
+package manager
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
+	"github.com/netbirdio/netbird/client/internal/lazyconn"
+	peerid "github.com/netbirdio/netbird/client/internal/peer/id"
+	"github.com/netbirdio/netbird/client/internal/peerstore"
+	"github.com/netbirdio/netbird/monotime"
+	"github.com/netbirdio/netbird/route"
+)
+
+// mockEndpointManager is a thread-safe device.EndpointManager for tests.
+type mockEndpointManager struct {
+	mu        sync.Mutex
+	endpoints map[netip.Addr]net.Conn
+}
+
+func newMockEndpointManager() *mockEndpointManager {
+	return &mockEndpointManager{endpoints: make(map[netip.Addr]net.Conn)}
+}
+
+func (m *mockEndpointManager) SetEndpoint(fakeIP netip.Addr, conn net.Conn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.endpoints[fakeIP] = conn
+}
+
+func (m *mockEndpointManager) RemoveEndpoint(fakeIP netip.Addr) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.endpoints, fakeIP)
+}
+
+// recordingWGIface implements lazyconn.WGIface (and bindProvider) in
+// userspace-bind mode. The bind listener installs the peer's wake endpoint
+// via UpdatePeer during construction, so the AllowedIPs it arms are recorded
+// synchronously per peer key.
+type recordingWGIface struct {
+	mu      sync.Mutex
+	lastIPs map[string][]netip.Prefix
+	bind    *mockEndpointManager
+}
+
+func newRecordingWGIface() *recordingWGIface {
+	return &recordingWGIface{
+		lastIPs: make(map[string][]netip.Prefix),
+		bind:    newMockEndpointManager(),
+	}
+}
+
+func (m *recordingWGIface) UpdatePeer(peerKey string, allowedIps []netip.Prefix, _ time.Duration, _ *net.UDPAddr, _ *wgtypes.Key) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cloned := make([]netip.Prefix, len(allowedIps))
+	copy(cloned, allowedIps)
+	m.lastIPs[peerKey] = cloned
+	return nil
+}
+
+func (m *recordingWGIface) allowedIPsFor(peerKey string) []netip.Prefix {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastIPs[peerKey]
+}
+
+func (m *recordingWGIface) RemovePeer(string) error { return nil }
+
+func (m *recordingWGIface) IsUserspaceBind() bool { return true }
+
+func (m *recordingWGIface) GetBind() device.EndpointManager { return m.bind }
+
+func (m *recordingWGIface) Address() wgaddr.Address {
+	return wgaddr.Address{
+		IP:      netip.MustParseAddr("100.64.0.1"),
+		Network: netip.MustParsePrefix("100.64.0.0/16"),
+	}
+}
+
+func (m *recordingWGIface) LastActivities() map[string]monotime.Time { return nil }
+
+func (m *recordingWGIface) MTU() uint16 { return 1280 }
+
+// connKey provides a stable identity for deriving a peer connection ID.
+type connKey struct{ id string }
+
+func (c *connKey) ConnID() peerid.ConnID { return peerid.ConnID(c) }
+
+func containsPrefix(prefixes []netip.Prefix, want netip.Prefix) bool {
+	for _, p := range prefixes {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+func staticRoute(peer string, prefix netip.Prefix) *route.Route {
+	return &route.Route{Peer: peer, Network: prefix, NetworkType: route.IPv4Network}
+}
+
+func overlayPeer(id string, overlay netip.Prefix) (*connKey, lazyconn.PeerConfig) {
+	key := &connKey{id: id}
+	return key, lazyconn.PeerConfig{
+		PublicKey:  id,
+		PeerConnID: key.ConnID(),
+		AllowedIPs: []netip.Prefix{overlay},
+		Log:        log.WithField("peer", id),
+	}
+}
+
+// TestManager_RoutingPeer_ArmsWakeEndpointWithRoutedPrefix asserts that a
+// routing peer's wake endpoint (installed via UpdatePeer when the activity
+// listener is armed) covers the routed subnet, not just the overlay /32.
+// The route is a single-peer (non-HA) route, which the HA-group builder
+// skips, so it also guards that lone routing peers keep their subnet.
+func TestManager_RoutingPeer_ArmsWakeEndpointWithRoutedPrefix(t *testing.T) {
+	wg := newRecordingWGIface()
+	mgr := NewManager(Config{}, context.Background(), peerstore.NewConnStore(), wg)
+
+	routedNet := netip.MustParsePrefix("10.99.0.0/24")
+	overlay := netip.MustParsePrefix("100.64.0.5/32")
+
+	mgr.UpdateRouteHAMap(route.HAMap{"group-a": {staticRoute("peerA", routedNet)}})
+
+	_, peerCfg := overlayPeer("peerA", overlay)
+	_, err := mgr.AddPeer(peerCfg)
+	require.NoError(t, err)
+
+	armed := wg.allowedIPsFor("peerA")
+	assert.True(t, containsPrefix(armed, routedNet),
+		"wake endpoint AllowedIPs %v must contain routed subnet %s", armed, routedNet)
+	assert.True(t, containsPrefix(armed, overlay),
+		"wake endpoint AllowedIPs %v must still contain overlay %s", armed, overlay)
+}
+
+// TestManager_RouteChange_DropsStalePrefixOnReArm asserts that when a routed
+// subnet moves away from a peer, a later idle->wake re-arm installs the new
+// subnet and no longer carries the stale one. Because WireGuard AllowedIPs are
+// peer-exclusive, a stale prefix would let this peer re-claim a subnet that has
+// since moved to another HA peer, breaking failover routing.
+func TestManager_RouteChange_DropsStalePrefixOnReArm(t *testing.T) {
+	wg := newRecordingWGIface()
+	mgr := NewManager(Config{}, context.Background(), peerstore.NewConnStore(), wg)
+
+	oldNet := netip.MustParsePrefix("10.99.0.0/24")
+	newNet := netip.MustParsePrefix("10.88.0.0/24")
+	overlay := netip.MustParsePrefix("100.64.0.5/32")
+
+	mgr.UpdateRouteHAMap(route.HAMap{"group-a": {staticRoute("peerA", oldNet)}})
+
+	key, peerCfg := overlayPeer("peerA", overlay)
+	_, err := mgr.AddPeer(peerCfg)
+	require.NoError(t, err)
+	require.True(t, containsPrefix(wg.allowedIPsFor("peerA"), oldNet), "initial arm must cover the old subnet")
+
+	// Move the peer into the inactivity watcher so it can be re-armed.
+	require.True(t, mgr.ActivatePeer("peerA"))
+
+	// The subnet migrates away from peerA to a different subnet it now serves.
+	mgr.UpdateRouteHAMap(route.HAMap{"group-a": {staticRoute("peerA", newNet)}})
+
+	// The stored base must stay pristine (overlay-only), never accumulating
+	// merged routed prefixes.
+	mgr.managedPeersMu.Lock()
+	stored := append([]netip.Prefix(nil), mgr.managedPeers["peerA"].AllowedIPs...)
+	mgr.managedPeersMu.Unlock()
+	assert.Equal(t, []netip.Prefix{overlay}, stored, "stored PeerConfig base must remain overlay-only")
+
+	// Idle -> wake re-arm.
+	mgr.DeactivatePeer(key.ConnID())
+
+	armed := wg.allowedIPsFor("peerA")
+	assert.True(t, containsPrefix(armed, newNet), "re-armed wake endpoint %v must contain new subnet %s", armed, newNet)
+	assert.True(t, containsPrefix(armed, overlay), "re-armed wake endpoint %v must contain overlay %s", armed, overlay)
+	assert.False(t, containsPrefix(armed, oldNet), "re-armed wake endpoint %v must NOT contain stale subnet %s", armed, oldNet)
+}
+
+// TestManager_MultiPeer_EachPeerKeepsOwnSubnet asserts that distinct routing
+// peers each arm only their own routed subnet: no peer's prefixes leak into
+// another's wake endpoint (which would let one peer steal the other's route).
+func TestManager_MultiPeer_EachPeerKeepsOwnSubnet(t *testing.T) {
+	wg := newRecordingWGIface()
+	mgr := NewManager(Config{}, context.Background(), peerstore.NewConnStore(), wg)
+
+	netA := netip.MustParsePrefix("10.99.0.0/24")
+	netB := netip.MustParsePrefix("10.88.0.0/24")
+	overlayA := netip.MustParsePrefix("100.64.0.5/32")
+	overlayB := netip.MustParsePrefix("100.64.0.6/32")
+
+	mgr.UpdateRouteHAMap(route.HAMap{
+		"group-a": {staticRoute("peerA", netA)},
+		"group-b": {staticRoute("peerB", netB)},
+	})
+
+	_, cfgA := overlayPeer("peerA", overlayA)
+	_, cfgB := overlayPeer("peerB", overlayB)
+	_, err := mgr.AddPeer(cfgA)
+	require.NoError(t, err)
+	_, err = mgr.AddPeer(cfgB)
+	require.NoError(t, err)
+
+	armedA := wg.allowedIPsFor("peerA")
+	assert.True(t, containsPrefix(armedA, netA), "peerA %v must contain its own subnet %s", armedA, netA)
+	assert.False(t, containsPrefix(armedA, netB), "peerA %v must NOT contain peerB subnet %s", armedA, netB)
+
+	armedB := wg.allowedIPsFor("peerB")
+	assert.True(t, containsPrefix(armedB, netB), "peerB %v must contain its own subnet %s", armedB, netB)
+	assert.False(t, containsPrefix(armedB, netA), "peerB %v must NOT contain peerA subnet %s", armedB, netA)
+}
+
+// TestManager_DynamicRoute_NotMergedIntoWakeEndpoint asserts that dynamic
+// (domain) routes are not merged into the wake endpoint: they have no fixed
+// subnet the client can pre-install for wakeups.
+func TestManager_DynamicRoute_NotMergedIntoWakeEndpoint(t *testing.T) {
+	wg := newRecordingWGIface()
+	mgr := NewManager(Config{}, context.Background(), peerstore.NewConnStore(), wg)
+
+	overlay := netip.MustParsePrefix("100.64.0.5/32")
+
+	dynamicRoute := &route.Route{
+		Peer:        "peerA",
+		NetworkType: route.DomainNetwork,
+	}
+	mgr.UpdateRouteHAMap(route.HAMap{"group-a": {dynamicRoute}})
+
+	_, peerCfg := overlayPeer("peerA", overlay)
+	_, err := mgr.AddPeer(peerCfg)
+	require.NoError(t, err)
+
+	armed := wg.allowedIPsFor("peerA")
+	assert.Equal(t, []netip.Prefix{overlay}, armed,
+		"dynamic route must not contribute prefixes; wake endpoint should be overlay-only, got %v", armed)
+}
+
+// TestManager_RemovePeer_ClearsRoutePrefixes guards against a map leak:
+// removing a managed peer must drop its routed-prefix bookkeeping.
+func TestManager_RemovePeer_ClearsRoutePrefixes(t *testing.T) {
+	wg := newRecordingWGIface()
+	mgr := NewManager(Config{}, context.Background(), peerstore.NewConnStore(), wg)
+
+	mgr.UpdateRouteHAMap(route.HAMap{"group-a": {staticRoute("peerA", netip.MustParsePrefix("10.99.0.0/24"))}})
+
+	_, peerCfg := overlayPeer("peerA", netip.MustParsePrefix("100.64.0.5/32"))
+	_, err := mgr.AddPeer(peerCfg)
+	require.NoError(t, err)
+
+	mgr.RemovePeer("peerA")
+
+	mgr.routesMu.RLock()
+	_, ok := mgr.peerToRoutePrefixes["peerA"]
+	mgr.routesMu.RUnlock()
+	assert.False(t, ok, "peerToRoutePrefixes must not retain removed peer")
+}
+
+// TestManager_Close_ClearsRoutePrefixes guards the same map leak on close.
+func TestManager_Close_ClearsRoutePrefixes(t *testing.T) {
+	wg := newRecordingWGIface()
+	mgr := NewManager(Config{}, context.Background(), peerstore.NewConnStore(), wg)
+
+	mgr.UpdateRouteHAMap(route.HAMap{"group-a": {staticRoute("peerA", netip.MustParsePrefix("10.99.0.0/24"))}})
+
+	mgr.close()
+
+	mgr.routesMu.RLock()
+	n := len(mgr.peerToRoutePrefixes)
+	mgr.routesMu.RUnlock()
+	assert.Equal(t, 0, n, "peerToRoutePrefixes must be empty after close")
+}


### PR DESCRIPTION
## Describe your changes

When a routing peer goes idle under lazy connections, its WireGuard peer is torn
down, which also drops the routed subnet prefixes the route watcher had installed.
The activity listener then re-arms the peer's wake endpoint with only the overlay
/32 (`PeerConfig.AllowedIPs`), so traffic destined for the routed subnet no longer
matches the peer's AllowedIPs and is black-holed until the peer is woken by other
means (e.g. a ping to its overlay IP).

The asynchronous route-watcher re-add via `AddAllowedIP` uses `UpdateOnly=true`;
when it races into the window where the peer does not exist, wireguard-go treats
update-only on a missing peer as a silent no-op, so no self-heal occurs and the
subnet stays out of AllowedIPs.

## Fix

Capture each routing peer's static routed prefixes in `UpdateRouteHAMap` and merge
them into the peer's AllowedIPs at activity-listener arm time, so the wake endpoint
covers both the overlay /32 and the routed subnets. The merge is applied to a copy
while the stored `PeerConfig` keeps its pristine overlay-only base; computing the
arm-time set fresh from the current route sync prevents stale prefixes from
accumulating across route changes. This matters because WireGuard AllowedIPs are
peer-exclusive: a stale prefix would let an idle peer re-claim a subnet that has
since moved to another HA peer, breaking failover.

Prefixes are gathered for every route, including single-peer (non-HA) routes,
covering both the cold-start and route-change paths. Dynamic (domain) routes are
skipped as they have no fixed subnet to pre-install.

## Testing

Adds `manager_routewake_test.go` (unit): verifies routed prefixes are merged into
the wake endpoint at arm time for HA and single-peer routes, that the stored
PeerConfig stays overlay-only, and that stale prefixes do not persist across route
changes. `go test ./client/internal/lazyconn/... -race` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787054567&installation_id=146802194&pr_number=6825&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6825&signature=40d0c57db5294410ed644c096386fab78b8576c308fda3dbaf8adb707cb442ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wake-up behavior for routed connections by including the appropriate routed subnet information.
  * Updated wake settings correctly when routes change, preventing stale routes from being used.
  * Ensured each connection receives only its own routed networks.
  * Excluded dynamic or domain-based routes from wake-up configuration.
  * Improved cleanup when connections are removed or the manager shuts down.

* **Tests**
  * Added coverage for route changes, multiple routed connections, dynamic routes, and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->