### PR TITLE
[client] Keep the UI running when the notification service fails to start

### DIFF
--- a/client/ui/main.go
+++ b/client/ui/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
-	"github.com/wailsapp/wails/v3/pkg/services/notifications"
 
 	"github.com/netbirdio/netbird/client/ui/authsession"
 	"github.com/netbirdio/netbird/client/ui/i18n"
@@ -63,7 +62,7 @@ type registeredServices struct {
 	profiles        *services.Profiles
 	update          *services.Update
 	daemonFeed      *services.DaemonFeed
-	notifier        *notifications.NotificationService
+	notifier        *Notifier
 	compat          *services.Compat
 	profileSwitcher *services.ProfileSwitcher
 	bundle          *i18n.Bundle
@@ -103,7 +102,7 @@ func main() {
 	updaterHolder := updater.NewHolder(app.Event)
 	update := services.NewUpdate(conn, updaterHolder)
 	daemonFeed := services.NewDaemonFeed(conn, app.Event, updaterHolder, debugLog)
-	notifier := notifications.New()
+	notifier := newNotifier()
 	compat := services.NewCompat(conn)
 	// macOS shows no toast until permission is requested. Run it after
 	// ApplicationStarted so the notifier's Startup has initialised the
@@ -210,7 +209,7 @@ func main() {
 // requestNotificationAuthorization prompts for macOS notification permission.
 // The request blocks until the user responds (up to 3 minutes), so callers run
 // it in a goroutine. No-op on Linux/Windows.
-func requestNotificationAuthorization(notifier *notifications.NotificationService) {
+func requestNotificationAuthorization(notifier *Notifier) {
 	authorized, err := notifier.CheckNotificationAuthorization()
 	if err != nil {
 		logrus.Debugf("check notification authorization: %v", err)

--- a/client/ui/notifier.go
+++ b/client/ui/notifier.go
@@ -94,6 +94,8 @@ func (n *Notifier) RegisterNotificationCategory(category notifications.Notificat
 
 // OnNotificationResponse registers the response callback. Pure Go state, so
 // it is safe (and simply inert) when the backend never started.
+//
+//wails:ignore
 func (n *Notifier) OnNotificationResponse(callback func(result notifications.NotificationResult)) {
 	n.inner.OnNotificationResponse(callback)
 }

--- a/client/ui/notifier.go
+++ b/client/ui/notifier.go
@@ -1,0 +1,99 @@
+//go:build !android && !ios && !freebsd && !js
+
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/services/notifications"
+)
+
+var errNotificationsUnavailable = errors.New("notifications unavailable")
+
+// Notifier wraps the Wails notification service so an unavailable backend
+// disables notifications instead of aborting the app. Startup fails for
+// environment reasons (a bare unbundled binary on macOS has no bundle
+// identifier, a headless Linux session has no D-Bus session bus), and Wails
+// treats a service startup error as fatal. After a failed startup every call
+// is a no-op: on macOS, touching UNUserNotificationCenter without a bundle
+// identifier raises an Objective-C exception that recover() cannot catch.
+type Notifier struct {
+	inner     *notifications.NotificationService
+	available atomic.Bool
+}
+
+func newNotifier() *Notifier {
+	return &Notifier{inner: notifications.New()}
+}
+
+// ServiceName implements the Wails service-name hook for startup logs.
+func (n *Notifier) ServiceName() string {
+	return n.inner.ServiceName()
+}
+
+// ServiceStartup starts the platform notifier, downgrading failure to a
+// warning so the app keeps running without notifications.
+func (n *Notifier) ServiceStartup(ctx context.Context, options application.ServiceOptions) error {
+	if err := n.inner.ServiceStartup(ctx, options); err != nil {
+		log.Warnf("notifications disabled: %v", err)
+		return nil
+	}
+	n.available.Store(true)
+	return nil
+}
+
+func (n *Notifier) ServiceShutdown() error {
+	if !n.available.Load() {
+		return nil
+	}
+	return n.inner.ServiceShutdown()
+}
+
+func (n *Notifier) CheckNotificationAuthorization() (bool, error) {
+	if !n.available.Load() {
+		return false, errNotificationsUnavailable
+	}
+	return n.inner.CheckNotificationAuthorization()
+}
+
+func (n *Notifier) RequestNotificationAuthorization() (bool, error) {
+	if !n.available.Load() {
+		return false, errNotificationsUnavailable
+	}
+	return n.inner.RequestNotificationAuthorization()
+}
+
+// SendNotification delivers a notification, silently dropping it when the
+// backend never started (notifications are best-effort everywhere).
+func (n *Notifier) SendNotification(options notifications.NotificationOptions) error {
+	if !n.available.Load() {
+		log.Debugf("notifications disabled, dropping %q", options.ID)
+		return nil
+	}
+	return n.inner.SendNotification(options)
+}
+
+func (n *Notifier) SendNotificationWithActions(options notifications.NotificationOptions) error {
+	if !n.available.Load() {
+		log.Debugf("notifications disabled, dropping %q", options.ID)
+		return nil
+	}
+	return n.inner.SendNotificationWithActions(options)
+}
+
+func (n *Notifier) RegisterNotificationCategory(category notifications.NotificationCategory) error {
+	if !n.available.Load() {
+		return nil
+	}
+	return n.inner.RegisterNotificationCategory(category)
+}
+
+// OnNotificationResponse registers the response callback. Pure Go state, so
+// it is safe (and simply inert) when the backend never started.
+func (n *Notifier) OnNotificationResponse(callback func(result notifications.NotificationResult)) {
+	n.inner.OnNotificationResponse(callback)
+}

--- a/client/ui/tray.go
+++ b/client/ui/tray.go
@@ -44,7 +44,7 @@ type TrayServices struct {
 	Profiles        *services.Profiles
 	Networks        *services.Networks
 	DaemonFeed      *services.DaemonFeed
-	Notifier        *notifications.NotificationService
+	Notifier        *Notifier
 	Update          *services.Update
 	ProfileSwitcher *services.ProfileSwitcher
 	WindowManager   *services.WindowManager

--- a/client/ui/tray_notify.go
+++ b/client/ui/tray_notify.go
@@ -44,7 +44,7 @@ func safeSendNotification(send sendFn, what string, opts notifications.Notificat
 // notifyIfDaemonOutdated probes the daemon once and fires an OS toast when it
 // is reachable but too old for this UI. A probe error means the daemon isn't
 // reachable (not outdated), so it is left to the normal connection flow.
-func notifyIfDaemonOutdated(compat *services.Compat, notifier *notifications.NotificationService, loc *Localizer) {
+func notifyIfDaemonOutdated(compat *services.Compat, notifier *Notifier, loc *Localizer) {
 	ready, err := compat.DaemonReady(context.Background())
 	if err != nil {
 		log.Debugf("daemon compatibility probe: %v", err)

--- a/client/ui/tray_update.go
+++ b/client/ui/tray_update.go
@@ -21,7 +21,7 @@ type trayUpdater struct {
 	app          *application.App
 	window       *application.WebviewWindow
 	update       *services.Update
-	notifier     *notifications.NotificationService
+	notifier     *Notifier
 	loc          *Localizer
 	onIconChange func()
 	// onMenuChange drives a full tray relayout: the update row lives in the
@@ -36,7 +36,7 @@ type trayUpdater struct {
 	progressWindowOpen bool
 }
 
-func newTrayUpdater(app *application.App, window *application.WebviewWindow, update *services.Update, notifier *notifications.NotificationService, loc *Localizer, onIconChange func(), onMenuChange func()) *trayUpdater {
+func newTrayUpdater(app *application.App, window *application.WebviewWindow, update *services.Update, notifier *Notifier, loc *Localizer, onIconChange func(), onMenuChange func()) *trayUpdater {
 	u := &trayUpdater{
 		app:          app,
 		window:       window,


### PR DESCRIPTION
## Describe your changes

Wails treats a service startup error as fatal, so when the notification backend cannot start (an unbundled binary on macOS has no bundle identifier, a headless Linux session has no D-Bus session bus) the whole UI exited on launch. Wrap the notification service so a startup failure only disables notifications.

- Downgrade a notification service startup failure to a warning instead of aborting the app
- Turn all notification calls into no-ops after a failed startup; on macOS, touching the notification center without a bundle identifier raises an Objective-C exception that cannot be recovered in Go

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal client fix, no user-facing behavior change)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird/pr/6959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787917689&installation_model_id=427504&pr_number=6959&repository=netbirdio%2Fnetbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird%2Fpull%2F6959&signature=2bed0722fa45f2b9f813c4a1bb9278bd4fc12198efe5f0f17eb70b8437868e9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification reliability when the system notification service is unavailable.
  - Notification startup failures no longer prevent the application from launching.
  - Notification requests safely degrade to no-ops when unavailable.
  - Tray notifications continue to work with the updated notification handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->