### PR TITLE
[client] Return watcher errors from network monitor instead of reporting a network change

### DIFF
--- a/client/internal/networkmonitor/monitor.go
+++ b/client/internal/networkmonitor/monitor.go
@@ -21,7 +21,10 @@ const (
 	debounceTime = 2 * time.Second
 )
 
-var checkChangeFn = checkChange
+var (
+	checkChangeFn = checkChange
+	getNextHopFn  = systemops.GetNextHop
+)
 
 // NetworkMonitor watches for changes in network configuration.
 type NetworkMonitor struct {
@@ -54,8 +57,8 @@ func (nw *NetworkMonitor) Listen(ctx context.Context) (err error) {
 
 	operation := func() error {
 		var errv4, errv6 error
-		nexthop4, errv4 = systemops.GetNextHop(netip.IPv4Unspecified())
-		nexthop6, errv6 = systemops.GetNextHop(netip.IPv6Unspecified())
+		nexthop4, errv4 = getNextHopFn(netip.IPv4Unspecified())
+		nexthop6, errv6 = getNextHopFn(netip.IPv6Unspecified())
 
 		if errv4 != nil && errv6 != nil {
 			return errors.New("failed to get default next hops")
@@ -86,7 +89,8 @@ func (nw *NetworkMonitor) Listen(ctx context.Context) (err error) {
 	}()
 
 	event := make(chan struct{}, 1)
-	go nw.checkChanges(ctx, event, nexthop4, nexthop6)
+	watchErrors := make(chan error, 1)
+	go nw.checkChanges(ctx, event, watchErrors, nexthop4, nexthop6)
 
 	log.Infof("start watching for network changes")
 	// debounce changes
@@ -98,6 +102,12 @@ func (nw *NetworkMonitor) Listen(ctx context.Context) (err error) {
 			timer.Reset(debounceTime)
 		case <-timer.C:
 			return nil
+		case watchErr := <-watchErrors:
+			timer.Stop()
+			if errors.Is(watchErr, context.Canceled) {
+				return ctx.Err()
+			}
+			return fmt.Errorf("watch network changes: %w", watchErr)
 		case <-ctx.Done():
 			timer.Stop()
 			return ctx.Err()
@@ -118,12 +128,15 @@ func (nw *NetworkMonitor) Stop() {
 	nw.wg.Wait()
 }
 
-func (nw *NetworkMonitor) checkChanges(ctx context.Context, event chan struct{}, nexthop4 systemops.Nexthop, nexthop6 systemops.Nexthop) {
-	defer close(event)
+func (nw *NetworkMonitor) checkChanges(ctx context.Context, event chan struct{}, watchErrors chan<- error, nexthop4 systemops.Nexthop, nexthop6 systemops.Nexthop) {
 	for {
 		if err := checkChangeFn(ctx, nexthop4, nexthop6); err != nil {
 			if !errors.Is(err, context.Canceled) {
 				log.Errorf("Network monitor: failed to check for changes: %v", err)
+			}
+			select {
+			case watchErrors <- err:
+			case <-ctx.Done():
 			}
 			return
 		}

--- a/client/internal/networkmonitor/monitor.go
+++ b/client/internal/networkmonitor/monitor.go
@@ -105,7 +105,9 @@ func (nw *NetworkMonitor) Listen(ctx context.Context) (err error) {
 		case watchErr := <-watchErrors:
 			timer.Stop()
 			if errors.Is(watchErr, context.Canceled) {
-				return ctx.Err()
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
 			}
 			return fmt.Errorf("watch network changes: %w", watchErr)
 		case <-ctx.Done():

--- a/client/internal/networkmonitor/monitor_test.go
+++ b/client/internal/networkmonitor/monitor_test.go
@@ -3,6 +3,8 @@ package networkmonitor
 import (
 	"context"
 	"errors"
+	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -10,12 +12,14 @@ import (
 )
 
 type MocMultiEvent struct {
-	counter int
+	counter       int
+	watcherExited chan struct{}
 }
 
 func (m *MocMultiEvent) checkChange(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
 	if m.counter == 0 {
 		<-ctx.Done()
+		close(m.watcherExited)
 		return ctx.Err()
 	}
 
@@ -25,8 +29,10 @@ func (m *MocMultiEvent) checkChange(ctx context.Context, nexthopv4, nexthopv6 sy
 }
 
 func TestNetworkMonitor_Close(t *testing.T) {
+	watcherExited := make(chan struct{})
 	checkChangeFn = func(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
 		<-ctx.Done()
+		close(watcherExited)
 		return ctx.Err()
 	}
 	nw := New()
@@ -42,17 +48,20 @@ func TestNetworkMonitor_Close(t *testing.T) {
 	nw.Stop()
 
 	<-done
+	<-watcherExited
 	if !errors.Is(resErr, context.Canceled) {
 		t.Errorf("unexpected error: %v", resErr)
 	}
 }
 
 func TestNetworkMonitor_Event(t *testing.T) {
+	watcherExited := make(chan struct{})
 	checkChangeFn = func(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
 		timeout, cancel := context.WithTimeout(ctx, 3*time.Second)
 		defer cancel()
 		select {
 		case <-ctx.Done():
+			close(watcherExited)
 			return ctx.Err()
 		case <-timeout.Done():
 			return nil
@@ -69,6 +78,7 @@ func TestNetworkMonitor_Event(t *testing.T) {
 	}()
 
 	<-done
+	<-watcherExited
 	if !errors.Is(resErr, nil) {
 		t.Errorf("unexpected error: %v", nil)
 	}
@@ -76,7 +86,7 @@ func TestNetworkMonitor_Event(t *testing.T) {
 
 func TestNetworkMonitor_MultiEvent(t *testing.T) {
 	eventsRepeated := 3
-	me := &MocMultiEvent{counter: eventsRepeated}
+	me := &MocMultiEvent{counter: eventsRepeated, watcherExited: make(chan struct{})}
 	checkChangeFn = me.checkChange
 
 	nw := New()
@@ -92,8 +102,68 @@ func TestNetworkMonitor_MultiEvent(t *testing.T) {
 	}()
 
 	<-done
+	<-me.watcherExited
 	expectedResponseTime := time.Duration(eventsRepeated)*time.Second + debounceTime
 	if time.Since(started) < expectedResponseTime {
 		t.Errorf("unexpected duration: %v", time.Since(started))
+	}
+}
+
+func TestNetworkMonitor_WatcherDoesNotCloseEvents(t *testing.T) {
+	watcherErr := errors.New("watcher failed")
+	previousCheckChangeFn := checkChangeFn
+	checkChangeFn = func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
+		return watcherErr
+	}
+	t.Cleanup(func() {
+		checkChangeFn = previousCheckChangeFn
+	})
+
+	events := make(chan struct{}, 1)
+	watchErrors := make(chan error, 1)
+	New().checkChanges(context.Background(), events, watchErrors, systemops.Nexthop{}, systemops.Nexthop{})
+
+	select {
+	case got := <-watchErrors:
+		if !errors.Is(got, watcherErr) {
+			t.Fatalf("watcher error = %v, want %v", got, watcherErr)
+		}
+	default:
+		t.Fatal("watcher error was not delivered")
+	}
+
+	select {
+	case got := <-watchErrors:
+		t.Fatalf("watcher error delivered more than once: %v", got)
+	default:
+	}
+
+	select {
+	case _, ok := <-events:
+		if !ok {
+			t.Fatal("event channel was closed by watcher")
+		}
+	default:
+	}
+}
+
+func TestNetworkMonitor_WatcherError(t *testing.T) {
+	watcherErr := errors.New("watcher failed")
+	previousCheckChangeFn := checkChangeFn
+	previousGetNextHopFn := getNextHopFn
+	checkChangeFn = func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
+		return watcherErr
+	}
+	getNextHopFn = func(netip.Addr) (systemops.Nexthop, error) {
+		return systemops.Nexthop{Intf: &net.Interface{Name: "test"}}, nil
+	}
+	t.Cleanup(func() {
+		checkChangeFn = previousCheckChangeFn
+		getNextHopFn = previousGetNextHopFn
+	})
+
+	err := New().Listen(context.Background())
+	if !errors.Is(err, watcherErr) {
+		t.Fatalf("Listen() error = %v, want wrapped %v", err, watcherErr)
 	}
 }

--- a/client/internal/networkmonitor/monitor_test.go
+++ b/client/internal/networkmonitor/monitor_test.go
@@ -185,3 +185,20 @@ func TestNetworkMonitor_WatcherError(t *testing.T) {
 		t.Fatalf("Listen() error = %v, want wrapped %v", err, watcherErr)
 	}
 }
+
+func TestNetworkMonitor_WatcherCanceledWithoutListenerCancellation(t *testing.T) {
+	useTestNextHop(t)
+
+	previousCheckChangeFn := checkChangeFn
+	checkChangeFn = func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
+		return context.Canceled
+	}
+	t.Cleanup(func() {
+		checkChangeFn = previousCheckChangeFn
+	})
+
+	err := New().Listen(context.Background())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Listen() error = %v, want wrapped %v", err, context.Canceled)
+	}
+}

--- a/client/internal/networkmonitor/monitor_test.go
+++ b/client/internal/networkmonitor/monitor_test.go
@@ -16,6 +16,18 @@ type MocMultiEvent struct {
 	watcherExited chan struct{}
 }
 
+func useTestNextHop(t *testing.T) {
+	t.Helper()
+
+	previousGetNextHopFn := getNextHopFn
+	getNextHopFn = func(netip.Addr) (systemops.Nexthop, error) {
+		return systemops.Nexthop{Intf: &net.Interface{Name: "test"}}, nil
+	}
+	t.Cleanup(func() {
+		getNextHopFn = previousGetNextHopFn
+	})
+}
+
 func (m *MocMultiEvent) checkChange(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
 	if m.counter == 0 {
 		<-ctx.Done()
@@ -29,6 +41,8 @@ func (m *MocMultiEvent) checkChange(ctx context.Context, nexthopv4, nexthopv6 sy
 }
 
 func TestNetworkMonitor_Close(t *testing.T) {
+	useTestNextHop(t)
+
 	watcherExited := make(chan struct{})
 	checkChangeFn = func(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
 		<-ctx.Done()
@@ -55,6 +69,8 @@ func TestNetworkMonitor_Close(t *testing.T) {
 }
 
 func TestNetworkMonitor_Event(t *testing.T) {
+	useTestNextHop(t)
+
 	watcherExited := make(chan struct{})
 	checkChangeFn = func(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
 		timeout, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -85,6 +101,8 @@ func TestNetworkMonitor_Event(t *testing.T) {
 }
 
 func TestNetworkMonitor_MultiEvent(t *testing.T) {
+	useTestNextHop(t)
+
 	eventsRepeated := 3
 	me := &MocMultiEvent{counter: eventsRepeated, watcherExited: make(chan struct{})}
 	checkChangeFn = me.checkChange

--- a/client/internal/networkmonitor/monitor_test.go
+++ b/client/internal/networkmonitor/monitor_test.go
@@ -28,6 +28,16 @@ func useTestNextHop(t *testing.T) {
 	})
 }
 
+func useTestCheckChange(t *testing.T, fn func(context.Context, systemops.Nexthop, systemops.Nexthop) error) {
+	t.Helper()
+
+	previousCheckChangeFn := checkChangeFn
+	checkChangeFn = fn
+	t.Cleanup(func() {
+		checkChangeFn = previousCheckChangeFn
+	})
+}
+
 func (m *MocMultiEvent) checkChange(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
 	if m.counter == 0 {
 		<-ctx.Done()
@@ -44,11 +54,11 @@ func TestNetworkMonitor_Close(t *testing.T) {
 	useTestNextHop(t)
 
 	watcherExited := make(chan struct{})
-	checkChangeFn = func(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
+	useTestCheckChange(t, func(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
 		<-ctx.Done()
 		close(watcherExited)
 		return ctx.Err()
-	}
+	})
 	nw := New()
 
 	var resErr error
@@ -72,7 +82,7 @@ func TestNetworkMonitor_Event(t *testing.T) {
 	useTestNextHop(t)
 
 	watcherExited := make(chan struct{})
-	checkChangeFn = func(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
+	useTestCheckChange(t, func(ctx context.Context, nexthopv4, nexthopv6 systemops.Nexthop) error {
 		timeout, cancel := context.WithTimeout(ctx, 3*time.Second)
 		defer cancel()
 		select {
@@ -82,7 +92,7 @@ func TestNetworkMonitor_Event(t *testing.T) {
 		case <-timeout.Done():
 			return nil
 		}
-	}
+	})
 	nw := New()
 	defer nw.Stop()
 
@@ -105,7 +115,7 @@ func TestNetworkMonitor_MultiEvent(t *testing.T) {
 
 	eventsRepeated := 3
 	me := &MocMultiEvent{counter: eventsRepeated, watcherExited: make(chan struct{})}
-	checkChangeFn = me.checkChange
+	useTestCheckChange(t, me.checkChange)
 
 	nw := New()
 	defer nw.Stop()
@@ -129,12 +139,8 @@ func TestNetworkMonitor_MultiEvent(t *testing.T) {
 
 func TestNetworkMonitor_WatcherDoesNotCloseEvents(t *testing.T) {
 	watcherErr := errors.New("watcher failed")
-	previousCheckChangeFn := checkChangeFn
-	checkChangeFn = func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
+	useTestCheckChange(t, func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
 		return watcherErr
-	}
-	t.Cleanup(func() {
-		checkChangeFn = previousCheckChangeFn
 	})
 
 	events := make(chan struct{}, 1)
@@ -167,16 +173,14 @@ func TestNetworkMonitor_WatcherDoesNotCloseEvents(t *testing.T) {
 
 func TestNetworkMonitor_WatcherError(t *testing.T) {
 	watcherErr := errors.New("watcher failed")
-	previousCheckChangeFn := checkChangeFn
 	previousGetNextHopFn := getNextHopFn
-	checkChangeFn = func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
+	useTestCheckChange(t, func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
 		return watcherErr
-	}
+	})
 	getNextHopFn = func(netip.Addr) (systemops.Nexthop, error) {
 		return systemops.Nexthop{Intf: &net.Interface{Name: "test"}}, nil
 	}
 	t.Cleanup(func() {
-		checkChangeFn = previousCheckChangeFn
 		getNextHopFn = previousGetNextHopFn
 	})
 
@@ -189,16 +193,34 @@ func TestNetworkMonitor_WatcherError(t *testing.T) {
 func TestNetworkMonitor_WatcherCanceledWithoutListenerCancellation(t *testing.T) {
 	useTestNextHop(t)
 
-	previousCheckChangeFn := checkChangeFn
-	checkChangeFn = func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
+	useTestCheckChange(t, func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
 		return context.Canceled
-	}
-	t.Cleanup(func() {
-		checkChangeFn = previousCheckChangeFn
 	})
 
 	err := New().Listen(context.Background())
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Listen() error = %v, want wrapped %v", err, context.Canceled)
+	}
+}
+
+func TestUseTestCheckChangeRestoresPreviousValue(t *testing.T) {
+	previousErr := errors.New("previous watcher")
+	useTestCheckChange(t, func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
+		return previousErr
+	})
+
+	overrideErr := errors.New("override watcher")
+	t.Run("override", func(t *testing.T) {
+		useTestCheckChange(t, func(context.Context, systemops.Nexthop, systemops.Nexthop) error {
+			return overrideErr
+		})
+
+		if got := checkChangeFn(context.Background(), systemops.Nexthop{}, systemops.Nexthop{}); !errors.Is(got, overrideErr) {
+			t.Fatalf("checkChangeFn() error = %v, want %v", got, overrideErr)
+		}
+	})
+
+	if got := checkChangeFn(context.Background(), systemops.Nexthop{}, systemops.Nexthop{}); !errors.Is(got, previousErr) {
+		t.Fatalf("checkChangeFn() error after cleanup = %v, want %v", got, previousErr)
 	}
 }


### PR DESCRIPTION
## Describe your changes

The network monitor's watcher goroutine (`checkChanges`) closed the shared `event` channel when the platform watcher returned an error. A closed channel made the `<-event` case in `Listen` fire in a busy loop until the debounce timer expired, so `Listen` returned `nil` — a watcher **failure** was reported as a **network change**, triggering an unnecessary client restart.

Changes:

- `checkChanges` no longer closes the `event` channel. It reports its error on a dedicated buffered `watchErrors` channel, guarded by `ctx.Done()` so the goroutine cannot block, and exits.
- `Listen` returns the watcher error wrapped (`watch network changes: %w`) instead of `nil`. On real cancellation it still returns `ctx.Err()`, preserving the existing clean-shutdown handling in the engine.
- If a watcher returns `context.Canceled` while the listener context is still active, `Listen` now returns the wrapped error instead of `nil`, so it cannot be mistaken for a detected network change.
- The default next-hop lookup is injectable, so the lifecycle tests no longer depend on host routes and run in restricted environments.
- New tests cover that the event channel is not closed, the error is delivered exactly once, `Listen` returns the wrapped watcher error, and the unexpected-cancellation edge case.

Verification: the new edge-case test fails against the previous implementation (`Listen() error = <nil>`) and passes with this change. The full package suite passes with `go test -race -count=1 ./client/internal/networkmonitor`, without requiring host routing access.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

Standalone PR based on `main`.

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal bug fix in the client's network monitor; no user-facing behavior, API, or configuration changes)

### Docs PR URL (required if "docs added" is checked)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network monitoring error handling so watcher errors are reported reliably.
  * Preserved correct cancellation behavior when network watchers stop independently.
  * Prevented event channels from closing unexpectedly during monitoring.

* **Tests**
  * Added coverage for watcher errors, cancellation scenarios, and event-channel behavior.
  * Improved test synchronization for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->