### PR TITLE
[client] Add CI check for translation key parity

### DIFF
--- a/.github/workflows/ui-translations.yml
+++ b/.github/workflows/ui-translations.yml
@@ -1,0 +1,42 @@
+name: UI Translations
+
+on:
+  pull_request:
+    paths:
+      - "client/ui/i18n/locales/**"
+      - "client/ui/i18n/check-translations.mjs"
+      - ".github/workflows/ui-translations.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "client/ui/i18n/locales/**"
+      - "client/ui/i18n/check-translations.mjs"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-translations:
+    name: Check translation key parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # English (en) is the source of truth for translation keys; every other
+      # locale declared in _index.json must carry the exact same key set.
+      - name: Check translation key parity
+        run: node client/ui/i18n/check-translations.mjs

--- a/client/ui/frontend/package.json
+++ b/client/ui/frontend/package.json
@@ -15,7 +15,8 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "check": "pnpm lint && pnpm typecheck && pnpm format:check",
-    "check:fix": "pnpm lint:fix && pnpm format && pnpm typecheck"
+    "check:fix": "pnpm lint:fix && pnpm format && pnpm typecheck",
+    "i18n:check": "node ../i18n/check-translations.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/client/ui/i18n/check-translations.mjs
+++ b/client/ui/i18n/check-translations.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Validates that every shipped translation bundle carries exactly the same set
+// of keys as the English source of truth. English (en) defines the keys; every
+// other locale declared in _index.json must match it 1:1:
+//
+//   - no missing keys — a missing key silently falls back to English at runtime
+//     (see i18n bundle fallback), so the gap never surfaces to users or CI
+//     without this check;
+//   - no orphaned keys — keys left behind after an English key is renamed or
+//     removed are dead weight and a sign the locale is drifting.
+//
+// Pure Node, no dependencies, so it runs without installing the frontend
+// toolchain.
+//
+//   Local:  node client/ui/i18n/check-translations.mjs   (or: pnpm i18n:check)
+//   CI:     .github/workflows/ui-translations.yml
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SOURCE = "en";
+const localesDir = join(dirname(fileURLToPath(import.meta.url)), "locales");
+const isCI = Boolean(process.env.GITHUB_ACTIONS);
+
+function readJSON(path) {
+    return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function keysOf(langCode) {
+    return Object.keys(readJSON(join(localesDir, langCode, "common.json")));
+}
+
+// Emit a GitHub Actions annotation so failures render inline on the PR diff.
+function annotate(file, message) {
+    if (isCI) console.log(`::error file=${file}::${message}`);
+}
+
+const index = readJSON(join(localesDir, "_index.json"));
+const declared = index.languages.map((l) => l.code);
+
+if (!declared.includes(SOURCE)) {
+    console.error(`FATAL: source language "${SOURCE}" is not declared in _index.json`);
+    process.exit(1);
+}
+
+const sourceKeys = keysOf(SOURCE);
+const sourceSet = new Set(sourceKeys);
+console.log(`Source of truth: ${SOURCE}/common.json — ${sourceKeys.length} keys\n`);
+
+let failed = false;
+
+for (const code of declared) {
+    if (code === SOURCE) continue;
+    const file = `client/ui/i18n/locales/${code}/common.json`;
+
+    let keys;
+    try {
+        keys = keysOf(code);
+    } catch (e) {
+        failed = true;
+        const msg = `bundle is declared in _index.json but common.json is missing or invalid (${e.message})`;
+        console.error(`✗ ${code}: ${msg}`);
+        annotate("client/ui/i18n/locales/_index.json", `${code}: ${msg}`);
+        continue;
+    }
+
+    const set = new Set(keys);
+    const missing = sourceKeys.filter((k) => !set.has(k));
+    const extra = keys.filter((k) => !sourceSet.has(k));
+
+    if (missing.length === 0 && extra.length === 0) {
+        console.log(`✓ ${code}: ${keys.length} keys`);
+        continue;
+    }
+
+    failed = true;
+    console.error(`✗ ${code}: ${keys.length} keys (expected ${sourceKeys.length})`);
+    if (missing.length) {
+        console.error(`    missing ${missing.length}: ${missing.join(", ")}`);
+        annotate(file, `Missing ${missing.length} key(s) present in ${SOURCE}: ${missing.join(", ")}`);
+    }
+    if (extra.length) {
+        console.error(`    extra ${extra.length}: ${extra.join(", ")}`);
+        annotate(file, `Has ${extra.length} key(s) not present in ${SOURCE}: ${extra.join(", ")}`);
+    }
+}
+
+// Locale directories present on disk but not declared in _index.json are never
+// loaded by the app — surface them so dead translation files don't rot silently.
+const onDisk = readdirSync(localesDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+const undeclared = onDisk.filter((d) => !declared.includes(d));
+if (undeclared.length) {
+    console.warn(`\n⚠ locale directories not declared in _index.json (not shipped): ${undeclared.join(", ")}`);
+}
+
+console.log();
+if (failed) {
+    console.error("Translation check FAILED — every locale must match the English key set.");
+    process.exit(1);
+}
+console.log("Translation check passed — all locales match the English key set.");

--- a/client/ui/i18n/locales/ja/common.json
+++ b/client/ui/i18n/locales/ja/common.json
@@ -1304,6 +1304,9 @@
     "daemon.outdated.description": {
         "message": "このアプリを使用するには NetBird サービスを更新してください。"
     },
+    "daemon.outdated.download": {
+        "message": "最新版をダウンロード"
+    },
     "error.jwt_clock_skew": {
         "message": "サインインに失敗しました: このデバイスの時計がサーバーと同期していません。システムの時計を同期してからもう一度お試しください。"
     },


### PR DESCRIPTION
English (`en`) is the source of truth for UI translation keys. The other nine locales rely on runtime English fallback for any missing key (see the i18n bundle fallback in `client/ui/i18n/bundle_test.go`), so an incomplete translation never surfaces in CI. This adds a check that makes key drift a hard failure.

## Describe your changes

- **`client/ui/i18n/check-translations.mjs`** — dependency-free Node script. Treats `en/common.json` as the source of truth and requires every locale declared in `_index.json` to carry the exact same key set. On mismatch it prints per-locale counts, lists the specific missing/orphaned keys, emits GitHub Actions `::error::` annotations (inline on the PR diff), and exits non-zero. Also warns about locale directories on disk not declared in `_index.json`.
- **`.github/workflows/ui-translations.yml`** — dedicated "UI Translations" workflow that runs the check on PRs and pushes to `main` when `client/ui/i18n/locales/**` (or the script) changes. Kept separate from `frontend-ui.yml` so it needs no pnpm/Wails/build toolchain — just checkout + Node 22 (~seconds).
- **`client/ui/frontend/package.json`** — added `pnpm i18n:check` so the same check runs locally.
- **`client/ui/i18n/locales/ja/common.json`** — close the one gap the check found: `ja` was missing `daemon.outdated.download` ("Download Latest"). Added `最新版をダウンロード`, placed after `daemon.outdated.description` to match the `en` ordering.

Chose key-set equality rather than a bare count comparison: it still enforces matching counts, but also catches a same-count-but-wrong-key drift and reports exactly which keys differ.

Verified: `node client/ui/i18n/check-translations.mjs` passes for all 10 locales at 444 keys each; confirmed it exits non-zero and names `ja: daemon.outdated.download` before the fix.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (CI/tooling check plus a one-string translation fix; no behavior, API, or configuration change)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787237121&installation_model_id=427504&pr_number=6852&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6852&signature=076f608f6199d944d1bf3e3758a0ad800983e6dfbed460ee5a2187cd3c377025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Japanese translation for the daemon outdated state, including guidance to download the latest version.
  * Added automated checks to verify translation keys remain consistent across supported locales.
  * Added a command to run translation validation locally and in continuous integration.

* **Bug Fixes**
  * Translation checks now flag missing, extra, invalid, or undeclared locale files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->