### PR TITLE
fix(idp): generate ephemeral session cookie key when none is configured (upgrade-path gap in #7056)

### DIFF
--- a/management/server/idp/embedded.go
+++ b/management/server/idp/embedded.go
@@ -316,7 +316,7 @@ func resolveSessionCookieEncryptionKey(configuredKey string) (string, error) {
 			return "", fmt.Errorf("no session cookie encryption key configured and failed to generate an ephemeral one: %w", err)
 		}
 		log.Warn("embedded IdP: no session cookie encryption key configured; using an ephemeral random key. Sessions will NOT survive restarts. Set " + sessionCookieEncryptionKeyEnv + " (or auth.sessionCookieEncryptionKey) to a persistent 32-byte key.")
-		return base64.StdEncoding.EncodeToString(generated), nil
+		return string(generated), nil
 	}
 
 	if validSessionCookieEncryptionKeyLength(len([]byte(key))) {

--- a/management/server/idp/embedded.go
+++ b/management/server/idp/embedded.go
@@ -2,6 +2,7 @@ package idp
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -304,7 +305,18 @@ func resolveSessionCookieEncryptionKey(configuredKey string) (string, error) {
 		key = strings.TrimSpace(os.Getenv(sessionCookieEncryptionKeyEnv))
 	}
 	if key == "" {
-		return "", nil
+		// No key configured: dex stores session cookies as PLAIN marshaled
+		// protobuf (userID + connectorID + nonce) when the encryption key is
+		// empty, so anyone who can read or predict a user ID can forge a
+		// session cookie without knowing any secret. Generate an ephemeral
+		// key instead of running unencrypted. Trade-off: sessions invalidate
+		// on restart until a persistent key is configured.
+		generated := make([]byte, 32)
+		if _, err := rand.Read(generated); err != nil {
+			return "", fmt.Errorf("no session cookie encryption key configured and failed to generate an ephemeral one: %w", err)
+		}
+		log.Warn("embedded IdP: no session cookie encryption key configured; using an ephemeral random key. Sessions will NOT survive restarts. Set " + sessionCookieEncryptionKeyEnv + " (or auth.sessionCookieEncryptionKey) to a persistent 32-byte key.")
+		return base64.StdEncoding.EncodeToString(generated), nil
 	}
 
 	if validSessionCookieEncryptionKeyLength(len([]byte(key))) {

--- a/management/server/idp/embedded_test.go
+++ b/management/server/idp/embedded_test.go
@@ -396,9 +396,7 @@ func TestResolveSessionCookieEncryptionKey(t *testing.T) {
 
 		key, err := resolveSessionCookieEncryptionKey("")
 		require.NoError(t, err)
-		decoded, decErr := base64.StdEncoding.DecodeString(key)
-		require.NoError(t, decErr)
-		assert.Len(t, decoded, 32)
+		assert.Len(t, []byte(key), 32)
 
 		// a second call generates a fresh key (per-process randomness, no fixed fallback)
 		key2, err := resolveSessionCookieEncryptionKey("")

--- a/management/server/idp/embedded_test.go
+++ b/management/server/idp/embedded_test.go
@@ -391,12 +391,19 @@ func TestResolveSessionCookieEncryptionKey(t *testing.T) {
 		assert.Equal(t, rawKey, key)
 	})
 
-	t.Run("empty key disables encryption", func(t *testing.T) {
+	t.Run("empty key generates an ephemeral key instead of running unencrypted", func(t *testing.T) {
 		t.Setenv(sessionCookieEncryptionKeyEnv, "")
 
 		key, err := resolveSessionCookieEncryptionKey("")
 		require.NoError(t, err)
-		assert.Empty(t, key)
+		decoded, decErr := base64.StdEncoding.DecodeString(key)
+		require.NoError(t, decErr)
+		assert.Len(t, decoded, 32)
+
+		// a second call generates a fresh key (per-process randomness, no fixed fallback)
+		key2, err := resolveSessionCookieEncryptionKey("")
+		require.NoError(t, err)
+		assert.NotEqual(t, key, key2)
 	})
 
 	t.Run("rejects invalid key length", func(t *testing.T) {


### PR DESCRIPTION
## Problem

When neither `auth.sessionCookieEncryptionKey` nor `NB_EMBEDDED_IDP_SESSION_COOKIE_ENCRYPTION_KEY` is set, the embedded IdP runs with an **empty** cookie encryption key. In the dex session layer, an empty key means session cookies are stored as **plain marshaled protobuf** (`userID` + `connectorID` + `nonce`) — encryption is only applied when the key is non-empty (`session.go`: `if len(encryptionKey) > 0`).

On such an install, anyone who can read or predict a user ID can **forge a session cookie** without knowing any secret.

#7056 fixed this for **fresh** installs by generating a key in the bootstrap scripts. Existing installs that upgrade keep their old config with no key, and stay unencrypted — this PR closes that upgrade-path gap.

## Fix

`resolveSessionCookieEncryptionKey` now generates an ephemeral 32-byte random key (base64) when nothing is configured, and logs a prominent warning:

```
embedded IdP: no session cookie encryption key configured; using an ephemeral random key.
Sessions will NOT survive restarts. Set NB_EMBEDDED_IDP_SESSION_COOKIE_ENCRYPTION_KEY
(or auth.sessionCookieEncryptionKey) to a persistent 32-byte key.
```

Trade-off: sessions invalidate on restart until a persistent key is configured. That is strictly better than silently serving forgeable cookies indefinitely. If generation itself fails, the function errors instead of falling back to unencrypted.

## Tests

- The previous `empty key disables encryption` test asserted the vulnerable behavior; it now asserts ephemeral-key generation (32-byte length, fresh randomness per call).
- Full `management/server/idp` package passes.

## How to verify

Run the management server with no key configured: startup logs the warning, and `netbird-session` cookies are AES-encrypted rather than base64 protobuf.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Session cookies are now automatically protected with a freshly generated encryption key when no key is configured.
  * The system reports an error if secure key generation fails, preventing unencrypted session cookies.
  * A warning is logged when an ephemeral key is generated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->