### PR TITLE
[client] Fix data race on agentDialerCancel in ICE connect error paths

### DIFF
--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -42,7 +42,10 @@ type WorkerICE struct {
 	statusRecorder    *Status
 	hasRelayOnLocally bool
 
-	agent             *icemaker.ThreadSafeAgent
+	agent *icemaker.ThreadSafeAgent
+	// agentDialerCancel must only be accessed while holding muxAgent
+	// (OnNewOffer, Close). connect receives the cancel func of its own
+	// dial attempt as a parameter instead of reading this field.
 	agentDialerCancel context.CancelFunc
 	agentConnecting   bool      // while it is true, drop all incoming offers
 	lastSuccess       time.Time // with this avoid the too frequent ICE agent recreation
@@ -151,7 +154,7 @@ func (w *WorkerICE) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 		w.remoteSessionID = ""
 	}
 
-	go w.connect(dialerCtx, agent, remoteOfferAnswer)
+	go w.connect(dialerCtx, agent, dialerCancel, remoteOfferAnswer)
 }
 
 // OnRemoteCandidate Handles ICE connection Candidate provided by the remote peer.
@@ -247,11 +250,17 @@ func (w *WorkerICE) SessionID() ICESessionID {
 // will block until connection succeeded
 // but it won't release if ICE Agent went into Disconnected or Failed state,
 // so we have to cancel it with the provided context once agent detected a broken connection
-func (w *WorkerICE) connect(ctx context.Context, agent *icemaker.ThreadSafeAgent, remoteOfferAnswer *OfferAnswer) {
+//
+// dialerCancel belongs to this connect attempt's dialer context (created as a
+// pair with ctx in OnNewOffer). connect must not read w.agentDialerCancel:
+// a concurrent OnNewOffer replaces that field under muxAgent, so reading it
+// here is a data race, and a stale error path would cancel the successor's
+// dial attempt instead of its own.
+func (w *WorkerICE) connect(ctx context.Context, agent *icemaker.ThreadSafeAgent, dialerCancel context.CancelFunc, remoteOfferAnswer *OfferAnswer) {
 	w.log.Debugf("gather candidates")
 	if err := agent.GatherCandidates(); err != nil {
 		w.log.Warnf("failed to gather candidates: %s", err)
-		w.closeAgent(agent, w.agentDialerCancel)
+		w.closeAgent(agent, dialerCancel)
 		return
 	}
 
@@ -259,19 +268,19 @@ func (w *WorkerICE) connect(ctx context.Context, agent *icemaker.ThreadSafeAgent
 	remoteConn, err := w.turnAgentDial(ctx, agent, remoteOfferAnswer)
 	if err != nil {
 		w.log.Debugf("failed to dial the remote peer: %s", err)
-		w.closeAgent(agent, w.agentDialerCancel)
+		w.closeAgent(agent, dialerCancel)
 		return
 	}
 	w.log.Debugf("agent dial succeeded")
 
 	pair, err := agent.GetSelectedCandidatePair()
 	if err != nil {
-		w.closeAgent(agent, w.agentDialerCancel)
+		w.closeAgent(agent, dialerCancel)
 		return
 	}
 	if pair == nil {
 		w.log.Warnf("selected candidate pair is nil, cannot proceed")
-		w.closeAgent(agent, w.agentDialerCancel)
+		w.closeAgent(agent, dialerCancel)
 		return
 	}
 

--- a/client/internal/peer/worker_ice_test.go
+++ b/client/internal/peer/worker_ice_test.go
@@ -1,0 +1,99 @@
+package peer
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+
+	icemaker "github.com/netbirdio/netbird/client/internal/peer/ice"
+)
+
+func newTestWorkerICE(t *testing.T) *WorkerICE {
+	t.Helper()
+	cfg := ConnConfig{
+		Key:      "LLHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
+		LocalKey: "RRHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
+		ICEConfig: icemaker.Config{
+			StunTurn: &icemaker.StunTurn{},
+		},
+	}
+	w, err := NewWorkerICE(context.Background(), log.WithField("peer", "test"), cfg, nil, nil, nil, NewRecorder("https://mgm"), false)
+	if err != nil {
+		t.Fatalf("failed to create ICE worker: %v", err)
+	}
+	return w
+}
+
+// newClosedTestAgent returns an ICE agent that is already closed, so
+// GatherCandidates deterministically fails and connect takes its first
+// error path without any network activity.
+func newClosedTestAgent(t *testing.T, w *WorkerICE) *icemaker.ThreadSafeAgent {
+	t.Helper()
+	agent, err := icemaker.NewAgent(context.Background(), nil, w.config.ICEConfig, icemaker.CandidateTypes(), w.localUfrag, w.localPwd)
+	if err != nil {
+		t.Fatalf("failed to create ICE agent: %v", err)
+	}
+	if err := agent.Close(); err != nil {
+		t.Fatalf("failed to close ICE agent: %v", err)
+	}
+	return agent
+}
+
+// TestWorkerICE_ConnectErrorPathUsesOwnDialerCancel pins that a failing
+// connect attempt cancels its own dialer context and never invokes the
+// worker-level agentDialerCancel, which may already belong to a successor
+// dial started by a concurrent OnNewOffer.
+func TestWorkerICE_ConnectErrorPathUsesOwnDialerCancel(t *testing.T) {
+	w := newTestWorkerICE(t)
+	agent := newClosedTestAgent(t, w)
+
+	var successorCancelled atomic.Bool
+	w.agentDialerCancel = func() { successorCancelled.Store(true) }
+
+	ownCtx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+	var ownCancelled atomic.Bool
+	ownCancel := func() {
+		ownCancelled.Store(true)
+		cancelFn()
+	}
+
+	w.connect(ownCtx, agent, ownCancel, &OfferAnswer{})
+
+	if successorCancelled.Load() {
+		t.Fatal("connect error path must not invoke the shared agentDialerCancel field")
+	}
+	if !ownCancelled.Load() {
+		t.Fatal("connect error path must cancel its own dialer context")
+	}
+}
+
+// TestWorkerICE_ConnectDoesNotRaceOnDialerCancel runs connect concurrently
+// with the field replacement OnNewOffer performs under muxAgent. Run with
+// -race: before the fix, connect read the field without the lock, which the
+// race detector reports.
+func TestWorkerICE_ConnectDoesNotRaceOnDialerCancel(t *testing.T) {
+	w := newTestWorkerICE(t)
+	agent := newClosedTestAgent(t, w)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		w.connect(ctx, agent, cancel, &OfferAnswer{})
+	}()
+	go func() {
+		defer wg.Done()
+		// mirror OnNewOffer's field replacement under muxAgent
+		w.muxAgent.Lock()
+		w.agentDialerCancel = func() {}
+		w.muxAgent.Unlock()
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
## Describe your changes

`WorkerICE.connect()` runs on its own goroutine (`go w.connect(...)` in
`OnNewOffer`) and read `w.agentDialerCancel` in its four error paths
(gather candidates failure, dial failure, selected-pair failure, nil pair)
without holding `muxAgent`, while a concurrent `OnNewOffer` replaces that
field under the lock.

Two consequences:
1. A data race on the field (reported by `go test -race`).
2. A functional bug: when a new offer has already re-created the agent,
   the stale error path invoked the **successor's** dialer cancel func,
   aborting the brand-new dial attempt instead of its own.

Fix: `connect()` now receives the cancel func belonging to its own dial
attempt as a parameter (created as a pair with `dialerCtx` in
`OnNewOffer`), mirroring how `onConnectionStateChange` already receives
`dialerCancel`. `w.agentDialerCancel` is now only accessed under
`muxAgent` (in `OnNewOffer` and `Close`).

Tests: a deterministic unit test pins that a failing connect attempt
cancels its own context and never touches the worker-level field, plus a
`-race` companion that exercises `connect` concurrently with the field
replacement.

## Issue ticket number and link

-

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787060577&installation_id=146802194&pr_number=6826&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6826&signature=787e14aeca1aadf922f374a1fab42b8faf0971ae583cac6804749467a28eb4a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection cancellation handling to prevent one connection attempt from interrupting another.
  * Reduced the risk of connection setup issues during concurrent dialing and offer processing.

* **Tests**
  * Added coverage for connection error handling and concurrent dial cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->