### PR TITLE
[client] Fix Linux tray right-click opening the main window

### DIFF
--- a/client/ui/tray_click_linux.go
+++ b/client/ui/tray_click_linux.go
@@ -4,17 +4,26 @@ package main
 
 // bindTrayClick wires the tray icon's left-click handler on Linux.
 //
-// Both Linux click paths converge on Wails' linuxSystemTray.Activate, which
-// fires the registered clickHandler:
-//   - Real SNI hosts (KDE Plasma, Waybar, GNOME Shell + AppIndicator) invoke
-//     org.kde.StatusNotifierItem.Activate over D-Bus on left-click.
-//   - The in-process StatusNotifierWatcher + XEmbed host used on minimal WMs
-//     (Fluxbox, i3, dwm, OpenBox) maps a Button1 press to that same Activate
-//     call itself (xembed_host_linux.go), so it routes through the same hook.
-// Registering OnClick here therefore covers both paths with one handler — no
-// changes to the watcher or XEmbed C code are needed. Left-click now opens the
-// main window; right-click still opens the menu via Wails' default
-// SecondaryActivate→OpenMenu handler (and the XEmbed GTK popup on minimal WMs).
+// Expected behaviour per tray host:
+//
+//	Host                           Left click              Right click
+//	KDE Plasma, Waybar             main window (Activate)  menu (host-rendered)
+//	GNOME Shell + AppIndicator     menu only               menu only
+//	Minimal WMs via XEmbed host    main window (Activate)  XEmbed GTK popup
+//
+// OnClick fires only on org.kde.StatusNotifierItem.Activate — a real left
+// click. KDE/Waybar send it over D-Bus; the in-process XEmbed host
+// (xembed_host_linux.go) maps a Button1 press to the same Activate call.
+//
+// GNOME Shell + AppIndicator never sends Activate: it renders the dbusmenu
+// on ANY click and only reports the menu opening via dbusmenu
+// Event("opened"). Upstream Wails treated that event as a click, so on GNOME
+// both buttons raised the main window on top of the menu, and on KDE/Waybar
+// a right click raised it over the freshly opened menu. The netbirdio/wails
+// fork (go.mod replace) drops that heuristic: a menu open never fires
+// OnClick. On GNOME the main window is reached via the "Open NetBird" menu
+// entry; left-click-opens-window is not achievable there anyway, since the
+// host always opens the menu itself.
 //
 // We do NOT register OnDoubleClick: Wails' Linux SNI backend never fires it
 // (unlike Windows). And we deliberately skip AttachWindow — it plus Wails3's

--- a/go.mod
+++ b/go.mod
@@ -340,4 +340,4 @@ replace github.com/dexidp/dex/api/v2 => github.com/netbirdio/dex/api/v2 v2.0.0-2
 
 replace github.com/mailru/easyjson => github.com/netbirdio/easyjson v0.9.0
 
-replace github.com/wailsapp/wails/v3 => github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260803171101-93fca4afca5c
+replace github.com/wailsapp/wails/v3 => github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260803205919-ad21e92381f4

--- a/go.mod
+++ b/go.mod
@@ -339,3 +339,5 @@ replace github.com/dexidp/dex => github.com/netbirdio/dex v0.244.1-0.20260716205
 replace github.com/dexidp/dex/api/v2 => github.com/netbirdio/dex/api/v2 v2.0.0-20260512110716-8d70ad8647c1
 
 replace github.com/mailru/easyjson => github.com/netbirdio/easyjson v0.9.0
+
+replace github.com/wailsapp/wails/v3 => github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260803171101-93fca4afca5c

--- a/go.sum
+++ b/go.sum
@@ -490,6 +490,8 @@ github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502 h1:3tHlFmhTdX9ax
 github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45 h1:ujgviVYmx243Ksy7NdSwrdGPSRNE3pb8kEDSpH0QuAQ=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
+github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260803171101-93fca4afca5c h1:Rk4w+B/nvOvFqsPxNeuPxjzMJgpAoBDMQxrDv0A8SB4=
+github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260803171101-93fca4afca5c/go.mod h1:BzATbK71VFikMMMCo434wAi0QcaI03P+xeaWgDvQvjw=
 github.com/netbirdio/wireguard-go v0.0.0-20260628102922-2834bebf6c1a h1:3CWK+yTvRKOcC0Q8VCTGy4l60TEb27CQVS7LkMxwjmw=
 github.com/netbirdio/wireguard-go v0.0.0-20260628102922-2834bebf6c1a/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -660,8 +662,6 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/wailsapp/wails/v3 v3.0.0-alpha2.117 h1:udyjqPG3AIgkod5QDR/WblCkpV8R86BFPSrsWxSyt5Y=
-github.com/wailsapp/wails/v3 v3.0.0-alpha2.117/go.mod h1:74WH2FScMsgucZvHHvv7eOefDXCm/CjuIxqhhZgPhKg=
 github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
 github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502 h1:3tHlFmhTdX9ax
 github.com/netbirdio/service v0.0.0-20240911161631-f62744f42502/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45 h1:ujgviVYmx243Ksy7NdSwrdGPSRNE3pb8kEDSpH0QuAQ=
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
-github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260803171101-93fca4afca5c h1:Rk4w+B/nvOvFqsPxNeuPxjzMJgpAoBDMQxrDv0A8SB4=
-github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260803171101-93fca4afca5c/go.mod h1:BzATbK71VFikMMMCo434wAi0QcaI03P+xeaWgDvQvjw=
+github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260803205919-ad21e92381f4 h1:UKztc3QjWvzU5DZk+uYaOWN0x62NSe/pkxuPvzqZIy4=
+github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260803205919-ad21e92381f4/go.mod h1:BzATbK71VFikMMMCo434wAi0QcaI03P+xeaWgDvQvjw=
 github.com/netbirdio/wireguard-go v0.0.0-20260628102922-2834bebf6c1a h1:3CWK+yTvRKOcC0Q8VCTGy4l60TEb27CQVS7LkMxwjmw=
 github.com/netbirdio/wireguard-go v0.0.0-20260628102922-2834bebf6c1a/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
## Describe your changes

On SNI hosts that report icon clicks via Activate (KDE Plasma, Waybar), Wails fired the left-click handler on every dbusmenu 'opened' event, so a right click opened the tray menu and immediately raised the main window, which stole focus and closed the menu.

	Host                           Left click              Right click
	KDE Plasma, Waybar             main window (Activate)  menu (host-rendered)
	GNOME Shell + AppIndicator     menu only               menu only
	Minimal WMs via XEmbed host    main window (Activate)  XEmbed GTK popup

Point the wails/v3 replace at the netbirdio fork (v3.0.0-beta.3 plus the fix): once the host has sent Activate/SecondaryActivate, a menu open no longer fires the click handler, while AppIndicator-only hosts that signal clicks solely via 'opened' keep the old behavior.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* Updated underlying application components to support compatibility and ongoing maintenance.
* Clarified Linux tray interaction documentation, including platform-specific left- and right-click behavior and menu activation.
* No user-facing features, workflow changes, or visual updates are included.
* Existing Linux tray behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->