### PR TITLE
fix(idp): fall back to an ephemeral session cookie key instead of running unencrypted

### DIFF
--- a/management/server/idp/embedded.go
+++ b/management/server/idp/embedded.go
@@ -1,6 +1,7 @@
 package idp
 
 import (
+	"crypto/rand"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -304,7 +305,19 @@ func resolveSessionCookieEncryptionKey(configuredKey string) (string, error) {
 		key = strings.TrimSpace(os.Getenv(sessionCookieEncryptionKeyEnv))
 	}
 	if key == "" {
-		return "", nil
+		// Sessions are always initialised (TOTP can be toggled at runtime), so an
+		// empty key here is not "sessions unused" - it silently runs session
+		// cookies unencrypted (a marshaled session triple anyone who observes it
+		// can replay). Bootstrap scripts generate a persisted key for fresh
+		// installs; upgraded/custom installs can still arrive here empty. Fall
+		// back to a random per-process key: cookies stay encrypted, sessions
+		// just don't survive restarts.
+		ephemeral := make([]byte, 32)
+		if _, err := rand.Read(ephemeral); err != nil {
+			return "", fmt.Errorf("generate ephemeral embedded IdP session cookie encryption key: %w", err)
+		}
+		log.Warnf("no embedded IdP session cookie encryption key configured (%s or sessionCookieEncryptionKey); using a random per-process key, sessions will not survive restarts", sessionCookieEncryptionKeyEnv)
+		return string(ephemeral), nil
 	}
 
 	if validSessionCookieEncryptionKeyLength(len([]byte(key))) {

--- a/management/server/idp/embedded_test.go
+++ b/management/server/idp/embedded_test.go
@@ -391,12 +391,16 @@ func TestResolveSessionCookieEncryptionKey(t *testing.T) {
 		assert.Equal(t, rawKey, key)
 	})
 
-	t.Run("empty key disables encryption", func(t *testing.T) {
+	t.Run("empty key falls back to a random per-process key", func(t *testing.T) {
 		t.Setenv(sessionCookieEncryptionKeyEnv, "")
 
 		key, err := resolveSessionCookieEncryptionKey("")
 		require.NoError(t, err)
-		assert.Empty(t, key)
+		// 32 raw bytes, and a fresh key per call
+		assert.Len(t, []byte(key), 32)
+		key2, err := resolveSessionCookieEncryptionKey("")
+		require.NoError(t, err)
+		assert.NotEqual(t, key, key2)
 	})
 
 	t.Run("rejects invalid key length", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`configureMFA` always initialises sessions (the comment says so: TOTP can be toggled at runtime). But `resolveSessionCookieEncryptionKey` returns `("", nil)` when no key is configured, and dex treats an empty key as *no encryption*: the session cookie becomes a cleartext marshaled `{userID, connectorID, nonce}` triple. The nonce is still bound server-side (constant-time compare against stored session state), so this is not forgeable from nothing — but anyone who *observes* a cookie (proxy logs, support bundles, a stray debug log) holds a replayable session token.

#7056 fixed this for **fresh** installs (bootstrap scripts generate a persisted key). Upgraded installs and hand-written configs can still arrive with no key, and today that silently disables encryption.

## Fix

When no key is configured, generate a random 32-byte per-process key and log a warning. Cookies stay encrypted; the only behavioral change is that sessions on key-less installs don't survive a server restart — which the warning states plainly.

## Tests

- Updated the resolver test: the old case asserted the insecure behavior ("empty key disables encryption"); it now asserts a 32-byte ephemeral key, fresh per call.
- `go test ./management/server/idp/` passes.

Made with Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Session cookies are now automatically protected with a randomly generated encryption key when no key is configured.
  * Added a warning when a key is generated automatically.
  * The system now reports an error if secure key generation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->