### PR TITLE
[management] fix ephemeral peers never deleted due to cleanup context is cancelled

### DIFF
--- a/management/internals/modules/peers/ephemeral/manager/ephemeral.go
+++ b/management/internals/modules/peers/ephemeral/manager/ephemeral.go
@@ -69,8 +69,9 @@ func (e *EphemeralManager) LoadInitialPeers(ctx context.Context) {
 
 	e.loadEphemeralPeers(ctx)
 	if e.headPeer != nil {
+		cleanupCtx := context.WithoutCancel(ctx)
 		e.timer = time.AfterFunc(e.lifeTime, func() {
-			e.cleanup(ctx)
+			e.cleanup(cleanupCtx)
 		})
 	}
 }
@@ -128,8 +129,9 @@ func (e *EphemeralManager) OnPeerDisconnected(ctx context.Context, peer *nbpeer.
 		if delay < 0 {
 			delay = 0
 		}
+		cleanupCtx := context.WithoutCancel(ctx)
 		e.timer = time.AfterFunc(delay, func() {
-			e.cleanup(ctx)
+			e.cleanup(cleanupCtx)
 		})
 	}
 }

--- a/management/internals/modules/peers/ephemeral/manager/ephemeral_test.go
+++ b/management/internals/modules/peers/ephemeral/manager/ephemeral_test.go
@@ -276,6 +276,98 @@ func TestCleanupSchedulingBehaviorIsBatched(t *testing.T) {
 	assert.Equal(t, ephemeralPeers, mockAM.GetDeletePeerCalls(), "should have deleted all peers")
 }
 
+// TestCleanupDeletesPeerAfterArmingContextCancelled drives the real OnPeerDisconnected -> timer ->
+// cleanup path and asserts a disconnected ephemeral peer is deleted after its lifetime even though
+// the request that armed the timer has already returned (its context cancelled). The peer-registration
+// path (AddPeer -> TrackEphemeralPeer) and the Sync setup-error path arm the timer with the per-request
+// gRPC context; capturing it makes cleanup's DeletePeers fail with context.Canceled and leak the peer.
+//
+// The DeletePeers fake honors ctx cancellation and swallows the error, mirroring managerImpl.DeletePeers
+// (each delete runs in store.ExecuteInTransaction(ctx, ...); the per-peer error is logged and DeletePeers
+// returns nil). This is the behavior the map-based fakes in the tests above do not model.
+func TestCleanupDeletesPeerAfterArmingContextCancelled(t *testing.T) {
+	store := &MockStore{account: newAccountWithId(context.Background(), "account", "", "", false)}
+	peer := &nbpeer.Peer{ID: "ephemeral_peer", AccountID: store.account.Id, Ephemeral: true}
+	store.account.Peers[peer.ID] = peer
+
+	ctrl := gomock.NewController(t)
+	peersManager := peers.NewMockManager(ctrl)
+
+	var deleteCtxErr error
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	peersManager.EXPECT().
+		DeletePeers(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).
+		DoAndReturn(func(ctx context.Context, accountID string, peerIDs []string, userID string, checkConnected bool) error {
+			deleteCtxErr = ctx.Err()
+			if deleteCtxErr == nil {
+				for _, peerID := range peerIDs {
+					delete(store.account.Peers, peerID)
+				}
+			}
+			wg.Done()
+			return nil
+		}).
+		Times(1)
+
+	mgr := NewEphemeralManager(store, peersManager)
+	mgr.lifeTime = 100 * time.Millisecond
+	mgr.cleanupWindow = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mgr.OnPeerDisconnected(ctx, peer)
+	cancel() // the arming request returns and cancels its context
+
+	wg.Wait()
+
+	assert.Empty(t, store.account.Peers,
+		"ephemeral peer must be deleted after its lifetime; a leak means cleanup ran under the "+
+			"cancelled request context (delete ctx err: %v)", deleteCtxErr)
+}
+
+// TestCleanupDeletesPeerWithDetachedContext is the control for the test above: the only difference is
+// that the cleanup timer is armed with a context that outlives the request (as cancelPeerRoutines
+// already derives via context.WithoutCancel), which lets cleanup delete the peer. This isolates the
+// cause to the lifetime of the context handed to the cleanup timer.
+func TestCleanupDeletesPeerWithDetachedContext(t *testing.T) {
+	store := &MockStore{account: newAccountWithId(context.Background(), "account", "", "", false)}
+	peer := &nbpeer.Peer{ID: "ephemeral_peer", AccountID: store.account.Id, Ephemeral: true}
+	store.account.Peers[peer.ID] = peer
+
+	ctrl := gomock.NewController(t)
+	peersManager := peers.NewMockManager(ctrl)
+
+	var deleteCtxErr error
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	peersManager.EXPECT().
+		DeletePeers(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).
+		DoAndReturn(func(ctx context.Context, accountID string, peerIDs []string, userID string, checkConnected bool) error {
+			deleteCtxErr = ctx.Err()
+			if deleteCtxErr == nil {
+				for _, peerID := range peerIDs {
+					delete(store.account.Peers, peerID)
+				}
+			}
+			wg.Done()
+			return nil
+		}).
+		Times(1)
+
+	mgr := NewEphemeralManager(store, peersManager)
+	mgr.lifeTime = 100 * time.Millisecond
+	mgr.cleanupWindow = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mgr.OnPeerDisconnected(context.WithoutCancel(ctx), peer)
+	cancel()
+
+	wg.Wait()
+
+	assert.NoError(t, deleteCtxErr, "cleanup must run under a live context")
+	assert.Empty(t, store.account.Peers, "ephemeral peer should be deleted when cleanup runs under a live context")
+}
+
 func seedPeers(store *MockStore, numberOfPeers int, numberOfEphemeralPeers int) {
 	store.account = newAccountWithId(context.Background(), "my account", "", "", false)
 


### PR DESCRIPTION
## Describe your changes

Ephemeral peers were not being deleted after their inactivity lifetime and accumulated in the store until the management server restarted.

Root cause: the ephemeral cleanup timer is armed with `time.AfterFunc(delay, func(){ e.cleanup(ctx) })` in `OnPeerDisconnected` and `LoadInitialPeers`, capturing whatever context was passed in. On the peer registration path (`AddPeer` -> `TrackEphemeralPeer`) and the Sync setup-error path (`cancelPeerRoutinesWithoutLock`), that context is the per-request gRPC context, which is cancelled as soon as the request returns. When the timer fires ~10 minutes later, `cleanup` runs `DeletePeers` under the dead context, every `store.ExecuteInTransaction(ctx, ...)` fails with `context.Canceled`, the per-peer error is logged and swallowed (`DeletePeers` returns nil), and the peers are never removed. Observed in production on v0.71.2 as repeated `manager.go: DeletePeers: failed to delete peer <id>: context canceled` and peers with a "last seen" far exceeding the 10 minute ephemeral lifetime. 

The defect dates back to v0.28.4 (commit 765aba2c, "Add context to throughout the project", #2209), which first threaded a caller-supplied context into the timer closures and into `DeletePeer`. Before that the timer used `e.cleanup` with no context, so it could not occur.

Fix: derive the timer's context with `context.WithoutCancel` at both arming sites, so cleanup survives the arming request being torn down while still carrying its log/trace values.

Tests: `TestCleanupDeletesPeerAfterArmingContextCancelled` drives the real `OnPeerDisconnected` -> timer -> `cleanup` path with a `DeletePeers` fake that honors context cancellation (mirroring `managerImpl.DeletePeers`), and fails without the fix. The existing tests missed this because their mocked `DeletePeers` deletes from a map unconditionally, ignoring the context. `TestCleanupDeletesPeerWithDetachedContext` is the passing control that isolates the cause to the context lifetime.

## Issue ticket number and link

N/A (happy to open an issue if preferred). 

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Documentation already states ephemeral peers are removed after inactivity; this restores that documented behavior rather than changing it.

### Docs PR URL (required if "docs added" is checked)
n/a

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787480035&installation_model_id=427504&pr_number=6882&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6882&signature=e122d42c3f0d610c3d898d8ab02debaac8a8bcc188e87ca03c7a143fb6f70541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability for ephemeral peers when the original request context is canceled.
  * Ensured scheduled cleanup continues after a peer disconnects, allowing expired peers to be removed as expected.

* **Tests**
  * Added coverage for cleanup behavior with canceled and detached contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->