### PR TITLE
[client] Fetch FreeBSD port files from GitHub mirror instead of cgit

### DIFF
--- a/release_files/freebsd-port-diff.sh
+++ b/release_files/freebsd-port-diff.sh
@@ -3,8 +3,8 @@
 # FreeBSD Port Diff Generator for NetBird
 #
 # This script generates the diff file required for submitting a FreeBSD port update.
-# It works on macOS, Linux, and FreeBSD by fetching files from FreeBSD cgit and
-# computing checksums from the Go module proxy.
+# It works on macOS, Linux, and FreeBSD by fetching files from the FreeBSD ports
+# GitHub mirror and computing checksums from the Go module proxy.
 #
 # Usage: ./freebsd-port-diff.sh [new_version]
 # Example: ./freebsd-port-diff.sh 0.60.7
@@ -14,7 +14,7 @@
 set -e
 
 GITHUB_REPO="netbirdio/netbird"
-PORTS_CGIT_BASE="https://cgit.freebsd.org/ports/plain/security/netbird"
+PORTS_MIRROR_BASE="https://raw.githubusercontent.com/freebsd/freebsd-ports/main/security/netbird"
 GO_PROXY="https://proxy.golang.org/github.com/netbirdio/netbird/@v"
 OUTPUT_DIR="${OUTPUT_DIR:-.}"
 AWK_FIRST_FIELD='{print $1}'
@@ -30,7 +30,7 @@ fetch_all_tags() {
 
 fetch_current_ports_version() {
     echo "Fetching current version from FreeBSD ports..." >&2
-    curl -sL "${PORTS_CGIT_BASE}/Makefile" 2>/dev/null | \
+    fetch_ports_file "Makefile" | \
         grep -E "^DISTVERSION=" | \
         sed 's/DISTVERSION=[[:space:]]*//' | \
         tr -d '\t '
@@ -45,7 +45,13 @@ fetch_latest_github_release() {
 
 fetch_ports_file() {
     local filename="$1"
-    curl -sL "${PORTS_CGIT_BASE}/${filename}" 2>/dev/null
+    local content
+    content=$(curl -fsL --retry 3 "${PORTS_MIRROR_BASE}/${filename}" 2>/dev/null) || content=""
+    if [[ "$content" == \<* ]]; then
+        echo "Error: Received HTML instead of ${filename} from ${PORTS_MIRROR_BASE}" >&2
+        content=""
+    fi
+    printf '%s' "$content"
     return 0
 }
 

--- a/release_files/freebsd-port-diff.sh
+++ b/release_files/freebsd-port-diff.sh
@@ -30,10 +30,17 @@ fetch_all_tags() {
 
 fetch_current_ports_version() {
     echo "Fetching current version from FreeBSD ports..." >&2
-    fetch_ports_file "Makefile" | \
+    local makefile version
+    makefile=$(fetch_ports_file "Makefile") || return 1
+    version=$(echo "$makefile" | \
         grep -E "^DISTVERSION=" | \
         sed 's/DISTVERSION=[[:space:]]*//' | \
-        tr -d '\t '
+        tr -d '\t ')
+    if [[ -z "$version" ]]; then
+        echo "Error: Could not extract DISTVERSION from ports Makefile" >&2
+        return 1
+    fi
+    echo "$version"
     return 0
 }
 
@@ -46,10 +53,13 @@ fetch_latest_github_release() {
 fetch_ports_file() {
     local filename="$1"
     local content
-    content=$(curl -fsL --retry 3 "${PORTS_MIRROR_BASE}/${filename}" 2>/dev/null) || content=""
+    if ! content=$(curl -fsL --proto '=https' --proto-redir '=https' --retry 3 "${PORTS_MIRROR_BASE}/${filename}" 2>/dev/null); then
+        echo "Error: Could not fetch ${filename} from ${PORTS_MIRROR_BASE}" >&2
+        return 1
+    fi
     if [[ "$content" == \<* ]]; then
         echo "Error: Received HTML instead of ${filename} from ${PORTS_MIRROR_BASE}" >&2
-        content=""
+        return 1
     fi
     printf '%s' "$content"
     return 0

--- a/release_files/freebsd-port-issue-body.sh
+++ b/release_files/freebsd-port-issue-body.sh
@@ -20,7 +20,7 @@ PORTS_MAKEFILE_URL="https://raw.githubusercontent.com/freebsd/freebsd-ports/main
 fetch_current_ports_version() {
     echo "Fetching current version from FreeBSD ports..." >&2
     local makefile_content
-    makefile_content=$(curl -fsL --retry 3 "$PORTS_MAKEFILE_URL" 2>/dev/null) || makefile_content=""
+    makefile_content=$(curl -fsL --proto '=https' --proto-redir '=https' --retry 3 "$PORTS_MAKEFILE_URL" 2>/dev/null) || makefile_content=""
     if [[ "$makefile_content" == \<* ]]; then
         echo "Error: Received HTML instead of Makefile from ${PORTS_MAKEFILE_URL}" >&2
         return 1

--- a/release_files/freebsd-port-issue-body.sh
+++ b/release_files/freebsd-port-issue-body.sh
@@ -9,18 +9,22 @@
 # Example: ./freebsd-port-issue-body.sh 0.56.0 0.59.1
 #
 # If no versions are provided, the script will:
-#   - Fetch OLD version from FreeBSD ports cgit (current version in ports tree)
+#   - Fetch OLD version from the FreeBSD ports GitHub mirror (current version in ports tree)
 #   - Fetch NEW version from latest NetBird GitHub release tag
 
 set -e
 
 GITHUB_REPO="netbirdio/netbird"
-PORTS_CGIT_URL="https://cgit.freebsd.org/ports/plain/security/netbird/Makefile"
+PORTS_MAKEFILE_URL="https://raw.githubusercontent.com/freebsd/freebsd-ports/main/security/netbird/Makefile"
 
 fetch_current_ports_version() {
     echo "Fetching current version from FreeBSD ports..." >&2
     local makefile_content
-    makefile_content=$(curl -sL "$PORTS_CGIT_URL" 2>/dev/null)
+    makefile_content=$(curl -fsL --retry 3 "$PORTS_MAKEFILE_URL" 2>/dev/null) || makefile_content=""
+    if [[ "$makefile_content" == \<* ]]; then
+        echo "Error: Received HTML instead of Makefile from ${PORTS_MAKEFILE_URL}" >&2
+        return 1
+    fi
     if [[ -z "$makefile_content" ]]; then
         echo "Error: Could not fetch Makefile from FreeBSD ports" >&2
         return 1


### PR DESCRIPTION
cgit.freebsd.org now sits behind an Anubis anti-bot challenge and intermittently returns an HTML challenge page with HTTP 200 instead of the requested file, breaking the FreeBSD port release job. Fetch the port Makefile and distinfo from the official freebsd-ports GitHub mirror, retry transient failures, and fail loudly if HTML is returned instead of the expected file.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787478670&installation_model_id=427504&pr_number=6880&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6880&signature=503a5d79f1671c21cebedac66516c7d7298d401a6382d9bf483813f9e7ee7591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving FreeBSD port metadata during release and issue preparation.
  * Added automatic retries and HTTPS-only redirect handling for safer downloads.
  * Validates fetched content to detect unexpected HTML responses and avoids processing invalid data.
  * Updated port metadata retrieval to use a more reliable mirror, improving version extraction and the resulting comparisons and regenerated release information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->