### PR TITLE
[client] parse NB_LAZY_CONN_INACTIVITY_THRESHOLD as a Go duration

### DIFF
--- a/client/internal/conn_mgr.go
+++ b/client/internal/conn_mgr.go
@@ -385,11 +385,20 @@ func inactivityThresholdEnv() *time.Duration {
 		return nil
 	}
 
-	parsedMinutes, err := strconv.Atoi(envValue)
-	if err != nil || parsedMinutes <= 0 {
-		return nil
+	// Documented format: a Go duration such as "30m" or "1h".
+	if d, err := time.ParseDuration(envValue); err == nil {
+		if d <= 0 {
+			return nil
+		}
+		return &d
 	}
 
-	d := time.Duration(parsedMinutes) * time.Minute
-	return &d
+	// Backwards compatibility: a bare integer used to be interpreted as minutes.
+	if parsedMinutes, err := strconv.Atoi(envValue); err == nil && parsedMinutes > 0 {
+		d := time.Duration(parsedMinutes) * time.Minute
+		return &d
+	}
+
+	log.Warnf("invalid %s value %q: expected a Go duration such as 30m or 1h", lazyconn.EnvInactivityThreshold, envValue)
+	return nil
 }

--- a/client/internal/conn_mgr_test.go
+++ b/client/internal/conn_mgr_test.go
@@ -104,3 +104,38 @@ func TestConnMgr_ActivatePeerConcurrentWithLifecycle(t *testing.T) {
 	close(done)
 	wg.Wait()
 }
+
+func TestInactivityThresholdEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		want *time.Duration
+	}{
+		{name: "unset", val: "", want: nil},
+		{name: "go duration minutes", val: "30m", want: durPtr(30 * time.Minute)},
+		{name: "go duration hours", val: "1h", want: durPtr(time.Hour)},
+		{name: "go duration seconds", val: "90s", want: durPtr(90 * time.Second)},
+		{name: "bare integer is minutes (backwards compat)", val: "5", want: durPtr(5 * time.Minute)},
+		{name: "zero duration", val: "0s", want: nil},
+		{name: "zero integer", val: "0", want: nil},
+		{name: "negative duration", val: "-5m", want: nil},
+		{name: "garbage", val: "abc", want: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(lazyconn.EnvInactivityThreshold, tc.val)
+			got := inactivityThresholdEnv()
+			switch {
+			case tc.want == nil && got != nil:
+				t.Fatalf("want nil, got %v", *got)
+			case tc.want != nil && got == nil:
+				t.Fatalf("want %v, got nil", *tc.want)
+			case tc.want != nil && *got != *tc.want:
+				t.Fatalf("want %v, got %v", *tc.want, *got)
+			}
+		})
+	}
+}
+
+func durPtr(d time.Duration) *time.Duration { return &d }


### PR DESCRIPTION
## Describe your changes

`NB_LAZY_CONN_INACTIVITY_THRESHOLD` was parsed with `strconv.Atoi`, i.e. as a bare
integer number of minutes. The documentation, however, states it takes a Go duration
(e.g. `30m`, `1h`). As a result any documented value such as `30m` or `5m` failed to
parse and **silently fell back to the 15m default**, so the setting appeared to have
no effect.

`inactivityThresholdEnv()` now parses the value with `time.ParseDuration`, matching
the docs. A bare integer is still accepted as a number of minutes for backwards
compatibility, and an unparseable value logs a warning and falls back to the default.

Added `TestInactivityThresholdEnv` covering Go-duration values (`30m`/`1h`/`90s`), the
bare-integer minutes fallback, and zero/negative/garbage inputs.

## Issue ticket number and link

N/A

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — backwards-compatible bug fix that aligns the env parsing with the already-documented behaviour.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

The docs already document the Go-duration format (`30m`, `1h`); this change makes the
code honour it, so no docs update is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787843718&installation_model_id=427504&pr_number=6947&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6947&signature=ccca9bdddf6a5e5b061dbcf665d2720ef4a4666cd8872f9d755b50b7f2518579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inactivity thresholds now support Go duration formats such as `30m`, `1h`, and `45s`.
  * Existing numeric values remain supported and are interpreted as minutes.
  * Invalid or non-positive values now generate a warning and are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->