### PR TITLE
[client] Skip status snapshot delivery to hidden UI windows

### DIFF
--- a/client/ui/main.go
+++ b/client/ui/main.go
@@ -152,7 +152,28 @@ func main() {
 	// re-centering on that environment; nil leaves placement to the WM on full
 	// desktops, macOS, and Windows.
 	windowManager.SetRecenterOnShow(recenterOnShowPredicate())
+	// Replay the latest snapshot into a window on (re)show, so a webview that
+	// was hidden while pushes flowed never paints stale state.
+	windowManager.SetShowReplay(func(w application.Window) {
+		if st := daemonFeed.LastStatus(); st != nil {
+			w.DispatchWailsEvent(&application.CustomEvent{Name: services.EventStatusSnapshot, Data: *st})
+		}
+	})
 	app.RegisterService(application.NewService(windowManager))
+
+	// On macOS, Wails' default applicationShouldHandleReopen handler Show()s
+	// every hidden window on dock-icon click, resurrecting hide-on-close
+	// surfaces like Settings. Cancel it in a hook (hooks run before listeners)
+	// and show only the main window. No-op elsewhere — the event never fires.
+	if runtime.GOOS == "darwin" {
+		app.Event.RegisterApplicationEventHook(events.Mac.ApplicationShouldHandleReopen, func(e *application.ApplicationEvent) {
+			e.Cancel()
+			if e.Context().HasVisibleWindows() {
+				return
+			}
+			windowManager.ShowMain()
+		})
+	}
 
 	// Welcome window, first launch only — Continue flips OnboardingCompleted
 	// so later launches skip it. ApplicationStarted hook so the Wails window
@@ -376,21 +397,6 @@ func newMainWindow(app *application.App, prefStore *preferences.Store) *applicat
 		e.Cancel()
 		window.Hide()
 	})
-
-	// On macOS, Wails' default applicationShouldHandleReopen handler Show()s
-	// every hidden window on dock-icon click, resurrecting hide-on-close
-	// surfaces like Settings. Cancel it in a hook (hooks run before listeners)
-	// and show only the main window. No-op elsewhere — the event never fires.
-	if runtime.GOOS == "darwin" {
-		app.Event.RegisterApplicationEventHook(events.Mac.ApplicationShouldHandleReopen, func(e *application.ApplicationEvent) {
-			e.Cancel()
-			if e.Context().HasVisibleWindows() {
-				return
-			}
-			window.Show()
-			window.Focus()
-		})
-	}
 
 	return window
 }

--- a/client/ui/main.go
+++ b/client/ui/main.go
@@ -103,6 +103,18 @@ func main() {
 	updaterHolder := updater.NewHolder(app.Event)
 	update := services.NewUpdate(conn, updaterHolder)
 	daemonFeed := services.NewDaemonFeed(conn, app.Event, updaterHolder, debugLog)
+	// Status snapshots go only to visible windows — a snapshot is full state,
+	// so a hidden webview loses nothing by being skipped; it gets the cached
+	// one on show (SetShowReplay below). Every other event stays on the bus.
+	daemonFeed.SetWindowDispatcher(func(st services.Status) {
+		ev := &application.CustomEvent{Name: services.EventStatusSnapshot, Data: st}
+		for _, w := range app.Window.GetAll() {
+			if w == nil || !w.IsVisible() {
+				continue
+			}
+			w.DispatchWailsEvent(ev)
+		}
+	})
 	notifier := notifications.New()
 	compat := services.NewCompat(conn)
 	// macOS shows no toast until permission is requested. Run it after

--- a/client/ui/main.go
+++ b/client/ui/main.go
@@ -165,11 +165,13 @@ func main() {
 	// desktops, macOS, and Windows.
 	windowManager.SetRecenterOnShow(recenterOnShowPredicate())
 	// Replay the latest snapshot into a window on (re)show, so a webview that
-	// was hidden while pushes flowed never paints stale state.
+	// was hidden while pushes flowed never paints stale state. ReplayLast keeps
+	// the feed's status lock across the dispatch, so a racing live push can't
+	// slip in between and then be overwritten by this older cached snapshot.
 	windowManager.SetShowReplay(func(w application.Window) {
-		if st := daemonFeed.LastStatus(); st != nil {
-			w.DispatchWailsEvent(&application.CustomEvent{Name: services.EventStatusSnapshot, Data: *st})
-		}
+		daemonFeed.ReplayLast(func(st services.Status) {
+			w.DispatchWailsEvent(&application.CustomEvent{Name: services.EventStatusSnapshot, Data: st})
+		})
 	})
 	app.RegisterService(application.NewService(windowManager))
 

--- a/client/ui/services/daemon_feed.go
+++ b/client/ui/services/daemon_feed.go
@@ -215,7 +215,7 @@ func (s *DaemonFeed) SetWindowDispatcher(fn func(Status)) {
 }
 
 // pushStatus delivers a snapshot to the Go-side subscribers and the frontend,
-// and caches it for LastStatus replays. Hidden windows are skipped by the
+// and caches it for ReplayLast. Hidden windows are skipped by the
 // window dispatcher; they catch up via the show replay (WindowManager).
 func (s *DaemonFeed) pushStatus(st Status) {
 	s.statusSubsMu.Lock()
@@ -233,12 +233,17 @@ func (s *DaemonFeed) pushStatus(st Status) {
 	s.emitter.Emit(EventStatusSnapshot, st)
 }
 
-// LastStatus returns the most recently pushed snapshot, or nil before the
-// first push. Windows becoming visible replay it so they never paint stale.
-func (s *DaemonFeed) LastStatus() *Status {
+// ReplayLast feeds the most recently pushed snapshot to dispatch; no-op before
+// the first push. The status lock is held across the dispatch so a concurrent
+// pushStatus cannot deliver a newer snapshot in between the read and the
+// dispatch — the replayed value is never older than anything already delivered.
+func (s *DaemonFeed) ReplayLast(dispatch func(Status)) {
 	s.statusSubsMu.Lock()
 	defer s.statusSubsMu.Unlock()
-	return s.lastStatus
+	if s.lastStatus == nil {
+		return
+	}
+	dispatch(*s.lastStatus)
 }
 
 // BeginProfileSwitch arms suppression for a switch from Connected/Connecting,

--- a/client/ui/services/daemon_feed.go
+++ b/client/ui/services/daemon_feed.go
@@ -171,9 +171,10 @@ type DaemonFeed struct {
 	// statusSubs are Go-side snapshot consumers (the tray), fed directly so
 	// they don't ride the window event bus. Callbacks run synchronously on
 	// the stream goroutine, so pushes arrive in order.
-	statusSubsMu sync.Mutex
-	statusSubs   []func(Status)
-	lastStatus   *Status
+	statusSubsMu     sync.Mutex
+	statusSubs       []func(Status)
+	lastStatus       *Status
+	windowDispatcher func(Status)
 
 	switchMu              sync.Mutex
 	switchInProgress      bool
@@ -204,15 +205,30 @@ func (s *DaemonFeed) OnStatus(cb func(Status)) {
 	s.statusSubsMu.Unlock()
 }
 
+// SetWindowDispatcher installs the frontend push path: it receives every
+// snapshot and decides which webview windows get it (visible ones). While
+// unset, pushStatus falls back to the event-bus broadcast.
+func (s *DaemonFeed) SetWindowDispatcher(fn func(Status)) {
+	s.statusSubsMu.Lock()
+	s.windowDispatcher = fn
+	s.statusSubsMu.Unlock()
+}
+
 // pushStatus delivers a snapshot to the Go-side subscribers and the frontend,
-// and caches it for LastStatus replays.
+// and caches it for LastStatus replays. Hidden windows are skipped by the
+// window dispatcher; they catch up via the show replay (WindowManager).
 func (s *DaemonFeed) pushStatus(st Status) {
 	s.statusSubsMu.Lock()
 	s.lastStatus = &st
 	subs := slices.Clone(s.statusSubs)
+	dispatch := s.windowDispatcher
 	s.statusSubsMu.Unlock()
 	for _, cb := range subs {
 		cb(st)
+	}
+	if dispatch != nil {
+		dispatch(st)
+		return
 	}
 	s.emitter.Emit(EventStatusSnapshot, st)
 }

--- a/client/ui/services/daemon_feed.go
+++ b/client/ui/services/daemon_feed.go
@@ -5,6 +5,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -167,6 +168,12 @@ type DaemonFeed struct {
 	cancel   context.CancelFunc
 	streamWg sync.WaitGroup
 
+	// statusSubs are Go-side snapshot consumers (the tray), fed directly so
+	// they don't ride the window event bus. Callbacks run synchronously on
+	// the stream goroutine, so pushes arrive in order.
+	statusSubsMu sync.Mutex
+	statusSubs   []func(Status)
+
 	switchMu              sync.Mutex
 	switchInProgress      bool
 	switchInProgressUntil time.Time
@@ -188,6 +195,25 @@ func NewDaemonFeed(conn DaemonConn, emitter Emitter, updaterHolder *updater.Hold
 	return &DaemonFeed{conn: conn, emitter: emitter, updater: updaterHolder, logCtl: logCtl}
 }
 
+// OnStatus registers a Go-side status subscriber. Not for the frontend —
+// React consumers subscribe to EventStatusSnapshot on the event bus.
+func (s *DaemonFeed) OnStatus(cb func(Status)) {
+	s.statusSubsMu.Lock()
+	s.statusSubs = append(s.statusSubs, cb)
+	s.statusSubsMu.Unlock()
+}
+
+// pushStatus delivers a snapshot to the Go-side subscribers and the frontend.
+func (s *DaemonFeed) pushStatus(st Status) {
+	s.statusSubsMu.Lock()
+	subs := slices.Clone(s.statusSubs)
+	s.statusSubsMu.Unlock()
+	for _, cb := range subs {
+		cb(st)
+	}
+	s.emitter.Emit(EventStatusSnapshot, st)
+}
+
 // BeginProfileSwitch arms suppression for a switch from Connected/Connecting,
 // where the daemon emits stale Connected updates during Down's teardown then an
 // Idle before the new Up; statusStreamLoop drops those, and a synthetic
@@ -201,7 +227,7 @@ func (s *DaemonFeed) BeginProfileSwitch() {
 	s.switchLoginWatch = true
 	s.switchLoginWatchUntil = now.Add(30 * time.Second)
 	s.switchMu.Unlock()
-	s.emitter.Emit(EventStatusSnapshot, Status{Status: StatusConnecting})
+	s.pushStatus(Status{Status: StatusConnecting})
 }
 
 // CancelProfileSwitch aborts a switch midway (tray Disconnect while Connecting):
@@ -343,7 +369,7 @@ func (s *DaemonFeed) statusStreamLoop(ctx context.Context) {
 			return
 		}
 		unavailable = true
-		s.emitter.Emit(EventStatusSnapshot, Status{Status: StatusDaemonUnavailable})
+		s.pushStatus(Status{Status: StatusDaemonUnavailable})
 	}
 
 	op := func() error {
@@ -403,7 +429,7 @@ func (s *DaemonFeed) emitStatus(st Status) {
 		log.Debugf("suppressing status=%q during profile switch", st.Status)
 		return
 	}
-	s.emitter.Emit(EventStatusSnapshot, st)
+	s.pushStatus(st)
 	if triggerLogin {
 		s.emitter.Emit(EventTriggerLogin)
 	}

--- a/client/ui/services/daemon_feed.go
+++ b/client/ui/services/daemon_feed.go
@@ -173,6 +173,7 @@ type DaemonFeed struct {
 	// the stream goroutine, so pushes arrive in order.
 	statusSubsMu sync.Mutex
 	statusSubs   []func(Status)
+	lastStatus   *Status
 
 	switchMu              sync.Mutex
 	switchInProgress      bool
@@ -203,15 +204,25 @@ func (s *DaemonFeed) OnStatus(cb func(Status)) {
 	s.statusSubsMu.Unlock()
 }
 
-// pushStatus delivers a snapshot to the Go-side subscribers and the frontend.
+// pushStatus delivers a snapshot to the Go-side subscribers and the frontend,
+// and caches it for LastStatus replays.
 func (s *DaemonFeed) pushStatus(st Status) {
 	s.statusSubsMu.Lock()
+	s.lastStatus = &st
 	subs := slices.Clone(s.statusSubs)
 	s.statusSubsMu.Unlock()
 	for _, cb := range subs {
 		cb(st)
 	}
 	s.emitter.Emit(EventStatusSnapshot, st)
+}
+
+// LastStatus returns the most recently pushed snapshot, or nil before the
+// first push. Windows becoming visible replay it so they never paint stale.
+func (s *DaemonFeed) LastStatus() *Status {
+	s.statusSubsMu.Lock()
+	defer s.statusSubsMu.Unlock()
+	return s.lastStatus
 }
 
 // BeginProfileSwitch arms suppression for a switch from Connected/Connecting,

--- a/client/ui/services/windowmanager.go
+++ b/client/ui/services/windowmanager.go
@@ -115,6 +115,9 @@ type WindowManager struct {
 	// recenterOnShow is set only on the minimal-WM/XEmbed path, where the WM neither centers nor
 	// restores position; nil on full desktops so re-centering can't fight a user-moved window.
 	recenterOnShow func() bool
+	// showReplay fires whenever a live-but-hidden window is (re)shown, so the
+	// caller can replay the latest status snapshot into its webview.
+	showReplay func(application.Window)
 }
 
 // NewWindowManager wires the manager to the main app; translator/prefs may be nil (tests). The
@@ -174,6 +177,7 @@ func (s *WindowManager) OpenSettings(tab string) {
 	s.app.Event.Emit(EventSettingsOpen, target)
 	s.settings.Show()
 	s.settings.Focus()
+	s.notifyShown(s.settings)
 	// Re-center (minimal-WM only; see centerWhenReady).
 	s.centerWhenReady(s.settings)
 }
@@ -220,6 +224,7 @@ func (s *WindowManager) OpenBrowserLogin(uri string) {
 	s.centerOnCursorScreen(s.browserLogin)
 	s.browserLogin.Show()
 	s.browserLogin.Focus()
+	s.notifyShown(s.browserLogin)
 }
 
 // BrowserLoginWindow returns the live SSO popup, or nil. While non-nil it is the
@@ -280,6 +285,7 @@ func (s *WindowManager) OpenSessionExpiration(seconds int) {
 	s.centerOnCursorScreen(s.sessionExpiration)
 	s.sessionExpiration.Show()
 	s.sessionExpiration.Focus()
+	s.notifyShown(s.sessionExpiration)
 }
 
 func (s *WindowManager) CloseSessionExpiration() {
@@ -347,6 +353,7 @@ func (s *WindowManager) OpenInstallProgress(version string) {
 	s.installProgress.SetURL(startURL)
 	s.installProgress.Show()
 	s.installProgress.Focus()
+	s.notifyShown(s.installProgress)
 	s.centerWhenReady(s.installProgress)
 }
 
@@ -380,6 +387,7 @@ func (s *WindowManager) OpenWelcome() {
 	}
 	s.welcome.Show()
 	s.welcome.Focus()
+	s.notifyShown(s.welcome)
 	s.centerWhenReady(s.welcome)
 }
 
@@ -417,6 +425,7 @@ func (s *WindowManager) OpenError(title, message string) {
 	s.errorDialog.SetURL(startURL)
 	s.errorDialog.Show()
 	s.errorDialog.Focus()
+	s.notifyShown(s.errorDialog)
 	s.centerWhenReady(s.errorDialog)
 }
 
@@ -443,6 +452,7 @@ func (s *WindowManager) ShowMain() {
 	}
 	s.mainWindow.Show()
 	s.mainWindow.Focus()
+	s.notifyShown(s.mainWindow)
 	// Re-center (minimal-WM only; see centerWhenReady).
 	s.centerWhenReady(s.mainWindow)
 }
@@ -450,6 +460,17 @@ func (s *WindowManager) ShowMain() {
 // SetRecenterOnShow installs the recenterOnShow predicate (see the field).
 func (s *WindowManager) SetRecenterOnShow(pred func() bool) {
 	s.recenterOnShow = pred
+}
+
+// SetShowReplay installs the shown-window hook (see the showReplay field).
+func (s *WindowManager) SetShowReplay(fn func(application.Window)) {
+	s.showReplay = fn
+}
+
+func (s *WindowManager) notifyShown(w application.Window) {
+	if s.showReplay != nil && w != nil {
+		s.showReplay(w)
+	}
 }
 
 // centerWhenReady centers w only on minimal WMs (recenterOnShow); elsewhere it
@@ -572,6 +593,7 @@ func (s *WindowManager) restoreHiddenWindowsLocked() {
 			continue
 		}
 		w.Show()
+		s.notifyShown(w)
 		if w == s.mainWindow {
 			mainRestored = true
 		}

--- a/client/ui/tray.go
+++ b/client/ui/tray.go
@@ -196,7 +196,7 @@ func NewTray(app *application.App, window *application.WebviewWindow, svc TraySe
 	// menu (e.g. GNOME Shell AppIndicator).
 	bindTrayClick(t)
 
-	app.Event.On(services.EventStatusSnapshot, t.onStatusEvent)
+	svc.DaemonFeed.OnStatus(t.applyStatus)
 	app.Event.On(services.EventDaemonNotification, t.onSystemEvent)
 	// Refresh the Profiles submenu on ProfileSwitcher's change event. A
 	// switch on an idle daemon drives no status transition, so without this

--- a/client/ui/tray.go
+++ b/client/ui/tray.go
@@ -172,7 +172,7 @@ func NewTray(app *application.App, window *application.WebviewWindow, svc TraySe
 		// in the right locale — no English flash then re-paint.
 		loc: svc.Localizer,
 	}
-	t.updater = newTrayUpdater(app, window, svc.Update, svc.Notifier, t.loc, func() { t.applyIcon() }, func() { t.relayoutMenu() })
+	t.updater = newTrayUpdater(app, window, svc.Update, svc.Notifier, t.loc, func() { t.applyIcon() }, func() { t.relayoutMenu() }, func() { t.showMainWindow() })
 	t.tray = app.SystemTray.New()
 	// Seed panel-theme detection before the first paint so the initial icon
 	// matches the panel's light/dark scheme (Linux only).
@@ -251,6 +251,19 @@ func (t *Tray) ShowWindow() {
 	}
 	t.window.Show()
 	t.window.Focus()
+}
+
+// showMainWindow brings the main window forward through the WindowManager so
+// the status replay and re-centering apply; falls back to a bare Show in tests.
+func (t *Tray) showMainWindow() {
+	if t.svc.WindowManager != nil {
+		t.svc.WindowManager.ShowMain()
+		return
+	}
+	if t.window != nil {
+		t.window.Show()
+		t.window.Focus()
+	}
 }
 
 // applyLanguage re-renders every translated surface in the Localizer's current

--- a/client/ui/tray_session.go
+++ b/client/ui/tray_session.go
@@ -30,11 +30,11 @@ const (
 // handleSessionExpired notifies and brings the window forward so the frontend's /login route drives renewal.
 func (t *Tray) handleSessionExpired() {
 	t.notify(t.loc.T("notify.sessionExpired.title"), t.loc.T("notify.sessionExpired.body"), notifyIDSessionExpired)
-	if t.window != nil {
-		t.window.SetURL("/#/login")
-		t.window.Show()
-		t.window.Focus()
+	if t.window == nil {
+		return
 	}
+	t.window.SetURL("/#/login")
+	t.showMainWindow()
 }
 
 // applySessionExpiry refreshes the cached SSO deadline and reports whether it changed.
@@ -310,8 +310,7 @@ func (t *Tray) openSessionExtendFlow() {
 	if seconds <= 0 {
 		if t.window != nil {
 			t.window.SetURL("/#/login")
-			t.window.Show()
-			t.window.Focus()
+			t.showMainWindow()
 		}
 		return
 	}

--- a/client/ui/tray_status.go
+++ b/client/ui/tray_status.go
@@ -5,18 +5,8 @@ package main
 import (
 	"strings"
 
-	"github.com/wailsapp/wails/v3/pkg/application"
-
 	"github.com/netbirdio/netbird/client/ui/services"
 )
-
-func (t *Tray) onStatusEvent(ev *application.CustomEvent) {
-	st, ok := ev.Data.(services.Status)
-	if !ok {
-		return
-	}
-	t.applyStatus(st)
-}
 
 // applyStatus repaints the tray from a daemon snapshot. Icon refresh is skipped
 // when no icon-relevant input changed: the daemon emits rapid SubscribeStatus

--- a/client/ui/tray_update.go
+++ b/client/ui/tray_update.go
@@ -28,6 +28,9 @@ type trayUpdater struct {
 	// About submenu, which KDE/Plasma caches on first open and never re-fetches
 	// on a plain SetLabel/SetHidden — only a relayout (fresh submenu ids) repaints.
 	onMenuChange func()
+	// showMain brings the main window forward via the WindowManager (status
+	// replay + centering); nil falls back to a bare window.Show.
+	showMain func()
 
 	mu                 sync.Mutex
 	item               *application.MenuItem
@@ -36,7 +39,7 @@ type trayUpdater struct {
 	progressWindowOpen bool
 }
 
-func newTrayUpdater(app *application.App, window *application.WebviewWindow, update *services.Update, notifier *notifications.NotificationService, loc *Localizer, onIconChange func(), onMenuChange func()) *trayUpdater {
+func newTrayUpdater(app *application.App, window *application.WebviewWindow, update *services.Update, notifier *notifications.NotificationService, loc *Localizer, onIconChange, onMenuChange, showMain func()) *trayUpdater {
 	u := &trayUpdater{
 		app:          app,
 		window:       window,
@@ -45,6 +48,7 @@ func newTrayUpdater(app *application.App, window *application.WebviewWindow, upd
 		loc:          loc,
 		onIconChange: onIconChange,
 		onMenuChange: onMenuChange,
+		showMain:     showMain,
 	}
 	app.Event.On(updater.EventStateChanged, u.onStateEvent)
 	// Seed from cached state to cover an event that fired before wiring completed.
@@ -193,6 +197,10 @@ func (u *trayUpdater) openProgressWindow(version string) {
 		url += "?version=" + version
 	}
 	u.window.SetURL(url)
+	if u.showMain != nil {
+		u.showMain()
+		return
+	}
 	u.window.Show()
 	u.window.Focus()
 }


### PR DESCRIPTION
## Describe your changes

The UI pushed every status snapshot into every webview window, including the permanently hidden main and Settings windows, so an idle tray app kept parsing and rendering full peer lists it never displayed, inflating the WebKit heap. Now the tray consumes status via a direct Go callback, snapshots are dispatched only to visible windows, and the latest snapshot is cached and replayed when a window is shown, so nothing ever paints stale state. Snapshots are full state rather than deltas, so skipped pushes lose no information.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787843193&installation_model_id=427504&pr_number=6946&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6946&signature=f2de939e0f17814c7534a2a613ad2bea1f13b0acb297f69b3386e0561c05586f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Status updates now appear only in visible windows, with the latest status replayed when a window is reopened.
  - Improved macOS dock-reopen behavior when no windows are visible.
  - Tray status and window actions now stay synchronized across the application.
  - Session expiration and update progress flows more reliably bring the appropriate window to the foreground.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->