### PR TITLE
client: explain unavailable daemon on connect

### DIFF
--- a/client/ui/frontend/src/modules/main/MainConnectionStatusSwitch.tsx
+++ b/client/ui/frontend/src/modules/main/MainConnectionStatusSwitch.tsx
@@ -160,7 +160,13 @@ export const MainConnectionStatusSwitch = () => {
     }, [driveLogin]);
 
     const handleSwitch = (next: boolean) => {
-        if (unreachable) return;
+        if (unreachable) {
+            void errorDialog({
+                Title: t("connect.error.daemonUnavailableTitle"),
+                Message: t("connect.error.daemonUnavailableMessage"),
+            });
+            return;
+        }
         if (isTransitioning) {
             if (canForceCancel) void forceCancel();
             return;

--- a/client/ui/i18n/locales/en/common.json
+++ b/client/ui/i18n/locales/en/common.json
@@ -171,6 +171,10 @@
         "message": "Failed to connect",
         "description": "Error notification body shown when connecting failed."
     },
+    "notify.error.daemonUnavailable": {
+        "message": "The NetBird background service is not running. Start or restart the NetBird system service, then try again.",
+        "description": "Actionable error shown when Connect is clicked but the background service cannot be reached."
+    },
     "notify.error.disconnect": {
         "message": "Failed to disconnect",
         "description": "Error notification body shown when disconnecting failed."
@@ -338,6 +342,14 @@
     "connect.status.daemonUnavailable": {
         "message": "Daemon unavailable",
         "description": "Connection toggle label when the background service is unavailable. 'Daemon' = background service."
+    },
+    "connect.error.daemonUnavailableTitle": {
+        "message": "NetBird service is not running",
+        "description": "Error dialog title shown when the connection toggle is clicked while the background service is unavailable."
+    },
+    "connect.error.daemonUnavailableMessage": {
+        "message": "Start or restart the NetBird system service, then try again.",
+        "description": "Actionable error dialog body shown when the background service is unavailable."
     },
     "connect.status.loginRequired": {
         "message": "Login required",

--- a/client/ui/tray.go
+++ b/client/ui/tray.go
@@ -324,9 +324,12 @@ func (t *Tray) relayoutMenu() {
 	}
 	if t.upItem != nil {
 		// Connect stays visible in the NeedsLogin states too — Up drives
-		// the SSO re-auth flow; hidden only when it would be a no-op.
-		t.upItem.SetHidden(connected || connecting || daemonUnavailable)
-		t.upItem.SetEnabled(!connected && !connecting && !daemonUnavailable)
+		// the SSO re-auth flow. Keep it actionable when the daemon is unavailable
+		// too, so a click can explain how to recover instead of silently hiding
+		// the primary action.
+		state := connectMenuState(connected, lastStatus)
+		t.upItem.SetHidden(state.hidden)
+		t.upItem.SetEnabled(state.enabled)
 	}
 	if t.downItem != nil {
 		// Disconnect doubles as the Connecting abort path.
@@ -358,6 +361,19 @@ func (t *Tray) relayoutMenu() {
 	// Single push of the whole tree: on Linux one LayoutUpdated with fresh
 	// container ids; on darwin an NSMenu rebuild against the cached pointer.
 	t.tray.SetMenu(t.menu)
+}
+
+type menuItemState struct {
+	hidden  bool
+	enabled bool
+}
+
+func connectMenuState(connected bool, status string) menuItemState {
+	connecting := strings.EqualFold(status, services.StatusConnecting)
+	return menuItemState{
+		hidden:  connected || connecting,
+		enabled: !connected && !connecting,
+	}
 }
 
 func (t *Tray) buildMenu() *application.Menu {
@@ -478,10 +494,15 @@ func (t *Tray) handleConnect(upItem *application.MenuItem) {
 	// the React startLogin() (which owns the BrowserLogin popup) drives it;
 	// the hidden main webview is alive and subscribed, so only the popup shows.
 	t.statusMu.Lock()
+	daemonUnavailable := strings.EqualFold(t.lastStatus, services.StatusDaemonUnavailable)
 	needsLogin := strings.EqualFold(t.lastStatus, services.StatusNeedsLogin) ||
 		strings.EqualFold(t.lastStatus, services.StatusSessionExpired) ||
 		strings.EqualFold(t.lastStatus, services.StatusLoginFailed)
 	t.statusMu.Unlock()
+	if daemonUnavailable {
+		t.notifyError(t.loc.T("notify.error.daemonUnavailable"))
+		return
+	}
 	if needsLogin {
 		t.app.Event.Emit(services.EventTriggerLogin)
 		return

--- a/client/ui/tray_connect_test.go
+++ b/client/ui/tray_connect_test.go
@@ -1,0 +1,17 @@
+//go:build !android && !ios && !freebsd && !js
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/ui/services"
+)
+
+func TestConnectMenuStateDaemonUnavailable(t *testing.T) {
+	state := connectMenuState(false, services.StatusDaemonUnavailable)
+	require.False(t, state.hidden)
+	require.True(t, state.enabled)
+}


### PR DESCRIPTION
## Describe your changes

When the desktop UI detects `DaemonUnavailable`, clicking the primary connection control currently does nothing:

- the tray hides and disables Connect;
- the main Wails UI explicitly returns from `handleSwitch` without feedback.

This change keeps Connect visible and enabled in the tray and provides an actionable, localized error in both the tray and main window. Users are told that the NetBird system service is not running and should be started or restarted before retrying.

The patch intentionally does not add a new privilege-elevation path to the user-session GUI. Automatically bootstrapping a root LaunchDaemon needs separate platform/security design; this fixes the confirmed silent no-op while keeping existing privilege boundaries intact.

## Issue ticket number and link

Triage discussion: https://github.com/netbirdio/netbird/discussions/6855

The repository now requires Discussion-first validation before a community issue can be created.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description).

> By submitting this pull request, I confirm that I have read and agree to the terms of the Contributor License Agreement.

## Validation

- `pnpm check`
- `pnpm build`
- `go test ./client/ui/...`

## Documentation

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change: this restores user-visible feedback for an existing error state and adds no new configuration or workflow.

### Docs PR URL

N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787298754&installation_model_id=427504&pr_number=6856&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6856&signature=d129bab25a3781c3600be7a06ae8d7beac9b6dc9ecfee7ebfec805f7423f71e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the background service is unavailable during connection attempts.
  * The Connect option remains available so users can receive clear error feedback instead of an unsuccessful connection attempt.

* **New Features**
  * Added localized error messages explaining that the background service could not be reached and providing actionable guidance.
  * Added a dedicated connection error dialog for this condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->