### PR TITLE
[client] Reword the firewalld package comment

### DIFF
--- a/client/firewall/firewalld/firewalld.go
+++ b/client/firewall/firewalld/firewalld.go
@@ -2,8 +2,8 @@
 // its wg interface into firewalld's "trusted" zone. This is required because
 // firewalld's nftables chains are created with NFT_CHAIN_OWNER on recent
 // versions, which returns EPERM to any other process that tries to insert
-// rules into them. The workaround mirrors what Tailscale does: let firewalld
-// itself add the accept rules to its own chains by trusting the interface.
+// rules into them. Trusting the interface makes firewalld itself add the
+// accept rules to its own chains instead.
 package firewalld
 
 // TrustedZone is the firewalld zone name used for interfaces whose traffic


### PR DESCRIPTION
## Describe your changes

Rewords the `firewalld` package comment. No functional change.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (comment-only change to an internal package)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that firewalld adds accept rules to its own chains when an interface is trusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->