### PR TITLE
[infrastructure] trigger release tests for stable and RC releases

### DIFF
--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,0 +1,88 @@
+name: Trigger release tests
+
+on:
+  push:
+    tags:
+      - "v*"
+  release:
+    types: [published]
+
+jobs:
+  trigger:
+    name: "Release tests / ${{ matrix.scenario }}"
+    if: >-
+      ${{ github.repository == 'netbirdio/netbird' &&
+          ((github.event_name == 'push' &&
+            (!contains(github.ref_name, '-') || contains(github.ref_name, '-rc.'))) ||
+           (github.event_name == 'release' && github.event.release.prerelease)) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [prerelease, upgrade]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve test versions
+        id: versions
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Unsupported release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          major=$((10#${BASH_REMATCH[1]}))
+          minor=$((10#${BASH_REMATCH[2]}))
+          if (( minor < 2 )); then
+            echo "Cannot select an N-2 release for $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          old_minor=$((minor - 2))
+          old_version=$(git tag --list "v${major}.${old_minor}.*" --sort=-version:refname | grep -E "^v${major}\.${old_minor}\.[0-9]+$" | head -n 1)
+          if [[ -z "$old_version" ]]; then
+            echo "No stable v${major}.${old_minor}.x release found" >&2
+            exit 1
+          fi
+
+          echo "target=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "old=$old_version" >> "$GITHUB_OUTPUT"
+
+      - name: Run prerelease scenarios
+        if: matrix.scenario == 'prerelease'
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
+        with:
+          workflow: netbird-prerelease.yml
+          repo: netbirdio/pre-release-tests
+          ref: main
+          token: ${{ secrets.RELEASE_TESTS_GITHUB_TOKEN }}
+          inputs: >-
+            { "netbird_version": "${{ steps.versions.outputs.target }}",
+              "netbird_server_version": "${{ steps.versions.outputs.target }}",
+              "netbird_server_image_repository": "ghcr.io/netbirdio/netbird-server" }
+
+      - name: Run upgrade scenarios
+        if: matrix.scenario == 'upgrade'
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
+        with:
+          workflow: netbird-selfhosted-upgrade.yml
+          repo: netbirdio/pre-release-tests
+          ref: main
+          token: ${{ secrets.RELEASE_TESTS_GITHUB_TOKEN }}
+          inputs: >-
+            { "netbird_version": "${{ steps.versions.outputs.target }}",
+              "old_netbird_server_version": "${{ steps.versions.outputs.old }}",
+              "netbird_server_version": "${{ steps.versions.outputs.target }}",
+              "netbird_server_image_repository": "ghcr.io/netbirdio/netbird-server" }


### PR DESCRIPTION
## Describe your changes

Adds a standalone, non-blocking workflow that dispatches prerelease and upgrade tests for:

- Stable tag pushes
- RC tag pushes
- Published GitHub pre-releases

The workflow uses the existing `sha-*` main-build artifacts and the latest stable release from minor N-2 for upgrade testing. It does not wait for test completion or gate release publishing.

Pushing an RC tag and later publishing it as a GitHub pre-release dispatches both test workflows twice.

Requires `RELEASE_TESTS_GITHUB_TOKEN` with Actions read/write access to `netbirdio/pre-release-tests`.

Validated with `actionlint`.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal CI automation only)

### Docs PR URL (required if "docs added" is checked)

N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787302559&installation_model_id=427504&pr_number=6858&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6858&signature=8fa6bc7785014f9d31b2c1fabaea18bae1b0f9c6a40309a0d6c441849cccbdbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated release validation for prerelease and self-hosted upgrade scenarios.
  * Release testing now verifies compatibility between the current release and an older supported version.
  * Unsupported release tag formats are rejected before tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->