### PR TITLE
[client] Don't ask for an SSO login when the login never reached management

### DIFF
--- a/client/server/login_outcome_test.go
+++ b/client/server/login_outcome_test.go
@@ -64,6 +64,11 @@ func TestLogin_AuthRefusalStartsSSOFlow(t *testing.T) {
 	require.Error(t, err)
 	require.NotErrorIs(t, err, refused,
 		"the refusal was handed back to the caller instead of starting the SSO flow")
+
+	status, stateErr := internal.CtxGetState(s.rootCtx).Status()
+	require.NoError(t, stateErr)
+	require.Equal(t, internal.StatusLoginFailed, status,
+		"the SSO flow setup was never reached with the broken key")
 }
 
 // breakProfilePrivateKey replaces the profile's private key with an unparseable

--- a/client/server/login_outcome_test.go
+++ b/client/server/login_outcome_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
+
+	"github.com/netbirdio/netbird/client/internal"
+	"github.com/netbirdio/netbird/client/proto"
+)
+
+// A login that never reached Management is not a decision about the peer's
+// credentials, so it must come back as a retryable error rather than an SSO
+// prompt: the user cannot finish a browser login while Management is down, and
+// the CLI's own backoff resolves the outage on its own once the daemon reports
+// the failure. Reproduces `netbird down; netbird up` printing a device-code URL
+// because Management happened to be restarting when the daemon dialed it.
+func TestLogin_ManagementUnreachableIsReturnedInsteadOfDemandingSSO(t *testing.T) {
+	s, _, _, username, _ := setupServerWithProfile(t)
+	s.rootCtx = internal.CtxInitState(context.Background())
+
+	unreachable := errors.New("create connection: dial context: context deadline exceeded")
+	attempts := 0
+	s.loginAttemptFn = func(context.Context, string, string) (internal.StatusType, error) {
+		attempts++
+		return internal.StatusLoginFailed, unreachable
+	}
+
+	resp, err := s.Login(userCtx(), &proto.LoginRequest{Username: &username})
+	require.Error(t, err)
+	require.ErrorIs(t, err, unreachable, "the transport failure was replaced by something else")
+	require.Nil(t, resp, "a failed login must not answer with a login response")
+	require.Equal(t, 1, attempts)
+	require.Nil(t, s.oauthAuthFlow.flow, "the daemon started an SSO flow for a peer whose login was never decided")
+
+	status, err := internal.CtxGetState(s.rootCtx).Status()
+	require.NoError(t, err)
+	require.Equal(t, internal.StatusLoginFailed, status,
+		"a peer that could not reach Management is not waiting on a login")
+}
+
+// The counterpart: Management refusing the peer's credentials is a decision, and
+// the SSO flow still has to start for it. The profile carries an unusable
+// private key so the flow setup fails immediately instead of dialing, which is
+// enough to show the branch was entered — the refusal itself is never what comes
+// back out.
+func TestLogin_AuthRefusalStartsSSOFlow(t *testing.T) {
+	s, _, _, username, cfgPath := setupServerWithProfile(t)
+	s.rootCtx = internal.CtxInitState(context.Background())
+	breakProfilePrivateKey(t, cfgPath)
+
+	refused := gstatus.Error(codes.PermissionDenied, "peer is not registered")
+	s.loginAttemptFn = func(context.Context, string, string) (internal.StatusType, error) {
+		return internal.StatusNeedsLogin, refused
+	}
+
+	_, err := s.Login(userCtx(), &proto.LoginRequest{Username: &username})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, refused,
+		"the refusal was handed back to the caller instead of starting the SSO flow")
+}
+
+// breakProfilePrivateKey replaces the profile's private key with an unparseable
+// one, which makes any attempt to build a Management client fail on the spot.
+func breakProfilePrivateKey(t *testing.T, cfgPath string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, json.Unmarshal(raw, &cfg))
+	cfg["PrivateKey"] = "not-a-key"
+
+	patched, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(cfgPath, patched, 0o600))
+}

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -132,6 +132,11 @@ type Server struct {
 	updateManager *updater.Manager
 
 	jwtCache *jwtCache
+
+	// loginAttemptFn stands in for the Management login round trip. Tests set
+	// it to drive the login outcomes that need a server on the other end;
+	// production leaves it nil, and every login goes through loginAttempt.
+	loginAttemptFn func(ctx context.Context, setupKey, jwtToken string) (internal.StatusType, error)
 }
 
 type oauthAuthFlow struct {
@@ -367,7 +372,19 @@ func (s *Server) connectionGoroutineRunning() bool {
 	}
 }
 
-// loginAttempt attempts to login using the provided information. it returns a status in case something fails
+// attemptLogin runs a login round trip against Management, or the stand-in a
+// test installed in place of it.
+func (s *Server) attemptLogin(ctx context.Context, setupKey, jwtToken string) (internal.StatusType, error) {
+	if s.loginAttemptFn != nil {
+		return s.loginAttemptFn(ctx, setupKey, jwtToken)
+	}
+	return s.loginAttempt(ctx, setupKey, jwtToken)
+}
+
+// loginAttempt attempts to login using the provided information. It returns
+// StatusNeedsLogin when Management refused the peer's credentials and
+// StatusLoginFailed for every other failure, so callers can tell an
+// authentication decision apart from a login that never got made.
 func (s *Server) loginAttempt(ctx context.Context, setupKey, jwtToken string) (internal.StatusType, error) {
 	authClient, err := auth.NewAuth(ctx, s.config.PrivateKey, s.config.ManagementURL, s.config)
 	if err != nil {
@@ -616,9 +633,21 @@ func (s *Server) Login(callerCtx context.Context, msg *proto.LoginRequest) (*pro
 	s.config = config
 	s.mutex.Unlock()
 
-	if _, err := s.loginAttempt(ctx, "", ""); err == nil {
+	loginStatus, err := s.attemptLogin(ctx, "", "")
+	if err == nil {
 		state.Set(internal.StatusIdle)
 		return &proto.LoginResponse{}, nil
+	}
+
+	// Only an authentication refusal means the peer has to (re-)authenticate.
+	// Any other failure leaves the login undecided: Management unreachable, a
+	// restart mid-request, an internal error. Those are returned for the caller
+	// to retry, because turning them into an SSO prompt asks the user to solve
+	// something that is not theirs to solve, and a browser login cannot succeed
+	// while Management is unreachable anyway.
+	if loginStatus != internal.StatusNeedsLogin {
+		state.Set(loginStatus)
+		return nil, err
 	}
 
 	if msg.SetupKey == "" {
@@ -677,7 +706,7 @@ func (s *Server) Login(callerCtx context.Context, msg *proto.LoginRequest) (*pro
 	// which returns NeedsLogin and parks on the browser leg.
 	state.Set(internal.StatusConnecting)
 
-	if loginStatus, err := s.loginAttempt(ctx, msg.SetupKey, ""); err != nil {
+	if loginStatus, err := s.attemptLogin(ctx, msg.SetupKey, ""); err != nil {
 		state.Set(loginStatus)
 		return nil, err
 	}
@@ -832,7 +861,7 @@ func (s *Server) WaitSSOLogin(callerCtx context.Context, msg *proto.WaitSSOLogin
 	s.oauthAuthFlow.expiresAt = time.Now()
 	s.mutex.Unlock()
 
-	if loginStatus, err := s.loginAttempt(ctx, "", tokenInfo.GetTokenToUse()); err != nil {
+	if loginStatus, err := s.attemptLogin(ctx, "", tokenInfo.GetTokenToUse()); err != nil {
 		state.Set(loginStatus)
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes

The daemon treated every failed login attempt as "this peer needs to log in", so a login that never reached the management server (unreachable, restarting, dial timeout) surfaced as an SSO prompt with a device code instead of a retryable error. A `netbird up` that happened to run while management was briefly away asked the user to re-authenticate, even though the session was still valid.

- Only start the SSO flow when management actually refused the peer's credentials; return any other login failure so the CLI's existing backoff can retry it
- Keep the login outcome that was already classified by the login attempt, matching how the setup-key and JWT paths already handle it

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): internal error handling in the daemon, no user-facing surface changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved login handling when Management is unreachable by returning a retryable error and preserving the failed-login state.
  - Login now starts the SSO flow only when it’s actually required, avoiding incorrect SSO triggers on other error types.
  - Permission-denied during the auth check now correctly proceeds into the SSO sign-in flow.
- **Tests**
  - Added coverage for Management connectivity failures, auth refusal behavior, and SSO login transition outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->