### PR TITLE
[misc] Restore the rootless-latest docker tag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -273,8 +273,8 @@ dockers_v2:
        - netbirdio/netbird
        - ghcr.io/netbirdio/netbird
      tags:
-       - "v{{ .Version }}-rootless"
-       - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}latest{{ end }}"
+       - "{{ .Version }}-rootless"
+       - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}rootless-latest{{ end }}"
      dockerfile: client/Dockerfile-rootless
      extra_files:
        - client/netbird-entrypoint.sh


### PR DESCRIPTION
## Describe your changes

The `rootless-latest` Docker tag stopped being published after the `dockers_v2` migration in #6438: the rootless entry's tag list was copied from the rootful one, so it emitted `latest` instead of `rootless-latest`. As a result `rootless-latest` still points at 0.72.4, and both the rootful and rootless builds were racing to claim `netbirdio/netbird:latest`.

- Publish `rootless-latest` again from the rootless image and stop it from overwriting `latest`
- Drop the leftover `v` prefix from the rootless version tag, so it is `<version>-rootless` in line with all other images since #6471

Note for the release notes: the versioned rootless tag changes from `v0.75.0-rootless` to `<version>-rootless`, so anyone who pinned a `v`-prefixed tag during that window needs to update.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why) — restores the previously documented tag name, no docs change required

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
