### PR TITLE
[misc] add dependencies to install.sh

### DIFF
--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -72,6 +72,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: prepare container
+        # The netbird package postinstall registers a SysV service when
+        # systemd is not running. The trixie and fedora images ship without
+        # the SysV directories and tools it needs, unlike the older images.
+        run: |
+          mkdir -p /etc/init.d
+          if command -v dnf >/dev/null 2>&1; then
+            dnf -y install initscripts-service || dnf -y install initscripts
+          fi
+
       - name: run install script
         env:
           XDG_CURRENT_DESKTOP: GNOME

--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - "release_files/install.sh"
+      - ".github/workflows/install-script-test.yml"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
   cancel-in-progress: true
@@ -37,3 +38,54 @@ jobs:
 
       - name: check cli binary
         run: command -v netbird
+
+  test-install-script-distros:
+    name: UI gating on ${{ matrix.image }}${{ matrix.install_epel && ' (EPEL pre-confirmed)' || '' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        include:
+          # GTK 4 below 4.10: desktop app must be skipped, CLI installed
+          - image: "ubuntu:22.04"
+            expect_ui: false
+          - image: "debian:12"
+            expect_ui: false
+          # GTK 4.10+ and WebKitGTK 6.0 available: desktop app installed
+          - image: "debian:13"
+            expect_ui: true
+          - image: "fedora:43"
+            expect_ui: true
+          # webkitgtk6.0 needs EPEL: skipped without confirmation,
+          # installed when NETBIRD_INSTALL_EPEL=true
+          - image: "almalinux:10"
+            expect_ui: false
+          - image: "almalinux:10"
+            expect_ui: true
+            install_epel: true
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: run install script
+        env:
+          XDG_CURRENT_DESKTOP: GNOME
+          NETBIRD_INSTALL_EPEL: ${{ matrix.install_epel && 'true' || '' }}
+        run: sh -x release_files/install.sh
+
+      - name: check binaries
+        run: |
+          command -v netbird
+          if [ "${{ matrix.expect_ui }}" = "true" ]; then
+            command -v netbird-ui
+          else
+            if command -v netbird-ui; then
+              echo "netbird-ui should not have been installed on ${{ matrix.image }}"
+              exit 1
+            fi
+          fi

--- a/release_files/install.sh
+++ b/release_files/install.sh
@@ -134,6 +134,72 @@ repo_gpgcheck=1
 EOF
 }
 
+# The desktop app renders in a GTK 4 WebKit webview and needs GTK 4.10+ with
+# WebKitGTK 6.0. The netbird-ui packages do not declare these libraries, so
+# the installer resolves them and degrades to a CLI-only install when the
+# system cannot provide them.
+UI_MIN_GTK_VERSION="4.10"
+
+skip_ui_app() {
+    SKIP_UI_APP=true
+    echo "NetBird UI installation will be omitted: $1"
+}
+
+install_ui_apt() {
+    GTK_CANDIDATE="$(apt-cache policy libgtk-4-1 2>/dev/null | awk '/Candidate:/ {print $2}')"
+    if [ -z "$GTK_CANDIDATE" ] || [ "$GTK_CANDIDATE" = "(none)" ]; then
+        skip_ui_app "GTK 4 is not available in the configured APT repositories"
+        return 0
+    fi
+    if ! dpkg --compare-versions "$GTK_CANDIDATE" ge "$UI_MIN_GTK_VERSION"; then
+        skip_ui_app "the desktop app needs GTK ${UI_MIN_GTK_VERSION}+ and this release provides ${GTK_CANDIDATE} (Ubuntu 24.04+ or Debian 13+ required)"
+        return 0
+    fi
+    if ! ${SUDO} apt-get install netbird-ui libgtk-4-1 libwebkitgtk-6.0-4 xdg-utils -y; then
+        skip_ui_app "the desktop app dependencies could not be installed"
+    fi
+}
+
+# Enabling EPEL changes the system's repository configuration, so it needs
+# an explicit go-ahead: either NETBIRD_INSTALL_EPEL=true in the environment
+# or an interactive confirmation. Returns 0 when EPEL is available.
+confirm_epel() {
+    if rpm -q epel-release >/dev/null 2>&1; then
+        return 0
+    fi
+    if [ "${NETBIRD_INSTALL_EPEL:-}" = "true" ]; then
+        echo "NETBIRD_INSTALL_EPEL=true is set, enabling the EPEL repository"
+        ${SUDO} dnf -y install epel-release
+        return $?
+    fi
+    if (exec < /dev/tty) 2>/dev/null; then
+        printf "The desktop app needs WebKitGTK 6.0 from the EPEL repository (https://docs.fedoraproject.org/en-US/epel/). Enable EPEL and continue? [y/N] "
+        read -r EPEL_REPLY < /dev/tty
+        case "$EPEL_REPLY" in
+            y|Y|yes|YES)
+                ${SUDO} dnf -y install epel-release
+                return $?
+            ;;
+        esac
+    fi
+    return 1
+}
+
+install_ui_dnf() {
+    # webkitgtk6.0 comes from EPEL on RHEL, AlmaLinux and Rocky Linux 10.
+    case "$OS_NAME" in
+        rhel|almalinux|rocky|centos)
+            if ! confirm_epel; then
+                skip_ui_app "the desktop app needs WebKitGTK 6.0 from EPEL; re-run with NETBIRD_INSTALL_EPEL=true to enable it"
+                return 0
+            fi
+        ;;
+    esac
+    if ! ${SUDO} dnf -y install netbird-ui gtk4 webkitgtk6.0 xdg-utils; then
+        skip_ui_app "GTK 4.10+ and WebKitGTK 6.0 are not available on this system (Fedora 43+ or RHEL 10+ required)"
+    fi
+}
+
 prepare_tun_module() {
   # Create the necessary file structure for /dev/net/tun
   if [ ! -c /dev/net/tun ]; then
@@ -226,14 +292,16 @@ install_netbird() {
         ${SUDO} apt-get install netbird -y
 
         if ! $SKIP_UI_APP; then
-            ${SUDO} apt-get install netbird-ui -y
+            install_ui_apt
         fi
     ;;
     yum)
         add_rpm_repo
         ${SUDO} yum -y install netbird
         if ! $SKIP_UI_APP; then
-            ${SUDO} yum -y install netbird-ui
+            # Systems where dnf is absent (RHEL 9, Amazon Linux) do not
+            # provide GTK 4.10+ or WebKitGTK 6.0.
+            skip_ui_app "this system does not provide the desktop app dependencies (RHEL 10+ required)"
         fi
     ;;
     dnf)
@@ -241,7 +309,7 @@ install_netbird() {
         ${SUDO} dnf -y install netbird
 
         if ! $SKIP_UI_APP; then
-            ${SUDO} dnf -y install netbird-ui
+            install_ui_dnf
         fi
     ;;
     rpm-ostree)
@@ -401,9 +469,8 @@ if type uname >/dev/null 2>&1; then
               OS_NAME="$(. /etc/os-release && echo "$ID")"
               INSTALL_DIR="/usr/bin"
 
-              # Allow netbird UI installation for x64 arch only
-              if [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ] \
-                  && [ "$ARCH" != "x86_64" ];then
+              # The netbird-ui Linux packages are built for x86_64 only
+              if [ "$ARCH" != "amd64" ] && [ "$ARCH" != "x86_64" ];then
                   SKIP_UI_APP=true
                   echo "NetBird UI installation will be omitted as $ARCH is not a compatible architecture"
               fi


### PR DESCRIPTION
- update workflow to test different containers

## Describe your changes

The install script now resolves the desktop app's runtime libraries (GTK 4.10+, WebKitGTK 6.0), which the `netbird-ui` packages do not declare:

- Install the GTK/WebKitGTK packages alongside `netbird-ui` on apt and dnf.
- Enforce the GTK 4.10 floor on apt (Ubuntu 22.04 / Debian 12 ship WebKitGTK 6.0 but GTK below 4.10, where the app crashes on the first file dialog).
- On RHEL / AlmaLinux / Rocky 10, `webkitgtk6.0` comes from EPEL. Enabling a third-party repo needs consent: the script prompts on a TTY, and `NETBIRD_INSTALL_EPEL=true` pre-confirms for unattended installs. Without either, the UI is skipped and the CLI install completes.
- Restrict the UI to x86_64 — no arm64 `netbird-ui` package exists, and the previous arch gate let arm64 desktops reach `apt-get install netbird-ui`, which failed and aborted the script between the CLI install and the service start (half-install).
- The `yum` path (RHEL 9, Amazon Linux) is CLI-only, as those systems lack the required stack.
- Any UI failure degrades to a CLI-only install instead of aborting under `set -e`.

The install-script workflow gains a container matrix (ubuntu:22.04, debian:12/13, fedora:43, almalinux:10 with and without EPEL pre-confirmation) asserting `netbird-ui` presence/absence per distro. Containers are prepped with the SysV directories the netbird package postinstall needs when systemd is not running.

Out of scope: the `--update` binary path performs no dependency checks (pre-existing).

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/888
