### PR TITLE
[client] Make Test_ConnectPeers handshake over loopback

### DIFF
--- a/client/iface/iface_test.go
+++ b/client/iface/iface_test.go
@@ -505,10 +505,12 @@ func Test_ConnectPeers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	localIP, err := getLocalIP()
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Peers talk to each other over loopback. The userspace WireGuard bind
+	// listens on 0.0.0.0, so 127.0.0.1 reaches it. Using the routable NIC IP
+	// instead makes the handshake hairpin through the host/container network
+	// stack, which drops packets under CI load and leaves WireGuard retrying
+	// only every REKEY_TIMEOUT (5s) — the root of the 30s flake.
+	localIP := "127.0.0.1"
 
 	peer1endpoint, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", localIP, peer1wgPort))
 	if err != nil {
@@ -622,27 +624,3 @@ func getPeer(ifaceName, peerPubKey string) (wgtypes.Peer, error) {
 	return wgtypes.Peer{}, fmt.Errorf("peer not found")
 }
 
-func getLocalIP() (string, error) {
-	// Get all interfaces
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return "", err
-	}
-
-	for _, addr := range addrs {
-		ipNet, ok := addr.(*net.IPNet)
-		if !ok {
-			continue
-		}
-		if ipNet.IP.IsLoopback() {
-			continue
-		}
-
-		if ipNet.IP.To4() == nil {
-			continue
-		}
-		return ipNet.IP.String(), nil
-	}
-
-	return "", fmt.Errorf("no local IP found")
-}


### PR DESCRIPTION
## Describe your changes

The previous busy-loop fix did not stop the flake: the test still timed out after 30s waiting for the peer handshake. Root cause might the endpoint address. The peers pointed at each other via the host's routable NIC IP (getLocalIP), so the handshake had to hairpin through the host/container network stack. Under CI load that drops packets, and WireGuard only retries a lost handshake initiation every REKEY_TIMEOUT (5s), stacking up to the ~30s timeout.

Point both endpoints at 127.0.0.1 instead. The userspace WireGuard bind listens on 0.0.0.0, so loopback reaches it over a path that never drops. Remove the now-unused getLocalIP helper.

## Stack

<!-- branch-stack -->

### Checklist
- [X ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787469068&installation_model_id=427504&pr_number=6877&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6877&signature=486d85d51c5f069ce3b876f7f1f299d7148cf879192f2a784514b89426c1f1ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated peer connection testing to use the local loopback address for UDP handshake validation.
  * Removed dependency on detecting a host’s network interfaces during these tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->