### PR TITLE
[client] Fix tray menu item leak on relayout

### DIFF
--- a/client/ui/tray.go
+++ b/client/ui/tray.go
@@ -67,8 +67,8 @@ type Tray struct {
 	loc       *Localizer
 
 	// menu and the *Item/*Submenu fields below are reassigned by buildMenu
-	// on every relayout (which destroys the replaced tree) — touch them only
-	// with menuMu held; snapshot under the lock, then call the item.
+	// on every relayout, which destroys the replaced tree — locate items and
+	// call them with menuMu held, so a relayout can't destroy one mid-call.
 	menu       *application.Menu
 	statusItem *application.MenuItem
 	// sessionExpiresItem shows the SSO deadline as a remaining-time label,
@@ -507,9 +507,8 @@ func (t *Tray) handleConnect() {
 
 func (t *Tray) setItemEnabled(get func() *application.MenuItem, enabled bool) {
 	t.menuMu.Lock()
-	item := get()
-	t.menuMu.Unlock()
-	if item != nil {
+	defer t.menuMu.Unlock()
+	if item := get(); item != nil {
 		item.SetEnabled(enabled)
 	}
 }

--- a/client/ui/tray.go
+++ b/client/ui/tray.go
@@ -67,9 +67,8 @@ type Tray struct {
 	loc       *Localizer
 
 	// menu and the *Item/*Submenu fields below are reassigned by buildMenu
-	// on every relayout — touch them only with menuMu held. Exceptions:
-	// the Connect/Disconnect OnClick closures capture their own item, and
-	// refreshSessionExpiresLabel snapshots its item under menuMu.
+	// on every relayout (which destroys the replaced tree) — touch them only
+	// with menuMu held; snapshot under the lock, then call the item.
 	menu       *application.Menu
 	statusItem *application.MenuItem
 	// sessionExpiresItem shows the SSO deadline as a remaining-time label,
@@ -286,6 +285,7 @@ func (t *Tray) relayoutMenu() {
 	t.menuMu.Lock()
 	defer t.menuMu.Unlock()
 
+	old := t.menu
 	t.menu = t.buildMenu()
 
 	t.statusMu.Lock()
@@ -356,6 +356,10 @@ func (t *Tray) relayoutMenu() {
 	// Single push of the whole tree: on Linux one LayoutUpdated with fresh
 	// container ids; on darwin an NSMenu rebuild against the cached pointer.
 	t.tray.SetMenu(t.menu)
+
+	if old != nil {
+		old.Destroy()
+	}
 }
 
 func (t *Tray) buildMenu() *application.Menu {
@@ -371,13 +375,11 @@ func (t *Tray) buildMenu() *application.Menu {
 
 	menu.AddSeparator()
 
-	// The OnClick closures capture the local item because t.upItem/t.downItem
-	// are menuMu-guarded and must not be read from the click goroutine.
 	upItem := menu.Add(t.loc.T("tray.menu.connect"))
-	upItem.OnClick(func(*application.Context) { t.handleConnect(upItem) })
+	upItem.OnClick(func(*application.Context) { t.handleConnect() })
 	t.upItem = upItem
 	downItem := menu.Add(t.loc.T("tray.menu.disconnect"))
-	downItem.OnClick(func(*application.Context) { t.handleDisconnect(downItem) })
+	downItem.OnClick(func(*application.Context) { t.handleDisconnect() })
 	downItem.SetHidden(true)
 	t.downItem = downItem
 
@@ -469,9 +471,7 @@ func (t *Tray) handleQuit() {
 	t.app.Quit()
 }
 
-// handleConnect receives the clicked item from the buildMenu closure —
-// t.upItem is menuMu-guarded and must not be read here.
-func (t *Tray) handleConnect(upItem *application.MenuItem) {
+func (t *Tray) handleConnect() {
 	// NeedsLogin/SessionExpired/LoginFailed won't honor a plain Up RPC — they
 	// need the Login → WaitSSOLogin → Up sequence. Emit EventTriggerLogin so
 	// the React startLogin() (which owns the BrowserLogin popup) drives it;
@@ -485,7 +485,7 @@ func (t *Tray) handleConnect(upItem *application.MenuItem) {
 		t.app.Event.Emit(services.EventTriggerLogin)
 		return
 	}
-	upItem.SetEnabled(false)
+	t.setItemEnabled(func() *application.MenuItem { return t.upItem }, false)
 	// Arm the SSO auto-handoff: Up() is async and the daemon may flip to
 	// NeedsLogin on an SSO peer with no cached token. applyStatus consumes the
 	// flag on that transition to trigger browser-login without a second Connect
@@ -500,18 +500,26 @@ func (t *Tray) handleConnect(upItem *application.MenuItem) {
 			t.statusMu.Lock()
 			t.pendingConnectLogin = false
 			t.statusMu.Unlock()
-			upItem.SetEnabled(true)
+			t.setItemEnabled(func() *application.MenuItem { return t.upItem }, true)
 		}
 	}()
+}
+
+func (t *Tray) setItemEnabled(get func() *application.MenuItem, enabled bool) {
+	t.menuMu.Lock()
+	item := get()
+	t.menuMu.Unlock()
+	if item != nil {
+		item.SetEnabled(enabled)
+	}
 }
 
 // handleDisconnect aborts any in-flight profile switch before sending Down —
 // otherwise the switcher's queued Up would reconnect right after, making the
 // click a no-op. Also clears Peers' optimistic-Connecting guard so the daemon's
 // Idle push paints through instead of being swallowed by the suppression filter.
-// Receives the clicked item from the buildMenu closure (see handleConnect).
-func (t *Tray) handleDisconnect(downItem *application.MenuItem) {
-	downItem.SetEnabled(false)
+func (t *Tray) handleDisconnect() {
+	t.setItemEnabled(func() *application.MenuItem { return t.downItem }, false)
 	t.profileMu.Lock()
 	if t.switchCancel != nil {
 		t.switchCancel()
@@ -523,7 +531,7 @@ func (t *Tray) handleDisconnect(downItem *application.MenuItem) {
 		if err := t.svc.Connection.Down(context.Background()); err != nil {
 			log.Errorf("disconnect: %v", err)
 			t.notifyError(t.loc.T("notify.error.disconnect"))
-			downItem.SetEnabled(true)
+			t.setItemEnabled(func() *application.MenuItem { return t.downItem }, true)
 		}
 	}()
 }

--- a/client/ui/tray_profiles.go
+++ b/client/ui/tray_profiles.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 
 	log "github.com/sirupsen/logrus"
@@ -59,10 +60,11 @@ func (t *Tray) loadConfig() {
 	t.profileMu.Unlock()
 }
 
-// loadProfiles fetches the profile list and relayouts the menu. Also called
-// from applyStatus to catch flips from another channel (CLI, autoconnect),
-// since the daemon emits no active-profile event. Full relayout (not
-// Clear()+Add()) is required for KDE/Plasma — see relayoutMenu's doc comment.
+// loadProfiles fetches the profile list and relayouts the menu when the rows
+// changed. Also called from applyStatus to catch flips from another channel
+// (CLI, autoconnect), since the daemon emits no active-profile event. Full
+// relayout (not Clear()+Add()) is required for KDE/Plasma — see relayoutMenu's
+// doc comment.
 func (t *Tray) loadProfiles() {
 	t.profileLoadMu.Lock()
 	defer t.profileLoadMu.Unlock()
@@ -80,11 +82,14 @@ func (t *Tray) loadProfiles() {
 	}
 
 	t.profilesMu.Lock()
+	changed := username != t.profilesUser || !slices.Equal(profiles, t.profiles)
 	t.profiles = profiles
 	t.profilesUser = username
 	t.profilesMu.Unlock()
 
-	t.relayoutMenu()
+	if changed {
+		t.relayoutMenu()
+	}
 }
 
 // fillProfileSubmenu paints cached profile rows into the freshly built submenu.

--- a/client/ui/tray_session.go
+++ b/client/ui/tray_session.go
@@ -104,21 +104,19 @@ func sessionRefreshInterval(remaining time.Duration) time.Duration {
 }
 
 // refreshSessionExpiresLabel updates only the countdown label, no relayout, to avoid disturbing an open menu.
-// The item is snapshotted under menuMu since buildMenu reassigns it on every relayout.
+// menuMu is held across the SetLabel so a relayout can't destroy the item mid-call.
 func (t *Tray) refreshSessionExpiresLabel() {
-	t.menuMu.Lock()
-	item := t.sessionExpiresItem
-	t.menuMu.Unlock()
-	if item == nil {
-		return
-	}
 	t.sessionMu.Lock()
 	deadline := t.sessionExpiresAt
 	t.sessionMu.Unlock()
 	if deadline.IsZero() {
 		return
 	}
-	item.SetLabel(t.sessionRowLabel(deadline))
+	t.menuMu.Lock()
+	defer t.menuMu.Unlock()
+	if t.sessionExpiresItem != nil {
+		t.sessionExpiresItem.SetLabel(t.sessionRowLabel(deadline))
+	}
 }
 
 func (t *Tray) sessionRowLabel(deadline time.Time) string {


### PR DESCRIPTION
## Describe your changes

Fix a memory leak in the tray menu: every relayout built a brand-new menu tree while the replaced one was never destroyed. Wails keeps each MenuItem in a process-global map until Destroy is called, so all items of every previous tree
(labels, click closures, bitmaps, submenus) stayed reachable forever and the GUI's memory grew with every status transition, profile refresh or language change.

The fix destroys the replaced tree right after SetMenu swaps in the new one. Since the old items can now be destroyed, the Connect/Disconnect click handlers no longer capture their own menu item for the async error path; they resolve
the current item under the menu lock instead. Additionally loadProfiles now relayouts only when the profile rows actually changed, which drops the redundant full menu rebuilds (previously 2-3 per status transition, now typically 1).

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787835850&installation_model_id=427504&pr_number=6939&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6939&signature=110b714e5a405c137ab8cb8f78bb9ee4f83a220b04bc43abfe923a28fb3bb24e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tray menu reliability for connect/disconnect actions, including safer handling while the menu is being rebuilt.
  * Prevented stale tray menu items from being referenced by current actions.
  * Reduced unnecessary tray menu relayouts by updating profiles only when user or profile list actually changes.
  * Improved tray updates when the active profile changes via background status flows.
  * Fixed concurrency issues updating the session-expires tray label to avoid conflicts during menu relayouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->