### PR TITLE
[client] Keep the profile name when enrolling with a setup key

### DIFF
--- a/client/android/login.go
+++ b/client/android/login.go
@@ -35,13 +35,28 @@ type Auth struct {
 	cfgPath string
 }
 
-// NewAuth instantiate Auth struct and validate the management URL
+// NewAuth instantiate Auth struct and validate the management URL.
+//
+// The config is read from cfgPath instead of being built from scratch, because a
+// successful login writes the whole struct back to that file: a config that did
+// not start from the stored one silently drops every field it never knew about.
+// The profile's display Name is the visible casualty — ConfigInput cannot carry
+// it, so enrolling a freshly added profile with a setup key would blank the name
+// the user had just typed. Only fall back to a fresh in-memory config when there
+// is no file to read, mirroring what the iOS binding already does.
 func NewAuth(cfgPath string, mgmURL string) (*Auth, error) {
 	inputCfg := profilemanager.ConfigInput{
+		ConfigPath:    cfgPath,
 		ManagementURL: mgmURL,
 	}
 
-	cfg, err := profilemanager.CreateInMemoryConfig(inputCfg)
+	var cfg *profilemanager.Config
+	var err error
+	if cfgPath != "" {
+		cfg, err = profilemanager.UpdateOrCreateConfig(inputCfg)
+	} else {
+		cfg, err = profilemanager.CreateInMemoryConfig(inputCfg)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes

NewAuth built its config with CreateInMemoryConfig, which ignores cfgPath and returns a struct with only the defaults plus the management URL. A successful login then writes that whole struct back over the profile file, so every field the in-memory config never knew about is lost.

ConfigInput has no Name field, so the display name AddProfile had just written was blanked: adding a profile and enrolling it with a setup key in one step left the profile listed under no name at all.

Read the stored config instead, falling back to an in-memory one only when there is no path to read from — the same guard the iOS binding already applies for the equivalent problem with the persisted WireGuard key.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login configuration handling when a configuration path is provided.
  * Existing configuration data is now preserved during updates.
  * In-memory configuration behavior remains unchanged when no path is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->