### PR TITLE
[client] Exit GUI immediately on Windows session end

### DIFF
--- a/client/ui/main.go
+++ b/client/ui/main.go
@@ -281,6 +281,9 @@ func newApplication(onSecondInstance func()) *application.App {
 		Linux: application.LinuxOptions{
 			ProgramName: "netbird",
 		},
+		Windows: application.WindowsOptions{
+			WndProcInterceptor: endSessionInterceptor(),
+		},
 		SingleInstance: &application.SingleInstanceOptions{
 			UniqueID: "io.netbird.ui",
 			OnSecondInstanceLaunch: func(_ application.SecondInstanceData) {
@@ -367,6 +370,9 @@ func newMainWindow(app *application.App, prefStore *preferences.Store) *applicat
 
 	// Hide instead of quit on close; "really quit" is reached via tray -> Quit.
 	window.RegisterHook(events.Common.WindowClosing, func(e *application.WindowEvent) {
+		if services.ShuttingDown() {
+			return
+		}
 		e.Cancel()
 		window.Hide()
 	})

--- a/client/ui/services/shutdown.go
+++ b/client/ui/services/shutdown.go
@@ -2,16 +2,23 @@ package services
 
 import "sync/atomic"
 
-var shuttingDown atomic.Bool
+var (
+	sessionEnding atomic.Bool
+	quitting      atomic.Bool
+)
 
-func BeginShutdown() {
-	shuttingDown.Store(true)
+func BeginSessionEnd() {
+	sessionEnding.Store(true)
 }
 
-func AbortShutdown() {
-	shuttingDown.Store(false)
+func AbortSessionEnd() {
+	sessionEnding.Store(false)
+}
+
+func BeginShutdown() {
+	quitting.Store(true)
 }
 
 func ShuttingDown() bool {
-	return shuttingDown.Load()
+	return sessionEnding.Load() || quitting.Load()
 }

--- a/client/ui/services/shutdown.go
+++ b/client/ui/services/shutdown.go
@@ -1,0 +1,17 @@
+package services
+
+import "sync/atomic"
+
+var shuttingDown atomic.Bool
+
+func BeginShutdown() {
+	shuttingDown.Store(true)
+}
+
+func AbortShutdown() {
+	shuttingDown.Store(false)
+}
+
+func ShuttingDown() bool {
+	return shuttingDown.Load()
+}

--- a/client/ui/services/windowmanager.go
+++ b/client/ui/services/windowmanager.go
@@ -154,6 +154,9 @@ func NewWindowManager(app *application.App, mainWindow *application.WebviewWindo
 	})
 	// Hide (not destroy) on close to keep React state; reset to General for a flash-free reopen.
 	s.settings.RegisterHook(events.Common.WindowClosing, func(e *application.WindowEvent) {
+		if ShuttingDown() {
+			return
+		}
 		e.Cancel()
 		s.app.Event.Emit(EventSettingsOpen, "general")
 		s.settings.Hide()
@@ -393,6 +396,9 @@ func (s *WindowManager) CloseWelcome() {
 // OpenError shows the custom error dialog; title/message are pre-localised and ride in the
 // start URL. A second error replaces the open one via SetURL. Singleton, destroyed on close.
 func (s *WindowManager) OpenError(title, message string) {
+	if ShuttingDown() {
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	startURL := errorDialogURL(title, message)

--- a/client/ui/shutdown_other.go
+++ b/client/ui/shutdown_other.go
@@ -1,0 +1,7 @@
+//go:build !windows && !android && !ios && !freebsd && !js
+
+package main
+
+func endSessionInterceptor() func(hwnd uintptr, msg uint32, wParam, lParam uintptr) (uintptr, bool) {
+	return nil
+}

--- a/client/ui/shutdown_windows.go
+++ b/client/ui/shutdown_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/client/ui/services"
+)
+
+const (
+	wmQueryEndSession = 0x0011
+	wmEndSession      = 0x0016
+)
+
+func endSessionInterceptor() func(hwnd uintptr, msg uint32, wParam, lParam uintptr) (uintptr, bool) {
+	return func(_ uintptr, msg uint32, wParam, _ uintptr) (uintptr, bool) {
+		switch msg {
+		case wmQueryEndSession:
+			services.BeginShutdown()
+			return 1, true
+		case wmEndSession:
+			if wParam == 0 {
+				services.AbortShutdown()
+				return 0, true
+			}
+			log.Info("windows session is ending; exiting immediately")
+			os.Exit(0)
+			return 0, true
+		default:
+			return 0, false
+		}
+	}
+}

--- a/client/ui/shutdown_windows.go
+++ b/client/ui/shutdown_windows.go
@@ -19,11 +19,11 @@ func endSessionInterceptor() func(hwnd uintptr, msg uint32, wParam, lParam uintp
 	return func(_ uintptr, msg uint32, wParam, _ uintptr) (uintptr, bool) {
 		switch msg {
 		case wmQueryEndSession:
-			services.BeginShutdown()
+			services.BeginSessionEnd()
 			return 1, true
 		case wmEndSession:
 			if wParam == 0 {
-				services.AbortShutdown()
+				services.AbortSessionEnd()
 				return 0, true
 			}
 			log.Info("windows session is ending; exiting immediately")

--- a/client/ui/tray.go
+++ b/client/ui/tray.go
@@ -453,6 +453,7 @@ func (t *Tray) buildMenu() *application.Menu {
 }
 
 func (t *Tray) handleQuit() {
+	services.BeginShutdown()
 	t.profileMu.Lock()
 	if t.switchCancel != nil {
 		t.switchCancel()

--- a/client/ui/tray_notify.go
+++ b/client/ui/tray_notify.go
@@ -25,6 +25,9 @@ type sendFn func(notifications.NotificationOptions) error
 // event-dispatch goroutine that panic is fatal process-wide; recover() turns
 // it into a logged no-op.
 func safeSendNotification(send sendFn, what string, opts notifications.NotificationOptions) (err error) {
+	if services.ShuttingDown() {
+		return nil
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			log.Errorf("notify %s: recovered from panic (notification bus unavailable): %v", what, r)


### PR DESCRIPTION
Wails v3 runs the full app teardown synchronously inside WM_ENDSESSION, overrunning the 5s end-session budget and triggering the "app is preventing shutdown" screen with a forced kill. Intercept WM_QUERYENDSESSION/WM_ENDSESSION and exit at once instead, and suppress error dialogs, toasts, and the hide-on-close hooks once shutdown or a tray quit has begun.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787474408&installation_model_id=427504&pr_number=6878&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6878&signature=f09980d83ad32e37b92aa30a7d4552c402a140dbd4e4662a3ca12d1868e9f04b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling on Windows by properly responding to system end-session requests.
  * Prevented the main window, settings window, and error dialogs from reopening or interfering while the app is closing.
  * Updated tray “Quit” flow to begin shutdown immediately, ensuring active profile/connection operations complete cleanly.
  * Suppressed UI notifications during shutdown to avoid stray messages after exit starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->