### PR TITLE
[client] stop offering to every peer when the relay transport drops

### DIFF
--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -823,13 +823,14 @@ func (conn *Conn) isConnectedOnAllWay() (status guard.ConnStatus) {
 	}
 
 	return evalConnStatus(connStatusInputs{
-		forceRelay:          IsForceRelayed(),
-		peerUsesRelay:       conn.workerRelay.IsRelayConnectionSupportedWithPeer(),
-		relayConnected:      conn.statusRelay.Get() == worker.StatusConnected,
-		remoteSupportsICE:   conn.handshaker.RemoteICESupported(),
-		iceWorkerCreated:    iceWorkerCreated,
-		iceStatusConnecting: conn.statusICE.Get() != worker.StatusDisconnected,
-		iceInProgress:       iceInProgress,
+		forceRelay:              IsForceRelayed(),
+		peerUsesRelay:           conn.workerRelay.IsRelayConnectionSupportedWithPeer(),
+		relayConnected:          conn.statusRelay.Get() == worker.StatusConnected,
+		relayTransportConnected: conn.workerRelay.IsTransportConnected(),
+		remoteSupportsICE:       conn.handshaker.RemoteICESupported(),
+		iceWorkerCreated:        iceWorkerCreated,
+		iceStatusConnecting:     conn.statusICE.Get() != worker.StatusDisconnected,
+		iceInProgress:           iceInProgress,
 	})
 }
 
@@ -1053,6 +1054,9 @@ func evalConnStatus(in connStatusInputs) guard.ConnStatus {
 		return guard.ConnStatusConnected
 	case relayUsedAndUp:
 		// Relay is up but ICE is down — partially connected.
+		return guard.ConnStatusPartiallyConnected
+	case iceUp && !in.relayTransportConnected:
+		// ICE is up and the shared relay transport is down — offers cannot restore it.
 		return guard.ConnStatusPartiallyConnected
 	default:
 		return guard.ConnStatusDisconnected

--- a/client/internal/peer/conn_status.go
+++ b/client/internal/peer/conn_status.go
@@ -17,13 +17,14 @@ const (
 // tri-state connection classification. Extracted so the decision logic can be unit-tested
 // without constructing full Worker/Handshaker objects.
 type connStatusInputs struct {
-	forceRelay          bool // NB_FORCE_RELAY or JS/WASM
-	peerUsesRelay       bool // remote peer advertises relay support AND local has relay
-	relayConnected      bool // statusRelay reports Connected (independent of whether peer uses relay)
-	remoteSupportsICE   bool // remote peer sent ICE credentials
-	iceWorkerCreated    bool // local WorkerICE exists (false in force-relay mode)
-	iceStatusConnecting bool // statusICE is anything other than Disconnected
-	iceInProgress       bool // a negotiation is currently in flight
+	forceRelay              bool // NB_FORCE_RELAY or JS/WASM
+	peerUsesRelay           bool // remote peer advertises relay support AND local has relay
+	relayConnected          bool // statusRelay reports Connected (independent of whether peer uses relay)
+	relayTransportConnected bool // the relay transport shared by all peers on that server is up
+	remoteSupportsICE       bool // remote peer sent ICE credentials
+	iceWorkerCreated        bool // local WorkerICE exists (false in force-relay mode)
+	iceStatusConnecting     bool // statusICE is anything other than Disconnected
+	iceInProgress           bool // a negotiation is currently in flight
 }
 
 // ConnStatus describe the status of a peer's connection

--- a/client/internal/peer/conn_status_eval_test.go
+++ b/client/internal/peer/conn_status_eval_test.go
@@ -166,15 +166,38 @@ func TestEvalConnStatus_FullyAvailable(t *testing.T) {
 			want: guard.ConnStatusDisconnected,
 		},
 		{
-			name: "ICE up, peer uses relay but relay down -> partial (relay required, ICE ignored)",
+			name: "ICE up, relay down for this peer but the shared transport is up -> disconnected",
 			mutator: func(in *connStatusInputs) {
 				in.peerUsesRelay = true
 				in.relayConnected = false
+				in.relayTransportConnected = true
 				in.iceStatusConnecting = true
 			},
-			// relayOK = false (peer uses relay but it's down), iceUp = true
-			// first switch arm fails (relayOK false), relayUsedAndUp = false (relay down),
-			// falls into default: Disconnected.
+			// The transport is fine, so the peer itself is unreachable over relay: it may have
+			// moved to another server, and only an offer carries its new relay address.
+			want: guard.ConnStatusDisconnected,
+		},
+		{
+			name: "ICE up, the shared relay transport is down -> partial",
+			mutator: func(in *connStatusInputs) {
+				in.peerUsesRelay = true
+				in.relayConnected = false
+				in.relayTransportConnected = false
+				in.iceStatusConnecting = true
+			},
+			// ICE carries the traffic and the relay transport is restored by the relay client's
+			// own guard, not by offers, so this must not trigger the aggressive retry.
+			want: guard.ConnStatusPartiallyConnected,
+		},
+		{
+			name: "ICE down and the shared relay transport is down -> disconnected",
+			mutator: func(in *connStatusInputs) {
+				in.peerUsesRelay = true
+				in.relayConnected = false
+				in.relayTransportConnected = false
+				in.iceStatusConnecting = false
+				in.iceInProgress = false
+			},
 			want: guard.ConnStatusDisconnected,
 		},
 		{

--- a/client/internal/peer/worker_relay.go
+++ b/client/internal/peer/worker_relay.go
@@ -107,6 +107,10 @@ func (w *WorkerRelay) RelayIsSupportedLocally() bool {
 	return w.relayManager.HasRelayAddress()
 }
 
+func (w *WorkerRelay) IsTransportConnected() bool {
+	return w.relayManager.Ready()
+}
+
 func (w *WorkerRelay) CloseConn() {
 	w.relayLock.Lock()
 	defer w.relayLock.Unlock()


### PR DESCRIPTION
## Describe your changes

The relay transport is shared: one connection per relay server carries the streams of every peer using it. When it drops, every one of those peers gets a `Disconnected` verdict from [`evalConnStatus`](https://github.com/netbirdio/netbird/blob/main/client/internal/peer/conn.go#L1029-L1060) even when ICE is still carrying its traffic. The reason is that `peerUsesRelay` comes from [`HasRelayAddress()`](https://github.com/netbirdio/netbird/blob/main/shared/relay/client/manager.go#L316-L318), which reports that management *offered* relay servers — a configuration property — not that we are connected to one. So `relayOK` is false, no branch matches, and the default applies.

`Disconnected` is answered with the aggressive retry ([guard.go:104-106](https://github.com/netbirdio/netbird/blob/main/client/internal/peer/guard/guard.go#L104-L106)): an offer over signal on every step of the exponential ladder, per peer. Those offers cannot restore the transport — the relay client's own guard does that — and they cannot even disturb
the working ICE connection, since `WorkerICE.OnNewOffer` discards an offer whose remote session ID is unchanged. They are pure signaling load, multiplied by the number of peers on that server, precisely while the relay infrastructure is already in trouble.

This feeds `relayManager.Ready()` into the status inputs and returns `PartiallyConnected` when ICE is up and the missing side is the shared transport. That is the existing "one path works, the other does not" branch: three retries and then hourly, instead of the ladder forever. 

Peers are not stranded waiting for the hourly tick. When the transport comes back, `Manager.onServerConnected` notifies `srWatcher`, and the guard's `srReconnectedChan` case resets the ticker to 800 ms and calls `iceState.reset()`, which clears the hourly mode.

Two cases keep the current verdict, deliberately:

- **transport up, this peer unreachable over relay** — it may have moved to another server, and
  only an offer carries its new `RelaySrvAddress`, so the aggressive retry is correct;
- **force-relay mode** (iOS and Android default) — `evalConnStatus` returns before the new
  branch, and relay being the only transport means its loss is a real disconnection.
  
  The retry policy does not stay sparse once the transport is back. `statusRelay` only becomes
Connected inside `onRelayConnectionIsReady`, i.e. after the per-peer stream is re-established
through an offer/answer exchange — the shared transport returning does not set it. So the moment
`relayManager.Ready()` flips back to true the new branch stops matching and the verdict returns
to `Disconnected`, which is correct: at that point an offer is exactly what is needed to reopen
the stream. Combined with the `srReconnectedChan` reset, the first useful offer goes out within
a second of the transport recovering.

| moment | `relayConnected` | `relayTransportConnected` | verdict | retry |
|---|---|---|---|---|
| transport drops | false | false | `PartiallyConnected` | sparse |
| transport returns | false | true | `Disconnected` | aggressive |
| stream reopened | true | true | `Connected` | none |


## Issue ticket number and link

No public issue. Found while analysing the first production sample of client metrics: 22,336
relay reconnection events in 24h, each one fanning out offers to every peer sharing that
transport. Related to https://github.com/netbirdio/netbird/pull/7067.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal retry-policy change with no user-visible surface: no CLI flag, configuration option or
API field is added or altered. Connectivity behaviour is unchanged — the peer keeps running over
ICE throughout, and relay is restored by the relay client's guard exactly as before; only the
rate of redundant signaling offers changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection status reporting when shared relay transport connectivity changes.
  * Connections now correctly show as partially connected when ICE remains active but shared relay transport is unavailable.
  * Distinguished peer relay availability from overall shared relay transport readiness.

* **Tests**
  * Added coverage for fully connected, partially connected, and disconnected relay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->