### PR TITLE
[client] Use platform installer URL for manual update downloads

### DIFF
--- a/client/ui/frontend/src/modules/auto-update/UpdateVersionCard.tsx
+++ b/client/ui/frontend/src/modules/auto-update/UpdateVersionCard.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Browser } from "@wailsio/runtime";
 import { DownloadIcon, NotepadText } from "lucide-react";
+import { Update as UpdateSvc } from "@bindings/services";
 import { Button } from "@/components/buttons/Button";
 import { useClientVersion } from "@/contexts/ClientVersionContext";
 import { cn } from "@/lib/cn";
@@ -12,6 +13,12 @@ function openUrl(url: string) {
     Browser.OpenURL(url).catch(() => {
         window.open(url, "_blank");
     });
+}
+
+function openInstallerDownload() {
+    UpdateSvc.DownloadURL()
+        .then(openUrl)
+        .catch(() => openUrl(GITHUB_RELEASES));
 }
 
 export function UpdateVersionCard() {
@@ -37,11 +44,7 @@ export function UpdateVersionCard() {
                         {t("update.card.installNow")}
                     </Button>
                 ) : (
-                    <Button
-                        variant={"primary"}
-                        size={"xs"}
-                        onClick={() => openUrl(GITHUB_RELEASES)}
-                    >
+                    <Button variant={"primary"} size={"xs"} onClick={openInstallerDownload}>
                         <DownloadIcon size={14} />
                         {t("update.card.getInstaller")}
                     </Button>

--- a/client/ui/services/update.go
+++ b/client/ui/services/update.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/netbirdio/netbird/client/proto"
 	"github.com/netbirdio/netbird/client/ui/updater"
+	"github.com/netbirdio/netbird/version"
 )
 
 // UpdateResult mirrors TriggerUpdateResponse.
@@ -31,6 +32,12 @@ func NewUpdate(conn DaemonConn, holder *updater.Holder) *Update {
 
 func (s *Update) GetState() updater.State {
 	return s.holder.Get()
+}
+
+// DownloadURL returns the platform-appropriate installer download link for
+// manual (non-enforced) updates.
+func (s *Update) DownloadURL() string {
+	return version.DownloadUrl()
 }
 
 // Quit exits the app. Scheduled off the calling goroutine so the JS caller's

--- a/client/ui/tray.go
+++ b/client/ui/tray.go
@@ -32,9 +32,8 @@ const (
 
 	quitDownTimeout = 5 * time.Second
 
-	urlGitHubRepo     = "https://github.com/netbirdio/netbird"
-	urlGitHubReleases = "https://github.com/netbirdio/netbird/releases/latest"
-	urlDocs           = "https://docs.netbird.io"
+	urlGitHubRepo = "https://github.com/netbirdio/netbird"
+	urlDocs       = "https://docs.netbird.io"
 )
 
 // TrayServices bundles the services the tray menu needs, grouped so NewTray

--- a/client/ui/tray_update.go
+++ b/client/ui/tray_update.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/netbirdio/netbird/client/ui/services"
 	"github.com/netbirdio/netbird/client/ui/updater"
+	"github.com/netbirdio/netbird/version"
 )
 
 // trayUpdater owns the tray UI that reacts to auto-update. Composed inside Tray.
@@ -76,15 +77,15 @@ func (u *trayUpdater) applyLanguage() {
 	u.refreshMenuItem(state)
 }
 
-// handleClick opens the GitHub releases page when not Enforced, otherwise shows
-// the progress page and asks the daemon to start the installer.
+// handleClick opens the installer download link when not Enforced, otherwise
+// shows the progress page and asks the daemon to start the installer.
 func (u *trayUpdater) handleClick() {
 	u.mu.Lock()
 	state := u.state
 	u.mu.Unlock()
 
 	if !state.Enforced {
-		_ = u.app.Browser.OpenURL(urlGitHubReleases)
+		_ = u.app.Browser.OpenURL(version.DownloadUrl())
 		return
 	}
 

--- a/version/url_darwin.go
+++ b/version/url_darwin.go
@@ -12,16 +12,10 @@ const (
 
 // DownloadUrl return with the proper download link
 func DownloadUrl() string {
-	cmd := exec.Command("brew", "list --formula | grep -i netbird")
-	if err := cmd.Start(); err != nil {
-		goto PKGINSTALL
-	}
-
-	if err := cmd.Wait(); err == nil {
+	if isBrewInstall() {
 		return downloadURL
 	}
 
-PKGINSTALL:
 	switch runtime.GOARCH {
 	case "amd64":
 		return urlMacIntel
@@ -30,4 +24,13 @@ PKGINSTALL:
 	default:
 		return downloadURL
 	}
+}
+
+// isBrewInstall reports whether NetBird is installed via Homebrew, either as
+// the netbird formula or the netbird-ui cask.
+func isBrewInstall() bool {
+	if err := exec.Command("brew", "list", "--formula", "netbird").Run(); err == nil {
+		return true
+	}
+	return exec.Command("brew", "list", "--cask", "netbird-ui").Run() == nil
 }

--- a/version/url_darwin.go
+++ b/version/url_darwin.go
@@ -26,11 +26,7 @@ func DownloadUrl() string {
 	}
 }
 
-// isBrewInstall reports whether NetBird is installed via Homebrew, either as
-// the netbird formula or the netbird-ui cask.
+// isBrewInstall reports whether NetBird is installed via Homebrew.
 func isBrewInstall() bool {
-	if err := exec.Command("brew", "list", "--formula", "netbird").Run(); err == nil {
-		return true
-	}
-	return exec.Command("brew", "list", "--cask", "netbird-ui").Run() == nil
+	return exec.Command("brew", "list", "netbird").Run() == nil
 }

--- a/version/url_darwin.go
+++ b/version/url_darwin.go
@@ -12,10 +12,16 @@ const (
 
 // DownloadUrl return with the proper download link
 func DownloadUrl() string {
-	if isBrewInstall() {
+	cmd := exec.Command("brew", "list --formula | grep -i netbird")
+	if err := cmd.Start(); err != nil {
+		goto PKGINSTALL
+	}
+
+	if err := cmd.Wait(); err == nil {
 		return downloadURL
 	}
 
+PKGINSTALL:
 	switch runtime.GOARCH {
 	case "amd64":
 		return urlMacIntel
@@ -24,9 +30,4 @@ func DownloadUrl() string {
 	default:
 		return downloadURL
 	}
-}
-
-// isBrewInstall reports whether NetBird is installed via Homebrew.
-func isBrewInstall() bool {
-	return exec.Command("brew", "list", "netbird").Run() == nil
 }


### PR DESCRIPTION
The Wails UI regressed the non-enforced update download to the plain GitHub releases page. Restore the old Fyne behavior: the tray update item and the About card's Get installer button now open version.DownloadUrl(), which points to the direct installer download (pkgs.netbird.io) per OS/arch and falls back to the generic install page where no installer exists.

Also fix the dead brew detection on darwin: exec.Command passed the whole pipeline as a single argument to brew, so the check always failed. Query the netbird formula and netbird-ui cask explicitly via exit codes instead.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787764680&installation_model_id=427504&pr_number=6922&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6922&signature=3d9d640b25a17589114cc704e1d631895ffcd9f554947ff5790fe90d54410d2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a direct installer download option for manual application updates.
  * Non-enforced updates now open the appropriate platform-specific installer instead of the general releases page.

* **Bug Fixes**
  * Improved macOS download behavior for Homebrew installations.
  * Preserved architecture-specific downloads for Intel and Apple silicon Macs.
  * Updated the tray “About” links to use the GitHub repository and documentation instead of the releases page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->