### PR TITLE
[client] Fix session expired relogin

### DIFF
--- a/client/server/server.go
+++ b/client/server/server.go
@@ -1798,6 +1798,9 @@ func (s *Server) RequestExtendAuthSession(
 	if connectClient == nil {
 		return nil, gstatus.Errorf(codes.FailedPrecondition, "client is not running")
 	}
+	if connectClient.Engine() == nil {
+		return nil, gstatus.Errorf(codes.FailedPrecondition, "session can no longer be extended, log in again to reconnect")
+	}
 
 	hint := ""
 	if msg.Hint != nil {

--- a/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
+++ b/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
@@ -11,7 +11,7 @@ import { DialogHeading } from "@/components/dialog/DialogHeading";
 import { SquareIcon } from "@/components/SquareIcon";
 import { Connection, Profiles as ProfilesSvc, Session, WindowManager } from "@bindings/services";
 import { useAutoSizeWindow } from "@/hooks/useAutoSizeWindow";
-import { EVENT_BROWSER_LOGIN_CANCEL } from "@/lib/connection";
+import { EVENT_BROWSER_LOGIN_CANCEL, EVENT_TRIGGER_LOGIN } from "@/lib/connection";
 import { errorDialog, formatErrorMessage } from "@/lib/errors.ts";
 import { formatRemaining } from "@/lib/formatters";
 
@@ -131,6 +131,21 @@ export default function SessionExpirationDialog() {
         }
     }, [busy, t]);
 
+    const authenticate = useCallback(async () => {
+        if (busy) return;
+        setBusy(true);
+        try {
+            await Events.Emit(EVENT_TRIGGER_LOGIN);
+            await WindowManager.CloseSessionExpiration();
+        } catch (e) {
+            setBusy(false);
+            await errorDialog({
+                Title: t("connect.error.loginTitle"),
+                Message: formatErrorMessage(e),
+            });
+        }
+    }, [busy, t]);
+
     const logout = useCallback(async () => {
         if (busy) return;
         setBusy(true);
@@ -185,7 +200,7 @@ export default function SessionExpirationDialog() {
                     variant={"primary"}
                     size={"md"}
                     className={"w-full"}
-                    onClick={stay}
+                    onClick={expired ? authenticate : stay}
                     disabled={busy}
                 >
                     {expired ? t("sessionExpiration.authenticate") : t("sessionExpiration.stay")}

--- a/client/ui/tray_session.go
+++ b/client/ui/tray_session.go
@@ -308,11 +308,7 @@ func (t *Tray) openSessionExtendFlow() {
 	}
 	seconds := int(time.Until(deadline).Seconds())
 	if seconds <= 0 {
-		if t.window != nil {
-			t.window.SetURL("/#/login")
-			t.window.Show()
-			t.window.Focus()
-		}
+		t.app.Event.Emit(services.EventTriggerLogin)
 		return
 	}
 	if t.svc.WindowManager == nil {

--- a/client/ui/tray_session.go
+++ b/client/ui/tray_session.go
@@ -27,11 +27,10 @@ const (
 	finalWarningCountdownSeconds = 120
 )
 
-// handleSessionExpired notifies and brings the window forward so the frontend's /login route drives renewal.
+// handleSessionExpired notifies and brings the window forward so the user can reconnect.
 func (t *Tray) handleSessionExpired() {
 	t.notify(t.loc.T("notify.sessionExpired.title"), t.loc.T("notify.sessionExpired.body"), notifyIDSessionExpired)
 	if t.window != nil {
-		t.window.SetURL("/#/login")
 		t.window.Show()
 		t.window.Focus()
 	}


### PR DESCRIPTION
## Describe your changes

After the SSO session expires, the daemon tears the engine down permanently
(management returns `PermissionDenied` → `runCancel()` → the retry loop exits
for good). The "Session expired" dialog's Login button still drove the
extend-session flow, which requires a live engine: the user completed the full
browser SSO + 2FA round trip only to get
`Failed to extend the session — engine is not initialised`, with no way out
other than quitting and relaunching the client.

Reproduce:
1. Log in on a desktop client with session expiration enabled (e.g. 16h TTL).
2. Let the session expire (e.g. leave the machine asleep overnight).
3. Wake it, click **Login** on the "Session expired" dialog, complete SSO + 2FA.
4. The error dialog appears and every retry fails the same way.

Changes:
- The expired branch of the session-expiration dialog now emits
  `trigger-login`, driving the full `Login → SSO → Up` sequence that rebuilds
  the client, instead of the extend flow (an expired session can no longer be
  extended).
- `RequestExtendAuthSession` fails fast when the engine is already gone, so the
  browser/2FA round trip is not wasted on a doomed extend.
- The expired tray row navigated the main window to `/#/login`, a route that
  does not exist and fell through to the main page without starting a login;
  it now emits `trigger-login` as well.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session extension handling when the client engine is unavailable by prompting users to log in again.
  - Updated expired-session behavior to trigger the standard login flow, providing a more consistent sign-in experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->