### PR TITLE
[client] Always connect on profile selection except in manage profiles

### DIFF
--- a/client/ui/frontend/src/contexts/ProfileContext.tsx
+++ b/client/ui/frontend/src/contexts/ProfileContext.tsx
@@ -28,6 +28,7 @@ type ProfileContextValue = {
     loaded: boolean;
     refresh: () => Promise<void>;
     switchProfile: (id: string) => Promise<void>;
+    switchProfileNoConnect: (id: string) => Promise<void>;
     addProfile: (name: string) => Promise<string>;
     removeProfile: (id: string) => Promise<void>;
     renameProfile: (id: string, newName: string) => Promise<void>;
@@ -112,6 +113,16 @@ export const ProfileProvider = ({ children }: { children: ReactNode }) => {
         [username, refresh],
     );
 
+    // Manage-profiles variant: switches without connecting, so the user can
+    // still adjust the management URL before bringing the connection up.
+    const switchProfileNoConnect = useCallback(
+        async (id: string) => {
+            await ProfileSwitcher.SwitchActiveNoConnect({ profileName: id, username });
+            await refresh();
+        },
+        [username, refresh],
+    );
+
     // addProfile creates a profile by display name and returns the
     // daemon-generated ID, so the caller can immediately address it by ID.
     const addProfile = useCallback(
@@ -158,6 +169,7 @@ export const ProfileProvider = ({ children }: { children: ReactNode }) => {
             loaded,
             refresh,
             switchProfile,
+            switchProfileNoConnect,
             addProfile,
             removeProfile,
             renameProfile,
@@ -171,6 +183,7 @@ export const ProfileProvider = ({ children }: { children: ReactNode }) => {
             loaded,
             refresh,
             switchProfile,
+            switchProfileNoConnect,
             addProfile,
             removeProfile,
             renameProfile,

--- a/client/ui/frontend/src/modules/profiles/ProfilesTab.tsx
+++ b/client/ui/frontend/src/modules/profiles/ProfilesTab.tsx
@@ -45,7 +45,7 @@ export function ProfilesTab() {
         activeProfileId,
         loaded,
         username,
-        switchProfile,
+        switchProfileNoConnect,
         addProfile,
         removeProfile,
         renameProfile,
@@ -100,7 +100,7 @@ export function ProfilesTab() {
             confirmLabel: t("profile.switch.confirm"),
         });
         if (!ok) return;
-        await guarded(i18next.t("profile.error.switchTitle"), () => switchProfile(id));
+        await guarded(i18next.t("profile.error.switchTitle"), () => switchProfileNoConnect(id));
     };
 
     const handleDeregister = async (id: string, name: string) => {
@@ -129,14 +129,13 @@ export function ProfilesTab() {
         await guarded(i18next.t("profile.error.createTitle"), async () => {
             const id = await addProfile(name);
             // SetConfig is keyed by the new profile's ID, so it writes the
-            // not-yet-active profile. Write before switching so any reconnect
-            // targets the right deployment.
+            // not-yet-active profile before the switch makes it current.
             if (!isNetbirdCloud(managementUrl)) {
                 await SettingsSvc.SetConfig(
                     new SetConfigParams({ profileName: id, username, managementUrl }),
                 );
             }
-            await switchProfile(id);
+            await switchProfileNoConnect(id);
         });
     };
 

--- a/client/ui/services/profileswitcher.go
+++ b/client/ui/services/profileswitcher.go
@@ -44,10 +44,12 @@ func (s *ProfileSwitcher) SwitchActiveNoConnect(ctx context.Context, p ProfileRe
 
 func (s *ProfileSwitcher) switchActive(ctx context.Context, p ProfileRef, connect bool) error {
 	prevStatus := ""
-	if st, err := s.feed.Get(ctx); err == nil {
-		prevStatus = st.Status
-	} else {
-		log.Warnf("profileswitcher: get status: %v", err)
+	if s.feed != nil {
+		if st, err := s.feed.Get(ctx); err == nil {
+			prevStatus = st.Status
+		} else {
+			log.Warnf("profileswitcher: get status: %v", err)
+		}
 	}
 
 	needsDown := strings.EqualFold(prevStatus, StatusConnected) ||
@@ -62,7 +64,7 @@ func (s *ProfileSwitcher) switchActive(ctx context.Context, p ProfileRef, connec
 	// Optimistic Connecting paint plus stale-push suppression during Down (see
 	// DaemonFeed suppression table); also arms the login-watch that pops
 	// browser-login when the new profile turns out to need SSO.
-	if connect {
+	if connect && s.feed != nil {
 		s.feed.BeginProfileSwitch()
 	}
 

--- a/client/ui/services/profileswitcher.go
+++ b/client/ui/services/profileswitcher.go
@@ -12,13 +12,15 @@ import (
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 )
 
-// ProfileSwitcher holds the reconnect policy shared by the tray and React
-// frontend so both flip profiles identically. The policy keys off prevStatus
-// from DaemonFeed.Get at SwitchActive entry:
+// ProfileSwitcher holds the switch policy shared by the tray and React
+// frontend so both flip profiles identically. SwitchActive (plain selection:
+// header dropdown, tray submenu) always connects after the switch;
+// SwitchActiveNoConnect (manage-profiles screen) never does, so the user can
+// still adjust the management URL before connecting. prevStatus from
+// DaemonFeed.Get at entry only decides the teardown:
 //
-//	Connected/Connecting → Switch + Down + Up; optimistic Connecting paint.
-//	NeedsLogin/LoginFailed/SessionExpired → Switch + Down; clear stale error for re-login.
-//	Idle → Switch only.
+//	Connected/Connecting/NeedsLogin/LoginFailed/SessionExpired → Down first.
+//	Idle → no Down.
 type ProfileSwitcher struct {
 	profiles   *Profiles
 	connection *Connection
@@ -29,8 +31,18 @@ func NewProfileSwitcher(profiles *Profiles, connection *Connection, feed *Daemon
 	return &ProfileSwitcher{profiles: profiles, connection: connection, feed: feed}
 }
 
-// SwitchActive switches to the named profile applying the reconnect policy.
+// SwitchActive switches to the named profile and always connects afterwards.
 func (s *ProfileSwitcher) SwitchActive(ctx context.Context, p ProfileRef) error {
+	return s.switchActive(ctx, p, true)
+}
+
+// SwitchActiveNoConnect switches to the named profile without connecting,
+// tearing down any existing connection first.
+func (s *ProfileSwitcher) SwitchActiveNoConnect(ctx context.Context, p ProfileRef) error {
+	return s.switchActive(ctx, p, false)
+}
+
+func (s *ProfileSwitcher) switchActive(ctx context.Context, p ProfileRef, connect bool) error {
 	prevStatus := ""
 	if st, err := s.feed.Get(ctx); err == nil {
 		prevStatus = st.Status
@@ -38,20 +50,19 @@ func (s *ProfileSwitcher) SwitchActive(ctx context.Context, p ProfileRef) error 
 		log.Warnf("profileswitcher: get status: %v", err)
 	}
 
-	wasActive := strings.EqualFold(prevStatus, StatusConnected) ||
-		strings.EqualFold(prevStatus, StatusConnecting)
-	needsDown := wasActive ||
+	needsDown := strings.EqualFold(prevStatus, StatusConnected) ||
+		strings.EqualFold(prevStatus, StatusConnecting) ||
 		strings.EqualFold(prevStatus, StatusNeedsLogin) ||
 		strings.EqualFold(prevStatus, StatusLoginFailed) ||
 		strings.EqualFold(prevStatus, StatusSessionExpired)
 
-	log.Infof("profileswitcher: switch profile=%q prevStatus=%q wasActive=%v needsDown=%v",
-		p.ProfileName, prevStatus, wasActive, needsDown)
+	log.Infof("profileswitcher: switch profile=%q prevStatus=%q connect=%v needsDown=%v",
+		p.ProfileName, prevStatus, connect, needsDown)
 
-	// Optimistic Connecting paint only when wasActive: those prevStatuses emit
-	// stale Connected + transient Idle pushes during Down that must be
-	// suppressed until Up resumes the stream (see DaemonFeed suppression table).
-	if wasActive {
+	// Optimistic Connecting paint plus stale-push suppression during Down (see
+	// DaemonFeed suppression table); also arms the login-watch that pops
+	// browser-login when the new profile turns out to need SSO.
+	if connect {
 		s.feed.BeginProfileSwitch()
 	}
 
@@ -76,9 +87,9 @@ func (s *ProfileSwitcher) SwitchActive(ctx context.Context, p ProfileRef) error 
 		}
 	}
 
-	if wasActive {
+	if connect {
 		if err := s.connection.Up(ctx, UpParams(p)); err != nil {
-			return fmt.Errorf("reconnect %q: %w", p.ProfileName, err)
+			return fmt.Errorf("connect %q: %w", p.ProfileName, err)
 		}
 	}
 


### PR DESCRIPTION
Selecting a profile from the header dropdown or the tray submenu now always brings the connection up after the switch, regardless of the previous daemon state. Switching from the manage-profiles screen (including profile creation) never connects, leaving a chance to adjust the management URL first.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787157550&installation_model_id=427504&pr_number=6838&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6838&signature=8fe9c5f0779df46c76b4135a373591762eb1498d890ff6996626fb75d6433e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to switch profiles without automatically establishing a connection.
  * Existing profile switching continues to connect when appropriate, while safely handling active or pending connections during the switch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->