### PR TITLE
[client] Drop stale connection-cycle callbacks after peer conn reopen

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -404,11 +404,17 @@ func (conn *Conn) ConnID() id.ConnID {
 }
 
 // configureConnection starts proxying traffic from/to local Wireguard and sets connection status to StatusConnected
-func (conn *Conn) onICEConnectionIsReady(priority conntype.ConnPriority, iceConnInfo ICEConnInfo) {
+//
+// ctx is the connection cycle that produced this callback (the workers'
+// creation context). Checking it in addition to conn.ctx drops callbacks
+// that straddle a Close()+Open() sequence: conn.ctx is replaced on reopen,
+// so it alone cannot detect a callback from the previous cycle (same
+// pattern as onWGDisconnected's watcherCtx).
+func (conn *Conn) onICEConnectionIsReady(ctx context.Context, priority conntype.ConnPriority, iceConnInfo ICEConnInfo) {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 
-	if conn.ctx.Err() != nil {
+	if conn.ctx.Err() != nil || ctx.Err() != nil {
 		return
 	}
 
@@ -485,11 +491,11 @@ func (conn *Conn) onICEConnectionIsReady(priority conntype.ConnPriority, iceConn
 	conn.doOnConnected(iceConnInfo.RosenpassPubKey, iceConnInfo.RosenpassAddr, updateTime)
 }
 
-func (conn *Conn) onICEStateDisconnected(sessionChanged bool) {
+func (conn *Conn) onICEStateDisconnected(ctx context.Context, sessionChanged bool) {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 
-	if conn.ctx.Err() != nil {
+	if conn.ctx.Err() != nil || ctx.Err() != nil {
 		return
 	}
 
@@ -549,11 +555,11 @@ func (conn *Conn) onICEStateDisconnected(sessionChanged bool) {
 	}
 }
 
-func (conn *Conn) onRelayConnectionIsReady(rci RelayConnInfo) {
+func (conn *Conn) onRelayConnectionIsReady(ctx context.Context, rci RelayConnInfo) {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 
-	if conn.ctx.Err() != nil {
+	if conn.ctx.Err() != nil || ctx.Err() != nil {
 		if err := rci.relayedConn.Close(); err != nil {
 			conn.Log.Warnf("failed to close unnecessary relayed connection: %v", err)
 		}
@@ -568,7 +574,7 @@ func (conn *Conn) onRelayConnectionIsReady(rci RelayConnInfo) {
 		conn.Log.Errorf("failed to add relayed net.Conn to local proxy: %v", err)
 		return
 	}
-	wgProxy.SetDisconnectListener(conn.onRelayDisconnected)
+	wgProxy.SetDisconnectListener(func() { conn.onRelayDisconnected(ctx) })
 
 	conn.dumpState.NewLocalProxy()
 
@@ -613,9 +619,17 @@ func (conn *Conn) onRelayConnectionIsReady(rci RelayConnInfo) {
 	conn.doOnConnected(rci.rosenpassPubKey, rci.rosenpassAddr, updateTime)
 }
 
-func (conn *Conn) onRelayDisconnected() {
+func (conn *Conn) onRelayDisconnected(ctx context.Context) {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
+
+	// Relay-manager close listeners and proxy disconnect listeners are
+	// registered per cycle but outlive Conn.Close; drop callbacks whose
+	// cycle is gone (see onICEConnectionIsReady).
+	if ctx.Err() != nil {
+		return
+	}
+
 	conn.handleRelayDisconnectedLocked()
 }
 

--- a/client/internal/peer/conn_test.go
+++ b/client/internal/peer/conn_test.go
@@ -3,17 +3,27 @@ package peer
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
+	"net/netip"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/netbirdio/netbird/client/iface"
+	"github.com/netbirdio/netbird/client/iface/configurer"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
+	"github.com/netbirdio/netbird/client/iface/wgproxy"
+	"github.com/netbirdio/netbird/client/internal/peer/conntype"
 	"github.com/netbirdio/netbird/client/internal/peer/dispatcher"
 	"github.com/netbirdio/netbird/client/internal/peer/guard"
 	"github.com/netbirdio/netbird/client/internal/peer/ice"
+	"github.com/netbirdio/netbird/client/internal/peer/worker"
 	"github.com/netbirdio/netbird/client/internal/stdnet"
 	"github.com/netbirdio/netbird/util"
 )
@@ -385,4 +395,161 @@ func TestConn_onWGDisconnected_NoEscalationWithoutRosenpass(t *testing.T) {
 		conn.onWGDisconnected(conn.ctx)
 	}
 	assert.Empty(t, disconnected, "escalation must be limited to rosenpass connections")
+}
+
+type mockCycleWGIface struct {
+	updatePeerCalls     atomic.Int32
+	removeEndpointCalls atomic.Int32
+}
+
+func (m *mockCycleWGIface) UpdatePeer(string, []netip.Prefix, time.Duration, *net.UDPAddr, *wgtypes.Key) error {
+	m.updatePeerCalls.Add(1)
+	return nil
+}
+func (m *mockCycleWGIface) RemovePeer(string) error { return nil }
+func (m *mockCycleWGIface) GetStats() (map[string]configurer.WGStats, error) {
+	return map[string]configurer.WGStats{}, nil
+}
+func (m *mockCycleWGIface) GetProxy() wgproxy.Proxy { return nil }
+func (m *mockCycleWGIface) Address() wgaddr.Address { return wgaddr.Address{} }
+func (m *mockCycleWGIface) RemoveEndpointAddress(string) error {
+	m.removeEndpointCalls.Add(1)
+	return nil
+}
+
+// fakeRemoteConn is a minimal net.Conn with UDP-shaped addresses so the
+// non-relayed ICE-ready path can resolve an endpoint.
+type fakeRemoteConn struct{}
+
+func (fakeRemoteConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (fakeRemoteConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (fakeRemoteConn) Close() error                     { return nil }
+func (fakeRemoteConn) LocalAddr() net.Addr              { return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1} }
+func (fakeRemoteConn) RemoteAddr() net.Addr             { return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2} }
+func (fakeRemoteConn) SetDeadline(time.Time) error      { return nil }
+func (fakeRemoteConn) SetReadDeadline(time.Time) error  { return nil }
+func (fakeRemoteConn) SetWriteDeadline(time.Time) error { return nil }
+
+// newCycleTestConn builds a Conn the way the callback-level tests need it:
+// liveCtx plays the role of the CURRENT cycle's conn.ctx.
+func newCycleTestConn(t *testing.T, liveCtx context.Context, iface WGIface) *Conn {
+	t.Helper()
+	cfg := ConnConfig{
+		Key:      "LLHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
+		LocalKey: "RRHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
+		WgConfig: WgConfig{
+			RemoteKey:   "LLHf3Ma6z6mdLbriAJbqhX7+nM/B71lgw2+91q3LfhU=",
+			WgInterface: iface,
+		},
+	}
+	logEntry := log.WithField("peer", cfg.Key)
+	statusRecorder := NewRecorder("https://mgm")
+	return &Conn{
+		ctx:             liveCtx,
+		config:          cfg,
+		Log:             logEntry,
+		statusICE:       worker.NewAtomicStatus(),
+		statusRelay:     worker.NewAtomicStatus(),
+		statusRecorder:  statusRecorder,
+		metricsStages:   &MetricsStages{},
+		dumpState:       newStateDump(cfg.Key, logEntry, statusRecorder),
+		endpointUpdater: NewEndpointUpdater(logEntry, cfg.WgConfig, isController(cfg)),
+		guard: guard.NewGuard(logEntry, func() guard.ConnStatus { return guard.ConnStatusConnected },
+			time.Second, guard.NewSRWatcher(nil, nil, nil, connConf.ICEConfig)),
+	}
+}
+
+// staleCycleCtx returns a cancelled context standing in for a closed
+// previous connection cycle.
+func staleCycleCtx() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+// TestConn_onICEStateDisconnected_IgnoresStaleCycle: a disconnect callback
+// from a previous connection cycle (its cycle context is cancelled) must not
+// tear down the state of the current cycle, while the same callback from the
+// live cycle still must.
+func TestConn_onICEStateDisconnected_IgnoresStaleCycle(t *testing.T) {
+	liveCtx, liveCancel := context.WithCancel(context.Background())
+	defer liveCancel()
+
+	iface := &mockCycleWGIface{}
+	conn := newCycleTestConn(t, liveCtx, iface)
+	conn.statusICE.SetConnected()
+	conn.currentConnPriority = conntype.ICEP2P
+
+	conn.onICEStateDisconnected(staleCycleCtx(), false)
+
+	assert.Equal(t, worker.StatusConnected, conn.statusICE.Get(), "stale callback must not touch live ICE status")
+	assert.Equal(t, conntype.ICEP2P, conn.currentConnPriority, "stale callback must not reset live priority")
+	assert.EqualValues(t, 0, iface.removeEndpointCalls.Load(), "stale callback must not remove the live endpoint")
+
+	// Control: the same callback from the live cycle must still tear down.
+	conn.onICEStateDisconnected(liveCtx, false)
+	assert.Equal(t, worker.StatusDisconnected, conn.statusICE.Get())
+	assert.Equal(t, conntype.None, conn.currentConnPriority)
+	assert.EqualValues(t, 1, iface.removeEndpointCalls.Load())
+}
+
+// TestConn_onICEConnectionIsReady_IgnoresStaleCycle: a success callback from
+// a previous cycle must not configure the WireGuard endpoint of the current
+// cycle to a dead connection.
+func TestConn_onICEConnectionIsReady_IgnoresStaleCycle(t *testing.T) {
+	liveCtx, liveCancel := context.WithCancel(context.Background())
+	defer liveCancel()
+
+	iface := &mockCycleWGIface{}
+	conn := newCycleTestConn(t, liveCtx, iface)
+
+	conn.onICEConnectionIsReady(staleCycleCtx(), conntype.ICEP2P, ICEConnInfo{RemoteConn: fakeRemoteConn{}})
+
+	assert.NotEqual(t, worker.StatusConnected, conn.statusICE.Get(), "stale ready callback must not mark ICE connected")
+	assert.Equal(t, conntype.None, conn.currentConnPriority, "stale ready callback must not raise the priority")
+	assert.EqualValues(t, 0, iface.updatePeerCalls.Load(), "stale ready callback must not configure the WG endpoint")
+	assert.Nil(t, conn.wgWatcher, "stale ready callback must not start a watcher")
+}
+
+// TestConn_onRelayDisconnected_IgnoresStaleCycle mirrors the ICE disconnect
+// test for the relay path (relay-manager close listeners outlive the cycle).
+func TestConn_onRelayDisconnected_IgnoresStaleCycle(t *testing.T) {
+	liveCtx, liveCancel := context.WithCancel(context.Background())
+	defer liveCancel()
+
+	iface := &mockCycleWGIface{}
+	conn := newCycleTestConn(t, liveCtx, iface)
+	conn.statusRelay.SetConnected()
+	conn.currentConnPriority = conntype.Relay
+
+	conn.onRelayDisconnected(staleCycleCtx())
+
+	assert.Equal(t, worker.StatusConnected, conn.statusRelay.Get(), "stale callback must not touch live relay status")
+	assert.Equal(t, conntype.Relay, conn.currentConnPriority)
+	assert.EqualValues(t, 0, iface.removeEndpointCalls.Load())
+
+	// Control: live cycle still tears down.
+	conn.onRelayDisconnected(liveCtx)
+	assert.Equal(t, worker.StatusDisconnected, conn.statusRelay.Get())
+	assert.Equal(t, conntype.None, conn.currentConnPriority)
+	assert.EqualValues(t, 1, iface.removeEndpointCalls.Load())
+}
+
+// TestConn_onRelayConnectionIsReady_IgnoresStaleCycle: a stale relay-ready
+// callback must close the relayed connection and leave the state untouched.
+func TestConn_onRelayConnectionIsReady_IgnoresStaleCycle(t *testing.T) {
+	liveCtx, liveCancel := context.WithCancel(context.Background())
+	defer liveCancel()
+
+	iface := &mockCycleWGIface{}
+	conn := newCycleTestConn(t, liveCtx, iface)
+
+	c1, c2 := net.Pipe()
+	defer c2.Close()
+
+	conn.onRelayConnectionIsReady(staleCycleCtx(), RelayConnInfo{relayedConn: c1})
+
+	assert.NotEqual(t, worker.StatusConnected, conn.statusRelay.Get(), "stale relay-ready must not mark relay connected")
+	_, err := c2.Write([]byte{0x1})
+	assert.ErrorIs(t, err, io.ErrClosedPipe, "stale relay conn must be closed")
 }

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -306,7 +306,7 @@ func (w *WorkerICE) connect(ctx context.Context, agent *icemaker.ThreadSafeAgent
 	w.muxAgent.Unlock()
 
 	// todo: the potential problem is a race between the onConnectionStateChange
-	w.conn.onICEConnectionIsReady(selectedPriority(pair), ci)
+	w.conn.onICEConnectionIsReady(w.ctx, selectedPriority(pair), ci)
 }
 
 func (w *WorkerICE) closeAgent(agent *icemaker.ThreadSafeAgent, cancel context.CancelFunc) bool {
@@ -524,7 +524,7 @@ func (w *WorkerICE) onConnectionStateChange(agent *icemaker.ThreadSafeAgent, dia
 
 			if w.lastKnownState == ice.ConnectionStateConnected {
 				w.lastKnownState = ice.ConnectionStateDisconnected
-				w.conn.onICEStateDisconnected(sessionChanged)
+				w.conn.onICEStateDisconnected(w.ctx, sessionChanged)
 			}
 		default:
 			return

--- a/client/internal/peer/worker_relay.go
+++ b/client/internal/peer/worker_relay.go
@@ -88,7 +88,7 @@ func (w *WorkerRelay) OnNewOffer(remoteOfferAnswer *OfferAnswer) {
 	}
 
 	w.log.Debugf("peer conn opened via Relay: %s", srv)
-	go w.conn.onRelayConnectionIsReady(RelayConnInfo{
+	go w.conn.onRelayConnectionIsReady(w.peerCtx, RelayConnInfo{
 		relayedConn:     relayedConn,
 		rosenpassPubKey: remoteOfferAnswer.RosenpassPubKey,
 		rosenpassAddr:   remoteOfferAnswer.RosenpassAddr,
@@ -134,5 +134,5 @@ func (w *WorkerRelay) preferredRelayServer(myRelayAddress, remoteRelayAddress st
 }
 
 func (w *WorkerRelay) onRelayClientDisconnected() {
-	go w.conn.onRelayDisconnected()
+	go w.conn.onRelayDisconnected(w.peerCtx)
 }


### PR DESCRIPTION
## Describe your changes

`Conn.Close()` cancels `conn.ctx`; `Conn.Open()` replaces it with a fresh
context. Several worker callbacks spawned in the previous connection cycle
can fire after such a Close+Open pair, and their only staleness guard is
`conn.ctx.Err()` - which belongs to the NEW cycle and therefore passes:

- `onICEConnectionIsReady`, called from the untracked `go w.connect(...)`
  goroutine: a dial that succeeded just before Close can configure the
  WireGuard endpoint of the fresh cycle to a dead remote connection and
  mark `statusICE` connected.
- `onICEStateDisconnected`, called from the old agent's pion
  connection-state callback: resets the fresh cycle's priority to None,
  removes the live WG endpoint and triggers a spurious guard reconnect.
- `onRelayConnectionIsReady`, dispatched via `go` from the relay worker.
- `onRelayDisconnected`, reachable both through the wgproxy disconnect
  listener and through relay-manager close listeners, which are never
  deregistered on `Conn.Close` and can fire arbitrarily late.

Fix: thread the connection-cycle context (the workers' creation context;
`WorkerICE.ctx` / `WorkerRelay.peerCtx` are the `conn.ctx` of the cycle
that created them) into these four callbacks and drop the callback when
that context is cancelled. This is the same pattern `onWGDisconnected`
already uses with `watcherCtx`. `Close()` cancels the cycle context while
holding `conn.mu`, so the check is race-free with respect to teardown and
reopen.

No behavior change within a live cycle: there the cycle context and
`conn.ctx` are the same object, so the combined check is equivalent to the
existing one.

Tests: deterministic callback-level tests (no sleeps, `-race` clean)
pinning for each callback that a cancelled-cycle invocation leaves the
live state untouched (status, priority, endpoint calls) while a live-cycle
invocation still performs the normal transition; the stale relay-ready
test also pins that the relayed connection is closed.

## Issue ticket number and link

-

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787060582&installation_id=146802194&pr_number=6828&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6828&signature=b78d85f4540f608efd5f6c77cef1f59c91c24530363acd80ea29feb7b5019edf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delayed connection and relay events from previous connection cycles from changing current connection state.
  * Improved handling of stale callbacks after a connection is closed and reopened.
  * Ensured obsolete relay connections are closed safely when their callbacks arrive late.
* **Tests**
  * Added coverage verifying that stale events are ignored while current-cycle events continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->