### PR TITLE
[client] Support user added CAs in android client

### DIFF
--- a/client/android/certpool.go
+++ b/client/android/certpool.go
@@ -1,0 +1,20 @@
+package android
+
+import (
+	"fmt"
+
+	"github.com/netbirdio/netbird/util"
+)
+
+// SetAndroidCertificates used to push android CA certificates to the golang code.
+func SetAndroidCertificates(pemCerts []byte) error {
+	pool := util.GetSystemCertPool()
+
+	if ok := pool.AppendCertsFromPEM(pemCerts); !ok {
+		return fmt.Errorf("failed to parse any certificates from android")
+	}
+
+	util.SetGlobalCertPool(pool)
+
+	return nil
+}

--- a/client/grpc/dialer.go
+++ b/client/grpc/dialer.go
@@ -3,19 +3,17 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"runtime"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 
-	"github.com/netbirdio/netbird/util/embeddedroots"
+	"github.com/netbirdio/netbird/util"
 )
 
 // Backoff returns a backoff configuration for gRPC calls
@@ -32,14 +30,8 @@ func CreateConnection(ctx context.Context, addr string, tlsEnabled bool, compone
 	transportOption := grpc.WithTransportCredentials(insecure.NewCredentials())
 	// for js, the outer websocket layer takes care of tls
 	if tlsEnabled && runtime.GOOS != "js" {
-		certPool, err := x509.SystemCertPool()
-		if err != nil || certPool == nil {
-			log.Debugf("System cert pool not available; falling back to embedded cert, error: %v", err)
-			certPool = embeddedroots.Get()
-		}
-
 		transportOption = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-			RootCAs: certPool,
+			RootCAs: util.GetGlobalCertPool(),
 		}))
 	}
 

--- a/client/internal/auth/device_flow.go
+++ b/client/internal/auth/device_flow.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,7 +14,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/netbirdio/netbird/util/embeddedroots"
+	"github.com/netbirdio/netbird/util"
 )
 
 // HostedGrantType grant type for device flow on Hosted
@@ -104,16 +103,8 @@ func NewDeviceAuthorizationFlow(config DeviceAuthProviderConfig) (*DeviceAuthori
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 	httpTransport.MaxIdleConns = 5
 
-	certPool, err := x509.SystemCertPool()
-	if err != nil || certPool == nil {
-		log.Debugf("System cert pool not available; falling back to embedded cert, error: %v", err)
-		certPool = embeddedroots.Get()
-	} else {
-		log.Debug("Using system certificate pool.")
-	}
-
 	httpTransport.TLSClientConfig = &tls.Config{
-		RootCAs: certPool,
+		RootCAs: util.GetGlobalCertPool(),
 	}
 
 	httpClient := &http.Client{

--- a/client/internal/auth/pkce_flow.go
+++ b/client/internal/auth/pkce_flow.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/netbirdio/netbird/client/internal/templates"
 	"github.com/netbirdio/netbird/shared/management/client/common"
+	"github.com/netbirdio/netbird/util"
 )
 
 var _ OAuthFlow = &PKCEAuthorizationFlow{}
@@ -198,7 +199,10 @@ func (p *PKCEAuthorizationFlow) WaitToken(ctx context.Context, info AuthFlowInfo
 		return TokenInfo{}, fmt.Errorf("failed to parse redirect URL: %v", err)
 	}
 
-	server := &http.Server{Addr: fmt.Sprintf(":%s", parsedURL.Port())}
+	server := &http.Server{
+		Addr:      fmt.Sprintf(":%s", parsedURL.Port()),
+		TLSConfig: &tls.Config{RootCAs: util.GetGlobalCertPool()},
+	}
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -229,6 +233,7 @@ func (p *PKCEAuthorizationFlow) startServer(server *http.Server, tokenChan chan<
 			tr := &http.Transport{
 				TLSClientConfig: &tls.Config{
 					Certificates: []tls.Certificate{*cert},
+					RootCAs:      util.GetGlobalCertPool(),
 				},
 			}
 			sslClient := &http.Client{Transport: tr}
@@ -274,9 +279,20 @@ func (p *PKCEAuthorizationFlow) handleRequest(req *http.Request) (*oauth2.Token,
 		return nil, fmt.Errorf("authentication failed: missing code")
 	}
 
+	ctxWithRootCAs := req.Context()
+	if p.providerConfig.ClientCertPair == nil {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{RootCAs: util.GetGlobalCertPool()}
+		ctxWithRootCAs = context.WithValue(
+			ctxWithRootCAs,
+			oauth2.HTTPClient,
+			&http.Client{Transport: transport},
+		)
+	}
+
 	exchangeStart := time.Now()
 	token, err := p.oAuthConfig.Exchange(
-		req.Context(),
+		ctxWithRootCAs,
 		code,
 		oauth2.SetAuthURLParam("code_verifier", p.codeVerifier),
 	)

--- a/flow/client/client.go
+++ b/flow/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/url"
@@ -19,7 +18,7 @@ import (
 
 	nbgrpc "github.com/netbirdio/netbird/client/grpc"
 	"github.com/netbirdio/netbird/flow/proto"
-	"github.com/netbirdio/netbird/util/embeddedroots"
+	"github.com/netbirdio/netbird/util"
 	"github.com/netbirdio/netbird/util/wsproxy"
 )
 
@@ -49,11 +48,7 @@ func NewClient(addr, payload, signature string, interval time.Duration) (*GRPCCl
 	var opts []grpc.DialOption
 	tlsEnabled := parsedURL.Scheme == "https"
 	if tlsEnabled {
-		certPool, err := x509.SystemCertPool()
-		if err != nil || certPool == nil {
-			log.Debugf("System cert pool not available; falling back to embedded cert, error: %v", err)
-			certPool = embeddedroots.Get()
-		}
+		certPool := util.GetGlobalCertPool()
 
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 			RootCAs: certPool,

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -10,7 +10,6 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -68,7 +67,7 @@ import (
 	"github.com/netbirdio/netbird/shared/management/domain"
 	"github.com/netbirdio/netbird/shared/management/proto"
 	"github.com/netbirdio/netbird/trustedproxy"
-	"github.com/netbirdio/netbird/util/embeddedroots"
+	"github.com/netbirdio/netbird/util"
 )
 
 // portRouter bundles a per-port Router with its listener and cancel func.
@@ -787,13 +786,8 @@ func (s *Server) dialManagement() (*grpc.ClientConn, error) {
 	creds := insecure.NewCredentials()
 	// Assume management TLS is enabled for gRPC as well if using HTTPS for the API.
 	if mgmtURL.Scheme == "https" {
-		certPool, err := x509.SystemCertPool()
-		if err != nil || certPool == nil {
-			// Fall back to embedded CAs if no OS-provided ones are available.
-			certPool = embeddedroots.Get()
-		}
 		creds = credentials.NewTLS(&tls.Config{
-			RootCAs: certPool,
+			RootCAs: util.GetGlobalCertPool(),
 		})
 	}
 	s.Logger.WithFields(log.Fields{

--- a/shared/relay/client/dialer/ws/ws.go
+++ b/shared/relay/client/dialer/ws/ws.go
@@ -3,7 +3,6 @@ package ws
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -11,11 +10,10 @@ import (
 	"net/url"
 
 	"github.com/coder/websocket"
-	log "github.com/sirupsen/logrus"
 
 	nbnet "github.com/netbirdio/netbird/client/net"
 	"github.com/netbirdio/netbird/shared/relay"
-	"github.com/netbirdio/netbird/util/embeddedroots"
+	"github.com/netbirdio/netbird/util"
 )
 
 type Dialer struct {
@@ -84,12 +82,6 @@ func prepareURL(address string) (string, error) {
 func httpClientNbDialer(serverName string, underlyingOut *net.Conn) *http.Client {
 	customDialer := nbnet.NewDialer()
 
-	certPool, err := x509.SystemCertPool()
-	if err != nil || certPool == nil {
-		log.Debugf("System cert pool not available; falling back to embedded cert, error: %v", err)
-		certPool = embeddedroots.Get()
-	}
-
 	customTransport := &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			c, err := customDialer.DialContext(ctx, network, addr)
@@ -99,7 +91,7 @@ func httpClientNbDialer(serverName string, underlyingOut *net.Conn) *http.Client
 			return c, err
 		},
 		TLSClientConfig: &tls.Config{
-			RootCAs:    certPool,
+			RootCAs:    util.GetGlobalCertPool(),
 			ServerName: serverName,
 		},
 	}

--- a/shared/relay/tls/client_dev.go
+++ b/shared/relay/tls/client_dev.go
@@ -4,23 +4,14 @@ package tls
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 
-	log "github.com/sirupsen/logrus"
-
-	"github.com/netbirdio/netbird/util/embeddedroots"
+	"github.com/netbirdio/netbird/util"
 )
 
 func ClientQUICTLSConfig() *tls.Config {
-	certPool, err := x509.SystemCertPool()
-	if err != nil || certPool == nil {
-		log.Debugf("System cert pool not available; falling back to embedded cert, error: %v", err)
-		certPool = embeddedroots.Get()
-	}
-
 	return &tls.Config{
 		InsecureSkipVerify: true,             // Debug mode allows insecure connections
 		NextProtos:         []string{NBalpn}, // Ensure this matches the server's ALPN
-		RootCAs:            certPool,
+		RootCAs:            util.GetGlobalCertPool(),
 	}
 }

--- a/shared/relay/tls/client_prod.go
+++ b/shared/relay/tls/client_prod.go
@@ -4,22 +4,13 @@ package tls
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 
-	log "github.com/sirupsen/logrus"
-
-	"github.com/netbirdio/netbird/util/embeddedroots"
+	"github.com/netbirdio/netbird/util"
 )
 
 func ClientQUICTLSConfig() *tls.Config {
-	certPool, err := x509.SystemCertPool()
-	if err != nil || certPool == nil {
-		log.Debugf("System cert pool not available; falling back to embedded cert, error: %v", err)
-		certPool = embeddedroots.Get()
-	}
-
 	return &tls.Config{
 		NextProtos: []string{NBalpn},
-		RootCAs:    certPool,
+		RootCAs:    util.GetGlobalCertPool(),
 	}
 }

--- a/util/certpool.go
+++ b/util/certpool.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"crypto/x509"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/util/embeddedroots"
+)
+
+var (
+	globalCertPool *x509.CertPool
+	systemCertPool *x509.CertPool
+	guard          sync.RWMutex
+)
+
+func init() {
+	systemPool, err := x509.SystemCertPool()
+	if err == nil && systemPool != nil {
+		log.Debug("Using system certificate pool.")
+		systemCertPool = systemPool
+	} else {
+		log.Debugf("System cert pool not available; falling back to embedded cert")
+		systemCertPool = embeddedroots.Get()
+	}
+
+	globalCertPool = systemCertPool.Clone()
+}
+
+// SetGlobalCertPool set the new pool of CA certificates.
+func SetGlobalCertPool(newCertPool *x509.CertPool) {
+	if newCertPool != nil {
+		newCertPool := newCertPool.Clone()
+		guard.Lock()
+		globalCertPool = newCertPool
+		guard.Unlock()
+	}
+}
+
+// GetGlobalCertPool can be used to gather the CA certificates.
+// They can be modified with SetGlobalCertPool.
+func GetGlobalCertPool() *x509.CertPool {
+	guard.RLock()
+	defer guard.RUnlock()
+	return globalCertPool.Clone()
+}
+
+// GetSystemCertPool can be used to gather the unmodified system CA certificates.
+func GetSystemCertPool() *x509.CertPool {
+	return systemCertPool.Clone()
+}


### PR DESCRIPTION
The android stores the Certificate Authorities separately which are installed by the user. The Golang ecosystem does not care about them by default, so there was no possibility to use them in self-hosted environment on android clients with user supplied CA.
As my understanding to fix that the android code should collect the Certificates Authorities with java API, supply them to go code, and consume it combined with the system provided CAs.
By default the system CAs will be used in Golang.

## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [X] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

Added some in-line comments in go code

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787840014&installation_model_id=427504&pr_number=6941&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6941&signature=0bfc62d3d319e9035608d5757b7a31cd7ce99bf7433fe347b91e11029d4d2233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing Android CA certificates to extend trusted TLS roots.
* **Improvements**
  * Centralized TLS certificate trust around a shared CA pool for gRPC, OAuth/PKCE flows, relay/WebSocket connections, and management links.
  * When system trust is unavailable, the client still initializes from bundled roots, and the shared pool is used consistently across connections.
  * This reduces certificate-verification inconsistencies across different parts of the client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->