### PR TITLE
[client] Fix activity listener churn race in lazyconn manager

### DIFF
--- a/client/internal/lazyconn/activity/listener_bind.go
+++ b/client/internal/lazyconn/activity/listener_bind.go
@@ -110,10 +110,12 @@ func (d *BindListener) setupLazyConn() error {
 }
 
 // ReadPackets blocks until activity is detected on the LazyConn or the listener is closed.
-func (d *BindListener) ReadPackets() {
+func (d *BindListener) ReadPackets() ActivityResult {
+	result := ActivityResultClosed
 	select {
 	case <-d.lazyConn.ActivityChan():
 		d.peerCfg.Log.Infof("activity detected via LazyConn")
+		result = ActivityResultTraffic
 	case <-d.lazyConn.ctx.Done():
 		d.peerCfg.Log.Infof("exit from activity listener")
 	}
@@ -122,6 +124,7 @@ func (d *BindListener) ReadPackets() {
 	_ = d.lazyConn.Close()
 	d.bind.RemoveEndpoint(d.fakeIP)
 	d.done.Done()
+	return result
 }
 
 // CapturedPacket is unused in userspace bind mode: first-packet reinjection is kernel-only.

--- a/client/internal/lazyconn/activity/listener_udp.go
+++ b/client/internal/lazyconn/activity/listener_udp.go
@@ -53,7 +53,8 @@ func NewUDPListener(wgIface WgInterface, cfg lazyconn.PeerConfig) (*UDPListener,
 // The first packet that triggers activity is captured so it can be reinjected through the real
 // transport once it is established. Without this, kernel WireGuard's handshake initiation would be
 // dropped and WG would only retry after REKEY_TIMEOUT.
-func (d *UDPListener) ReadPackets() {
+func (d *UDPListener) ReadPackets() ActivityResult {
+	result := ActivityResultClosed
 	for {
 		buf := make([]byte, int(d.wgIface.MTU())+bufsize.WGBufferOverhead)
 		n, remoteAddr, err := d.conn.ReadFromUDP(buf)
@@ -72,6 +73,7 @@ func (d *UDPListener) ReadPackets() {
 		}
 		d.capturedPacket = slices.Clone(buf[:n])
 		d.peerCfg.Log.Infof("activity detected, captured %d bytes for reinjection", n)
+		result = ActivityResultTraffic
 		break
 	}
 
@@ -80,6 +82,7 @@ func (d *UDPListener) ReadPackets() {
 	// triggered activation.
 	_ = d.conn.Close()
 	d.done.Unlock()
+	return result
 }
 
 // CapturedPacket returns the first packet that triggered activity, or nil if none was captured.

--- a/client/internal/lazyconn/activity/manager.go
+++ b/client/internal/lazyconn/activity/manager.go
@@ -117,7 +117,13 @@ func (m *Manager) waitForTraffic(l listener, peerConnID peerid.ConnID) {
 	l.ReadPackets()
 
 	m.mu.Lock()
-	if _, ok := m.peers[peerConnID]; !ok {
+	cur, ok := m.peers[peerConnID]
+	if !ok || cur != l {
+		// The entry is gone (RemovePeer/Close) or was already replaced by a
+		// fresh listener for the same conn ID (remove -> re-arm churn). This
+		// goroutine no longer owns the map entry: it must neither delete the
+		// replacement nor fire an activity event on its behalf - a stale
+		// event would wake a peer without real traffic.
 		m.mu.Unlock()
 		return
 	}

--- a/client/internal/lazyconn/activity/manager.go
+++ b/client/internal/lazyconn/activity/manager.go
@@ -15,9 +15,27 @@ import (
 	peerid "github.com/netbirdio/netbird/client/internal/peer/id"
 )
 
+// ActivityResult reports why ReadPackets returned. waitForTraffic needs the
+// reason to disambiguate a listener that lost the removal/re-arm race: real
+// consumed traffic must still be delivered, while a Close() teardown must
+// stay silent.
+type ActivityResult int
+
+const (
+	// ActivityResultClosed means the listener was torn down (Close() or a
+	// read error) without consuming wake-worthy traffic. It is deliberately
+	// the zero value so a forgotten return path degrades to the conservative
+	// "no event" semantics.
+	ActivityResultClosed ActivityResult = iota
+	// ActivityResultTraffic means real traffic was consumed (kernel mode: a
+	// frame was captured for reinjection; userspace mode: an activity edge
+	// was signalled).
+	ActivityResultTraffic
+)
+
 // listener defines the contract for activity detection listeners.
 type listener interface {
-	ReadPackets()
+	ReadPackets() ActivityResult
 	Close()
 	CapturedPacket() []byte
 }
@@ -114,22 +132,33 @@ func (m *Manager) Close() {
 }
 
 func (m *Manager) waitForTraffic(l listener, peerConnID peerid.ConnID) {
-	l.ReadPackets()
+	result := l.ReadPackets()
 
 	m.mu.Lock()
 	cur, ok := m.peers[peerConnID]
-	if !ok || cur != l {
-		// The entry is gone (RemovePeer/Close) or was already replaced by a
-		// fresh listener for the same conn ID (remove -> re-arm churn). This
-		// goroutine no longer owns the map entry: it must neither delete the
-		// replacement nor fire an activity event on its behalf - a stale
-		// event would wake a peer without real traffic.
-		m.mu.Unlock()
-		return
+	owned := ok && cur == l
+	if owned {
+		delete(m.peers, peerConnID)
 	}
-	delete(m.peers, peerConnID)
 	m.mu.Unlock()
 
+	if !owned && result != ActivityResultTraffic {
+		// The entry is gone (RemovePeer/Close) or was already replaced by a
+		// fresh listener for the same conn ID (remove -> re-arm churn), and
+		// this listener was merely torn down. It must neither touch the
+		// replacement nor fire an event: a stale close event would wake a
+		// peer without real traffic.
+		return
+	}
+
+	// Two delivery cases:
+	//   owned: this goroutine still owns the map entry (deleted above).
+	//   !owned with traffic: the listener consumed real traffic but lost the
+	//   race against RemovePeer + re-arm. The replacement listener is left
+	//   untouched, but the consumed packet must still be delivered, otherwise
+	//   the first packet is blackholed (kernel mode: reinjection lost;
+	//   userspace mode: the only wake edge lost). The consumer ignores events
+	//   for unknown conn IDs and already-active peers.
 	m.notify(Event{PeerConnID: peerConnID, FirstPacket: l.CapturedPacket()})
 }
 

--- a/client/internal/lazyconn/activity/manager_test.go
+++ b/client/internal/lazyconn/activity/manager_test.go
@@ -198,8 +198,9 @@ func TestManager_MultiPeerActivity(t *testing.T) {
 // deterministically hold open the window between ReadPackets returning and
 // waitForTraffic acquiring m.mu (no sleeps).
 type fakeChurnListener struct {
-	released chan struct{} // closed by Close() (or by the test to simulate traffic)
-	proceed  chan struct{} // test gate: ReadPackets returns only after this is closed
+	released chan struct{}  // closed by Close() (or by the test to simulate traffic)
+	proceed  chan struct{}  // test gate: ReadPackets returns only after this is closed
+	result   ActivityResult // reason ReadPackets reports (zero value = Closed)
 	captured []byte
 }
 
@@ -210,9 +211,10 @@ func newFakeChurnListener() *fakeChurnListener {
 	}
 }
 
-func (f *fakeChurnListener) ReadPackets() {
+func (f *fakeChurnListener) ReadPackets() ActivityResult {
 	<-f.released
 	<-f.proceed
+	return f.result
 }
 
 func (f *fakeChurnListener) Close() {
@@ -286,6 +288,7 @@ func TestManager_WaitForTraffic_StaleListenerMustNotDisarmReplacement(t *testing
 	// Step 5: B stays fully functional - traffic (released without Close,
 	// then proceed) delivers exactly one event and B removes itself.
 	b.captured = []byte{0x01}
+	b.result = ActivityResultTraffic
 	close(b.released)
 	close(b.proceed)
 	select {
@@ -303,6 +306,74 @@ func TestManager_WaitForTraffic_StaleListenerMustNotDisarmReplacement(t *testing
 	}
 	if _, ok := mgr.GetPeerListener(connID); ok {
 		t.Fatal("listener B must have removed itself after delivering traffic")
+	}
+}
+
+// TestManager_WaitForTraffic_RealTrafficSurvivesRemoveRearm pins the reason
+// contract: listener A consumes REAL traffic, then loses the m.mu race
+// against RemovePeer + re-arm (B, same conn ID). B must stay armed
+// (identity guard), but A's event including the captured packet must still
+// be delivered - otherwise the first packet is blackholed (kernel mode:
+// reinjection lost; userspace mode: the only wake edge lost).
+func TestManager_WaitForTraffic_RealTrafficSurvivesRemoveRearm(t *testing.T) {
+	mgr := NewManager(&MocWGIface{})
+	defer mgr.Close()
+
+	peer := &MocPeer{PeerID: "examplePublicKeyChurnTraffic"}
+	connID := peer.ConnID()
+	logger := log.WithField("peer", peer.PeerID)
+
+	// Step 1: arm listener A; A will report real traffic.
+	a := newFakeChurnListener()
+	a.result = ActivityResultTraffic
+	a.captured = []byte{0x04, 0x00, 0x00, 0x00, 0xAA, 0xBB}
+	aDone := mgr.armListener(connID, a)
+
+	// Step 2: A consumes traffic (released without Close) but is held right
+	// before acquiring m.mu.
+	close(a.released)
+
+	// Step 3: RemovePeer + re-arm B run inside the race window.
+	mgr.RemovePeer(logger, connID)
+	b := newFakeChurnListener()
+	bDone := mgr.armListener(connID, b)
+
+	// Step 4: A's goroutine loses the race only now.
+	close(a.proceed)
+	select {
+	case <-aDone:
+	case <-time.After(5 * time.Second): // hang protection only
+		t.Fatal("listener A goroutine did not finish")
+	}
+
+	// Core asserts: B stays armed AND A's real event is delivered.
+	if cur, ok := mgr.GetPeerListener(connID); !ok || cur != listener(b) {
+		t.Fatal("map entry must still be exactly listener B")
+	}
+	select {
+	case ev := <-mgr.OnActivityChan:
+		if ev.PeerConnID != connID {
+			t.Fatalf("wrong conn ID in delivered event: %v", ev.PeerConnID)
+		}
+		if !bytes.Equal(ev.FirstPacket, a.captured) {
+			t.Fatalf("event must carry A's captured packet, got %v", ev.FirstPacket)
+		}
+	default:
+		t.Fatal("real traffic consumed by the raced-out listener must be delivered")
+	}
+
+	// Teardown: remove B via the close path - no further event.
+	mgr.RemovePeer(logger, connID)
+	close(b.proceed)
+	select {
+	case <-bDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener B goroutine did not finish")
+	}
+	select {
+	case ev := <-mgr.OnActivityChan:
+		t.Fatalf("closed listener B must not fire an event (got %v)", ev.PeerConnID)
+	default:
 	}
 }
 

--- a/client/internal/lazyconn/activity/manager_test.go
+++ b/client/internal/lazyconn/activity/manager_test.go
@@ -194,6 +194,118 @@ func TestManager_MultiPeerActivity(t *testing.T) {
 	}
 }
 
+// fakeChurnListener implements the listener interface with channel gates to
+// deterministically hold open the window between ReadPackets returning and
+// waitForTraffic acquiring m.mu (no sleeps).
+type fakeChurnListener struct {
+	released chan struct{} // closed by Close() (or by the test to simulate traffic)
+	proceed  chan struct{} // test gate: ReadPackets returns only after this is closed
+	captured []byte
+}
+
+func newFakeChurnListener() *fakeChurnListener {
+	return &fakeChurnListener{
+		released: make(chan struct{}),
+		proceed:  make(chan struct{}),
+	}
+}
+
+func (f *fakeChurnListener) ReadPackets() {
+	<-f.released
+	<-f.proceed
+}
+
+func (f *fakeChurnListener) Close() {
+	select {
+	case <-f.released:
+	default:
+		close(f.released)
+	}
+}
+
+func (f *fakeChurnListener) CapturedPacket() []byte { return f.captured }
+
+// armListener mirrors MonitorPeerActivity for injected fake listeners:
+// register under m.mu, then start waitForTraffic. Returns a channel that is
+// closed when the goroutine finishes.
+func (m *Manager) armListener(connID peerid.ConnID, l listener) chan struct{} {
+	m.mu.Lock()
+	m.peers[connID] = l
+	m.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		m.waitForTraffic(l, connID)
+		close(done)
+	}()
+	return done
+}
+
+// TestManager_WaitForTraffic_StaleListenerMustNotDisarmReplacement pins the
+// identity guard in waitForTraffic: a stale goroutine (listener A) that loses
+// the m.mu race against RemovePeer + re-arm (listener B, same conn ID) must
+// neither delete B from the map nor fire an activity event.
+func TestManager_WaitForTraffic_StaleListenerMustNotDisarmReplacement(t *testing.T) {
+	mgr := NewManager(&MocWGIface{})
+	defer mgr.Close()
+
+	peer := &MocPeer{PeerID: "examplePublicKeyChurn"}
+	connID := peer.ConnID()
+	logger := log.WithField("peer", peer.PeerID)
+
+	// Step 1: arm listener A; its goroutine blocks in ReadPackets.
+	a := newFakeChurnListener()
+	aDone := mgr.armListener(connID, a)
+
+	// Step 2: RemovePeer closes A; A's goroutine is held right before
+	// acquiring m.mu by the proceed gate.
+	mgr.RemovePeer(logger, connID)
+
+	// Step 3: re-arm a fresh listener B for the same conn ID.
+	b := newFakeChurnListener()
+	bDone := mgr.armListener(connID, b)
+
+	// Step 4: A's goroutine loses the race only now.
+	close(a.proceed)
+	select {
+	case <-aDone:
+	case <-time.After(5 * time.Second): // hang protection only
+		t.Fatal("listener A goroutine did not finish")
+	}
+
+	// Core asserts: B must stay armed, and A must not have fired an event.
+	if cur, ok := mgr.GetPeerListener(connID); !ok || cur != listener(b) {
+		t.Fatal("map entry must still be exactly listener B")
+	}
+	select {
+	case ev := <-mgr.OnActivityChan:
+		t.Fatalf("closed stale listener must not fire an event (got %v)", ev.PeerConnID)
+	default:
+	}
+
+	// Step 5: B stays fully functional - traffic (released without Close,
+	// then proceed) delivers exactly one event and B removes itself.
+	b.captured = []byte{0x01}
+	close(b.released)
+	close(b.proceed)
+	select {
+	case <-bDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener B goroutine did not finish")
+	}
+	select {
+	case ev := <-mgr.OnActivityChan:
+		if ev.PeerConnID != connID {
+			t.Fatalf("unexpected conn ID: %v", ev.PeerConnID)
+		}
+	default:
+		t.Fatal("live listener B must deliver its traffic event")
+	}
+	if _, ok := mgr.GetPeerListener(connID); ok {
+		t.Fatal("listener B must have removed itself after delivering traffic")
+	}
+}
+
 func trigger(addr string) error {
 	// Create a connection to the destination UDP address and port
 	conn, err := net.Dial("udp", addr)


### PR DESCRIPTION
## Describe your changes

`activity.Manager.waitForTraffic` deletes the peers map entry by conn ID
only, without checking that the entry still belongs to the listener the
goroutine owns:

```go
m.mu.Lock()
if _, ok := m.peers[peerConnID]; !ok { ... }
delete(m.peers, peerConnID)
```

This is a latent race, triggered under rapid re-arm: `RemovePeer`
followed by `MonitorPeerActivity` for the same conn ID (for example when
a peer is removed and re-added around a lazy-connection exclude-list
update, or activation followed by the inactivity re-arm). A goroutine
whose listener was already closed can be parked between `ReadPackets`
returning and acquiring `m.mu`; when it wakes up it then:

1. deletes the **fresh** replacement listener from the map — the
   replacement keeps reading but is no longer reachable via `RemovePeer`
   (leak), and its future real traffic event is dropped by the map check,
   leaving the peer unwakeable, and
2. fires a stale activity event with a nil first packet — a spurious wake
   without real traffic.

Fix, part 1: compare-and-delete under `m.mu` — only delete and notify when
the map entry still points at the exact listener this goroutine owns.
Listener objects are never re-inserted, so pointer identity is a safe
ownership token.

Fix, part 2: the naive guard alone would drop **real** traffic consumed by
the raced-out listener (kernel mode: the captured frame for reinjection is
lost; userspace bind mode: the only wake edge is lost). `ReadPackets` now
reports why it returned (`ActivityResultTraffic` vs
`ActivityResultClosed`); a raced-out listener that consumed real traffic
still delivers its event including the captured packet, while leaving the
replacement listener untouched. The consumer (`onPeerActivity`) is
idempotent: unknown conn IDs are ignored and the `expectedWatcher` guard
drops duplicate activations.

Tests: two deterministic churn tests using channel-gated fake listeners
(no sleeps) — one pinning that a stale closed listener neither disarms the
replacement nor fires an event, one pinning that real consumed traffic
survives the remove/re-arm race. Both pass under `-race`.

## Issue ticket number and link

-

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787060579&installation_id=146802194&pr_number=6827&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6827&signature=08d1722f152a29e654b766dc1454ecc8e6c0683d88efbb5efb2653d8a00c9cbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity monitoring to distinguish closed connections from connections that received traffic.
  * Prevented stale listeners from disrupting replacement listeners during rapid connection changes.
  * Preserved detected traffic events and packet data even when a listener is replaced.
  * Improved reliability when removing and re-arming connections under concurrent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->