### PR TITLE
[client] peer: re-arm the WireGuard watcher after a lazy wake

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -307,6 +307,14 @@ func (conn *Conn) Close(signalToRemote bool) {
 
 	if conn.wgWatcherCancel != nil {
 		conn.wgWatcherCancel()
+		// The Conn struct is reused across lazy deactivate/activate. ctxCancel above
+		// already stopped the watcher goroutine (its ctx derives from conn.ctx), but
+		// enableWgWatcherIfNeeded skips while conn.wgWatcher is non-nil — so a stale
+		// pointer here would leave the peer with no watcher after the next Open, and thus
+		// no WireGuard handshake-timeout detection once a lazy connection has idled and
+		// woken. Clear it so the next Open starts a fresh watcher.
+		conn.wgWatcher = nil
+		conn.wgWatcherCancel = nil
 	}
 	conn.workerRelay.CloseConn()
 	if conn.workerICE != nil {

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -307,12 +307,6 @@ func (conn *Conn) Close(signalToRemote bool) {
 
 	if conn.wgWatcherCancel != nil {
 		conn.wgWatcherCancel()
-		// The Conn struct is reused across lazy deactivate/activate. ctxCancel above
-		// already stopped the watcher goroutine (its ctx derives from conn.ctx), but
-		// enableWgWatcherIfNeeded skips while conn.wgWatcher is non-nil — so a stale
-		// pointer here would leave the peer with no watcher after the next Open, and thus
-		// no WireGuard handshake-timeout detection once a lazy connection has idled and
-		// woken. Clear it so the next Open starts a fresh watcher.
 		conn.wgWatcher = nil
 		conn.wgWatcherCancel = nil
 	}


### PR DESCRIPTION
## Describe your changes

The Conn struct is reused across lazy-connection deactivate/activate. Close
cancels the WireGuard watcher (via wgWatcherCancel, and ctxCancel also tears
down its context) but left conn.wgWatcher pointing at the stopped instance.
enableWgWatcherIfNeeded skips while conn.wgWatcher is non-nil, so the next Open
never started a fresh watcher: once a lazy connection had idled and woken, the
peer ran with no watcher at all — no WireGuard handshake-timeout detection and
none of the escalation that depends on it.

Clear conn.wgWatcher and conn.wgWatcherCancel in Close so the next Open re-arms
a fresh watcher.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [X] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection cleanup by fully releasing WireGuard watcher resources when a connection closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->