### PR TITLE
[client] Fix macOS platform info parsing from ioreg

### DIFF
--- a/client/system/info_darwin.go
+++ b/client/system/info_darwin.go
@@ -73,29 +73,40 @@ func GetInfo(ctx context.Context) *Info {
 }
 
 func sysInfo() (serialNumber string, productName string, manufacturer string) {
-	out, _ := exec.Command("/usr/sbin/ioreg", "-l").Output() // err ignored for brevity
-	for _, l := range strings.Split(string(out), "\n") {
-		if strings.Contains(l, "IOPlatformSerialNumber") {
-			serialNumber = trimIoRegLine(l)
-		}
-
-		if strings.Contains(l, "ModelNumber") && productName == "" {
-			productName = trimIoRegLine(l)
-		}
-
-		if strings.Contains(l, "device manufacturer") && manufacturer == "" {
-			manufacturer = trimIoRegLine(l)
-		}
-
-	}
-	return
+	out, _ := exec.Command("/usr/sbin/ioreg", "-rd1", "-c", "IOPlatformExpertDevice").Output()
+	return parsePlatformInfo(out)
 }
 
-func trimIoRegLine(l string) string {
-	kv := strings.Split(l, "=")
-	if len(kv) != 2 {
-		return ""
+func parsePlatformInfo(out []byte) (serialNumber, productName, manufacturer string) {
+	for _, line := range strings.Split(string(out), "\n") {
+		keyValue := strings.SplitN(line, "=", 2)
+		if len(keyValue) != 2 {
+			continue
+		}
+
+		key := strings.Trim(strings.TrimSpace(strings.TrimLeft(keyValue[0], " \t|")), `"`)
+		value := normalizeIORegValue(keyValue[1])
+
+		switch key {
+		case "IOPlatformSerialNumber":
+			serialNumber = value
+		case "model":
+			productName = value
+		case "manufacturer":
+			manufacturer = value
+		}
 	}
-	s := strings.TrimSpace(kv[1])
-	return strings.Trim(s, `"`)
+
+	return serialNumber, productName, manufacturer
+}
+
+func normalizeIORegValue(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, `<"`) && strings.HasSuffix(value, `">`) {
+		return strings.TrimSuffix(strings.TrimPrefix(value, `<"`), `">`)
+	}
+	if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+		return strings.TrimSuffix(strings.TrimPrefix(value, `"`), `"`)
+	}
+	return value
 }

--- a/client/system/info_darwin_test.go
+++ b/client/system/info_darwin_test.go
@@ -6,6 +6,87 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func TestParsePlatformInfo(t *testing.T) {
+	tests := []struct {
+		name                              string
+		output                            []byte
+		wantSerialNumber, wantProductName string
+		wantManufacturer                  string
+	}{
+		{
+			name: "parses quoted Intel platform values",
+			output: []byte(`
+    | |   "IOPlatformSerialNumber" = "C02INTEL1234"
+    | |   "model" = "MacBookPro15,1"
+    | |   "manufacturer" = "Apple Inc."
+`),
+			wantSerialNumber: "C02INTEL1234",
+			wantProductName:  "MacBookPro15,1",
+			wantManufacturer: "Apple Inc.",
+		},
+		{
+			name: "parses angle bracket Apple Silicon platform values",
+			output: []byte(`
+    | |   "IOPlatformSerialNumber" = <"F9APPLE1234">
+    | |   "model" = <"Mac15,3">
+    | |   "manufacturer" = <"Apple Inc.">
+`),
+			wantSerialNumber: "F9APPLE1234",
+			wantProductName:  "Mac15,3",
+			wantManufacturer: "Apple Inc.",
+		},
+		{
+			name: "ignores unrelated keys",
+			output: []byte(`
+    | |   "IOPlatformSerialNumberBackup" = "wrong serial"
+    | |   "ModelNumber" = "wrong model"
+    | |   "device manufacturer" = "wrong manufacturer"
+    | |   "IOPlatformSerialNumber" = "C02RIGHT1234"
+    | |   "model" = "MacBookAir10,1"
+    | |   "manufacturer" = "Apple Inc."
+`),
+			wantSerialNumber: "C02RIGHT1234",
+			wantProductName:  "MacBookAir10,1",
+			wantManufacturer: "Apple Inc.",
+		},
+		{
+			name: "leaves missing platform values empty",
+			output: []byte(`
+    | |   "IOPlatformSerialNumber" = "C02ONLYSERIAL"
+    | |   "board-id" = "Mac-1234567890ABCDEF"
+`),
+			wantSerialNumber: "C02ONLYSERIAL",
+		},
+		{
+			name: "preserves equals signs in values",
+			output: []byte(`
+    | |   "IOPlatformSerialNumber" = "C02=SERIAL"
+    | |   "model" = "Mac=Model"
+    | |   "manufacturer" = "Apple=Inc."
+`),
+			wantSerialNumber: "C02=SERIAL",
+			wantProductName:  "Mac=Model",
+			wantManufacturer: "Apple=Inc.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSerialNumber, gotProductName, gotManufacturer := parsePlatformInfo(tt.output)
+
+			if gotSerialNumber != tt.wantSerialNumber {
+				t.Errorf("serial number = %q, want %q", gotSerialNumber, tt.wantSerialNumber)
+			}
+			if gotProductName != tt.wantProductName {
+				t.Errorf("product name = %q, want %q", gotProductName, tt.wantProductName)
+			}
+			if gotManufacturer != tt.wantManufacturer {
+				t.Errorf("manufacturer = %q, want %q", gotManufacturer, tt.wantManufacturer)
+			}
+		})
+	}
+}
+
 func Test_sysInfoMac(t *testing.T) {
 	t.Skip("skipping darwin test")
 	serialNum, prodName, manufacturer := sysInfo()


### PR DESCRIPTION
## Describe your changes

`sysInfo` on macOS scanned the entire `ioreg -l` output with substring matches for keys that do not exist on Macs ("ModelNumber", "device manufacturer"), so product name and manufacturer were effectively never reported, and the serial-number substring match could pick up unrelated keys.

It now runs `/usr/sbin/ioreg -rd1 -c IOPlatformExpertDevice` and parses the exact `IOPlatformSerialNumber`, `model`, and `manufacturer` keys, handling both quoted values and the `<"...">` data-string form, and preserving `=` characters inside values.

Added table-driven tests covering the quoted and data-string forms, exact-key matching against similarly named keys, missing values, and values containing `=`. Real Apple Silicon output was checked with the serial redacted; the Intel format is fixture-tested. Verified with `go test -count=1 ./client/system` and `git diff --check`.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

Standalone PR based on `main`.

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal fix to system-information collection; no user-facing configuration or documented behavior changes.

### Docs PR URL (required if "docs added" is checked)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS device information detection for serial numbers, model names, and manufacturers.
  * Correctly handles quoted values, wrapped values, missing fields, exact key matches, and values containing equals signs.

* **Tests**
  * Added coverage for varied macOS platform information formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->