### PR TITLE
[client] Android - Create the Android fake IP manager lazily on DNS flag enable

### DIFF
--- a/client/internal/routemanager/dnsinterceptor/handler.go
+++ b/client/internal/routemanager/dnsinterceptor/handler.go
@@ -479,7 +479,7 @@ func (d *DnsInterceptor) removeDNATMappings(realPrefixes []netip.Prefix, logger 
 
 // internalDnatFw checks if the firewall supports internal DNAT
 func (d *DnsInterceptor) internalDnatFw() (internalDNATer, bool) {
-	if d.firewall == nil || runtime.GOOS != "android" {
+	if d.firewall == nil || d.fakeIPManager == nil || runtime.GOOS != "android" {
 		return nil, false
 	}
 	fw, ok := d.firewall.(internalDNATer)

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -165,29 +165,34 @@ func (m *DefaultManager) setupAndroidRoutes(config ManagerConfig) {
 	routesForComparison := slices.Clone(cr)
 
 	if config.DNSFeatureFlag {
-		m.fakeIPManager = fakeip.NewManager()
-
-		v4ID := uuid.NewString()
-		fakeIPRoute := &route.Route{
-			ID:          route.ID(v4ID),
-			Network:     m.fakeIPManager.GetFakeIPBlock(),
-			NetID:       route.NetID(v4ID),
-			Peer:        m.pubKey,
-			NetworkType: route.IPv4Network,
-		}
-		v6ID := uuid.NewString()
-		fakeIPv6Route := &route.Route{
-			ID:          route.ID(v6ID),
-			Network:     m.fakeIPManager.GetFakeIPv6Block(),
-			NetID:       route.NetID(v6ID),
-			Peer:        m.pubKey,
-			NetworkType: route.IPv6Network,
-		}
-		cr = append(cr, fakeIPRoute, fakeIPv6Route)
-		m.notifier.SetFakeIPRoutes([]*route.Route{fakeIPRoute, fakeIPv6Route})
+		cr = append(cr, m.enableFakeIPRoutes()...)
 	}
 
 	m.notifier.SetInitialClientRoutes(cr, routesForComparison)
+}
+
+func (m *DefaultManager) enableFakeIPRoutes() []*route.Route {
+	m.fakeIPManager = fakeip.NewManager()
+
+	v4ID := uuid.NewString()
+	fakeIPRoute := &route.Route{
+		ID:          route.ID(v4ID),
+		Network:     m.fakeIPManager.GetFakeIPBlock(),
+		NetID:       route.NetID(v4ID),
+		Peer:        m.pubKey,
+		NetworkType: route.IPv4Network,
+	}
+	v6ID := uuid.NewString()
+	fakeIPv6Route := &route.Route{
+		ID:          route.ID(v6ID),
+		Network:     m.fakeIPManager.GetFakeIPv6Block(),
+		NetID:       route.NetID(v6ID),
+		Peer:        m.pubKey,
+		NetworkType: route.IPv6Network,
+	}
+	fakeRoutes := []*route.Route{fakeIPRoute, fakeIPv6Route}
+	m.notifier.SetFakeIPRoutes(fakeRoutes)
+	return fakeRoutes
 }
 
 func (m *DefaultManager) setupRefCounters(useNoop bool) {
@@ -464,6 +469,9 @@ func (m *DefaultManager) UpdateRoutes(
 
 	var merr *multierror.Error
 	if !m.disableClientRoutes {
+		if runtime.GOOS == "android" && useNewDNSRoute && m.fakeIPManager == nil {
+			m.enableFakeIPRoutes()
+		}
 
 		// Update route selector based on management server's isSelected status
 		m.updateRouteSelectorFromManagement(clientRoutes)

--- a/client/internal/routemanager/notifier/notifier_android.go
+++ b/client/internal/routemanager/notifier/notifier_android.go
@@ -41,6 +41,7 @@ func (n *Notifier) SetInitialClientRoutes(initialRoutes []*route.Route, routesFo
 // SetFakeIPRoutes stores the fake IP routes to be included in every TUN rebuild.
 func (n *Notifier) SetFakeIPRoutes(routes []*route.Route) {
 	n.fakeIPRoutes = routes
+	n.notify()
 }
 
 func (n *Notifier) OnNewRoutes(idMap route.HAMap) {


### PR DESCRIPTION
## Describe your changes

The fake IP manager was only created at route manager construction, from the DNS feature flag fetched by the initial GetNetworkMap call. When the flag flipped to true mid-session, UpdateRoutes set useNewDNSRoute but never created the manager, so domain routes added after the flip got a DNS interceptor with a nil fake IP manager.

internalDnatFw only checked for a firewall and GOOS, so the interceptor took the DNAT path and called GetFakeIP/AllocateFakeIP on the nil *fakeip.Manager. These methods lock m.mu first, which is a nil pointer dereference: the first DNS answer for such a route panicked and crashed the VPN service. The fake IP blocks (240.0.0.0/8 and its v6 pair) also never reached the TUN, since only the constructor registered them.

Create the manager and its TUN routes from UpdateRoutes when the flag turns on, notify so the fake IP blocks get into the TUN without a client route change, and treat a nil manager as no internal DNAT.

This is groundwork for removing the initial GetNetworkMap fetch, after which every startup goes through the flag-off-to-on transition.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android routing behavior when fake-IP support is unavailable or not yet initialized.
  * Fake-IP routes are now enabled only when the relevant Android DNS setting is active.
  * Network changes are now refreshed when fake-IP routes are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->