### PR TITLE
[client] Make Test_ConnectPeers deterministic under Docker/eBPF kernel / Darwin CI

### DIFF
--- a/client/iface/iface_test.go
+++ b/client/iface/iface_test.go
@@ -464,6 +464,18 @@ func Test_RemovePeer(t *testing.T) {
 }
 
 func Test_ConnectPeers(t *testing.T) {
+	// This test brings up two kernel WireGuard interfaces in the same process.
+	// The eBPF proxy manager is a singleton with a single shared XDP program
+	// and settings map, so the second interface's factory overwrites the
+	// wg_port/proxy_port of the first. The shared program can then no longer
+	// serve both peers and the handshake is dropped, making this test
+	// incompatible with the eBPF factory. The proxy only loads when the runner
+	// grants the required BPF capabilities (reliably so inside the privileged
+	// Docker CI container), which is what turned this test red. Disable it so
+	// the peers handshake directly over loopback. Running the suite across all
+	// three modes — eBPF, UDP proxy and ICE bind — would need a larger refactor.
+	t.Setenv("NB_DISABLE_EBPF_WG_PROXY", "true")
+
 	peer1ifaceName := fmt.Sprintf("utun%d", WgIntNumber+400)
 	peer1wgIP := netip.MustParsePrefix("10.99.99.17/30")
 	peer1Key, _ := wgtypes.GeneratePrivateKey()

--- a/client/iface/iface_test.go
+++ b/client/iface/iface_test.go
@@ -464,16 +464,6 @@ func Test_RemovePeer(t *testing.T) {
 }
 
 func Test_ConnectPeers(t *testing.T) {
-	// This test brings up two kernel WireGuard interfaces in the same process.
-	// The eBPF proxy manager is a singleton with a single shared XDP program
-	// and settings map, so the second interface's factory overwrites the
-	// wg_port/proxy_port of the first. The shared program can then no longer
-	// serve both peers and the handshake is dropped, making this test
-	// incompatible with the eBPF factory. The proxy only loads when the runner
-	// grants the required BPF capabilities (reliably so inside the privileged
-	// Docker CI container), which is what turned this test red. Disable it so
-	// the peers handshake directly over loopback. Running the suite across all
-	// three modes — eBPF, UDP proxy and ICE bind — would need a larger refactor.
 	t.Setenv("NB_DISABLE_EBPF_WG_PROXY", "true")
 
 	peer1ifaceName := fmt.Sprintf("utun%d", WgIntNumber+400)
@@ -517,10 +507,6 @@ func Test_ConnectPeers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Use 127.0.0.1 (distinguished by port) for both peers. It is the only
-	// loopback address that is local on every platform: Linux routes all of
-	// 127.0.0.0/8 to lo, but macOS/BSD only assign 127.0.0.1 to lo0, so a
-	// 127.x.y.z endpoint is unreachable there and the handshake never lands.
 	localIP1 := "127.0.0.1"
 	peer1endpoint, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", localIP1, peer1wgPort))
 	if err != nil {
@@ -633,29 +619,4 @@ func getPeer(ifaceName, peerPubKey string) (wgtypes.Peer, error) {
 		}
 	}
 	return wgtypes.Peer{}, fmt.Errorf("peer not found")
-}
-
-func getLocalIP() (string, error) {
-	// Get all interfaces
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return "", err
-	}
-
-	for _, addr := range addrs {
-		ipNet, ok := addr.(*net.IPNet)
-		if !ok {
-			continue
-		}
-		if ipNet.IP.IsLoopback() {
-			continue
-		}
-
-		if ipNet.IP.To4() == nil {
-			continue
-		}
-		return ipNet.IP.String(), nil
-	}
-
-	return "", fmt.Errorf("no local IP found")
 }

--- a/client/iface/iface_test.go
+++ b/client/iface/iface_test.go
@@ -517,7 +517,11 @@ func Test_ConnectPeers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	localIP1 := "127.1.0.1"
+	// Use 127.0.0.1 (distinguished by port) for both peers. It is the only
+	// loopback address that is local on every platform: Linux routes all of
+	// 127.0.0.0/8 to lo, but macOS/BSD only assign 127.0.0.1 to lo0, so a
+	// 127.x.y.z endpoint is unreachable there and the handshake never lands.
+	localIP1 := "127.0.0.1"
 	peer1endpoint, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", localIP1, peer1wgPort))
 	if err != nil {
 		t.Fatal(err)
@@ -554,7 +558,7 @@ func Test_ConnectPeers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	localIP2 := "127.1.0.2"
+	localIP2 := "127.0.0.1"
 	peer2endpoint, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", localIP2, peer2wgPort))
 	if err != nil {
 		t.Fatal(err)

--- a/client/iface/iface_test.go
+++ b/client/iface/iface_test.go
@@ -517,12 +517,8 @@ func Test_ConnectPeers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	localIP, err := getLocalIP()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	peer1endpoint, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", localIP, peer1wgPort))
+	localIP1 := "127.1.0.1"
+	peer1endpoint, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", localIP1, peer1wgPort))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -558,7 +554,8 @@ func Test_ConnectPeers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	peer2endpoint, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", localIP, peer2wgPort))
+	localIP2 := "127.1.0.2"
+	peer2endpoint, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", localIP2, peer2wgPort))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sharedsock/sock_linux.go
+++ b/sharedsock/sock_linux.go
@@ -24,7 +24,7 @@ import (
 )
 
 // ErrSharedSockStopped indicates that shared socket has been stopped
-var ErrSharedSockStopped = fmt.Errorf("shared socked stopped")
+var ErrSharedSockStopped = fmt.Errorf("shared socket stopped")
 
 // SharedSocket is a net.PacketConn that initiates two raw sockets (ipv4 and ipv6) and listens to UDP packets filtered
 // by BPF instructions (e.g., IncomingSTUNFilter that checks and sends only STUN packets to the listeners (ReadFrom)).


### PR DESCRIPTION
## Describe your changes

Make `Test_ConnectPeers` deterministic. Two issues, both surfaced once the
privileged suite moved into a `--privileged` Docker container (#6425):

1. The peers used `getLocalIP()` as their WireGuard endpoint, i.e. the host's
   routable NIC IP (the docker bridge IP `172.17.0.2` in CI). That address might
   not hairpin reliably inside the container, so the handshake intermittently
   timed out (flaky). Use loopback (`127.1.0.x`) instead — always self-reachable.
2. On a Linux runner with the WG kernel module the iface uses the eBPF proxy
   factory. Its manager is a singleton with one shared XDP program + settings
   map, so bringing up the two ifaces makes the second factory overwrite the
   first's `wg_port`/`proxy_port` and the handshake is dropped. The test is
   incompatible with the eBPF factory, so disable it via
   `NB_DISABLE_EBPF_WG_PROXY` (peers then handshake directly over loopback).
   Running the suite across all three modes (eBPF / UDP proxy / ICE bind) would
   need a larger refactor.

Also fixes a typo in the `ErrSharedSockStopped` message (`socked` → `socket`).

## Issue ticket number and link

No public issue — CI flakiness follow-up to #6871 on `Test_ConnectPeers`
(https://github.com/netbirdio/netbird/blob/main/client/iface/iface_test.go).

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Test-only change (plus a log-string typo). No public API, CLI, config, or
behavior change.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787485967&installation_model_id=427504&pr_number=6884&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6884&signature=09fb996715d039bd02775a140e8cc03deca5cb42540790b82a744527264a30ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the “shared socket stopped” error message for clearer output.
* **Tests**
  * Improved peer connection test reliability in privileged CI by disabling the eBPF WireGuard proxy and using fixed loopback UDP endpoints for deterministic setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->