### PR TITLE
[client]  Export agent version info for iOS

### DIFF
--- a/client/ios/NetBirdSDK/version.go
+++ b/client/ios/NetBirdSDK/version.go
@@ -10,9 +10,3 @@ import "github.com/netbirdio/netbird/version"
 func GoClientVersion() string {
 	return version.NetbirdVersion()
 }
-
-// GoClientCommit returns the VCS revision of the Go client build, or an empty
-// string when no build info is embedded.
-func GoClientCommit() string {
-	return version.NetbirdCommit()
-}

--- a/client/ios/NetBirdSDK/version.go
+++ b/client/ios/NetBirdSDK/version.go
@@ -1,0 +1,18 @@
+//go:build ios
+
+package NetBirdSDK
+
+import "github.com/netbirdio/netbird/version"
+
+// GoClientVersion returns the NetBird Go client version that was baked into
+// the framework at compile time via
+// -ldflags "-X github.com/netbirdio/netbird/version.version=<version>".
+func GoClientVersion() string {
+	return version.NetbirdVersion()
+}
+
+// GoClientCommit returns the VCS revision of the Go client build, or an empty
+// string when no build info is embedded.
+func GoClientCommit() string {
+	return version.NetbirdCommit()
+}


### PR DESCRIPTION
## Describe your changes

Export agent version info for iOS

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787750541&installation_model_id=427504&pr_number=6918&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6918&signature=c2de74d89c36b01aac5866422b0be0b7525f7c6e26e46174efc280339eb864b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->