### PR TITLE
fix(client): Windows dial fallback across route candidate interfaces

### DIFF
--- a/client/internal/routemanager/systemops/systemops_windows.go
+++ b/client/internal/routemanager/systemops/systemops_windows.go
@@ -25,6 +25,7 @@ import (
 
 func init() {
 	nbnet.GetBestInterfaceFunc = GetBestInterface
+	nbnet.GetCandidateInterfacesFunc = GetCandidateInterfaces
 }
 
 const (
@@ -903,6 +904,21 @@ func sortRouteCandidates(candidates []candidateRoute) {
 // 2. Lowest route metric
 // 3. Lowest interface metric
 func GetBestInterface(dest netip.Addr, vpnIntf string) (*net.Interface, error) {
+	ifaces, err := GetCandidateInterfaces(dest, vpnIntf)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("route lookup for %s: selected interface %s (index %d)", dest, ifaces[0].Name, ifaces[0].Index)
+	return ifaces[0], nil
+}
+
+// GetCandidateInterfaces returns all usable interfaces that can reach dest,
+// ordered by the same priority as GetBestInterface. Callers that dial with
+// IP_UNICAST_IF can fall back through this list when the metric-preferred
+// interface has a route but no actual connectivity (common with dual-homed
+// Windows hosts: Ethernet up with a low metric but no working internet, Wi-Fi
+// with a higher metric that does reach the destination).
+func GetCandidateInterfaces(dest netip.Addr, vpnIntf string) ([]*net.Interface, error) {
 	var skipInterfaceIndex int
 	if vpnIntf != "" {
 		if iface, err := net.InterfaceByName(vpnIntf); err == nil {
@@ -928,6 +944,8 @@ func GetBestInterface(dest netip.Addr, vpnIntf string) (*net.Interface, error) {
 	// Sort routes: prefix length -> route metric -> interface metric
 	sortRouteCandidates(candidates)
 
+	seen := make(map[int]struct{}, len(candidates))
+	var ifaces []*net.Interface
 	for _, candidate := range candidates {
 		iface, err := net.InterfaceByIndex(int(candidate.interfaceIndex))
 		if err != nil {
@@ -944,12 +962,21 @@ func GetBestInterface(dest netip.Addr, vpnIntf string) (*net.Interface, error) {
 			continue
 		}
 
-		log.Debugf("route lookup for %s: selected interface %s (index %d), route metric %d, interface metric %d",
+		if _, ok := seen[iface.Index]; ok {
+			continue
+		}
+		seen[iface.Index] = struct{}{}
+
+		log.Debugf("route candidate for %s: interface %s (index %d), route metric %d, interface metric %d",
 			dest, iface.Name, iface.Index, candidate.routeMetric, candidate.interfaceMetric)
-		return iface, nil
+		ifaces = append(ifaces, iface)
 	}
 
-	return nil, fmt.Errorf("no usable interface found for %s", dest)
+	if len(ifaces) == 0 {
+		return nil, fmt.Errorf("no usable interface found for %s", dest)
+	}
+
+	return ifaces, nil
 }
 
 // formatRouteAge formats the route age in seconds to a human-readable string

--- a/client/net/dialer_advanced.go
+++ b/client/net/dialer_advanced.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package net
+
+import (
+	"context"
+	"net"
+)
+
+func (d *Dialer) dialAdvanced(ctx context.Context, network, address string) (net.Conn, error) {
+	return d.Dialer.DialContext(ctx, network, address)
+}

--- a/client/net/dialer_advanced_windows.go
+++ b/client/net/dialer_advanced_windows.go
@@ -1,0 +1,142 @@
+package net
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"syscall"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	minDialAttemptTimeout = 2 * time.Second
+	maxDialAttemptTimeout = 8 * time.Second
+)
+
+// dialAdvanced dials with IP_UNICAST_IF binding. When multiple interfaces have a
+// route to the destination, it tries each candidate in route-priority order with
+// a split timeout so a metric-preferred but non-working NIC (e.g. Ethernet
+// without upstream connectivity) does not exhaust the whole dial deadline
+// before a working alternate (e.g. Wi-Fi) is attempted.
+func (d *Dialer) dialAdvanced(ctx context.Context, network, address string) (net.Conn, error) {
+	ifaces, dest, err := d.candidateInterfacesForDial(ctx, network, address)
+	if err != nil || len(ifaces) <= 1 {
+		if err != nil {
+			log.Debugf("advanced dial fallback unavailable for %s: %v", address, err)
+		}
+		return d.Dialer.DialContext(ctx, network, address)
+	}
+
+	var lastErr error
+	for i, iface := range ifaces {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return nil, fmt.Errorf("%w (last dial error: %v)", err, lastErr)
+			}
+			return nil, err
+		}
+
+		attemptTimeout := dialAttemptTimeout(ctx, len(ifaces)-i)
+		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+		conn, dialErr := d.dialViaInterface(attemptCtx, network, address, dest, iface)
+		cancel()
+		if dialErr == nil {
+			if i > 0 {
+				// Avoid logging hostnames above debug; interface identity is enough.
+				log.Infof("advanced dial succeeded via fallback interface %s (index %d) after %d failed attempt(s)",
+					iface.Name, iface.Index, i)
+			}
+			return conn, nil
+		}
+
+		log.Debugf("dial %s %s via interface %s (index %d) failed: %v", network, address, iface.Name, iface.Index, dialErr)
+		lastErr = dialErr
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no interface candidates for %s", address)
+	}
+	return nil, lastErr
+}
+
+func (d *Dialer) candidateInterfacesForDial(ctx context.Context, network, address string) ([]*net.Interface, netip.Addr, error) {
+	if GetCandidateInterfacesFunc == nil {
+		return nil, netip.Addr{}, fmt.Errorf("GetCandidateInterfacesFunc not initialized")
+	}
+
+	dest, err := parseDestinationAddressContext(ctx, network, address, d.Resolver)
+	if err != nil {
+		return nil, netip.Addr{}, err
+	}
+	dest = dest.Unmap()
+	if !dest.IsValid() {
+		return nil, netip.Addr{}, fmt.Errorf("invalid destination address for %s", address)
+	}
+
+	ifaces, err := GetCandidateInterfacesFunc(dest, GetVPNInterfaceName())
+	if err != nil {
+		return nil, dest, err
+	}
+	return ifaces, dest, nil
+}
+
+func (d *Dialer) dialViaInterface(ctx context.Context, network, address string, dest netip.Addr, iface *net.Interface) (net.Conn, error) {
+	attempt := &net.Dialer{
+		Timeout:   d.Timeout,
+		Deadline:  d.Deadline,
+		KeepAlive: d.KeepAlive,
+		Resolver:  d.Resolver,
+	}
+
+	selection := selectionForInterface(dest, iface)
+	attempt.Control = func(network, address string, c syscall.RawConn) error {
+		var controlErr error
+		if err := c.Control(func(fd uintptr) {
+			controlErr = setUnicastIf(fd, network, selection, address)
+		}); err != nil {
+			return fmt.Errorf("control: %w", err)
+		}
+		return controlErr
+	}
+
+	return attempt.DialContext(ctx, network, address)
+}
+
+func selectionForInterface(dest netip.Addr, iface *net.Interface) *interfaceSelection {
+	if dest.Is6() {
+		return &interfaceSelection{iface6: iface, iface4: iface}
+	}
+	return &interfaceSelection{iface4: iface}
+}
+
+func dialAttemptTimeout(ctx context.Context, remainingAttempts int) time.Duration {
+	if remainingAttempts < 1 {
+		remainingAttempts = 1
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return maxDialAttemptTimeout
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return time.Millisecond
+	}
+
+	per := remaining / time.Duration(remainingAttempts)
+	if per < minDialAttemptTimeout {
+		// Keep enough time for at least one more attempt when possible.
+		if remaining < minDialAttemptTimeout {
+			return remaining
+		}
+		return minDialAttemptTimeout
+	}
+	if per > maxDialAttemptTimeout {
+		return maxDialAttemptTimeout
+	}
+	return per
+}

--- a/client/net/dialer_advanced_windows_test.go
+++ b/client/net/dialer_advanced_windows_test.go
@@ -1,0 +1,53 @@
+package net
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDialAttemptTimeoutSplitsBudget(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+
+	got := dialAttemptTimeout(ctx, 3)
+	assert.GreaterOrEqual(t, got, minDialAttemptTimeout, "split timeout should respect minDialAttemptTimeout")
+	assert.LessOrEqual(t, got, maxDialAttemptTimeout, "split timeout should respect maxDialAttemptTimeout")
+	assert.InDelta(t, float64(4*time.Second), float64(got), float64(50*time.Millisecond),
+		"12s budget across 3 attempts should be ~4s each")
+}
+
+func TestDialAttemptTimeoutRespectsShortDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	got := dialAttemptTimeout(ctx, 2)
+	require.Greater(t, got, time.Duration(0), "short-deadline split timeout should stay positive")
+	assert.LessOrEqual(t, got, 1500*time.Millisecond, "split timeout should not exceed remaining deadline")
+}
+
+func TestDialAttemptTimeoutWithoutDeadline(t *testing.T) {
+	got := dialAttemptTimeout(context.Background(), 2)
+	assert.Equal(t, maxDialAttemptTimeout, got, "no deadline should use maxDialAttemptTimeout")
+}
+
+func TestSelectionForInterface(t *testing.T) {
+	iface := &net.Interface{Index: 7, Name: "Wi-Fi"}
+
+	v4 := netip.MustParseAddr("1.2.3.4")
+	sel4 := selectionForInterface(v4, iface)
+	require.NotNil(t, sel4.iface4, "IPv4 selection should set iface4")
+	assert.Equal(t, 7, sel4.iface4.Index, "IPv4 selection should keep interface index")
+	assert.Nil(t, sel4.iface6, "IPv4 selection should not set iface6")
+
+	v6 := netip.MustParseAddr("2001:db8::1")
+	sel6 := selectionForInterface(v6, iface)
+	require.NotNil(t, sel6.iface6, "IPv6 selection should set iface6")
+	assert.Equal(t, 7, sel6.iface6.Index, "IPv6 selection should keep interface index")
+	require.NotNil(t, sel6.iface4, "IPv6 dual-stack selection should also set iface4")
+}

--- a/client/net/dialer_dial.go
+++ b/client/net/dialer_dial.go
@@ -19,8 +19,11 @@ import (
 func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	log.Debugf("Dialing %s %s", network, address)
 
-	if CustomRoutingDisabled() || AdvancedRouting() {
+	if CustomRoutingDisabled() {
 		return d.Dialer.DialContext(ctx, network, address)
+	}
+	if AdvancedRouting() {
+		return d.dialAdvanced(ctx, network, address)
 	}
 
 	connID := hooks.GenerateConnID()

--- a/client/net/net_windows.go
+++ b/client/net/net_windows.go
@@ -28,13 +28,26 @@ const (
 // GetBestInterfaceFunc is set at runtime to avoid import cycle
 var GetBestInterfaceFunc func(dest netip.Addr, vpnIntf string) (*net.Interface, error)
 
+// GetCandidateInterfacesFunc is set at runtime to avoid import cycle.
+// It returns all usable interfaces for dest, best-first.
+var GetCandidateInterfacesFunc func(dest netip.Addr, vpnIntf string) ([]*net.Interface, error)
+
 // nativeToBigEndian converts a uint32 from native byte order to big-endian
 func nativeToBigEndian(v uint32) uint32 {
 	return (v&0xff)<<24 | (v&0xff00)<<8 | (v&0xff0000)>>8 | (v&0xff000000)>>24
 }
 
-// parseDestinationAddress parses the destination address from various formats
+// parseDestinationAddress parses the destination address from various formats.
+// DNS uses a short background timeout for Control callbacks that have no caller ctx.
 func parseDestinationAddress(network, address string) (netip.Addr, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return parseDestinationAddressContext(ctx, network, address, nil)
+}
+
+// parseDestinationAddressContext parses the destination address, resolving hostnames
+// with the provided context and optional resolver.
+func parseDestinationAddressContext(ctx context.Context, network, address string, resolver *net.Resolver) (netip.Addr, error) {
 	if address == "" {
 		if strings.HasSuffix(network, "6") {
 			return netip.IPv6Unspecified(), nil
@@ -63,10 +76,11 @@ func parseDestinationAddress(network, address string) (netip.Addr, error) {
 		return netip.IPv4Unspecified(), nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
 
-	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	ips, err := resolver.LookupIPAddr(ctx, host)
 	if err != nil || len(ips) == 0 {
 		return netip.Addr{}, fmt.Errorf("resolve destination %s: %w", host, err)
 	}


### PR DESCRIPTION
## Describe your changes

On dual-homed Windows hosts, advanced routing (`IP_UNICAST_IF`) can pin management/signal gRPC dials to a metric-preferred NIC that has a default route but no working upstream. The dial then times out and never tries another interface that can reach the management server.

This change:
- Adds `GetCandidateInterfaces` (all usable interfaces, best-first)
- Retries Windows advanced-routing dials across candidates with a split timeout budget
- Logs when a fallback interface succeeds

## Issue ticket number and link

https://github.com/netbirdio/netbird/discussions/7045

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactoring
- [x] Added unit tests for timeout splitting / interface selection helpers

## Documentation
- [x] Not needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Windows network routing by selecting and trying multiple suitable interfaces.
  * Added interface-aware IPv4 and IPv6 connection attempts.
  * Added support for resolving destinations before selecting connection interfaces.
  * Preserved fallback behavior when advanced routing is unavailable.
* **Bug Fixes**
  * Improved handling of unavailable, loopback, inactive, excluded, and duplicate interfaces.
  * Preserved connection timeouts, cancellation, and error reporting.
* **Tests**
  * Added coverage for timeout handling, deadlines, and IP version interface selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->