### PR TITLE
[client] Escape dots in interface names for sysctl configuration

### DIFF
--- a/client/internal/routemanager/sysctl/sysctl_linux.go
+++ b/client/internal/routemanager/sysctl/sysctl_linux.go
@@ -20,7 +20,8 @@ const (
 	rpFilterPath          = "net.ipv4.conf.all.rp_filter"
 	rpFilterInterfacePath = "net.ipv4.conf.%s.rp_filter"
 	srcValidMarkPath      = "net.ipv4.conf.all.src_valid_mark"
-	dotEscape             = "__DOT__"
+	percentEscape         = "%25"
+	dotEscape             = "%2E"
 )
 
 type iface interface {
@@ -57,8 +58,10 @@ func Setup(wgIface iface) (map[string]int, error) {
 			continue
 		}
 
-		// Escape dots in the interface name (e.g. flannel.1 -> flannel__DOT__1)
-		safeName := strings.ReplaceAll(intf.Name, ".", dotEscape)
+		// Escape '%' and '.' so they survive the dot-to-slash conversion in Set()
+		safeName := strings.ReplaceAll(intf.Name, "%", percentEscape)
+		safeName = strings.ReplaceAll(safeName, ".", dotEscape)
+
 		i := fmt.Sprintf(rpFilterInterfacePath, safeName)
 		oldVal, err := Set(i, 2, true)
 		if err != nil {
@@ -74,8 +77,9 @@ func Setup(wgIface iface) (map[string]int, error) {
 // Set sets a sysctl configuration, if onlyIfOne is true it will only set the new value if it's set to 1
 func Set(key string, desiredValue int, onlyIfOne bool) (int, error) {
 	path := strings.ReplaceAll(key, ".", "/")
-	// Unescape dot in interface name (e.g. flannel__DOT__1 -> flannel.1)
+	// Unescape interface dots and percent signs
 	path = strings.ReplaceAll(path, dotEscape, ".")
+	path = strings.ReplaceAll(path, percentEscape, "%")
 	path = fmt.Sprintf("/proc/sys/%s", path)
 	currentValue, err := os.ReadFile(path)
 	if err != nil {

--- a/client/internal/routemanager/sysctl/sysctl_linux.go
+++ b/client/internal/routemanager/sysctl/sysctl_linux.go
@@ -20,6 +20,7 @@ const (
 	rpFilterPath          = "net.ipv4.conf.all.rp_filter"
 	rpFilterInterfacePath = "net.ipv4.conf.%s.rp_filter"
 	srcValidMarkPath      = "net.ipv4.conf.all.src_valid_mark"
+	dotEscape             = "__DOT__"
 )
 
 type iface interface {
@@ -56,7 +57,9 @@ func Setup(wgIface iface) (map[string]int, error) {
 			continue
 		}
 
-		i := fmt.Sprintf(rpFilterInterfacePath, intf.Name)
+		// Escape dots in the interface name (e.g. flannel.1 -> flannel__DOT__1)
+		safeName := strings.ReplaceAll(intf.Name, ".", dotEscape)
+		i := fmt.Sprintf(rpFilterInterfacePath, safeName)
 		oldVal, err := Set(i, 2, true)
 		if err != nil {
 			result = multierror.Append(result, err)
@@ -70,7 +73,10 @@ func Setup(wgIface iface) (map[string]int, error) {
 
 // Set sets a sysctl configuration, if onlyIfOne is true it will only set the new value if it's set to 1
 func Set(key string, desiredValue int, onlyIfOne bool) (int, error) {
-	path := fmt.Sprintf("/proc/sys/%s", strings.ReplaceAll(key, ".", "/"))
+	path := strings.ReplaceAll(key, ".", "/")
+	// Unescape dot in interface name (e.g. flannel__DOT__1 -> flannel.1)
+	path = strings.ReplaceAll(path, dotEscape, ".")
+	path = fmt.Sprintf("/proc/sys/%s", path)
 	currentValue, err := os.ReadFile(path)
 	if err != nil {
 		return -1, fmt.Errorf("read sysctl %s: %w", key, err)


### PR DESCRIPTION
## Describe your changes
This PR fixes a bug where sysctl settings fail to apply on network interfaces that contain dots in their names, such as `flannel.1`. 

Previously, the `Set` function blindly replaced all dots in the sysctl key with slashes (`/`). For an interface like `flannel.1`, this incorrectly resolved to `/proc/sys/net/ipv4/conf/flannel/1/rp_filter`, which caused the operation to fail.

**Changes made:**
- Introduced a `dotEscape` and `percentEscape` placeholder.
- In `Setup()`, dots and percent signs inside interface names are now temporarily escaped before they are formatted into the standard sysctl key.
- In `Set()`, after all standard dots are converted to directory slashes, the placeholder dots and percent signs are unescaped back into their literal representation for the final `/proc/sys/...` file path.
- This ensures interface names are perfectly preserved on the filesystem without breaking the standard dotted sysctl format used in the `keys` map and `Cleanup()` routine.
- Prevents path injection by combingin dots and percent sign replacement.

## Issue ticket number and link
Closes #4396 - [IP routing fails with flannel interface](https://github.com/netbirdio/netbird/issues/4396)

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)
*Explanation: This is an internal fix for sysctl file path resolution on Linux to support interfaces with dots in their names (like flannel). It does not change any user-facing configuration, APIs, or CLI commands.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787776674&installation_model_id=427504&pr_number=6930&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6930&signature=d139afd28be4fdd61e11d12d6971aae72bdfff6de1211f3fc58f0675fa509109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of periods in network interface names when configuring Linux sysctl settings.
  * Ensured interface-specific reverse path filtering settings are applied to the correct system paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->