### PR TITLE
[client] Fix Homebrew install detection for the macOS download URL

### DIFF
--- a/version/url_darwin.go
+++ b/version/url_darwin.go
@@ -1,18 +1,24 @@
 package version
 
 import (
+	"context"
 	"os/exec"
 	"runtime"
+	"time"
 )
 
 const (
-	urlMacIntel = "https://pkgs.netbird.io/macos/amd64"
-	urlMacM1M2  = "https://pkgs.netbird.io/macos/arm64"
+	urlMacIntel          = "https://pkgs.netbird.io/macos/amd64"
+	urlMacM1M2           = "https://pkgs.netbird.io/macos/arm64"
+	homebrewCheckTimeout = 5 * time.Second
 )
 
 // DownloadUrl return with the proper download link
 func DownloadUrl() string {
-	if isHomebrewInstall() {
+	ctx, cancel := context.WithTimeout(context.Background(), homebrewCheckTimeout)
+	defer cancel()
+
+	if isHomebrewInstall(ctx) {
 		return downloadURL
 	}
 
@@ -26,17 +32,17 @@ func DownloadUrl() string {
 	}
 }
 
-func isHomebrewInstall() bool {
+func isHomebrewInstall(ctx context.Context) bool {
 	brew := brewExecutable()
 	if brew == "" {
 		return false
 	}
 
-	if err := exec.Command(brew, "list", "--formula", "netbird").Run(); err == nil {
+	if err := exec.CommandContext(ctx, brew, "list", "--formula", "netbird").Run(); err == nil {
 		return true
 	}
 
-	return exec.Command(brew, "list", "--cask", "netbird-ui").Run() == nil
+	return exec.CommandContext(ctx, brew, "list", "--cask", "netbird-ui").Run() == nil
 }
 
 func brewExecutable() string {

--- a/version/url_darwin.go
+++ b/version/url_darwin.go
@@ -12,16 +12,10 @@ const (
 
 // DownloadUrl return with the proper download link
 func DownloadUrl() string {
-	cmd := exec.Command("brew", "list --formula | grep -i netbird")
-	if err := cmd.Start(); err != nil {
-		goto PKGINSTALL
-	}
-
-	if err := cmd.Wait(); err == nil {
+	if isHomebrewInstall() {
 		return downloadURL
 	}
 
-PKGINSTALL:
 	switch runtime.GOARCH {
 	case "amd64":
 		return urlMacIntel
@@ -30,4 +24,31 @@ PKGINSTALL:
 	default:
 		return downloadURL
 	}
+}
+
+func isHomebrewInstall() bool {
+	brew := brewExecutable()
+	if brew == "" {
+		return false
+	}
+
+	if err := exec.Command(brew, "list", "--formula", "netbird").Run(); err == nil {
+		return true
+	}
+
+	return exec.Command(brew, "list", "--cask", "netbird-ui").Run() == nil
+}
+
+func brewExecutable() string {
+	if brew, err := exec.LookPath("brew"); err == nil {
+		return brew
+	}
+
+	for _, path := range []string{"/opt/homebrew/bin/brew", "/usr/local/bin/brew"} {
+		if brew, err := exec.LookPath(path); err == nil {
+			return brew
+		}
+	}
+
+	return ""
 }

--- a/version/url_darwin_test.go
+++ b/version/url_darwin_test.go
@@ -1,0 +1,81 @@
+package version
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDownloadURL_HomebrewFormula(t *testing.T) {
+	recordedArgs := installBrew(t, "list --formula netbird")
+
+	if got := DownloadUrl(); got != downloadURL {
+		t.Fatalf("DownloadUrl() = %q, want %q", got, downloadURL)
+	}
+
+	assertBrewArgs(t, recordedArgs, "list --formula netbird")
+}
+
+func TestDownloadURL_HomebrewCask(t *testing.T) {
+	recordedArgs := installBrew(t, "list --cask netbird-ui")
+
+	if got := DownloadUrl(); got != downloadURL {
+		t.Fatalf("DownloadUrl() = %q, want %q", got, downloadURL)
+	}
+
+	assertBrewArgs(t, recordedArgs, "list --formula netbird\nlist --cask netbird-ui")
+}
+
+func TestDownloadURL_PackageFallback(t *testing.T) {
+	recordedArgs := installBrew(t, "")
+
+	want := urlMacIntel
+	if runtime.GOARCH == "arm64" {
+		want = urlMacM1M2
+	}
+
+	if got := DownloadUrl(); got != want {
+		t.Fatalf("DownloadUrl() = %q, want %q", got, want)
+	}
+
+	assertBrewArgs(t, recordedArgs, "list --formula netbird\nlist --cask netbird-ui")
+}
+
+func installBrew(t *testing.T, successfulArgs string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	recordedArgs := filepath.Join(dir, "brew-arguments")
+	brew := filepath.Join(dir, "brew")
+	script := "#!/bin/sh\n" +
+		"printf '%s %s %s\\n' \"$1\" \"$2\" \"$3\" >> \"$BREW_ARGUMENTS_FILE\"\n" +
+		"case \"$1 $2 $3\" in\n" +
+		"  \"list --formula netbird\"|\"list --cask netbird-ui\") ;;\n" +
+		"  *) exit 1 ;;\n" +
+		"esac\n" +
+		"[ \"$1 $2 $3\" = \"$BREW_SUCCESSFUL_ARGS\" ]\n"
+	if err := os.WriteFile(brew, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("BREW_ARGUMENTS_FILE", recordedArgs)
+	t.Setenv("BREW_SUCCESSFUL_ARGS", successfulArgs)
+	t.Setenv("PATH", dir)
+
+	return recordedArgs
+}
+
+func assertBrewArgs(t *testing.T, file, want string) {
+	t.Helper()
+
+	contents, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := strings.TrimSpace(string(contents)); got != want {
+		t.Fatalf("brew arguments = %q, want %q", got, want)
+	}
+}

--- a/version/url_darwin_test.go
+++ b/version/url_darwin_test.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -41,6 +42,35 @@ func TestDownloadURL_PackageFallback(t *testing.T) {
 	}
 
 	assertBrewArgs(t, recordedArgs, "list --formula netbird\nlist --cask netbird-ui")
+}
+
+func TestIsHomebrewInstall_CanceledContext(t *testing.T) {
+	tests := []struct {
+		name           string
+		successfulArgs string
+	}{
+		{
+			name:           "formula",
+			successfulArgs: "list --formula netbird",
+		},
+		{
+			name:           "cask",
+			successfulArgs: "list --cask netbird-ui",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installBrew(t, tt.successfulArgs)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			if isHomebrewInstall(ctx) {
+				t.Fatal("isHomebrewInstall() = true, want false for canceled context")
+			}
+		})
+	}
 }
 
 func installBrew(t *testing.T, successfulArgs string) string {


### PR DESCRIPTION
## Describe your changes

`DownloadUrl` passed an entire shell pipeline (`list --formula | grep -i netbird`) as a single argument to `brew`, which always failed, so Homebrew installs were never detected and users were always pointed at the pkg installer.

This resolves the `brew` executable from PATH with fallbacks to the standard Apple Silicon (`/opt/homebrew/bin/brew`) and Intel (`/usr/local/bin/brew`) locations, then queries the `netbird` formula and the `netbird-ui` cask directly. Homebrew installs now get the install-page URL; non-Homebrew installs keep the architecture-specific pkg URL.

Added tests that stub `brew` on PATH and cover formula detection, cask detection, and the pkg fallback, asserting the exact arguments passed to `brew`. Verified with `go test -count=1 ./version` on macOS.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

Standalone PR based on `main`.

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal bug fix restoring intended update-URL behavior; no user-facing configuration or documented behavior changes.

### Docs PR URL (required if "docs added" is checked)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS download selection for installations made through Homebrew.
  * Correctly recognizes Homebrew formula and cask installations.
  * Preserves architecture-specific package selection when Homebrew is unavailable.
  * Added timeout handling to keep download detection responsive when Homebrew checks are delayed or canceled.

* **Tests**
  * Added coverage for Homebrew formula, Homebrew cask, package fallback, architecture selection, and canceled detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->