### PR TITLE
[proxy] remove cluster tag from proxy metrics

### DIFF
--- a/management/internals/modules/reverseproxy/proxy/manager/controller.go
+++ b/management/internals/modules/reverseproxy/proxy/manager/controller.go
@@ -36,7 +36,7 @@ func NewGRPCController(proxyGRPCServer *nbgrpc.ProxyServiceServer, meter metric.
 // SendServiceUpdateToCluster sends a service update to a specific proxy cluster.
 func (c *GRPCController) SendServiceUpdateToCluster(ctx context.Context, accountID string, update *proto.ProxyMapping, clusterAddr string) {
 	c.proxyGRPCServer.SendServiceUpdateToCluster(ctx, update, clusterAddr)
-	c.metrics.IncrementServiceUpdateSendCount(clusterAddr)
+	c.metrics.IncrementServiceUpdateSendCount()
 }
 
 // GetOIDCValidationConfig returns the OIDC validation configuration from the gRPC server.
@@ -53,7 +53,7 @@ func (c *GRPCController) RegisterProxyToCluster(ctx context.Context, clusterAddr
 	proxySet.(*sync.Map).Store(proxyID, struct{}{})
 	log.WithContext(ctx).Debugf("Registered proxy %s to cluster %s", proxyID, clusterAddr)
 
-	c.metrics.IncrementProxyConnectionCount(clusterAddr)
+	c.metrics.IncrementProxyConnectionCount()
 
 	return nil
 }
@@ -67,7 +67,7 @@ func (c *GRPCController) UnregisterProxyFromCluster(ctx context.Context, cluster
 		proxySet.(*sync.Map).Delete(proxyID)
 		log.WithContext(ctx).Debugf("Unregistered proxy %s from cluster %s", proxyID, clusterAddr)
 
-		c.metrics.DecrementProxyConnectionCount(clusterAddr)
+		c.metrics.DecrementProxyConnectionCount()
 	}
 	return nil
 }

--- a/management/internals/modules/reverseproxy/proxy/manager/metrics.go
+++ b/management/internals/modules/reverseproxy/proxy/manager/metrics.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -48,25 +47,16 @@ func newMetrics(meter metric.Meter) (*metrics, error) {
 	}, nil
 }
 
-func (m *metrics) IncrementProxyConnectionCount(clusterAddr string) {
-	m.proxyConnectionCount.Add(context.Background(), 1,
-		metric.WithAttributes(
-			attribute.String("cluster", clusterAddr),
-		))
+func (m *metrics) IncrementProxyConnectionCount() {
+	m.proxyConnectionCount.Add(context.Background(), 1)
 }
 
-func (m *metrics) DecrementProxyConnectionCount(clusterAddr string) {
-	m.proxyConnectionCount.Add(context.Background(), -1,
-		metric.WithAttributes(
-			attribute.String("cluster", clusterAddr),
-		))
+func (m *metrics) DecrementProxyConnectionCount() {
+	m.proxyConnectionCount.Add(context.Background(), -1)
 }
 
-func (m *metrics) IncrementServiceUpdateSendCount(clusterAddr string) {
-	m.serviceUpdateSendCount.Add(context.Background(), 1,
-		metric.WithAttributes(
-			attribute.String("cluster", clusterAddr),
-		))
+func (m *metrics) IncrementServiceUpdateSendCount() {
+	m.serviceUpdateSendCount.Add(context.Background(), 1)
 }
 
 func (m *metrics) IncrementProxyHeartbeatCount() {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy and service metrics reliability by removing cluster-specific labels from metric updates.
  * Standardized connection, service update, and heartbeat measurements for more consistent monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->