### PR TITLE
[client] Fix UI crash on Windows builds without dark-mode support

### DIFF
--- a/client/ui/services/windowtheme_windows.go
+++ b/client/ui/services/windowtheme_windows.go
@@ -1,0 +1,14 @@
+package services
+
+import "github.com/wailsapp/wails/v3/pkg/w32"
+
+// Wails assigns w32.AllowDarkModeForWindow only on builds >= 18334 but calls it
+// without a nil check when a window requests the Dark theme, crashing older
+// builds such as Windows Server 2019 (17763). Those builds still get a dark
+// title bar via the pre-20H1 DWM attribute that w32.SetTheme applies, so a
+// no-op stub keeps the Dark theme fully working there.
+func init() {
+	if w32.AllowDarkModeForWindow == nil {
+		w32.AllowDarkModeForWindow = func(w32.HWND, bool) uintptr { return 0 }
+	}
+}


### PR DESCRIPTION
## Describe your changes

The UI crashes on startup on Windows builds older than 18334 (e.g. Windows Server 2019). Wails only assigns `w32.AllowDarkModeForWindow` when the dark-mode uxtheme entry points exist, but calls it without a nil check whenever a window requests the dark theme, so window creation hits a nil pointer dereference.

- Install a no-op stub for the missing function on affected builds so windows using the dark theme open normally
- The dark title bar still renders there via the pre-20H1 DWM attribute that Wails applies separately; newer builds are unaffected

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): crash fix with no user-facing behavior change

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787916434&installation_model_id=427504&pr_number=6958&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6958&signature=85e0bd21d91f6caf8b27e10acb2eb11a468d9698622e6d51200c58bad8b470b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark theme compatibility on older Windows builds.
  * Prevented crashes when dark mode support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->