### PR TITLE
[client] Stop and remove the daemon on netbird-ui cask uninstall

### DIFF
--- a/client/ui/netbird-ui.rb.tmpl
+++ b/client/ui/netbird-ui.rb.tmpl
@@ -29,8 +29,13 @@ cask "{{ $projectName }}" do
   end
 
   uninstall_preflight do
-    system_command "#{appdir}/Netbird UI.app/uninstaller.sh",
-                   sudo: false
+    system_command "/bin/sh",
+                   args: ["-c", <<~CMD],
+                     launchctl bootout system/netbird 2>/dev/null || \
+                       launchctl unload /Library/LaunchDaemons/netbird.plist 2>/dev/null || true
+                     rm -f /Library/LaunchDaemons/netbird.plist
+                   CMD
+                   sudo: true
   end
 
   name "Netbird UI"


### PR DESCRIPTION
## Describe your changes

`brew uninstall --cask netbird-ui` left the daemon running and its LaunchDaemon plist in place, because the cask invoked the bundled `uninstaller.sh` without sudo and that script only printed instructions. The same fix was merged into the tap in netbirdio/homebrew-tap#6, but the cask is regenerated from this template on every release, so it was overwritten again.

- Boot out the `netbird` system daemon and remove `/Library/LaunchDaemons/netbird.plist` on cask uninstall
- Run the cleanup with sudo and inline, so it no longer depends on a script bundled inside the `.app`

## Issue ticket number and link

Fixes #5852, #1924, #5135
Tap-side fix: netbirdio/homebrew-tap#6

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Packaging fix with no user-facing change beyond uninstall behaving as documented.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS uninstallation by removing the NetBird system launch daemon and its configuration file.
  * Added elevated permissions and fallback handling to help ensure complete cleanup, even if the service is not currently loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->