### PR TITLE
[client] Fix expression order in legacy nftables route rules

### DIFF
--- a/client/firewall/nftables/legacy_rule_linux_test.go
+++ b/client/firewall/nftables/legacy_rule_linux_test.go
@@ -1,0 +1,60 @@
+package nftables
+
+import (
+	"testing"
+
+	"github.com/google/nftables/expr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildLegacyRouteRuleExpressions(t *testing.T) {
+	sourcePayload := &expr.Payload{}
+	sourceCmp := &expr.Cmp{}
+	destinationPayload := &expr.Payload{}
+	destinationCmp := &expr.Cmp{}
+	nilSourceDestination := &expr.Payload{}
+	nilDestinationSource := &expr.Cmp{}
+
+	tests := []struct {
+		name        string
+		source      []expr.Any
+		destination []expr.Any
+		matches     []expr.Any
+	}{
+		{
+			name:        "both non-empty",
+			source:      []expr.Any{sourcePayload, sourceCmp},
+			destination: []expr.Any{destinationPayload, destinationCmp},
+			matches:     []expr.Any{sourcePayload, sourceCmp, destinationPayload, destinationCmp},
+		},
+		{
+			name:        "nil source",
+			destination: []expr.Any{nilSourceDestination},
+			matches:     []expr.Any{nilSourceDestination},
+		},
+		{
+			name:    "nil destination",
+			source:  []expr.Any{nilDestinationSource},
+			matches: []expr.Any{nilDestinationSource},
+		},
+		{
+			name: "both nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildLegacyRouteRuleExpressions(tt.source, tt.destination)
+
+			require.Len(t, got, len(tt.matches)+2)
+			for i, match := range tt.matches {
+				require.Same(t, match, got[i])
+			}
+
+			require.IsType(t, &expr.Counter{}, got[len(tt.matches)])
+			verdict, ok := got[len(tt.matches)+1].(*expr.Verdict)
+			require.True(t, ok)
+			require.Equal(t, expr.VerdictAccept, verdict.Kind)
+		})
+	}
+}

--- a/client/firewall/nftables/router_linux.go
+++ b/client/firewall/nftables/router_linux.go
@@ -953,6 +953,17 @@ func (r *router) addMSSClampingRules() error {
 	return r.conn.Flush()
 }
 
+func buildLegacyRouteRuleExpressions(sourceExp, destExp []expr.Any) []expr.Any {
+	exprs := make([]expr.Any, 0, len(sourceExp)+len(destExp)+2)
+	exprs = append(exprs, sourceExp...)
+	exprs = append(exprs, destExp...)
+	exprs = append(exprs,
+		&expr.Counter{},
+		&expr.Verdict{Kind: expr.VerdictAccept},
+	)
+	return exprs
+}
+
 // addLegacyRouteRule adds a legacy routing rule for mgmt servers pre route acls
 func (r *router) addLegacyRouteRule(pair firewall.RouterPair) error {
 	sourceExp, err := r.applyNetwork(pair.Source, nil, true)
@@ -965,15 +976,7 @@ func (r *router) addLegacyRouteRule(pair firewall.RouterPair) error {
 		return fmt.Errorf("apply destination: %w", err)
 	}
 
-	exprs := []expr.Any{
-		&expr.Counter{},
-		&expr.Verdict{
-			Kind: expr.VerdictAccept,
-		},
-	}
-
-	exprs = append(exprs, sourceExp...)
-	exprs = append(exprs, destExp...)
+	exprs := buildLegacyRouteRuleExpressions(sourceExp, destExp)
 
 	ruleKey := firewall.GenKey(firewall.ForwardingFormat, pair)
 


### PR DESCRIPTION
## Describe your changes

On the retained compatibility path used with management servers older than v0.30.0, routing peers using the legacy nftables route implementation installed a forwarding rule whose expressions were assembled in the wrong order. In `addLegacyRouteRule` the `Counter` and `Verdict{Kind: VerdictAccept}` expressions were appended to the rule **before** the source and destination match expressions produced by `applyNetwork`.

nftables evaluates the expressions of a rule sequentially and stops at the first terminal verdict. With the accept verdict placed first, a packet reaching the generated rule was accepted immediately, and the source and destination matches that followed were never evaluated. This PR is scoped only to correcting that legacy compatibility path.

**Fix**

The expression slice is now built as `source matches -> destination matches -> counter -> accept verdict`, so the verdict is only reached once all match expressions have passed. The assembly was extracted into a small helper, `buildLegacyRouteRuleExpressions`, which keeps `addLegacyRouteRule` unchanged in behavior other than the ordering and makes the ordering directly testable.

**Test**

`TestBuildLegacyRouteRuleExpressions` is a table-driven unit test covering non-empty source and destination expressions as well as the empty source, empty destination, and both-empty cases. It asserts that the caller supplied match expressions come first and in their original order (compared by identity), and that they are followed by exactly a `Counter` and an accept `Verdict`. The test fails against the previous ordering.

The targeted regression test and the complete `client/firewall/nftables` package test suite pass on Linux amd64.

## Issue ticket number and link

N/A - found during static review. The affected code is the compatibility path for management servers older than v0.30.0.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature - OR I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): the change corrects the internal ordering of nftables rule expressions so the existing behavior is actually applied. No user-facing configuration, CLI or service flags, gRPC protocols, or public APIs change.

### Docs PR URL (required if "docs added" is checked)
Paste the link from https://github.com/netbirdio/docs here:

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy firewall route rule construction to consistently apply source and destination matches, counters, and accept actions.
  * Added coverage for routes with missing or optional source and destination criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
