### PR TITLE
[client, android] Fix profile account path test on Windows

### DIFF
--- a/client/android/profile_state_test.go
+++ b/client/android/profile_state_test.go
@@ -16,17 +16,17 @@ func TestProfileAccountPathFor(t *testing.T) {
 		{
 			name:       "default profile",
 			configPath: "/data/data/io.netbird.client/files/netbird.cfg",
-			want:       "/data/data/io.netbird.client/files/netbird.account.json",
+			want:       filepath.FromSlash("/data/data/io.netbird.client/files/netbird.account.json"),
 		},
 		{
 			name:       "id profile",
 			configPath: "/data/data/io.netbird.client/files/profiles/4c5f5c8198c3989cffb5b5394f5a7ae0.json",
-			want:       "/data/data/io.netbird.client/files/profiles/4c5f5c8198c3989cffb5b5394f5a7ae0.account.json",
+			want:       filepath.FromSlash("/data/data/io.netbird.client/files/profiles/4c5f5c8198c3989cffb5b5394f5a7ae0.account.json"),
 		},
 		{
 			name:       "legacy name-keyed profile is handled the same way",
 			configPath: "/data/data/io.netbird.client/files/profiles/work.json",
-			want:       "/data/data/io.netbird.client/files/profiles/work.account.json",
+			want:       filepath.FromSlash("/data/data/io.netbird.client/files/profiles/work.account.json"),
 		},
 		{
 			name:       "empty path is rejected",


### PR DESCRIPTION
## Describe your changes

The expected paths were hardcoded with Unix separators while profileAccountPathFor builds the result with filepath.Join, so the comparison failed on Windows. Derive the expectations with filepath.FromSlash to keep the test platform-independent.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated profile account path test expectations to use platform-appropriate path separators, improving test reliability across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->