### PR TITLE
[client] Do not misroute WireGuard packets to the STUN handler

### DIFF
--- a/client/iface/bind/ice_bind.go
+++ b/client/iface/bind/ice_bind.go
@@ -27,8 +27,9 @@ const (
 	wgMsgTypeHandshakeInitiation uint32 = 1
 	// wgMsgTypeTransport is the highest WireGuard message type.
 	wgMsgTypeTransport uint32 = 4
-	// wgKeepaliveSize is the size of a WireGuard transport message with an empty payload.
-	wgKeepaliveSize = 32
+	// wgMinMsgSize is the smallest WireGuard message: transport data with an empty
+	// payload, which is what a keepalive is.
+	wgMinMsgSize = 32
 )
 
 type receiverCreator struct {
@@ -229,9 +230,10 @@ func (s *ICEBind) createReceiverFn(pc wgConn.BatchReader, conn *net.UDPConn, rxO
 				if err != nil {
 					log.Debugf("failed to handle STUN packet from %s: %v", msg.Addr, err)
 				}
-				// WireGuard reuses sizes and eps across reads and only skips a slot whose size is
-				// below the minimum message size. Leaving a consumed slot untouched makes it
-				// process this buffer again under the previous packet's length and endpoint.
+				// WireGuard reuses sizes and eps across reads and only skips a slot
+				// whose size is below the minimum message size. Leaving a consumed
+				// slot untouched makes it process this buffer again under the
+				// previous packet's length and endpoint.
 				sizes[i] = 0
 				continue
 			}
@@ -367,17 +369,19 @@ func putMessages(msgs *[]ipv6.Message, msgsPool *sync.Pool) {
 	msgsPool.Put(msgs)
 }
 
-// isWireGuardMsg reports whether the packet carries a WireGuard message header: a little-endian
-// uint32 message type in the range 1..4, which leaves the three bytes following the type byte zero.
+// isWireGuardMsg reports whether the packet carries a WireGuard message header: a
+// little-endian uint32 message type in the range 1..4, which leaves the three bytes
+// after the type byte zero, in a packet long enough to hold any WireGuard message.
 //
-// No STUN message that ICE exchanges can take that shape. The low byte of a STUN message type holds
-// the bottom method bits and a class bit, and it is non-zero for Binding (0x0001, 0x0101, 0x0111,
-// 0x0011) and for every other method pion implements, so the two framings do not overlap. That
-// matters because stun.IsMessage only looks at the magic cookie, which in a WireGuard message
-// overlaps the receiver index: a session whose index happens to equal the cookie would otherwise
-// have all of its inbound data misrouted to the STUN handler until the next rekey.
+// A well formed STUN message cannot take that shape. Its length field sits in the two
+// bytes the type must leave zero, and for a message of at least wgMinMsgSize bytes that
+// field holds at least 12, so the two framings do not overlap. The test has to be this
+// tight because stun.IsMessage only looks at the magic cookie, which in a WireGuard
+// message overlaps the receiver index: a session whose index happens to equal the cookie
+// would otherwise have all of its inbound data misrouted to the STUN handler until the
+// next rekey.
 func isWireGuardMsg(pkt []byte) bool {
-	if len(pkt) < 4 {
+	if len(pkt) < wgMinMsgSize {
 		return false
 	}
 
@@ -385,13 +389,14 @@ func isWireGuardMsg(pkt []byte) bool {
 	return msgType >= wgMsgTypeHandshakeInitiation && msgType <= wgMsgTypeTransport
 }
 
-// isTransportPkg reports whether the packet is WireGuard transport data carrying a payload, which
-// is what counts as peer activity. Keepalives hold no payload and are exactly wgKeepaliveSize.
+// isTransportPkg reports whether the packet is WireGuard transport data carrying a
+// payload, which is what counts as peer activity. A keepalive holds no payload and is
+// exactly wgMinMsgSize bytes.
 func isTransportPkg(buffers [][]byte, n int) bool {
 	if n < 4 || n > len(buffers[0]) {
 		return false
 	}
 
 	msgType := binary.LittleEndian.Uint32(buffers[0][:4])
-	return msgType == wgMsgTypeTransport && n > wgKeepaliveSize
+	return msgType == wgMsgTypeTransport && n > wgMinMsgSize
 }

--- a/client/iface/bind/ice_bind.go
+++ b/client/iface/bind/ice_bind.go
@@ -22,6 +22,15 @@ import (
 	nbnet "github.com/netbirdio/netbird/client/net"
 )
 
+const (
+	// wgMsgTypeHandshakeInitiation is the lowest WireGuard message type.
+	wgMsgTypeHandshakeInitiation uint32 = 1
+	// wgMsgTypeTransport is the highest WireGuard message type.
+	wgMsgTypeTransport uint32 = 4
+	// wgKeepaliveSize is the size of a WireGuard transport message with an empty payload.
+	wgKeepaliveSize = 32
+)
+
 type receiverCreator struct {
 	iceBind *ICEBind
 }
@@ -216,8 +225,10 @@ func (s *ICEBind) createReceiverFn(pc wgConn.BatchReader, conn *net.UDPConn, rxO
 		for i := 0; i < numMsgs; i++ {
 			msg := &(*msgs)[i]
 
-			// todo: handle err
-			if ok, _ := s.filterOutStunMessages(msg.Buffers, msg.N, msg.Addr); ok {
+			if ok, err := s.filterOutStunMessages(msg.Buffers, msg.N, msg.Addr); ok {
+				if err != nil {
+					log.Debugf("failed to handle STUN packet from %s: %v", msg.Addr, err)
+				}
 				continue
 			}
 			sizes[i] = msg.N
@@ -271,11 +282,16 @@ func (s *ICEBind) createOrUpdateMux() {
 
 func (s *ICEBind) filterOutStunMessages(buffers [][]byte, n int, addr net.Addr) (bool, error) {
 	for i := range buffers {
-		if !stun.IsMessage(buffers[i]) {
+		if n > len(buffers[i]) {
+			continue
+		}
+		pkt := buffers[i][:n]
+
+		if isWireGuardMsg(pkt) || !stun.IsMessage(pkt) {
 			continue
 		}
 
-		msg, err := s.parseSTUNMessage(buffers[i][:n])
+		msg, err := s.parseSTUNMessage(pkt)
 		if err != nil {
 			buffers[i] = []byte{}
 			return true, err
@@ -347,18 +363,31 @@ func putMessages(msgs *[]ipv6.Message, msgsPool *sync.Pool) {
 	msgsPool.Put(msgs)
 }
 
+// isWireGuardMsg reports whether the packet carries a WireGuard message header: a little-endian
+// uint32 message type in the range 1..4, which leaves the three bytes following the type byte zero.
+//
+// No STUN message can take that shape. The low byte of a STUN message type holds method and class
+// bits and is non-zero for every method (Binding is 0x0001, 0x0101, 0x0111, 0x0011), so the two
+// framings are disjoint and this test is exact rather than heuristic. That matters because
+// stun.IsMessage only looks at the magic cookie, which in a WireGuard message overlaps the receiver
+// index: a session whose index happens to equal the cookie would otherwise have all of its inbound
+// data misrouted to the STUN handler until the next rekey.
+func isWireGuardMsg(pkt []byte) bool {
+	if len(pkt) < 4 {
+		return false
+	}
+
+	msgType := binary.LittleEndian.Uint32(pkt[:4])
+	return msgType >= wgMsgTypeHandshakeInitiation && msgType <= wgMsgTypeTransport
+}
+
+// isTransportPkg reports whether the packet is WireGuard transport data carrying a payload, which
+// is what counts as peer activity. Keepalives hold no payload and are exactly wgKeepaliveSize.
 func isTransportPkg(buffers [][]byte, n int) bool {
-	// The first buffer should contain at least 4 bytes for type
-	if len(buffers[0]) < 4 {
-		return true
+	if n < 4 || n > len(buffers[0]) {
+		return false
 	}
 
-	// WireGuard packet type is a little-endian uint32 at start
-	packetType := binary.LittleEndian.Uint32(buffers[0][:4])
-
-	// Check if packetType matches known WireGuard message types
-	if packetType == 4 && n > 32 {
-		return true
-	}
-	return false
+	msgType := binary.LittleEndian.Uint32(buffers[0][:4])
+	return msgType == wgMsgTypeTransport && n > wgKeepaliveSize
 }

--- a/client/iface/bind/ice_bind.go
+++ b/client/iface/bind/ice_bind.go
@@ -229,6 +229,10 @@ func (s *ICEBind) createReceiverFn(pc wgConn.BatchReader, conn *net.UDPConn, rxO
 				if err != nil {
 					log.Debugf("failed to handle STUN packet from %s: %v", msg.Addr, err)
 				}
+				// WireGuard reuses sizes and eps across reads and only skips a slot whose size is
+				// below the minimum message size. Leaving a consumed slot untouched makes it
+				// process this buffer again under the previous packet's length and endpoint.
+				sizes[i] = 0
 				continue
 			}
 			sizes[i] = msg.N
@@ -366,12 +370,12 @@ func putMessages(msgs *[]ipv6.Message, msgsPool *sync.Pool) {
 // isWireGuardMsg reports whether the packet carries a WireGuard message header: a little-endian
 // uint32 message type in the range 1..4, which leaves the three bytes following the type byte zero.
 //
-// No STUN message can take that shape. The low byte of a STUN message type holds method and class
-// bits and is non-zero for every method (Binding is 0x0001, 0x0101, 0x0111, 0x0011), so the two
-// framings are disjoint and this test is exact rather than heuristic. That matters because
-// stun.IsMessage only looks at the magic cookie, which in a WireGuard message overlaps the receiver
-// index: a session whose index happens to equal the cookie would otherwise have all of its inbound
-// data misrouted to the STUN handler until the next rekey.
+// No STUN message that ICE exchanges can take that shape. The low byte of a STUN message type holds
+// the bottom method bits and a class bit, and it is non-zero for Binding (0x0001, 0x0101, 0x0111,
+// 0x0011) and for every other method pion implements, so the two framings do not overlap. That
+// matters because stun.IsMessage only looks at the magic cookie, which in a WireGuard message
+// overlaps the receiver index: a session whose index happens to equal the cookie would otherwise
+// have all of its inbound data misrouted to the STUN handler until the next rekey.
 func isWireGuardMsg(pkt []byte) bool {
 	if len(pkt) < 4 {
 		return false

--- a/client/iface/bind/stun_filter_test.go
+++ b/client/iface/bind/stun_filter_test.go
@@ -6,10 +6,13 @@ import (
 	"encoding/binary"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/ipv4"
+	wgConn "golang.zx2c4.com/wireguard/conn"
 )
 
 // magicCookieBytes is the STUN magic cookie as it appears on the wire. In a WireGuard message the
@@ -128,6 +131,39 @@ func TestFilterOutStunMessages_IgnoresBytesBeyondPacket(t *testing.T) {
 	filtered, err := bind.filterOutStunMessages(buffers, 2, &net.UDPAddr{})
 	assert.NoError(t, err)
 	assert.False(t, filtered, "a 2 byte packet must not be classified from stale buffer bytes")
+}
+
+// TestReceiveFn_ClearsSizeOfConsumedPacket covers the accounting WireGuard relies on: sizes is
+// reused across reads, so a slot whose packet was consumed as STUN must be reported as empty.
+// Otherwise WireGuard reprocesses the same buffer under the previous packet's length, which for a
+// WireGuard-shaped packet means it is handled twice.
+func TestReceiveFn_ClearsSizeOfConsumedPacket(t *testing.T) {
+	conn := listenUDP(t, "udp4", "127.0.0.1:0")
+	defer conn.Close()
+
+	recvFn := receiverCreator{setupICEBind(t)}.CreateReceiverFn(
+		ipv4.NewPacketConn(conn), conn, false, createMsgPool(),
+	)
+
+	msg, err := stun.Build(stun.BindingRequest, stun.TransactionID, stun.Fingerprint)
+	require.NoError(t, err)
+
+	sender := listenUDP(t, "udp4", "127.0.0.1:0")
+	defer sender.Close()
+	_, err = sender.WriteTo(msg.Raw, conn.LocalAddr())
+	require.NoError(t, err)
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(3*time.Second)))
+
+	bufs := [][]byte{make([]byte, 1500)}
+	// A leftover size from an earlier read, which is what makes the missing reset observable.
+	sizes := []int{148}
+	eps := make([]wgConn.Endpoint, 1)
+
+	n, err := recvFn(bufs, sizes, eps)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	assert.Zero(t, sizes[0], "consumed STUN packet must not leave a size behind for WireGuard")
 }
 
 func TestIsTransportPkg(t *testing.T) {

--- a/client/iface/bind/stun_filter_test.go
+++ b/client/iface/bind/stun_filter_test.go
@@ -15,15 +15,15 @@ import (
 	wgConn "golang.zx2c4.com/wireguard/conn"
 )
 
-// magicCookieBytes is the STUN magic cookie as it appears on the wire. In a WireGuard message the
-// same offset holds the receiver (or sender) index, which is a random uint32, so a session can draw
-// exactly this value.
+// magicCookieBytes is the STUN magic cookie as it appears on the wire. In a
+// WireGuard message the same offset holds the receiver (or sender) index, which is
+// a random uint32, so a session can draw exactly this value.
 var magicCookieBytes = []byte{0x21, 0x12, 0xA4, 0x42}
 
 const testBufSize = 1500
 
-// wgMsg builds a WireGuard message of the given type and size, with the index field at bytes 4:8
-// set to index.
+// wgMsg builds a WireGuard message of the given type and size, with the index field
+// at bytes 4:8 set to index.
 func wgMsg(msgType uint32, size int, index []byte) []byte {
 	pkt := make([]byte, size)
 	binary.LittleEndian.PutUint32(pkt[:4], msgType)
@@ -31,8 +31,8 @@ func wgMsg(msgType uint32, size int, index []byte) []byte {
 	return pkt
 }
 
-// intoBuffer copies pkt into a full-size receive buffer, the way the kernel read does, so tests see
-// the same buffer/length split as the hot path.
+// intoBuffer copies pkt into a full-size receive buffer, the way the kernel read
+// does, so tests see the same buffer/length split as the hot path.
 func intoBuffer(pkt []byte) [][]byte {
 	buf := make([]byte, testBufSize)
 	copy(buf, pkt)
@@ -46,7 +46,7 @@ func TestFilterOutStunMessages_PassesWireGuardWithCookieShapedIndex(t *testing.T
 		size    int
 	}{
 		{"transport data", wgMsgTypeTransport, 128},
-		{"keepalive", wgMsgTypeTransport, wgKeepaliveSize},
+		{"keepalive", wgMsgTypeTransport, wgMinMsgSize},
 		{"handshake initiation", wgMsgTypeHandshakeInitiation, 148},
 		{"handshake response", 2, 92},
 		{"cookie reply", 3, 64},
@@ -81,8 +81,9 @@ func TestFilterOutStunMessages_FiltersRealSTUNMessage(t *testing.T) {
 	assert.Empty(t, buffers[0], "consumed buffer must be emptied so WireGuard does not see it")
 }
 
-// TestIsWireGuardMsg_DisjointFromSTUN locks the invariant the filter relies on: the second byte of a
-// STUN message type is never zero, so no STUN message can be mistaken for a WireGuard header.
+// TestIsWireGuardMsg_DisjointFromSTUN locks the invariant the filter relies on: a
+// well formed STUN message long enough to be a WireGuard message always has a
+// non-zero length field, so it cannot be mistaken for a WireGuard header.
 func TestIsWireGuardMsg_DisjointFromSTUN(t *testing.T) {
 	types := []stun.MessageType{
 		stun.BindingRequest,
@@ -92,9 +93,13 @@ func TestIsWireGuardMsg_DisjointFromSTUN(t *testing.T) {
 	}
 
 	for _, msgType := range types {
-		msg, err := stun.Build(msgType, stun.TransactionID)
+		// Long enough that the length guard is not what makes this pass.
+		msg, err := stun.Build(msgType, stun.TransactionID,
+			stun.NewUsername("remoteUfrag:localUfrag"), stun.Fingerprint)
 		require.NoError(t, err)
-		assert.False(t, isWireGuardMsg(msg.Raw), "%s must not look like a WireGuard message", msgType)
+		require.GreaterOrEqual(t, len(msg.Raw), wgMinMsgSize, "precondition: %s", msgType)
+		assert.False(t, isWireGuardMsg(msg.Raw),
+			"%s must not look like a WireGuard message", msgType)
 	}
 }
 
@@ -115,13 +120,13 @@ func TestIsWireGuardMsg(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, isWireGuardMsg(tc.pkt))
+			assert.Equal(t, tc.want, isWireGuardMsg(tc.pkt), "wrong classification for %s", tc.name)
 		})
 	}
 }
 
-// TestFilterOutStunMessages_IgnoresBytesBeyondPacket guards against classifying on buffer contents
-// left over from an earlier, longer packet.
+// TestFilterOutStunMessages_IgnoresBytesBeyondPacket guards against classifying on
+// buffer contents left over from an earlier, longer packet.
 func TestFilterOutStunMessages_IgnoresBytesBeyondPacket(t *testing.T) {
 	buf := make([]byte, testBufSize)
 	copy(buf[4:8], magicCookieBytes)
@@ -133,10 +138,11 @@ func TestFilterOutStunMessages_IgnoresBytesBeyondPacket(t *testing.T) {
 	assert.False(t, filtered, "a 2 byte packet must not be classified from stale buffer bytes")
 }
 
-// TestReceiveFn_ClearsSizeOfConsumedPacket covers the accounting WireGuard relies on: sizes is
-// reused across reads, so a slot whose packet was consumed as STUN must be reported as empty.
-// Otherwise WireGuard reprocesses the same buffer under the previous packet's length, which for a
-// WireGuard-shaped packet means it is handled twice.
+// TestReceiveFn_ClearsSizeOfConsumedPacket covers the accounting WireGuard relies
+// on: sizes is reused across reads, so a slot whose packet was consumed as STUN must
+// be reported as empty. Otherwise WireGuard reprocesses the same buffer under the
+// previous packet's length, which for a WireGuard-shaped packet means it is handled
+// twice.
 func TestReceiveFn_ClearsSizeOfConsumedPacket(t *testing.T) {
 	conn := listenUDP(t, "udp4", "127.0.0.1:0")
 	defer conn.Close()
@@ -156,7 +162,8 @@ func TestReceiveFn_ClearsSizeOfConsumedPacket(t *testing.T) {
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(3*time.Second)))
 
 	bufs := [][]byte{make([]byte, 1500)}
-	// A leftover size from an earlier read, which is what makes the missing reset observable.
+	// A leftover size from an earlier read, which is what makes the missing reset
+	// observable.
 	sizes := []int{148}
 	eps := make([]wgConn.Endpoint, 1)
 
@@ -174,14 +181,35 @@ func TestIsTransportPkg(t *testing.T) {
 		want bool
 	}{
 		{"transport data with payload", wgMsg(wgMsgTypeTransport, 128, nil), 128, true},
-		{"keepalive", wgMsg(wgMsgTypeTransport, wgKeepaliveSize, nil), wgKeepaliveSize, false},
+		{"keepalive", wgMsg(wgMsgTypeTransport, wgMinMsgSize, nil), wgMinMsgSize, false},
 		{"handshake initiation", wgMsg(wgMsgTypeHandshakeInitiation, 148, nil), 148, false},
 		{"stale type bytes beyond packet", wgMsg(wgMsgTypeTransport, 128, nil), 2, false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, isTransportPkg(intoBuffer(tc.pkt), tc.n))
+			assert.Equal(t, tc.want, isTransportPkg(intoBuffer(tc.pkt), tc.n),
+				"wrong activity classification for %s", tc.name)
 		})
 	}
+}
+
+// TestFilterOutStunMessages_ConsumesSTUNWithWireGuardShapedType covers the one STUN
+// encoding whose leading bytes collide with a WireGuard message type: method 0x080 as a
+// request encodes to 0x0200, so the type byte reads as a handshake response and the byte
+// after it is zero. Only the length check keeps such a message out of WireGuard's hands.
+// pion implements no method in that range, so this is a synthetic worst case rather than
+// traffic ICE produces.
+func TestFilterOutStunMessages_ConsumesSTUNWithWireGuardShapedType(t *testing.T) {
+	msg, err := stun.Build(stun.NewType(stun.Method(0x080), stun.ClassRequest), stun.TransactionID)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x02, 0x00, 0x00, 0x00}, msg.Raw[:4],
+		"precondition: the leading bytes read as a WireGuard message type")
+
+	buffers := intoBuffer(msg.Raw)
+	bind := &ICEBind{}
+
+	filtered, err := bind.filterOutStunMessages(buffers, len(msg.Raw), &net.UDPAddr{})
+	assert.NoError(t, err)
+	assert.True(t, filtered, "STUN message must be consumed despite its WireGuard-shaped type")
 }

--- a/client/iface/bind/stun_filter_test.go
+++ b/client/iface/bind/stun_filter_test.go
@@ -1,0 +1,151 @@
+//go:build !js
+
+package bind
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// magicCookieBytes is the STUN magic cookie as it appears on the wire. In a WireGuard message the
+// same offset holds the receiver (or sender) index, which is a random uint32, so a session can draw
+// exactly this value.
+var magicCookieBytes = []byte{0x21, 0x12, 0xA4, 0x42}
+
+const testBufSize = 1500
+
+// wgMsg builds a WireGuard message of the given type and size, with the index field at bytes 4:8
+// set to index.
+func wgMsg(msgType uint32, size int, index []byte) []byte {
+	pkt := make([]byte, size)
+	binary.LittleEndian.PutUint32(pkt[:4], msgType)
+	copy(pkt[4:8], index)
+	return pkt
+}
+
+// intoBuffer copies pkt into a full-size receive buffer, the way the kernel read does, so tests see
+// the same buffer/length split as the hot path.
+func intoBuffer(pkt []byte) [][]byte {
+	buf := make([]byte, testBufSize)
+	copy(buf, pkt)
+	return [][]byte{buf}
+}
+
+func TestFilterOutStunMessages_PassesWireGuardWithCookieShapedIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgType uint32
+		size    int
+	}{
+		{"transport data", wgMsgTypeTransport, 128},
+		{"keepalive", wgMsgTypeTransport, wgKeepaliveSize},
+		{"handshake initiation", wgMsgTypeHandshakeInitiation, 148},
+		{"handshake response", 2, 92},
+		{"cookie reply", 3, 64},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pkt := wgMsg(tc.msgType, tc.size, magicCookieBytes)
+			require.True(t, stun.IsMessage(pkt), "precondition: pion sees this as STUN")
+
+			buffers := intoBuffer(pkt)
+			bind := &ICEBind{}
+
+			filtered, err := bind.filterOutStunMessages(buffers, tc.size, &net.UDPAddr{})
+			assert.NoError(t, err)
+			assert.False(t, filtered, "WireGuard message must be handed to WireGuard, not the STUN handler")
+			assert.Len(t, buffers[0], testBufSize, "buffer must be left intact for WireGuard")
+		})
+	}
+}
+
+func TestFilterOutStunMessages_FiltersRealSTUNMessage(t *testing.T) {
+	msg, err := stun.Build(stun.BindingRequest, stun.TransactionID, stun.Fingerprint)
+	require.NoError(t, err)
+
+	buffers := intoBuffer(msg.Raw)
+	bind := &ICEBind{}
+
+	filtered, err := bind.filterOutStunMessages(buffers, len(msg.Raw), &net.UDPAddr{})
+	assert.NoError(t, err)
+	assert.True(t, filtered, "STUN message must be consumed by the STUN handler")
+	assert.Empty(t, buffers[0], "consumed buffer must be emptied so WireGuard does not see it")
+}
+
+// TestIsWireGuardMsg_DisjointFromSTUN locks the invariant the filter relies on: the second byte of a
+// STUN message type is never zero, so no STUN message can be mistaken for a WireGuard header.
+func TestIsWireGuardMsg_DisjointFromSTUN(t *testing.T) {
+	types := []stun.MessageType{
+		stun.BindingRequest,
+		stun.BindingSuccess,
+		stun.BindingError,
+		{Method: stun.MethodBinding, Class: stun.ClassIndication},
+	}
+
+	for _, msgType := range types {
+		msg, err := stun.Build(msgType, stun.TransactionID)
+		require.NoError(t, err)
+		assert.False(t, isWireGuardMsg(msg.Raw), "%s must not look like a WireGuard message", msgType)
+	}
+}
+
+func TestIsWireGuardMsg(t *testing.T) {
+	tests := []struct {
+		name string
+		pkt  []byte
+		want bool
+	}{
+		{"transport data", wgMsg(wgMsgTypeTransport, 128, nil), true},
+		{"handshake initiation", wgMsg(wgMsgTypeHandshakeInitiation, 148, nil), true},
+		{"unknown type 5", wgMsg(5, 128, nil), false},
+		{"type 0", wgMsg(0, 128, nil), false},
+		{"non-zero reserved byte", []byte{0x04, 0x00, 0x01, 0x00}, false},
+		{"too short", []byte{0x04, 0x00, 0x00}, false},
+		{"empty", nil, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isWireGuardMsg(tc.pkt))
+		})
+	}
+}
+
+// TestFilterOutStunMessages_IgnoresBytesBeyondPacket guards against classifying on buffer contents
+// left over from an earlier, longer packet.
+func TestFilterOutStunMessages_IgnoresBytesBeyondPacket(t *testing.T) {
+	buf := make([]byte, testBufSize)
+	copy(buf[4:8], magicCookieBytes)
+	buffers := [][]byte{buf}
+	bind := &ICEBind{}
+
+	filtered, err := bind.filterOutStunMessages(buffers, 2, &net.UDPAddr{})
+	assert.NoError(t, err)
+	assert.False(t, filtered, "a 2 byte packet must not be classified from stale buffer bytes")
+}
+
+func TestIsTransportPkg(t *testing.T) {
+	tests := []struct {
+		name string
+		pkt  []byte
+		n    int
+		want bool
+	}{
+		{"transport data with payload", wgMsg(wgMsgTypeTransport, 128, nil), 128, true},
+		{"keepalive", wgMsg(wgMsgTypeTransport, wgKeepaliveSize, nil), wgKeepaliveSize, false},
+		{"handshake initiation", wgMsg(wgMsgTypeHandshakeInitiation, 148, nil), 148, false},
+		{"stale type bytes beyond packet", wgMsg(wgMsgTypeTransport, 128, nil), 2, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isTransportPkg(intoBuffer(tc.pkt), tc.n))
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes

Packets are classified as STUN by looking only at the magic cookie, which sits at the same offset as the WireGuard receiver index. That index is a random uint32 drawn fresh on every handshake, so a session can draw the cookie value, and while that keypair lives every inbound packet of the session is handed to the STUN handler instead of to WireGuard.

The odds are 1 in 2^32 per session. Since an active session rekeys every 120 seconds, a peer with 50 active sessions draws roughly 25 indices per minute, which puts the expected interval for any single client in the range of centuries. It scales linearly with the number of sessions in existence, however, so it is worth fixing rather than dismissing. The consequence is asymmetric and self-healing, which makes it hard to attribute: outbound traffic keeps flowing because it carries the remote index, while inbound traffic is dropped for up to one rekey interval, and then the next handshake draws a new index and the peer recovers on its own. The handshake watcher does not cover it: only messages carrying our own index in that field are affected, which is transport data and cookie replies, while a handshake response carries the responder's index there and ours further in. Handshakes therefore keep succeeding on schedule and the peer reports itself connected with a recent handshake while nothing inbound arrives. A handshake initiation whose sender index collides is dropped the same way, but WireGuard retries every 5 seconds with a fresh index, so that case clears on the next attempt.

- Reject WireGuard-shaped packets before the STUN cookie check, which is exact rather than heuristic because the low byte of a STUN message type is non-zero for every method in use
- Classify on the received length instead of the buffer capacity, so leftover bytes from an earlier packet cannot decide the outcome
- Clear the reported size of a packet consumed by the STUN handler, so WireGuard no longer processes that buffer again under the previous packet's length and endpoint
- Skip counting a packet too short to hold a WireGuard header as peer activity

Only the userspace path is affected. In kernel mode the equivalent check lives in a BPF filter on a raw socket, which receives a copy rather than consuming the packet, so a collision there costs a log line instead of the traffic.

## Issue ticket number and link

Trivial fix, no behavior or API change.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal packet classification, no user-visible surface)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network packet handling by safely validating short, malformed, and partially received packets.
  - Improved distinction between WireGuard traffic and STUN messages, including packets with overlapping header patterns.
  - Prevented stale data from previously processed packets from affecting subsequent network activity detection.
  - Improved handling and reporting of invalid STUN messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->