### PR TITLE
[client] Coalesce SubscribeStatus snapshot bursts

### DIFF
--- a/client/server/status_stream.go
+++ b/client/server/status_stream.go
@@ -1,10 +1,15 @@
 package server
 
 import (
+	"context"
+	"time"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/netbirdio/netbird/client/proto"
 )
+
+const statusCoalesceWindow = 200 * time.Millisecond
 
 // SubscribeStatus pushes a fresh StatusResponse on every connection state
 // change. The first message is the current snapshot, so a re-subscribing
@@ -12,9 +17,11 @@ import (
 // the peer recorder reports any of: connected/disconnected/connecting,
 // management or signal flip, address change, or peers list change.
 //
-// The change channel coalesces bursts to a single tick. If the consumer
-// is slow the daemon drops extras (not blocks), and the next snapshot
-// the consumer pulls already reflects everything.
+// Bursts are coalesced deterministically: the first tick after a quiet
+// period is sent immediately, then a short window swallows the rest of the
+// burst and a single trailing snapshot covers whatever arrived meanwhile.
+// Every send is a full snapshot of the recorder's current state, so
+// swallowed ticks lose no information.
 func (s *Server) SubscribeStatus(req *proto.StatusRequest, stream proto.DaemonService_SubscribeStatusServer) error {
 	subID, ch := s.statusRecorder.SubscribeToStateChanges()
 	defer func() {
@@ -37,8 +44,38 @@ func (s *Server) SubscribeStatus(req *proto.StatusRequest, stream proto.DaemonSe
 			if err := s.sendStatusSnapshot(req, stream); err != nil {
 				return err
 			}
+			pending, open := collectStatusBurst(stream.Context(), ch)
+			if pending {
+				if err := s.sendStatusSnapshot(req, stream); err != nil {
+					return err
+				}
+			}
+			if !open {
+				return nil
+			}
 		case <-stream.Context().Done():
 			return nil
+		}
+	}
+}
+
+// collectStatusBurst waits out the coalesce window, absorbing further ticks.
+// pending reports whether any tick arrived; open is false when the channel
+// closed or the stream context ended.
+func collectStatusBurst(ctx context.Context, ch <-chan struct{}) (pending, open bool) {
+	timer := time.NewTimer(statusCoalesceWindow)
+	defer timer.Stop()
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return pending, false
+			}
+			pending = true
+		case <-timer.C:
+			return pending, true
+		case <-ctx.Done():
+			return false, false
 		}
 	}
 }

--- a/client/server/status_stream.go
+++ b/client/server/status_stream.go
@@ -73,6 +73,14 @@ func collectStatusBurst(ctx context.Context, ch <-chan struct{}) (pending, open 
 			}
 			pending = true
 		case <-timer.C:
+			select {
+			case _, ok := <-ch:
+				if !ok {
+					return pending, false
+				}
+				pending = true
+			default:
+			}
 			return pending, true
 		case <-ctx.Done():
 			return false, false


### PR DESCRIPTION
## Describe your changes

SubscribeStatus sent a full status snapshot for every state change tick, so bursts (route reevaluation, peer connect and teardown, engine start and stop) produced many redundant sends of identical or nearly identical snapshots, each one serialized and rendered again by the desktop UI.

This change coalesces bursts deterministically: the first tick is sent immediately, then a 200ms window absorbs the rest and a single trailing snapshot covers whatever arrived meanwhile. Every send remains a full snapshot of the current
state, so no information is lost. In local testing a connect cycle dropped from about 15 sends to 6.


## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787840501&installation_model_id=427504&pr_number=6942&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6942&signature=61c1c895e3a0dc34306da11e330d1248d5e5457e9a71abb548eb38f7db362683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status update delivery by consistently coalescing rapid bursts of changes.
  * Added a short coalescing window to send fewer, more complete updates while keeping the latest status.
  * Enhanced stream cancellation/closure handling to stop cleanly without leaving consumers waiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->