### PR TITLE
[management, proxy] Meter custom provider model costs

### DIFF
--- a/management/internals/modules/agentnetwork/synthesizer.go
+++ b/management/internals/modules/agentnetwork/synthesizer.go
@@ -227,6 +227,10 @@ func SynthesizeServices(ctx context.Context, s store.Store, accountID string) ([
 	if err != nil {
 		return nil, err
 	}
+	costMeterCfgJSON, err := buildCostMeterConfigJSON(enabledProviders, groupIndex)
+	if err != nil {
+		return nil, err
+	}
 
 	identityInjectJSON, err := buildIdentityInjectConfigJSON(enabledProviders, groupIndex)
 	if err != nil {
@@ -248,7 +252,7 @@ func SynthesizeServices(ctx context.Context, s store.Store, accountID string) ([
 	// Use the merged decision (account settings OR policy-required redaction),
 	// not the raw account flag, so a policy that mandates PII redaction is
 	// honored by the capture parsers even when the account toggle is off.
-	middlewares := buildMiddlewareChain(routerCfgJSON, identityInjectJSON, guardrailJSON, mergedGuardrails.PromptCapture.RedactPii, mergedGuardrails.PromptCapture.Enabled)
+	middlewares := buildMiddlewareChain(routerCfgJSON, costMeterCfgJSON, identityInjectJSON, guardrailJSON, mergedGuardrails.PromptCapture.RedactPii, mergedGuardrails.PromptCapture.Enabled)
 
 	priv, pub, err := pickServiceSessionKeys(enabledProviders)
 	if err != nil {
@@ -377,6 +381,24 @@ type routerProviderRoute struct {
 	SkipTLSVerify bool `json:"skip_tls_verify,omitempty"`
 }
 
+// costMeterConfig mirrors the provider-scoped prices accepted by the proxy's
+// cost_meter middleware. The router emits the selected provider ID, allowing
+// the cost meter to distinguish identically named models on separate routes.
+type costMeterConfig struct {
+	ProviderPrices []costMeterProviderPrices `json:"provider_prices"`
+}
+
+type costMeterProviderPrices struct {
+	ProviderID string                `json:"provider_id"`
+	Models     []costMeterModelPrice `json:"models"`
+}
+
+type costMeterModelPrice struct {
+	ID          string  `json:"id"`
+	InputPer1k  float64 `json:"input_per_1k"`
+	OutputPer1k float64 `json:"output_per_1k"`
+}
+
 // indexProviderGroups walks the enabled policies and returns, per
 // provider id, the sorted union of source group ids across every
 // policy that authorises the provider. Providers with no authorising
@@ -465,6 +487,43 @@ func buildRouterConfigJSON(providers []*types.Provider, groupIndex map[string][]
 	out, err := json.Marshal(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("marshal llm_router middleware config: %w", err)
+	}
+	return out, nil
+}
+
+// buildCostMeterConfigJSON emits configured model prices for reachable
+// providers. Catalog pricing remains the fallback when a route has no custom
+// price for the selected model.
+func buildCostMeterConfigJSON(providers []*types.Provider, groupIndex map[string][]string) ([]byte, error) {
+	cfg := costMeterConfig{ProviderPrices: make([]costMeterProviderPrices, 0, len(providers))}
+	for _, p := range providers {
+		if _, hasPolicy := groupIndex[p.ID]; !hasPolicy || len(p.Models) == 0 {
+			continue
+		}
+		prices := costMeterProviderPrices{
+			ProviderID: p.ID,
+			Models:     make([]costMeterModelPrice, 0, len(p.Models)),
+		}
+		for _, model := range p.Models {
+			// A zero-value model row can exist in older records. It is not a
+			// configured price, so preserve catalog pricing rather than turning
+			// a known model into a free route.
+			if model.ID == "" || model.InputPer1k < 0 || model.OutputPer1k < 0 || (model.InputPer1k == 0 && model.OutputPer1k == 0) {
+				continue
+			}
+			prices.Models = append(prices.Models, costMeterModelPrice{
+				ID:          model.ID,
+				InputPer1k:  model.InputPer1k,
+				OutputPer1k: model.OutputPer1k,
+			})
+		}
+		if len(prices.Models) > 0 {
+			cfg.ProviderPrices = append(cfg.ProviderPrices, prices)
+		}
+	}
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal cost_meter middleware config: %w", err)
 	}
 	return out, nil
 }
@@ -700,7 +759,7 @@ func buildIdentityExtraHeaders(p *types.Provider, extras []catalog.ExtraHeader) 
 // requests bound for gateways like LiteLLM that key budgets and
 // attribution off request headers. CanMutate is required so its
 // HeadersAdd / HeadersRemove pass the framework's mutation gate.
-func buildMiddlewareChain(routerCfgJSON, identityInjectJSON, guardrailJSON []byte, redactPii, capturePromptContent bool) []rpservice.MiddlewareConfig {
+func buildMiddlewareChain(routerCfgJSON, costMeterCfgJSON, identityInjectJSON, guardrailJSON []byte, redactPii, capturePromptContent bool) []rpservice.MiddlewareConfig {
 	// Both parsers receive an explicit capture flag derived from the account's
 	// enable_prompt_collection toggle; nil/unset would default to the legacy
 	// "always emit" behavior in the middleware, which is precisely what we
@@ -772,7 +831,7 @@ func buildMiddlewareChain(routerCfgJSON, identityInjectJSON, guardrailJSON []byt
 			ID:         middlewareIDCostMeter,
 			Enabled:    true,
 			Slot:       rpservice.MiddlewareSlotOnResponse,
-			ConfigJSON: []byte("{}"),
+			ConfigJSON: costMeterCfgJSON,
 		},
 		{
 			ID:         middlewareIDLLMResponseParser,

--- a/management/internals/modules/agentnetwork/synthesizer_test.go
+++ b/management/internals/modules/agentnetwork/synthesizer_test.go
@@ -214,7 +214,11 @@ func TestSynthesizeServices_HappyPath(t *testing.T) {
 
 	assert.Equal(t, middlewareIDCostMeter, mws[6].ID, "seventh middleware is the cost meter")
 	assert.Equal(t, rpservice.MiddlewareSlotOnResponse, mws[6].Slot, "cost meter runs on_response")
-	assert.Equal(t, []byte("{}"), mws[6].ConfigJSON, "cost meter carries an explicit empty config")
+	var costCfg costMeterConfig
+	require.NoError(t, json.Unmarshal(mws[6].ConfigJSON, &costCfg), "cost meter config must unmarshal")
+	require.Equal(t, []costMeterProviderPrices{
+		{ProviderID: openai.ID, Models: []costMeterModelPrice{{ID: "gpt-5.4", InputPer1k: 0.0025, OutputPer1k: 0.015}}},
+	}, costCfg.ProviderPrices, "configured route prices must reach cost meter")
 
 	assert.Equal(t, middlewareIDLLMResponseParser, mws[7].ID, "eighth middleware is the response parser")
 	assert.Equal(t, rpservice.MiddlewareSlotOnResponse, mws[7].Slot, "response parser runs on_response")

--- a/proxy/internal/middleware/builtin/cost_meter/factory.go
+++ b/proxy/internal/middleware/builtin/cost_meter/factory.go
@@ -21,6 +21,21 @@ type Config struct {
 	// file probed inside the proxy data directory. When empty the
 	// loader falls back to "pricing.yaml".
 	PricingPath string `json:"pricing_path"`
+	// ProviderPrices overrides static pricing for an exact router provider ID
+	// and model pair. It is supplied by Agent Network synthesis for custom
+	// providers whose model pricing is not present in the static table.
+	ProviderPrices []ProviderPrices `json:"provider_prices"`
+}
+
+type ProviderPrices struct {
+	ProviderID string       `json:"provider_id"`
+	Models     []ModelPrice `json:"models"`
+}
+
+type ModelPrice struct {
+	ID          string  `json:"id"`
+	InputPer1k  float64 `json:"input_per_1k"`
+	OutputPer1k float64 `json:"output_per_1k"`
 }
 
 // Factory builds cost_meter instances from raw config bytes.
@@ -53,7 +68,7 @@ func (Factory) New(rawConfig []byte) (middleware.Middleware, error) {
 
 	cancel := startReloader(fctx.Context, loader)
 
-	return newMiddleware(loader, cancel), nil
+	return newMiddleware(loader, cancel, cfg.ProviderPrices), nil
 }
 
 // startReloader binds the loader's mtime-poll goroutine to a context

--- a/proxy/internal/middleware/builtin/cost_meter/middleware.go
+++ b/proxy/internal/middleware/builtin/cost_meter/middleware.go
@@ -206,11 +206,12 @@ func (m *Middleware) customCosts(metadata []middleware.KV, provider, model strin
 	input := float64(inputTokens) / 1000 * price.InputPer1k
 	cachedInput := 0.0
 	cacheCreation := 0.0
-	if provider == "openai" {
+	switch provider {
+	case "openai":
 		cachedTokens = min(cachedTokens, inputTokens)
 		input = float64(inputTokens-cachedTokens) / 1000 * price.InputPer1k
 		cachedInput = float64(cachedTokens) / 1000 * price.InputPer1k
-	} else if provider == "anthropic" || provider == "bedrock" {
+	case "anthropic", "bedrock":
 		cachedInput = float64(cachedTokens) / 1000 * price.InputPer1k
 		cacheCreation = float64(cacheCreationTokens) / 1000 * price.InputPer1k
 	}

--- a/proxy/internal/middleware/builtin/cost_meter/middleware.go
+++ b/proxy/internal/middleware/builtin/cost_meter/middleware.go
@@ -44,7 +44,8 @@ var metadataKeys = []string{
 // Middleware computes a per-response cost estimate from the token
 // counts emitted upstream by llm_response_parser.
 type Middleware struct {
-	loader *pricing.Loader
+	loader         *pricing.Loader
+	providerPrices map[string]map[string]ModelPrice
 	// cancel stops this instance's pricing-reload goroutine. Non-nil only
 	// when the loader watches an override file; Close calls it so a chain
 	// rebuild doesn't leak a poll goroutine per retired instance.
@@ -53,8 +54,21 @@ type Middleware struct {
 
 // newMiddleware constructs a Middleware bound to the given pricing loader.
 // cancel may be nil (defaults-only loader with no reloader to stop).
-func newMiddleware(loader *pricing.Loader, cancel context.CancelFunc) *Middleware {
-	return &Middleware{loader: loader, cancel: cancel}
+func newMiddleware(loader *pricing.Loader, cancel context.CancelFunc, prices []ProviderPrices) *Middleware {
+	providerPrices := make(map[string]map[string]ModelPrice, len(prices))
+	for _, provider := range prices {
+		models := make(map[string]ModelPrice, len(provider.Models))
+		for _, model := range provider.Models {
+			if model.ID == "" || model.InputPer1k < 0 || model.OutputPer1k < 0 || (model.InputPer1k == 0 && model.OutputPer1k == 0) {
+				continue
+			}
+			models[model.ID] = model
+		}
+		if provider.ProviderID != "" && len(models) > 0 {
+			providerPrices[provider.ProviderID] = models
+		}
+	}
+	return &Middleware{loader: loader, cancel: cancel, providerPrices: providerPrices}
 }
 
 // ID returns the registry identifier.
@@ -144,8 +158,11 @@ func (m *Middleware) Invoke(_ context.Context, in *middleware.Input) (*middlewar
 		return out, nil
 	}
 
-	table := m.loader.Get()
-	costs, ok := table.Costs(provider, model, inTokens, outTokens, cachedTokens, cacheCreationTokens)
+	costs, ok := m.customCosts(in.Metadata, provider, model, inTokens, outTokens, cachedTokens, cacheCreationTokens)
+	if !ok {
+		table := m.loader.Get()
+		costs, ok = table.Costs(provider, model, inTokens, outTokens, cachedTokens, cacheCreationTokens)
+	}
 	if !ok {
 		out.Metadata = skip(skipUnknownModel)
 		return out, nil
@@ -176,6 +193,37 @@ func (m *Middleware) Invoke(_ context.Context, in *middleware.Input) (*middlewar
 // 10k such rows reports 0.02 instead of 0.016. Nano-dollar precision keeps the
 // per-row error ~1000x below the smallest realistic bucket.
 func usd(v float64) string { return fmt.Sprintf("%.9f", v) }
+
+// customCosts returns a configured exact-route price, if the router recorded a
+// resolved provider ID and that provider declares the requested model. Custom
+// prices have no cache-specific rates, so cache buckets use the input rate.
+func (m *Middleware) customCosts(metadata []middleware.KV, provider, model string, inputTokens, outputTokens, cachedTokens, cacheCreationTokens int64) (pricing.Costs, bool) {
+	providerID := lookupKV(metadata, middleware.KeyLLMResolvedProviderID)
+	price, ok := m.providerPrices[providerID][model]
+	if !ok {
+		return pricing.Costs{}, false
+	}
+	input := float64(inputTokens) / 1000 * price.InputPer1k
+	cachedInput := 0.0
+	cacheCreation := 0.0
+	if provider == "openai" {
+		cachedTokens = min(cachedTokens, inputTokens)
+		input = float64(inputTokens-cachedTokens) / 1000 * price.InputPer1k
+		cachedInput = float64(cachedTokens) / 1000 * price.InputPer1k
+	} else if provider == "anthropic" || provider == "bedrock" {
+		cachedInput = float64(cachedTokens) / 1000 * price.InputPer1k
+		cacheCreation = float64(cacheCreationTokens) / 1000 * price.InputPer1k
+	}
+	output := float64(outputTokens) / 1000 * price.OutputPer1k
+	return pricing.Costs{
+		InputUSD:         input,
+		CachedInputUSD:   cachedInput,
+		CacheCreationUSD: cacheCreation,
+		OutputUSD:        output,
+		TotalUSD:         input + cachedInput + cacheCreation + output,
+		CacheUSD:         cachedInput + cacheCreation,
+	}, true
+}
 
 // skip returns a single-entry metadata slice carrying the given skip
 // reason under KeyCostSkipped.

--- a/proxy/internal/middleware/builtin/cost_meter/middleware_test.go
+++ b/proxy/internal/middleware/builtin/cost_meter/middleware_test.go
@@ -140,6 +140,100 @@ func TestFactory_PricingPathOverride(t *testing.T) {
 	assert.Equal(t, "0.015000000", value, "2*0.0025 + 1*0.01 = 0.015 with 9-decimal format")
 }
 
+func TestInvoke_PrefersConfiguredProviderPrice(t *testing.T) {
+	configureBuiltin(t)
+	raw, err := json.Marshal(Config{ProviderPrices: []ProviderPrices{{
+		ProviderID: "custom-provider",
+		Models: []ModelPrice{{
+			ID:          "gpt-4o",
+			InputPer1k:  0.1,
+			OutputPer1k: 0.2,
+		}},
+	}, {
+		ProviderID: "other-provider",
+		Models: []ModelPrice{{
+			ID:          "gpt-4o",
+			InputPer1k:  0.3,
+			OutputPer1k: 0.4,
+		}},
+	}}})
+	require.NoError(t, err)
+	mw := buildMiddleware(t, raw)
+
+	out, err := mw.Invoke(context.Background(), &middleware.Input{Metadata: []middleware.KV{
+		{Key: middleware.KeyLLMProvider, Value: "openai"},
+		{Key: middleware.KeyLLMResolvedProviderID, Value: "custom-provider"},
+		{Key: middleware.KeyLLMModel, Value: "gpt-4o"},
+		{Key: middleware.KeyLLMInputTokens, Value: "1000"},
+		{Key: middleware.KeyLLMOutputTokens, Value: "1000"},
+	}})
+	require.NoError(t, err)
+
+	value, ok := metaValue(t, out.Metadata, middleware.KeyCostUSDTotal)
+	require.True(t, ok, "configured provider price must produce a cost")
+	assert.Equal(t, "0.300000", value, "configured route price must override static vendor pricing")
+
+	out, err = mw.Invoke(context.Background(), &middleware.Input{Metadata: []middleware.KV{
+		{Key: middleware.KeyLLMProvider, Value: "openai"},
+		{Key: middleware.KeyLLMResolvedProviderID, Value: "other-provider"},
+		{Key: middleware.KeyLLMModel, Value: "gpt-4o"},
+		{Key: middleware.KeyLLMInputTokens, Value: "1000"},
+		{Key: middleware.KeyLLMOutputTokens, Value: "1000"},
+	}})
+	require.NoError(t, err)
+	value, ok = metaValue(t, out.Metadata, middleware.KeyCostUSDTotal)
+	require.True(t, ok, "second configured provider price must produce a cost")
+	assert.Equal(t, "0.700000", value, "resolved provider ID must select the matching price for a shared model")
+}
+
+func TestInvoke_ConfiguredProviderPriceUsesCacheFallbackRates(t *testing.T) {
+	configureBuiltin(t)
+	raw, err := json.Marshal(Config{ProviderPrices: []ProviderPrices{{
+		ProviderID: "custom-provider",
+		Models:     []ModelPrice{{ID: "claude-sonnet-4-5", InputPer1k: 0.1, OutputPer1k: 0.2}},
+	}}})
+	require.NoError(t, err)
+	mw := buildMiddleware(t, raw)
+
+	out, err := mw.Invoke(context.Background(), &middleware.Input{Metadata: []middleware.KV{
+		{Key: middleware.KeyLLMProvider, Value: "anthropic"},
+		{Key: middleware.KeyLLMResolvedProviderID, Value: "custom-provider"},
+		{Key: middleware.KeyLLMModel, Value: "claude-sonnet-4-5"},
+		{Key: middleware.KeyLLMInputTokens, Value: "1000"},
+		{Key: middleware.KeyLLMOutputTokens, Value: "1000"},
+		{Key: middleware.KeyLLMCachedInputTokens, Value: "1000"},
+		{Key: middleware.KeyLLMCacheCreationTokens, Value: "1000"},
+	}})
+	require.NoError(t, err)
+
+	value, ok := metaValue(t, out.Metadata, middleware.KeyCostUSDTotal)
+	require.True(t, ok, "configured provider price must produce a cost")
+	assert.Equal(t, "0.500000", value, "cache buckets must fall back to configured input price")
+}
+
+func TestInvoke_ZeroConfiguredPriceFallsBackToStaticTable(t *testing.T) {
+	configureBuiltin(t)
+	raw, err := json.Marshal(Config{ProviderPrices: []ProviderPrices{{
+		ProviderID: "custom-provider",
+		Models:     []ModelPrice{{ID: "gpt-4o"}},
+	}}})
+	require.NoError(t, err)
+	mw := buildMiddleware(t, raw)
+
+	out, err := mw.Invoke(context.Background(), &middleware.Input{Metadata: []middleware.KV{
+		{Key: middleware.KeyLLMProvider, Value: "openai"},
+		{Key: middleware.KeyLLMResolvedProviderID, Value: "custom-provider"},
+		{Key: middleware.KeyLLMModel, Value: "gpt-4o"},
+		{Key: middleware.KeyLLMInputTokens, Value: "1000"},
+		{Key: middleware.KeyLLMOutputTokens, Value: "1000"},
+	}})
+	require.NoError(t, err)
+
+	value, ok := metaValue(t, out.Metadata, middleware.KeyCostUSDTotal)
+	require.True(t, ok, "static table must price a zero-valued configured model")
+	assert.Equal(t, "0.012500", value, "zero configured price must not override static vendor pricing")
+}
+
 func TestInvoke_ComputesCostForKnownModel(t *testing.T) {
 	configureBuiltin(t)
 	mw := buildMiddleware(t, nil)
@@ -493,7 +587,7 @@ func TestInvoke_UnparseableCachedTokensSkippedSilently(t *testing.T) {
 // the mtime-poll loop doesn't outlive the chain.
 func TestMiddleware_CloseCancelsReloader(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	m := newMiddleware(nil, cancel)
+	m := newMiddleware(nil, cancel, nil)
 
 	require.NoError(t, m.Close(), "Close must not error")
 	require.Error(t, ctx.Err(), "Close must cancel the reloader context so the poll goroutine exits")
@@ -502,7 +596,7 @@ func TestMiddleware_CloseCancelsReloader(t *testing.T) {
 // TestMiddleware_CloseNilSafe confirms Close is a no-op (no panic) for an
 // instance with no reloader and for a nil receiver.
 func TestMiddleware_CloseNilSafe(t *testing.T) {
-	require.NoError(t, newMiddleware(nil, nil).Close(), "no-reloader Close must be a no-op")
+	require.NoError(t, newMiddleware(nil, nil, nil).Close(), "no-reloader Close must be a no-op")
 	var m *Middleware
 	require.NoError(t, m.Close(), "nil-receiver Close must be safe")
 }

--- a/proxy/internal/middleware/builtin/cost_meter/middleware_test.go
+++ b/proxy/internal/middleware/builtin/cost_meter/middleware_test.go
@@ -171,7 +171,7 @@ func TestInvoke_PrefersConfiguredProviderPrice(t *testing.T) {
 
 	value, ok := metaValue(t, out.Metadata, middleware.KeyCostUSDTotal)
 	require.True(t, ok, "configured provider price must produce a cost")
-	assert.Equal(t, "0.300000", value, "configured route price must override static vendor pricing")
+	assert.Equal(t, "0.300000000", value, "configured route price must override static vendor pricing")
 
 	out, err = mw.Invoke(context.Background(), &middleware.Input{Metadata: []middleware.KV{
 		{Key: middleware.KeyLLMProvider, Value: "openai"},
@@ -183,7 +183,7 @@ func TestInvoke_PrefersConfiguredProviderPrice(t *testing.T) {
 	require.NoError(t, err)
 	value, ok = metaValue(t, out.Metadata, middleware.KeyCostUSDTotal)
 	require.True(t, ok, "second configured provider price must produce a cost")
-	assert.Equal(t, "0.700000", value, "resolved provider ID must select the matching price for a shared model")
+	assert.Equal(t, "0.700000000", value, "resolved provider ID must select the matching price for a shared model")
 }
 
 func TestInvoke_ConfiguredProviderPriceUsesCacheFallbackRates(t *testing.T) {
@@ -208,7 +208,7 @@ func TestInvoke_ConfiguredProviderPriceUsesCacheFallbackRates(t *testing.T) {
 
 	value, ok := metaValue(t, out.Metadata, middleware.KeyCostUSDTotal)
 	require.True(t, ok, "configured provider price must produce a cost")
-	assert.Equal(t, "0.500000", value, "cache buckets must fall back to configured input price")
+	assert.Equal(t, "0.500000000", value, "cache buckets must fall back to configured input price")
 }
 
 func TestInvoke_ZeroConfiguredPriceFallsBackToStaticTable(t *testing.T) {
@@ -231,7 +231,7 @@ func TestInvoke_ZeroConfiguredPriceFallsBackToStaticTable(t *testing.T) {
 
 	value, ok := metaValue(t, out.Metadata, middleware.KeyCostUSDTotal)
 	require.True(t, ok, "static table must price a zero-valued configured model")
-	assert.Equal(t, "0.012500", value, "zero configured price must not override static vendor pricing")
+	assert.Equal(t, "0.012500000", value, "zero configured price must not override static vendor pricing")
 }
 
 func TestInvoke_ComputesCostForKnownModel(t *testing.T) {


### PR DESCRIPTION
## Summary
- propagate valid configured provider model prices into synthesized cost-meter middleware config
- meter prices by the router-resolved provider ID and model, with static pricing as the fallback
- preserve provider cache-token semantics using configured input prices

Closes #6888

## Testing
- `go test ./management/internals/modules/agentnetwork ./proxy/internal/middleware/builtin/cost_meter -count=1`
- `go test ./proxy/... -count=1`

## Checklist
- [x] Documentation is **not needed**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787652786&installation_model_id=427504&pr_number=6904&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6904&signature=b71e0492609813cea64ea43d33e17148c64387cd174d6a5beb2b6022966c242c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider- and model-specific pricing overrides for cost calculations.
  * Exact pricing can be applied when provider and model details are available.
  * Generated pricing configuration now includes valid pricing for reachable, enabled providers and configured models.
* **Bug Fixes**
  * Invalid, placeholder, or zero-value overrides no longer replace built-in pricing.
  * Cache-related costs now use the appropriate configured input rates when applicable.
* **Tests**
  * Expanded coverage for pricing overrides, cache fallback behavior, and zero-price fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->