### PR TITLE
[client] Publish engine route manager only after successful start

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -182,6 +183,10 @@ type EngineServices struct {
 	MetricsCtx     context.Context
 }
 
+type routeManagerPublication struct {
+	manager routemanager.Manager
+}
+
 // Engine is a mechanism responsible for reacting on Signal and Management stream events and managing connections to the remote peers.
 type Engine struct {
 	// signal is a Signal Service client
@@ -239,6 +244,7 @@ type Engine struct {
 
 	firewall          firewallManager.Manager
 	routeManager      routemanager.Manager
+	publishedRouteMgr atomic.Pointer[routeManagerPublication]
 	acl               acl.Manager
 	dnsForwardMgr     *dnsfwd.Manager
 	ingressGatewayMgr *ingressgw.Manager
@@ -400,6 +406,8 @@ func (e *Engine) Stop() error {
 // step is nil-guarded. It does not wait on shutdownWg — the caller does that
 // after releasing the lock, since the goroutines also take syncMsgMux.
 func (e *Engine) stopLocked() {
+	e.unpublishRouteManager()
+
 	if e.connMgr != nil {
 		e.connMgr.Close()
 	}
@@ -709,6 +717,7 @@ func (e *Engine) Start(netbirdConfig *mgmProto.NetbirdConfig, mgmtURL *url.URL) 
 		}
 	}()
 
+	e.publishRouteManager()
 	return nil
 }
 
@@ -2226,9 +2235,21 @@ func (e *Engine) newDnsServer(dnsConfig *nbdns.Config) (dns.Server, error) {
 	}
 }
 
-// GetRouteManager returns the route manager
+func (e *Engine) publishRouteManager() {
+	e.publishedRouteMgr.Store(&routeManagerPublication{manager: e.routeManager})
+}
+
+func (e *Engine) unpublishRouteManager() {
+	e.publishedRouteMgr.Store(nil)
+}
+
+// GetRouteManager returns the route manager after the engine has started successfully.
 func (e *Engine) GetRouteManager() routemanager.Manager {
-	return e.routeManager
+	published := e.publishedRouteMgr.Load()
+	if published == nil {
+		return nil
+	}
+	return published.manager
 }
 
 // GetFirewallManager returns the firewall manager.

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -68,6 +68,62 @@ type MockWGIface struct {
 	LastActivitiesFunc         func() map[string]monotime.Time
 }
 
+func TestEngineGetRouteManagerBeforePublish(t *testing.T) {
+	manager := &routemanager.MockManager{}
+	engine := &Engine{routeManager: manager}
+
+	assert.Nil(t, engine.GetRouteManager())
+}
+
+func TestEngineGetRouteManagerAfterPublish(t *testing.T) {
+	manager := &routemanager.MockManager{}
+	engine := &Engine{routeManager: manager}
+
+	engine.publishRouteManager()
+
+	assert.Same(t, manager, engine.GetRouteManager())
+}
+
+func TestEngineGetRouteManagerAfterUnpublish(t *testing.T) {
+	manager := &routemanager.MockManager{}
+	engine := &Engine{routeManager: manager}
+	engine.publishRouteManager()
+
+	engine.unpublishRouteManager()
+
+	assert.Nil(t, engine.GetRouteManager())
+}
+
+func TestEngineRouteManagerPublicationConcurrent(t *testing.T) {
+	manager := &routemanager.MockManager{}
+	engine := &Engine{routeManager: manager}
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			engine.publishRouteManager()
+			engine.unpublishRouteManager()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			got := engine.GetRouteManager()
+			if got != nil && got != manager {
+				t.Errorf("unexpected route manager: got %p, want %p", got, manager)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
 func (m *MockWGIface) RenewTun(_ int) error {
 	return nil
 }

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -635,7 +635,10 @@ func (c *Client) SelectRoute(id string) error {
 		return fmt.Errorf("not connected")
 	}
 
-	routeManager := engine.GetRouteManager()
+	routeManager, err := requireRouteManager(engine.GetRouteManager())
+	if err != nil {
+		return err
+	}
 	if id == "All" {
 		log.Debugf("select all routes")
 		routeManager.SelectAllRoutes()
@@ -660,7 +663,10 @@ func (c *Client) DeselectRoute(id string) error {
 		return fmt.Errorf("not connected")
 	}
 
-	routeManager := engine.GetRouteManager()
+	routeManager, err := requireRouteManager(engine.GetRouteManager())
+	if err != nil {
+		return err
+	}
 	if id == "All" {
 		log.Debugf("deselect all routes")
 		routeManager.DeselectAllRoutes()

--- a/client/ios/NetBirdSDK/route_manager.go
+++ b/client/ios/NetBirdSDK/route_manager.go
@@ -1,0 +1,17 @@
+//go:build darwin || ios
+
+package NetBirdSDK
+
+import (
+	"fmt"
+
+	"github.com/netbirdio/netbird/client/internal/routemanager"
+)
+
+func requireRouteManager(manager routemanager.Manager) (routemanager.Manager, error) {
+	if manager == nil {
+		return nil, fmt.Errorf("could not get route manager")
+	}
+
+	return manager, nil
+}

--- a/client/ios/NetBirdSDK/route_manager_test.go
+++ b/client/ios/NetBirdSDK/route_manager_test.go
@@ -1,0 +1,18 @@
+//go:build darwin || ios
+
+package NetBirdSDK
+
+import "testing"
+
+func TestRequireRouteManagerNil(t *testing.T) {
+	manager, err := requireRouteManager(nil)
+	if manager != nil {
+		t.Fatal("expected nil route manager")
+	}
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got, want := err.Error(), "could not get route manager"; got != want {
+		t.Errorf("unexpected error: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Describe your changes

iOS SDK route calls read `Engine.GetRouteManager` while `Engine.Start` could still be assigning the field, so callers could observe a nil, partially initialized, or concurrently written route manager (a data race).

The engine now publishes the route manager through an `atomic.Pointer` only after `Start` completes successfully and unpublishes it at the top of teardown (shared by `Stop` and `Start`'s failure path), so `GetRouteManager` returns either nil or a fully initialized manager.

The iOS `SelectRoute`/`DeselectRoute` bridges now return a "could not get route manager" error instead of panicking when the engine is not started; all other existing callers already nil-check.

Added unit tests for publish/unpublish/read ordering plus a concurrent publication test, run under `go test -race`, and an iOS helper test. Verified with the focused core tests under `-race`, the iOS helper test, an iOS arm64 CGO compile, and `git diff --check`.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

Standalone PR based on `main`.

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal concurrency fix; no user-facing behavior, API, or configuration changes.

### Docs PR URL (required if "docs added" is checked)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route management is now available only after successful startup and is cleared during shutdown.
  * Route selection and removal report a clear error when route management is unavailable.
  * Improved safety for concurrent route-manager access.
* **Tests**
  * Added coverage for route-manager availability throughout the startup and shutdown lifecycle, including concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->