### PR TITLE
[client] Fix device flow polling interval defaults and slow_down handling

### DIFF
--- a/client/internal/auth/device_flow.go
+++ b/client/internal/auth/device_flow.go
@@ -22,6 +22,7 @@ import (
 const (
 	HostedGrantType                  = "urn:ietf:params:oauth:grant-type:device_code"
 	defaultDeviceFlowPollingInterval = 5 * time.Second
+	deviceFlowSlowDownIncrement      = 5 * time.Second
 )
 
 var _ OAuthFlow = &DeviceAuthorizationFlow{}
@@ -255,6 +256,10 @@ func initialDeviceFlowPollingInterval(seconds int) time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
+func slowDownDeviceFlowPollingInterval(interval time.Duration) time.Duration {
+	return interval + deviceFlowSlowDownIncrement
+}
+
 // WaitToken waits user's login and authorize the app. Once the user's authorize
 // it retrieves the access token from Hosted's endpoint and validates it before returning.
 // The method creates a timeout context internally based on info.ExpiresIn.
@@ -290,7 +295,7 @@ func (d *DeviceAuthorizationFlow) WaitToken(ctx context.Context, info AuthFlowIn
 					log.Tracef("device flow: authorization still pending after poll %d", polls)
 					continue
 				} else if tokenResponse.Error == "slow_down" {
-					interval += (3 * time.Second)
+					interval = slowDownDeviceFlowPollingInterval(interval)
 					ticker.Reset(interval)
 					log.Infof("device flow: IdP requested slow_down, polling interval increased to %s", interval)
 					continue

--- a/client/internal/auth/device_flow.go
+++ b/client/internal/auth/device_flow.go
@@ -20,7 +20,8 @@ import (
 
 // HostedGrantType grant type for device flow on Hosted
 const (
-	HostedGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+	HostedGrantType                  = "urn:ietf:params:oauth:grant-type:device_code"
+	defaultDeviceFlowPollingInterval = 5 * time.Second
 )
 
 var _ OAuthFlow = &DeviceAuthorizationFlow{}
@@ -246,6 +247,14 @@ func (d *DeviceAuthorizationFlow) requestToken(info AuthFlowInfo) (TokenRequestR
 	return tokenResponse, nil
 }
 
+func initialDeviceFlowPollingInterval(seconds int) time.Duration {
+	if seconds <= 0 {
+		return defaultDeviceFlowPollingInterval
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
 // WaitToken waits user's login and authorize the app. Once the user's authorize
 // it retrieves the access token from Hosted's endpoint and validates it before returning.
 // The method creates a timeout context internally based on info.ExpiresIn.
@@ -255,7 +264,7 @@ func (d *DeviceAuthorizationFlow) WaitToken(ctx context.Context, info AuthFlowIn
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	interval := time.Duration(info.Interval) * time.Second
+	interval := initialDeviceFlowPollingInterval(info.Interval)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 

--- a/client/internal/auth/device_flow.go
+++ b/client/internal/auth/device_flow.go
@@ -20,9 +20,11 @@ import (
 
 // HostedGrantType grant type for device flow on Hosted
 const (
-	HostedGrantType                  = "urn:ietf:params:oauth:grant-type:device_code"
-	defaultDeviceFlowPollingInterval = 5 * time.Second
-	deviceFlowSlowDownIncrement      = 5 * time.Second
+	HostedGrantType                     = "urn:ietf:params:oauth:grant-type:device_code"
+	defaultDeviceFlowPollingInterval    = 5 * time.Second
+	deviceFlowSlowDownIncrement         = 5 * time.Second
+	maxDeviceFlowPollingInterval        = time.Duration(1<<63 - 1)
+	maxDeviceFlowPollingIntervalSeconds = int64(maxDeviceFlowPollingInterval / time.Second)
 )
 
 var _ OAuthFlow = &DeviceAuthorizationFlow{}
@@ -249,14 +251,30 @@ func (d *DeviceAuthorizationFlow) requestToken(info AuthFlowInfo) (TokenRequestR
 }
 
 func initialDeviceFlowPollingInterval(seconds int) time.Duration {
+	return deviceFlowPollingIntervalFromSeconds(int64(seconds))
+}
+
+// deviceFlowPollingIntervalFromSeconds uses int64 so exact overflow boundaries
+// remain testable without breaking 32-bit builds.
+func deviceFlowPollingIntervalFromSeconds(seconds int64) time.Duration {
 	if seconds <= 0 {
 		return defaultDeviceFlowPollingInterval
+	}
+	if seconds > maxDeviceFlowPollingIntervalSeconds {
+		return maxDeviceFlowPollingInterval
 	}
 
 	return time.Duration(seconds) * time.Second
 }
 
 func slowDownDeviceFlowPollingInterval(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return defaultDeviceFlowPollingInterval
+	}
+	if interval > maxDeviceFlowPollingInterval-deviceFlowSlowDownIncrement {
+		return maxDeviceFlowPollingInterval
+	}
+
 	return interval + deviceFlowSlowDownIncrement
 }
 

--- a/client/internal/auth/device_flow_test.go
+++ b/client/internal/auth/device_flow_test.go
@@ -306,3 +306,32 @@ func TestHosted_WaitToken(t *testing.T) {
 		})
 	}
 }
+
+func TestHosted_WaitTokenMissingInterval(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deviceFlow := &DeviceAuthorizationFlow{}
+	tokenInfo, err := deviceFlow.WaitToken(ctx, AuthFlowInfo{ExpiresIn: 10})
+
+	require.Empty(t, tokenInfo)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestInitialDeviceFlowPollingInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int
+		want    time.Duration
+	}{
+		{name: "missing", seconds: 0, want: 5 * time.Second},
+		{name: "negative", seconds: -1, want: 5 * time.Second},
+		{name: "provided", seconds: 7, want: 7 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, initialDeviceFlowPollingInterval(tt.seconds))
+		})
+	}
+}

--- a/client/internal/auth/device_flow_test.go
+++ b/client/internal/auth/device_flow_test.go
@@ -318,6 +318,18 @@ func TestHosted_WaitTokenMissingInterval(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestHosted_WaitTokenMaximumInterval(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deviceFlow := &DeviceAuthorizationFlow{}
+	maxInt := int(^uint(0) >> 1)
+	tokenInfo, err := deviceFlow.WaitToken(ctx, AuthFlowInfo{ExpiresIn: 10, Interval: maxInt})
+
+	require.Empty(t, tokenInfo)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestInitialDeviceFlowPollingInterval(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -337,5 +349,102 @@ func TestInitialDeviceFlowPollingInterval(t *testing.T) {
 }
 
 func TestSlowDownDeviceFlowPollingInterval(t *testing.T) {
-	require.Equal(t, 7*time.Second, slowDownDeviceFlowPollingInterval(2*time.Second))
+	interval := slowDownDeviceFlowPollingInterval(2 * time.Second)
+	require.Equal(t, 7*time.Second, interval)
+
+	interval = slowDownDeviceFlowPollingInterval(interval)
+	require.Equal(t, 12*time.Second, interval)
+}
+
+func TestDeviceFlowPollingIntervalFromSeconds(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int64
+		want    time.Duration
+	}{
+		{
+			name:    "largest safe whole second",
+			seconds: maxDeviceFlowPollingIntervalSeconds,
+			want:    time.Duration(maxDeviceFlowPollingIntervalSeconds) * time.Second,
+		},
+		{
+			name:    "above largest safe whole second",
+			seconds: maxDeviceFlowPollingIntervalSeconds + 1,
+			want:    maxDeviceFlowPollingInterval,
+		},
+		{
+			name:    "maximum int64",
+			seconds: int64(1<<63 - 1),
+			want:    maxDeviceFlowPollingInterval,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, deviceFlowPollingIntervalFromSeconds(tt.seconds))
+		})
+	}
+}
+
+func TestInitialDeviceFlowPollingIntervalMaximumInt(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	got := initialDeviceFlowPollingInterval(maxInt)
+
+	if int64(maxInt) > maxDeviceFlowPollingIntervalSeconds {
+		require.Equal(t, maxDeviceFlowPollingInterval, got)
+		return
+	}
+
+	require.Equal(t, time.Duration(maxInt)*time.Second, got)
+}
+
+func TestSlowDownDeviceFlowPollingIntervalBoundaries(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval time.Duration
+		want     time.Duration
+	}{
+		{
+			name:     "non-positive",
+			interval: 0,
+			want:     defaultDeviceFlowPollingInterval,
+		},
+		{
+			name:     "exact fit",
+			interval: maxDeviceFlowPollingInterval - deviceFlowSlowDownIncrement,
+			want:     maxDeviceFlowPollingInterval,
+		},
+		{
+			name:     "addition would overflow",
+			interval: maxDeviceFlowPollingInterval - deviceFlowSlowDownIncrement + 1,
+			want:     maxDeviceFlowPollingInterval,
+		},
+		{
+			name:     "already saturated",
+			interval: maxDeviceFlowPollingInterval,
+			want:     maxDeviceFlowPollingInterval,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, slowDownDeviceFlowPollingInterval(tt.interval))
+		})
+	}
+}
+
+func TestDeviceFlowPollingIntervalTickerSafe(t *testing.T) {
+	durations := []time.Duration{
+		initialDeviceFlowPollingInterval(0),
+		deviceFlowPollingIntervalFromSeconds(int64(1<<63 - 1)),
+		slowDownDeviceFlowPollingInterval(maxDeviceFlowPollingInterval),
+	}
+
+	for _, duration := range durations {
+		require.NotPanics(t, func() {
+			ticker := time.NewTicker(duration)
+			ticker.Reset(duration)
+			ticker.Stop()
+		})
+	}
 }

--- a/client/internal/auth/device_flow_test.go
+++ b/client/internal/auth/device_flow_test.go
@@ -335,3 +335,7 @@ func TestInitialDeviceFlowPollingInterval(t *testing.T) {
 		})
 	}
 }
+
+func TestSlowDownDeviceFlowPollingInterval(t *testing.T) {
+	require.Equal(t, 7*time.Second, slowDownDeviceFlowPollingInterval(2*time.Second))
+}


### PR DESCRIPTION
## Describe your changes

The device authorization flow mishandled the polling interval in two RFC-relevant ways and also lacked bounds checks for values that cannot be represented safely as `time.Duration`.

1. `interval` is optional in the device authorization response ([RFC 8628, section 3.2](https://datatracker.ietf.org/doc/html/rfc8628#section-3.2)). If an IdP omitted it, the field decoded to `0`, and `WaitToken` passed `0` into `time.NewTicker`, which panics with `non-positive interval for NewTicker`. Login against such an IdP crashed instead of polling.
2. On a `slow_down` error the interval was increased by 3 seconds. [RFC 8628, section 3.5](https://datatracker.ietf.org/doc/html/rfc8628#section-3.5) requires the polling interval to be increased by 5 seconds for this and all subsequent requests. Each later `slow_down` response applies the same rule again, so repeated responses increase the interval cumulatively.
3. Very large positive intervals could overflow when converted to `time.Duration`, and repeated `slow_down` increases could overflow during addition.

Changes:

- `initialDeviceFlowPollingInterval` uses the RFC's 5-second default when `interval` is omitted and decoded as zero. Because `AuthFlowInfo.Interval` is an `int`, an explicit zero is indistinguishable from omission; non-positive values also fall back to 5 seconds as defensive hardening.
- `deviceFlowPollingIntervalFromSeconds` converts positive values safely and saturates values above the largest whole-second duration representable by `time.Duration`.
- `slowDownDeviceFlowPollingInterval` adds 5 seconds for each `slow_down` response when representable and saturates at the maximum positive `time.Duration`.

These helpers are unexported; production polling reaches them only through `WaitToken`. The change touches `client/internal/auth/device_flow.go` and its test file only. No public API, gRPC protocol, CLI or service flag, JSON payload, persistence format, or PKCE behavior is affected.

The tests are deterministic and cover omitted and provided intervals, non-positive values, maximum integer inputs, exact overflow boundaries, cumulative `slow_down`, saturation behavior, canceled contexts, and ticker safety. They require no real sleeps, fake clocks, or new dependencies.

Note on the last checklist item: this is a behavior fix, so the client's runtime polling behavior does change. The omitted-interval default and the five-second `slow_down` increase align the client with RFC 8628; handling explicit non-positive and unrepresentably large values is additional defensive hardening. I left that box unchecked rather than claim no behavior change. Happy to discuss if you want it handled differently.

## Issue ticket number and link

N/A

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature, **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): this corrects internal polling behavior to the existing RFC 8628 contract. No user-facing configuration, API, or flag changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device authorization polling when providers omit, provide invalid values, or specify extremely large intervals.
  * Applied the RFC's 5-second default and saturated unrepresentable intervals to prevent duration overflow and invalid ticker durations.
  * Increased polling delays consistently after `slow_down` responses, including boundary cases.
  * Ensured canceled authorization requests return promptly without issuing a token.
  * Improved reliability across a wider range of provider polling behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->