### PR TITLE
[client] Stop the macOS UI on pkg upgrade

### DIFF
--- a/release_files/darwin_pkg/preinstall
+++ b/release_files/darwin_pkg/preinstall
@@ -4,8 +4,58 @@ set -x
 
 LOG_FILE=/var/log/netbird/client_pre_install.log
 AGENT=/usr/local/bin/netbird
+UI_PROCESS=netbird-ui
 
 mkdir -p /var/log/netbird/
+
+# wait_for_ui_exit polls for up to $1 seconds, returning 0 as soon as no UI
+# process is left and 1 if one is still running when the time is up.
+wait_for_ui_exit() {
+    waited=0
+    while [ "$waited" -lt "$1" ]; do
+        pgrep -x "$UI_PROCESS" > /dev/null 2>&1 || return 0
+        sleep 1
+        waited=$((waited + 1))
+    done
+    return 1
+}
+
+# quit_ui stops a running UI so the app bundle can be replaced underneath it.
+# The installer runs as root outside the console user's GUI session, so the
+# quit Apple event has to be sent from inside that session; sending it straight
+# from here always fails with -600. A UI process that survives the install keeps
+# serving the old binary until it is quit by hand, so anything still alive after
+# the quit request is signalled.
+quit_ui() {
+    console_user=$(stat -f%Su /dev/console 2>/dev/null)
+    case "$console_user" in
+        ""|root|loginwindow|_mbsetupuser)
+            echo "No active GUI user session (console user: '${console_user:-none}'); skipping the quit request."
+            ;;
+        *)
+            uid=$(id -u "$console_user" 2>/dev/null)
+            if [ -z "$uid" ]; then
+                echo "Could not resolve uid for console user '$console_user'; skipping the quit request."
+            else
+                echo "Asking the NetBird UI to quit as console user $console_user (uid $uid)."
+                launchctl asuser "$uid" sudo -u "$console_user" -H osascript -e 'quit app "NetBird"' || true
+            fi
+            ;;
+    esac
+
+    if wait_for_ui_exit 10; then
+        return 0
+    fi
+
+    echo "NetBird UI still running after the quit request; terminating it."
+    pkill -x "$UI_PROCESS" || true
+    if wait_for_ui_exit 3; then
+        return 0
+    fi
+
+    echo "NetBird UI ignored SIGTERM; killing it."
+    pkill -KILL -x "$UI_PROCESS" || true
+}
 
 {
     # check if it was installed with brew
@@ -15,10 +65,9 @@ mkdir -p /var/log/netbird/
         echo "NetBird has been installed with Brew. Please use Brew to update the package."
         exit 1
     fi
-    osascript -e 'quit app "Netbird"' || true
+    quit_ui
     $AGENT service stop || true
 
     echo "Preinstall complete"
     exit 0 # all good
 } &> $LOG_FILE
-

--- a/release_files/darwin_pkg/preinstall
+++ b/release_files/darwin_pkg/preinstall
@@ -20,34 +20,42 @@ wait_for_ui_exit() {
     return 1
 }
 
-# quit_ui stops a running UI so the app bundle can be replaced underneath it.
-# The installer runs as root outside the console user's GUI session, so the
-# quit Apple event has to be sent from inside that session; sending it straight
-# from here always fails with -600. A UI process that survives the install keeps
-# serving the old binary until it is quit by hand, so anything still alive after
-# the quit request is signalled.
-quit_ui() {
+# request_ui_quit asks the UI to quit from inside the console user's session and
+# reports whether the request could be sent at all. The installer runs as root
+# outside that session, so a quit Apple event sent straight from here always
+# fails with -600.
+request_ui_quit() {
     console_user=$(stat -f%Su /dev/console 2>/dev/null)
     case "$console_user" in
         ""|root|loginwindow|_mbsetupuser)
             echo "No active GUI user session (console user: '${console_user:-none}'); skipping the quit request."
-            ;;
-        *)
-            uid=$(id -u "$console_user" 2>/dev/null)
-            if [ -z "$uid" ]; then
-                echo "Could not resolve uid for console user '$console_user'; skipping the quit request."
-            else
-                echo "Asking the NetBird UI to quit as console user $console_user (uid $uid)."
-                launchctl asuser "$uid" sudo -u "$console_user" -H osascript -e 'quit app "NetBird"' || true
-            fi
+            return 1
             ;;
     esac
 
-    if wait_for_ui_exit 10; then
+    uid=$(id -u "$console_user" 2>/dev/null)
+    if [ -z "$uid" ]; then
+        echo "Could not resolve uid for console user '$console_user'; skipping the quit request."
+        return 1
+    fi
+
+    echo "Asking the NetBird UI to quit as console user $console_user (uid $uid)."
+    launchctl asuser "$uid" sudo -u "$console_user" -H osascript -e 'quit app "NetBird"' || true
+}
+
+# quit_ui stops a running UI so the app bundle can be replaced underneath it. A
+# UI process that survives the install keeps serving the old binary until it is
+# quit by hand, so anything still running once the quit request is out of the
+# way is signalled. Waiting for a graceful exit only makes sense when a quit
+# request was actually sent.
+quit_ui() {
+    if request_ui_quit && wait_for_ui_exit 10; then
         return 0
     fi
 
-    echo "NetBird UI still running after the quit request; terminating it."
+    pgrep -x "$UI_PROCESS" > /dev/null 2>&1 || return 0
+
+    echo "NetBird UI still running; terminating it."
     pkill -x "$UI_PROCESS" || true
     if wait_for_ui_exit 3; then
         return 0


### PR DESCRIPTION
## Describe your changes

On macOS the pkg installer never stopped the running UI on upgrade. The preinstall script sent the quit request as root, from outside the console user's GUI session, where it always fails, so the app kept running the replaced binary until the user quit it by hand. The postinstall's relaunch could not recover from this either, since opening an already-running app just activates it.

- Send the quit request from inside the console user's session, the same way the postinstall already launches the UI after an install
- Terminate the UI if it does not exit on the quit request, so the bundle is never replaced underneath a live process
- Match the app name used in the quit request to the bundle name

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (installer-internal behavior, nothing user-facing to document)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS package upgrades by cleanly closing the NetBird UI before stopping the background service.
  * Added fallback handling to force-close the UI if it does not exit promptly, helping installations complete reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->