### PR TITLE
[management] Force routing-peer DNS resolution for reverse-proxy domain targets

### DIFF
--- a/management/internals/shared/grpc/components_envelope_response.go
+++ b/management/internals/shared/grpc/components_envelope_response.go
@@ -50,7 +50,7 @@ func ToComponentSyncResponse(
 	// TODO (dmitri) consider using invariants?
 	//
 	enableSSH := computeSSHEnabledForPeer(components, peer)
-	peerConfig := toPeerConfig(peer, components.Network, dnsName, settings, httpConfig, deviceFlowConfig, enableSSH)
+	peerConfig := toPeerConfig(peer, components.Network, dnsName, settings, httpConfig, deviceFlowConfig, enableSSH, components.ForceRoutingPeerDNSResolution)
 
 	includeIPv6 := peer.SupportsIPv6() && peer.IPv6.IsValid()
 	useSourcePrefixes := peer.SupportsSourcePrefixes()

--- a/management/internals/shared/grpc/conversion.go
+++ b/management/internals/shared/grpc/conversion.go
@@ -119,7 +119,7 @@ func toNetbirdConfig(config *nbconfig.Config, turnCredentials *Token, relayToken
 	return nbConfig
 }
 
-func toPeerConfig(peer *nbpeer.Peer, network *types.Network, dnsName string, settings *types.Settings, httpConfig *nbconfig.HttpServerConfig, deviceFlowConfig *nbconfig.DeviceAuthorizationFlow, enableSSH bool) *proto.PeerConfig {
+func toPeerConfig(peer *nbpeer.Peer, network *types.Network, dnsName string, settings *types.Settings, httpConfig *nbconfig.HttpServerConfig, deviceFlowConfig *nbconfig.DeviceAuthorizationFlow, enableSSH bool, forceRoutingPeerDNS bool) *proto.PeerConfig {
 	netmask, _ := network.Net.Mask.Size()
 	fqdn := peer.FQDN(dnsName)
 
@@ -135,7 +135,7 @@ func toPeerConfig(peer *nbpeer.Peer, network *types.Network, dnsName string, set
 		Address:                         fmt.Sprintf("%s/%d", peer.IP.String(), netmask),
 		SshConfig:                       sshConfig,
 		Fqdn:                            fqdn,
-		RoutingPeerDnsResolutionEnabled: settings.RoutingPeerDNSResolutionEnabled,
+		RoutingPeerDnsResolutionEnabled: settings.RoutingPeerDNSResolutionEnabled || peer.ProxyMeta.Embedded || forceRoutingPeerDNS,
 		LazyConnectionEnabled:           settings.LazyConnectionEnabled,
 		AutoUpdate: &proto.AutoUpdateSettings{
 			Version:      settings.AutoUpdateVersion,
@@ -162,12 +162,12 @@ func ToSyncResponse(ctx context.Context, config *nbconfig.Config, httpConfig *nb
 	useSourcePrefixes := peer.SupportsSourcePrefixes()
 
 	response := &proto.SyncResponse{
-		PeerConfig: toPeerConfig(peer, networkMap.Network, dnsName, settings, httpConfig, deviceFlowConfig, networkMap.EnableSSH),
+		PeerConfig: toPeerConfig(peer, networkMap.Network, dnsName, settings, httpConfig, deviceFlowConfig, networkMap.EnableSSH, networkMap.ForceRoutingPeerDNSResolution),
 		NetworkMap: &proto.NetworkMap{
 			Serial:     networkMap.Network.CurrentSerial(),
 			Routes:     networkmap.ToProtocolRoutes(networkMap.Routes),
 			DNSConfig:  networkmap.ToProtocolDNSConfig(networkMap.DNSConfig, dnsCache, dnsFwdPort),
-			PeerConfig: toPeerConfig(peer, networkMap.Network, dnsName, settings, httpConfig, deviceFlowConfig, networkMap.EnableSSH),
+			PeerConfig: toPeerConfig(peer, networkMap.Network, dnsName, settings, httpConfig, deviceFlowConfig, networkMap.EnableSSH, networkMap.ForceRoutingPeerDNSResolution),
 		},
 		Checks: toProtocolChecks(ctx, checks),
 	}

--- a/management/internals/shared/grpc/conversion_test.go
+++ b/management/internals/shared/grpc/conversion_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"fmt"
+	"net"
 	"net/netip"
 	"reflect"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/netbirdio/netbird/management/internals/controllers/network_map"
 	"github.com/netbirdio/netbird/management/internals/controllers/network_map/controller/cache"
 	nbconfig "github.com/netbirdio/netbird/management/internals/server/config"
+	nbpeer "github.com/netbirdio/netbird/management/server/peer"
 	"github.com/netbirdio/netbird/management/server/types"
 	"github.com/netbirdio/netbird/shared/management/networkmap"
 )
@@ -300,4 +302,36 @@ func TestToNetbirdConfig_RelayInvariant(t *testing.T) {
 		require.NotNil(t, nbCfg.Metrics)
 		assert.True(t, nbCfg.Metrics.Enabled, "metrics flag should carry the settings value")
 	})
+}
+
+func TestToPeerConfig_RoutingPeerDNSResolution(t *testing.T) {
+	network := &types.Network{Net: net.IPNet{IP: net.IPv4(100, 0, 0, 0), Mask: net.CIDRMask(8, 32)}}
+
+	newPeer := func(embedded bool) *nbpeer.Peer {
+		p := &nbpeer.Peer{IP: netip.MustParseAddr("100.0.0.1")}
+		p.ProxyMeta.Embedded = embedded
+		return p
+	}
+
+	tests := []struct {
+		name        string
+		globalFlag  bool
+		embedded    bool
+		forceParam  bool
+		wantEnabled bool
+	}{
+		{name: "global off, regular peer, no force", wantEnabled: false},
+		{name: "global on wins", globalFlag: true, wantEnabled: true},
+		{name: "embedded proxy peer forced", embedded: true, wantEnabled: true},
+		{name: "routing peer forced via param", forceParam: true, wantEnabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := &types.Settings{RoutingPeerDNSResolutionEnabled: tt.globalFlag}
+			cfg := toPeerConfig(newPeer(tt.embedded), network, "netbird.selfhosted", settings, nil, nil, false, tt.forceParam)
+			assert.Equal(t, tt.wantEnabled, cfg.RoutingPeerDnsResolutionEnabled,
+				"RoutingPeerDnsResolutionEnabled should reflect global || embedded || forced")
+		})
+	}
 }

--- a/management/internals/shared/grpc/server.go
+++ b/management/internals/shared/grpc/server.go
@@ -921,7 +921,7 @@ func (s *Server) prepareLoginResponse(ctx context.Context, peer *nbpeer.Peer, ne
 	// if peer has reached this point then it has logged in
 	loginResp := &proto.LoginResponse{
 		NetbirdConfig: toNetbirdConfig(s.config, nil, relayToken, nil, settings),
-		PeerConfig:    toPeerConfig(peer, network, s.networkMapController.GetDNSDomain(settings), settings, s.config.HttpConfig, s.config.DeviceAuthorizationFlow, enableSSH),
+		PeerConfig:    toPeerConfig(peer, network, s.networkMapController.GetDNSDomain(settings), settings, s.config.HttpConfig, s.config.DeviceAuthorizationFlow, enableSSH, false),
 		Checks:        toProtocolChecks(ctx, postureChecks),
 	}
 

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -1517,6 +1517,54 @@ func (a *Account) GetResourceRoutersMap() map[string]map[string]*routerTypes.Net
 	return routers
 }
 
+// forcesRoutingPeerDNSResolution reports whether the given peer must run
+// routing-peer DNS resolution regardless of the account-global
+// RoutingPeerDNSResolutionEnabled setting. It returns true when the peer is a
+// router for a domain network resource that is targeted by an enabled
+// reverse-proxy service, so the peer's DNS forwarder starts and can resolve
+// the target for the embedded proxy peers. Embedded proxy peers themselves are
+// handled at PeerConfig build time.
+func (a *Account) forcesRoutingPeerDNSResolution(peerID string, routers map[string]map[string]*routerTypes.NetworkRouter) bool {
+	targeted := a.proxyTargetedDomainResourceIDs()
+	if len(targeted) == 0 {
+		return false
+	}
+
+	for _, resource := range a.NetworkResources {
+		if resource == nil || !resource.Enabled {
+			continue
+		}
+		if _, ok := targeted[resource.ID]; !ok {
+			continue
+		}
+		if _, isRouter := routers[resource.NetworkID][peerID]; isRouter {
+			return true
+		}
+	}
+
+	return false
+}
+
+// proxyTargetedDomainResourceIDs returns the set of domain network resource IDs
+// targeted by an enabled, non-terminated reverse-proxy service.
+func (a *Account) proxyTargetedDomainResourceIDs() map[string]struct{} {
+	ids := make(map[string]struct{})
+	for _, svc := range a.Services {
+		if svc == nil || !svc.Enabled || svc.Terminated {
+			continue
+		}
+		for _, target := range svc.Targets {
+			if target == nil || !target.Enabled {
+				continue
+			}
+			if target.TargetType == service.TargetTypeDomain {
+				ids[target.TargetId] = struct{}{}
+			}
+		}
+	}
+	return ids
+}
+
 // getPoliciesSourcePeers collects all unique peers from the source groups defined in the given policies.
 func getPoliciesSourcePeers(policies []*Policy, groups map[string]*Group) map[string]struct{} {
 	sourcePeers := make(map[string]struct{})

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -1531,7 +1531,7 @@ func (a *Account) forcesRoutingPeerDNSResolution(peerID string, routers map[stri
 	}
 
 	for _, resource := range a.NetworkResources {
-		if resource == nil || !resource.Enabled {
+		if resource == nil || !resource.Enabled || resource.Type != resourceTypes.Domain {
 			continue
 		}
 		if _, ok := targeted[resource.ID]; !ok {

--- a/management/server/types/account_components.go
+++ b/management/server/types/account_components.go
@@ -140,6 +140,8 @@ func (a *Account) GetPeerNetworkMapComponents(
 		RouterPeers:               make(map[string]*ComponentPeer),
 		NetworkXIDToPublicID:      make(map[string]string, len(a.Networks)),
 		PostureCheckXIDToPublicID: make(map[string]string, len(a.PostureChecks)),
+
+		ForceRoutingPeerDNSResolution: a.forcesRoutingPeerDNSResolution(peerID, routers),
 	}
 	for _, n := range a.Networks {
 		if n != nil {

--- a/management/server/types/account_test.go
+++ b/management/server/types/account_test.go
@@ -1751,3 +1751,61 @@ func hasPrivateAccessPolicy(account *Account, serviceID string) bool {
 	}
 	return false
 }
+
+func TestForcesRoutingPeerDNSResolution(t *testing.T) {
+	buildAccount := func(serviceEnabled, targetEnabled, resourceEnabled bool, targetType service.TargetType) *Account {
+		return &Account{
+			Id: "accountID",
+			Groups: map[string]*Group{
+				"router-group": {ID: "router-group", Peers: []string{"router-peer-grp"}},
+			},
+			NetworkRouters: []*routerTypes.NetworkRouter{
+				{ID: "r1", NetworkID: "net-1", AccountID: "accountID", Peer: "router-peer", Enabled: true},
+				{ID: "r2", NetworkID: "net-1", AccountID: "accountID", PeerGroups: []string{"router-group"}, Enabled: true},
+			},
+			NetworkResources: []*resourceTypes.NetworkResource{
+				{ID: "res-domain", AccountID: "accountID", NetworkID: "net-1", Type: resourceTypes.Domain, Domain: "ipinfo.io", Enabled: resourceEnabled},
+			},
+			Services: []*service.Service{
+				{
+					ID: "svc-1", AccountID: "accountID", Enabled: serviceEnabled,
+					Targets: []*service.Target{
+						{TargetId: "res-domain", TargetType: targetType, Enabled: targetEnabled},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("router peer for RP-targeted domain resource is forced", func(t *testing.T) {
+		account := buildAccount(true, true, true, service.TargetTypeDomain)
+		routers := account.GetResourceRoutersMap()
+		assert.True(t, account.forcesRoutingPeerDNSResolution("router-peer", routers), "direct router peer should be forced")
+		assert.True(t, account.forcesRoutingPeerDNSResolution("router-peer-grp", routers), "group-member router peer should be forced")
+	})
+
+	t.Run("non-router peer is not forced", func(t *testing.T) {
+		account := buildAccount(true, true, true, service.TargetTypeDomain)
+		assert.False(t, account.forcesRoutingPeerDNSResolution("other-peer", account.GetResourceRoutersMap()))
+	})
+
+	t.Run("not forced when service disabled", func(t *testing.T) {
+		account := buildAccount(false, true, true, service.TargetTypeDomain)
+		assert.False(t, account.forcesRoutingPeerDNSResolution("router-peer", account.GetResourceRoutersMap()))
+	})
+
+	t.Run("not forced when target disabled", func(t *testing.T) {
+		account := buildAccount(true, false, true, service.TargetTypeDomain)
+		assert.False(t, account.forcesRoutingPeerDNSResolution("router-peer", account.GetResourceRoutersMap()))
+	})
+
+	t.Run("not forced when resource disabled", func(t *testing.T) {
+		account := buildAccount(true, true, false, service.TargetTypeDomain)
+		assert.False(t, account.forcesRoutingPeerDNSResolution("router-peer", account.GetResourceRoutersMap()))
+	})
+
+	t.Run("not forced for non-domain target type", func(t *testing.T) {
+		account := buildAccount(true, true, true, service.TargetTypePeer)
+		assert.False(t, account.forcesRoutingPeerDNSResolution("router-peer", account.GetResourceRoutersMap()))
+	})
+}

--- a/management/server/types/account_test.go
+++ b/management/server/types/account_test.go
@@ -1753,7 +1753,7 @@ func hasPrivateAccessPolicy(account *Account, serviceID string) bool {
 }
 
 func TestForcesRoutingPeerDNSResolution(t *testing.T) {
-	buildAccount := func(serviceEnabled, targetEnabled, resourceEnabled bool, targetType service.TargetType) *Account {
+	buildAccountRes := func(serviceEnabled, targetEnabled, resourceEnabled bool, targetType service.TargetType, resType resourceTypes.NetworkResourceType) *Account {
 		return &Account{
 			Id: "accountID",
 			Groups: map[string]*Group{
@@ -1764,7 +1764,7 @@ func TestForcesRoutingPeerDNSResolution(t *testing.T) {
 				{ID: "r2", NetworkID: "net-1", AccountID: "accountID", PeerGroups: []string{"router-group"}, Enabled: true},
 			},
 			NetworkResources: []*resourceTypes.NetworkResource{
-				{ID: "res-domain", AccountID: "accountID", NetworkID: "net-1", Type: resourceTypes.Domain, Domain: "ipinfo.io", Enabled: resourceEnabled},
+				{ID: "res-domain", AccountID: "accountID", NetworkID: "net-1", Type: resType, Domain: "example.org", Enabled: resourceEnabled},
 			},
 			Services: []*service.Service{
 				{
@@ -1775,6 +1775,10 @@ func TestForcesRoutingPeerDNSResolution(t *testing.T) {
 				},
 			},
 		}
+	}
+
+	buildAccount := func(serviceEnabled, targetEnabled, resourceEnabled bool, targetType service.TargetType) *Account {
+		return buildAccountRes(serviceEnabled, targetEnabled, resourceEnabled, targetType, resourceTypes.Domain)
 	}
 
 	t.Run("router peer for RP-targeted domain resource is forced", func(t *testing.T) {
@@ -1807,5 +1811,11 @@ func TestForcesRoutingPeerDNSResolution(t *testing.T) {
 	t.Run("not forced for non-domain target type", func(t *testing.T) {
 		account := buildAccount(true, true, true, service.TargetTypePeer)
 		assert.False(t, account.forcesRoutingPeerDNSResolution("router-peer", account.GetResourceRoutersMap()))
+	})
+
+	t.Run("not forced when targeted resource is not a domain", func(t *testing.T) {
+		account := buildAccountRes(true, true, true, service.TargetTypeDomain, resourceTypes.Host)
+		assert.False(t, account.forcesRoutingPeerDNSResolution("router-peer", account.GetResourceRoutersMap()),
+			"a domain target pointing at a non-domain resource must not force resolution")
 	})
 }

--- a/shared/management/types/network.go
+++ b/shared/management/types/network.go
@@ -47,6 +47,10 @@ type NetworkMap struct {
 	ForwardingRules     []*ForwardingRule
 	AuthorizedUsers     map[string]map[string]struct{}
 	EnableSSH           bool
+	// ForceRoutingPeerDNSResolution forces the peer to run/use routing-peer DNS
+	// resolution regardless of the account-global setting, for reverse-proxy
+	// domain targets.
+	ForceRoutingPeerDNSResolution bool
 }
 
 func (nm *NetworkMap) Merge(other *NetworkMap) {
@@ -56,6 +60,7 @@ func (nm *NetworkMap) Merge(other *NetworkMap) {
 	nm.FirewallRules = mergeUnique(nm.FirewallRules, other.FirewallRules)
 	nm.RoutesFirewallRules = mergeUnique(nm.RoutesFirewallRules, other.RoutesFirewallRules)
 	nm.ForwardingRules = mergeUnique(nm.ForwardingRules, other.ForwardingRules)
+	nm.ForceRoutingPeerDNSResolution = nm.ForceRoutingPeerDNSResolution || other.ForceRoutingPeerDNSResolution
 }
 
 type comparableObject[T any] interface {

--- a/shared/management/types/networkmap_components.go
+++ b/shared/management/types/networkmap_components.go
@@ -56,6 +56,11 @@ type NetworkMapComponents struct {
 
 	// true when returning an empty-like map (returned instead of nil)
 	empty bool
+
+	// ForceRoutingPeerDNSResolution forces the peer to run/use routing-peer DNS
+	// resolution regardless of the account-global setting, for reverse-proxy
+	// domain targets.
+	ForceRoutingPeerDNSResolution bool
 }
 
 type routeIndexEntry struct {
@@ -190,6 +195,8 @@ func (c *NetworkMapComponents) Calculate(ctx context.Context) *NetworkMap {
 		RoutesFirewallRules: append(networkResourcesFirewallRules, routesFirewallRules...),
 		AuthorizedUsers:     authorizedUsers,
 		EnableSSH:           sshEnabled,
+
+		ForceRoutingPeerDNSResolution: c.ForceRoutingPeerDNSResolution,
 	}
 }
 


### PR DESCRIPTION
## Describe your changes

Reverse-proxy services that target a domain network resource rely on DNS resolution happening on the routing peer, but that only occurs when the account-global "DNS via routing peer" setting is enabled. This forces routing-peer DNS resolution on per-peer for the peers involved in a reverse-proxy domain target, so the feature works without requiring the account-wide setting.

- Force the flag on for embedded reverse-proxy client peers so they route domain DNS to the resolving peer instead of resolving locally
- Force the flag on for peers that route a domain network resource targeted by an enabled reverse-proxy service, so their DNS forwarder starts
- Carry the decision on the per-peer network map so both the streaming and initial-sync paths emit it, leaving the account-global setting untouched

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal behavior change: no user-facing setting or API surface is added; the existing account setting is unchanged.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787414293&installation_model_id=427504&pr_number=6872&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6872&signature=71f4142d96e7800c5f39482b3eec964cd90ba8f3adedded69c51a4bb33d0c1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routing peers can now automatically enable DNS resolution when required for reverse-proxy domain targets.
  * DNS resolution behavior is propagated through network maps and generated peer configuration in sync/login responses.
  * A new per-network-map override can force DNS resolution beyond the account-wide setting.

* **Bug Fixes**
  * Improved DNS resolution behavior for embedded peers and explicitly routed scenarios.

* **Tests**
  * Added unit tests covering combinations of global/override settings, embedded behavior, and domain-targeted resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->