### PR TITLE
[client] Android - Serialize Android tunnel reconfiguration callbacks

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -113,11 +113,14 @@ func (c *ConnectClient) RunOnAndroid(
 	stateFilePath string,
 	cacheDir string,
 ) error {
+	notifier := tunnelnotifier.New(networkChangeListener, nil)
+	defer notifier.Close()
+
 	// in case of non Android os these variables will be nil
 	mobileDependency := MobileDependency{
 		TunAdapter:            tunAdapter,
 		IFaceDiscover:         iFaceDiscover,
-		NetworkChangeListener: networkChangeListener,
+		NetworkChangeListener: notifier,
 		HostDNSAddresses:      dnsAddresses,
 		DnsReadyListener:      dnsReadyListener,
 		StateFilePath:         stateFilePath,

--- a/client/internal/dns/notifier.go
+++ b/client/internal/dns/notifier.go
@@ -51,7 +51,5 @@ func (n *notifier) notify() {
 		return
 	}
 
-	go func(l listener.NetworkChangeListener) {
-		l.OnNetworkChanged("")
-	}(n.listener)
+	n.listener.OnNetworkChanged("")
 }

--- a/client/internal/routemanager/dnsinterceptor/handler.go
+++ b/client/internal/routemanager/dnsinterceptor/handler.go
@@ -479,7 +479,7 @@ func (d *DnsInterceptor) removeDNATMappings(realPrefixes []netip.Prefix, logger 
 
 // internalDnatFw checks if the firewall supports internal DNAT
 func (d *DnsInterceptor) internalDnatFw() (internalDNATer, bool) {
-	if d.firewall == nil || runtime.GOOS != "android" {
+	if d.firewall == nil || d.fakeIPManager == nil || runtime.GOOS != "android" {
 		return nil, false
 	}
 	fw, ok := d.firewall.(internalDNATer)

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -165,29 +165,34 @@ func (m *DefaultManager) setupAndroidRoutes(config ManagerConfig) {
 	routesForComparison := slices.Clone(cr)
 
 	if config.DNSFeatureFlag {
-		m.fakeIPManager = fakeip.NewManager()
-
-		v4ID := uuid.NewString()
-		fakeIPRoute := &route.Route{
-			ID:          route.ID(v4ID),
-			Network:     m.fakeIPManager.GetFakeIPBlock(),
-			NetID:       route.NetID(v4ID),
-			Peer:        m.pubKey,
-			NetworkType: route.IPv4Network,
-		}
-		v6ID := uuid.NewString()
-		fakeIPv6Route := &route.Route{
-			ID:          route.ID(v6ID),
-			Network:     m.fakeIPManager.GetFakeIPv6Block(),
-			NetID:       route.NetID(v6ID),
-			Peer:        m.pubKey,
-			NetworkType: route.IPv6Network,
-		}
-		cr = append(cr, fakeIPRoute, fakeIPv6Route)
-		m.notifier.SetFakeIPRoutes([]*route.Route{fakeIPRoute, fakeIPv6Route})
+		cr = append(cr, m.enableFakeIPRoutes()...)
 	}
 
 	m.notifier.SetInitialClientRoutes(cr, routesForComparison)
+}
+
+func (m *DefaultManager) enableFakeIPRoutes() []*route.Route {
+	m.fakeIPManager = fakeip.NewManager()
+
+	v4ID := uuid.NewString()
+	fakeIPRoute := &route.Route{
+		ID:          route.ID(v4ID),
+		Network:     m.fakeIPManager.GetFakeIPBlock(),
+		NetID:       route.NetID(v4ID),
+		Peer:        m.pubKey,
+		NetworkType: route.IPv4Network,
+	}
+	v6ID := uuid.NewString()
+	fakeIPv6Route := &route.Route{
+		ID:          route.ID(v6ID),
+		Network:     m.fakeIPManager.GetFakeIPv6Block(),
+		NetID:       route.NetID(v6ID),
+		Peer:        m.pubKey,
+		NetworkType: route.IPv6Network,
+	}
+	fakeRoutes := []*route.Route{fakeIPRoute, fakeIPv6Route}
+	m.notifier.SetFakeIPRoutes(fakeRoutes)
+	return fakeRoutes
 }
 
 func (m *DefaultManager) setupRefCounters(useNoop bool) {
@@ -464,6 +469,9 @@ func (m *DefaultManager) UpdateRoutes(
 
 	var merr *multierror.Error
 	if !m.disableClientRoutes {
+		if runtime.GOOS == "android" && useNewDNSRoute && m.fakeIPManager == nil {
+			m.enableFakeIPRoutes()
+		}
 
 		// Update route selector based on management server's isSelected status
 		m.updateRouteSelectorFromManagement(clientRoutes)

--- a/client/internal/routemanager/notifier/notifier_android.go
+++ b/client/internal/routemanager/notifier/notifier_android.go
@@ -41,6 +41,7 @@ func (n *Notifier) SetInitialClientRoutes(initialRoutes []*route.Route, routesFo
 // SetFakeIPRoutes stores the fake IP routes to be included in every TUN rebuild.
 func (n *Notifier) SetFakeIPRoutes(routes []*route.Route) {
 	n.fakeIPRoutes = routes
+	n.notify()
 }
 
 func (n *Notifier) OnNewRoutes(idMap route.HAMap) {

--- a/client/internal/routemanager/notifier/notifier_android.go
+++ b/client/internal/routemanager/notifier/notifier_android.go
@@ -79,9 +79,7 @@ func (n *Notifier) notify() {
 
 	routeStrings := n.routesToStrings(allRoutes)
 	sort.Strings(routeStrings)
-	go func(l listener.NetworkChangeListener) {
-		l.OnNetworkChanged(strings.Join(routeStrings, ","))
-	}(n.listener)
+	n.listener.OnNetworkChanged(strings.Join(routeStrings, ","))
 }
 
 func filterStatic(routes []*route.Route) []*route.Route {
@@ -103,16 +101,11 @@ func (n *Notifier) routesToStrings(routes []*route.Route) []string {
 }
 
 func (n *Notifier) hasRouteDiff(a []*route.Route, b []*route.Route) bool {
-	slices.SortFunc(a, func(x, y *route.Route) int {
-		return strings.Compare(x.NetString(), y.NetString())
-	})
-	slices.SortFunc(b, func(x, y *route.Route) int {
-		return strings.Compare(x.NetString(), y.NetString())
-	})
-
-	return !slices.EqualFunc(a, b, func(x, y *route.Route) bool {
-		return x.NetString() == y.NetString()
-	})
+	as := n.routesToStrings(a)
+	bs := n.routesToStrings(b)
+	sort.Strings(as)
+	sort.Strings(bs)
+	return !slices.Equal(as, bs)
 }
 
 func (n *Notifier) GetInitialRouteRanges() []string {


### PR DESCRIPTION
## Describe your changes

The Android route notifier and the DNS search-domain notifier both delivered OnNetworkChanged from a fire-and-forget goroutine per update. Two updates in quick succession could reach the Java side reordered: the TUN rebuild handler applies them in arrival order and compares against the last applied parameters, so a stale route set delivered last won as the final TUN state. This is the same reordering hazard fixed for iOS in #6454.

Wrap the Android network change listener into the shared tunnelnotifier FIFO introduced in #6870, the same way RunOniOS does, and deliver both notifiers synchronously into it. Enqueueing is non-blocking, a single delivery goroutine preserves order, and calls into Java never overlap.

Also stop hasRouteDiff from sorting the notifier's shared route slices in place; compare sorted copies instead.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
