### PR TITLE
[relay] randomize the relay reconnect backoff

### DIFF
--- a/shared/relay/client/guard.go
+++ b/shared/relay/client/guard.go
@@ -156,9 +156,11 @@ func (g *Guard) notifyReconnected() {
 func (g *Guard) exponentTicker(ctx context.Context) *backoff.Ticker {
 	bo := backoff.WithContext(&backoff.ExponentialBackOff{
 		InitialInterval: 2 * time.Second,
-		Multiplier:      2,
-		MaxInterval:     g.maxBackoffInterval,
-		Clock:           backoff.SystemClock,
+		// Spreads the reconnects of every client that lost the same relay server.
+		RandomizationFactor: backoff.DefaultRandomizationFactor,
+		Multiplier:          2,
+		MaxInterval:         g.maxBackoffInterval,
+		Clock:               backoff.SystemClock,
 	}, ctx)
 
 	return backoff.NewTicker(bo)


### PR DESCRIPTION
## Describe your changes

The relay client's reconnect backoff was constructed without a `RandomizationFactor` ([guard.go:156-165](https://github.com/netbirdio/netbird/blob/main/shared/relay/client/guard.go#L156-L165)), so it kept the zero value: every client that lost the same relay server retried on the identical 2/4/8/16/32/60, potentially in waves.

It was the only exponential backoff in the codebase without a randomization factor.

Use `backoff.DefaultRandomizationFactor`, as random factor.

## Issue ticket number and link

No public issue. Found while reviewing the relay reconnect path for the client-metrics review:
22k relay reconnection events in 24h, and the shared transport's own retry schedule was
identical across all clients.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal retry-timing change with no user-visible surface: no CLI flag, configuration option
or API field is added or altered, and the mean reconnect delay is unchanged.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnect timing to distribute repeated connection attempts more evenly and reduce synchronized retry spikes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->