### PR TITLE
client/iface: let a TunAdapter supply the tun.Device itself

### DIFF
--- a/client/iface/device/adapter.go
+++ b/client/iface/device/adapter.go
@@ -1,8 +1,30 @@
 package device
 
+import "golang.zx2c4.com/wireguard/tun"
+
 // TunAdapter is an interface for create tun device from external service
 type TunAdapter interface {
 	ConfigureInterface(address string, addressV6 string, mtu int, dns string, searchDomains string, routes string) (int, error)
 	UpdateAddr(address string) error
 	ProtectSocket(fd int32) bool
+}
+
+// TunDeviceProvider is an optional interface a [TunAdapter] may also implement to supply the
+// tun.Device itself, instead of a file descriptor for NetBird to open.
+//
+// ConfigureInterface returns a descriptor, which NetBird passes to
+// tun.CreateUnmonitoredTUNFromFD; that call ioctls TUNGETIFF for the interface name, so it accepts
+// only a real tun. A host that already owns the tun therefore cannot use it — and on Android a host
+// may have no choice, because the platform permits exactly one active VpnService per user profile.
+// An app running NetBird alongside another backend must own that single tun and route packets to
+// whichever backend claims each destination; it has no second tun to hand over, and handing over
+// the shared one would give NetBird every other backend's traffic.
+//
+// A TunAdapter that implements this is asked for a device and never for a descriptor. One that does
+// not is unaffected: the descriptor path is unchanged, and gomobile bindings — which cannot express
+// a Go interface return — simply do not implement this.
+type TunDeviceProvider interface {
+	// TunDevice returns the device NetBird should read and write, given the same interface
+	// parameters ConfigureInterface receives, and the name to report for it.
+	TunDevice(address string, addressV6 string, mtu int, dns string, searchDomains string, routes string) (tun.Device, string, error)
 }

--- a/client/iface/device/device_android.go
+++ b/client/iface/device/device_android.go
@@ -63,21 +63,35 @@ func (t *WGTunDevice) Create(routes []string, dns string, searchDomains []string
 		searchDomainsToString = ""
 	}
 
-	fd, err := t.tunAdapter.ConfigureInterface(t.address.String(), t.address.IPv6String(), int(t.mtu), dns, searchDomainsToString, routesString)
-	if err != nil {
-		log.Errorf("failed to create Android interface: %s", err)
-		return nil, err
+	var (
+		tunDevice tun.Device
+		name      string
+		err       error
+	)
+	if provider, ok := t.tunAdapter.(TunDeviceProvider); ok {
+		// The host owns the tun and hands us the device directly; see TunDeviceProvider.
+		tunDevice, name, err = provider.TunDevice(t.address.String(), t.address.IPv6String(), int(t.mtu), dns, searchDomainsToString, routesString)
+		if err != nil {
+			log.Errorf("failed to obtain a tun device from the host: %s", err)
+			return nil, err
+		}
+	} else {
+		var fd int
+		fd, err = t.tunAdapter.ConfigureInterface(t.address.String(), t.address.IPv6String(), int(t.mtu), dns, searchDomainsToString, routesString)
+		if err != nil {
+			log.Errorf("failed to create Android interface: %s", err)
+			return nil, err
+		}
+
+		tunDevice, name, err = tun.CreateUnmonitoredTUNFromFD(fd)
+		if err != nil {
+			_ = unix.Close(fd)
+			log.Errorf("failed to create Android interface: %s", err)
+			return nil, err
+		}
 	}
 
-	unmonitoredTUN, name, err := tun.CreateUnmonitoredTUNFromFD(fd)
-	if err != nil {
-		_ = unix.Close(fd)
-		log.Errorf("failed to create Android interface: %s", err)
-		return nil, err
-	}
-
-	t.renewableTun.AddDevice(unmonitoredTUN)
-
+	t.renewableTun.AddDevice(tunDevice)
 	t.name = name
 	t.filteredDevice = newDeviceFilter(t.renewableTun)
 


### PR DESCRIPTION
Implements the change discussed in #7023. Opening it so the shape is concrete — happy to rework the API if you would prefer a different one.

## Problem

Android permits exactly one active `VpnService` per user profile. An application running NetBird alongside another overlay backend must therefore own that tun itself and route each packet to whichever backend claims its destination — it has no second tun to hand over, and handing over the shared one would give NetBird every other backend's traffic.

The only Android injection point is `TunAdapter.ConfigureInterface`, which returns a file descriptor that goes to `tun.CreateUnmonitoredTUNFromFD`. That ioctls `TUNGETIFF`, so it accepts only a real tun.

## Change

`TunDeviceProvider`, an optional interface a `TunAdapter` may also implement:

```go
type TunDeviceProvider interface {
    TunDevice(address, addressV6 string, mtu int, dns, searchDomains, routes string) (tun.Device, string, error)
}
```

`WGTunDevice.Create` type-asserts for it. When present it asks for the device; when absent the existing descriptor path runs unchanged, so every current caller is unaffected. gomobile cannot express a Go interface return, so gomobile bindings cannot accidentally implement it either.

49 lines across `adapter.go` and `device_android.go`.

## Verification

Builds for `android/arm64`. Running in an application that carries ZeroTier, WireGuard, Tailscale and NetBird simultaneously on one tun — NetBird in its own process, reading and writing a channel-backed `tun.Device` — verified on a Galaxy S23 (Android 16): all four providers reachable, and NetBird still reachable after 90 minutes in deep Doze.

No test included: exercising it needs a `tun.Device` implementation and an Android host, and I did not want to add a mock without knowing whether you would want one and in what shape. Glad to add whatever you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for compatible adapters to provide a TUN device and interface name directly.
  * Existing descriptor-based adapter behavior remains supported.

* **Bug Fixes**
  * Improved error handling during TUN device creation.
  * Ensured resources are properly closed when device creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->