### PR TITLE
[client] Fix daemon lock order inversion between SetConfig and login

### DIFF
--- a/client/server/lock_order_test.go
+++ b/client/server/lock_order_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/proto"
+)
+
+// The daemon takes guardedConfigMu before s.mutex. authorizeAndPrepareLogin
+// takes s.mutex while holding guardedConfigMu, so a SetConfig that grabbed
+// s.mutex first and then waited for guardedConfigMu would deadlock the daemon
+// against a concurrent login: two unprivileged IPC calls are enough.
+//
+// The held guardedConfigMu below stands in for that login. While SetConfig waits
+// for it, s.mutex must stay free, otherwise the login waiting for s.mutex could
+// never release guardedConfigMu.
+func TestSetConfig_TakesGuardedConfigMuBeforeServerMutex(t *testing.T) {
+	s, ctx, profName, username, _ := setupServerWithProfile(t)
+
+	s.guardedConfigMu.Lock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.SetConfig(ctx, &proto.SetConfigRequest{
+			ProfileName: profName,
+			Username:    username,
+		})
+		done <- err
+	}()
+
+	require.Never(t, func() bool {
+		if !s.mutex.TryLock() {
+			return true
+		}
+		s.mutex.Unlock()
+		return false
+	}, 500*time.Millisecond, 10*time.Millisecond,
+		"SetConfig held s.mutex while waiting for guardedConfigMu, which deadlocks against a concurrent login")
+
+	s.guardedConfigMu.Unlock()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("SetConfig did not finish after guardedConfigMu was released")
+	}
+}

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -393,6 +393,16 @@ func (s *Server) loginAttempt(ctx context.Context, setupKey, jwtToken string) (i
 
 // Login uses setup key to prepare configuration for the daemon.
 func (s *Server) SetConfig(callerCtx context.Context, msg *proto.SetConfigRequest) (*proto.SetConfigResponse, error) {
+	// Privilege gate: refuse the parts of the request that would let a local
+	// user turn the root daemon into a root shell. Held across the write so the
+	// config cannot gain the SSH server between the decision and the update.
+	//
+	// Taken before s.mutex: authorizeAndPrepareLogin takes s.mutex while holding
+	// guardedConfigMu, so acquiring the two in the other order here would let a
+	// concurrent login deadlock the daemon.
+	s.guardedConfigMu.Lock()
+	defer s.guardedConfigMu.Unlock()
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -416,12 +426,6 @@ func (s *Server) SetConfig(callerCtx context.Context, msg *proto.SetConfigReques
 	if err := rejectMDMManagedFieldConflicts(mdmManagedFieldConflicts(msg, policy)); err != nil {
 		return nil, err
 	}
-
-	// Privilege gate: refuse the parts of the request that would let a local
-	// user turn the root daemon into a root shell. Held across the write so the
-	// config cannot gain the SSH server between the decision and the update.
-	s.guardedConfigMu.Lock()
-	defer s.guardedConfigMu.Unlock()
 
 	stored, err := s.storedProfileConfig(msg.ProfileName, msg.Username)
 	if err != nil {


### PR DESCRIPTION
## Describe your changes

`SetConfig` and the login path acquired the daemon's server mutex and the guarded-config mutex in opposite orders, so two concurrent daemon requests could wedge each other permanently. `SetConfig` now takes the guarded-config mutex first, matching the login path, which gives the two locks a single order across the daemon.

- Fix the lock order inversion between `SetConfig` and login by acquiring the guarded-config lock before the server lock
- Add a test that fails on the old order

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal locking fix with no user-visible surface.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration updates to prevent potential deadlocks during concurrent login and configuration operations.
  * Preserved existing validation and configuration update behavior.

* **Tests**
  * Added coverage to verify safe lock ordering during configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->