### PR TITLE
[management] Affected peers for user updates

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1629,7 +1629,6 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 	var user *types.User
 	var change affectedpeers.Change
 	var snap *affectedpeers.Snapshot
-	var requiresAccountUpdate bool
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
 		user, err = transaction.GetUserByUserID(ctx, store.LockingStrengthNone, userAuth.UserId)
 		if err != nil {
@@ -1673,15 +1672,20 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 		// group -> user mapping even when no peer moves between groups.
 		change.UserGroupIDs = allGroupChanges
 
+		// The user's peers are the changed entity in every scenario the sync can
+		// produce — group membership, IPv6 assignment, SSH mappings — so they refresh
+		// together with every peer they can connect to, like on a regular peer update.
+		userPeers, err := transaction.GetUserPeers(ctx, store.LockingStrengthNone, userAuth.AccountId, userAuth.UserId)
+		if err != nil {
+			return fmt.Errorf("error getting user peers: %w", err)
+		}
+		for _, peer := range userPeers {
+			change.ChangedPeerIDs = append(change.ChangedPeerIDs, peer.ID)
+		}
+
 		// Propagate changes to peers if group propagation is enabled
 		if settings.GroupsPropagationEnabled {
-			peers, err := transaction.GetUserPeers(ctx, store.LockingStrengthNone, userAuth.AccountId, userAuth.UserId)
-			if err != nil {
-				return fmt.Errorf("error getting user peers: %w", err)
-			}
-
-			for _, peer := range peers {
-				change.OutputPeerIDs = append(change.OutputPeerIDs, peer.ID)
+			for _, peer := range userPeers {
 				for _, g := range addNewGroups {
 					if err := transaction.AddPeerToGroup(ctx, userAuth.AccountId, peer.ID, g); err != nil {
 						return fmt.Errorf("error adding peer %s to group %s: %w", peer.ID, g, err)
@@ -1695,10 +1699,6 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 			}
 
 			change.LinkGroups = allGroupChanges
-
-			// The reconciliation reassigns IPv6 addresses across the account, which
-			// every peer that can reach the reassigned ones observes.
-			requiresAccountUpdate = ipv6ReconcileNeeded(settings, allGroupChanges)
 
 			if err = am.reconcileIPv6ForGroupChanges(ctx, transaction, userAuth.AccountId, allGroupChanges); err != nil {
 				return fmt.Errorf("reconcile IPv6 for group changes: %w", err)
@@ -1747,12 +1747,6 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 			}
 			am.StoreEvent(ctx, user.Id, user.Id, userAuth.AccountId, activity.GroupRemovedFromUser, meta)
 		}
-	}
-
-	if requiresAccountUpdate {
-		log.WithContext(ctx).Tracef("user %s: JWT group membership changed, updating account peers", userAuth.UserId)
-		am.BufferUpdateAccountPeers(ctx, userAuth.AccountId, types.UpdateReason{Resource: types.UpdateResourceUser, Operation: types.UpdateOperationUpdate})
-		return nil
 	}
 
 	log.WithContext(ctx).Tracef("user %s: JWT group membership changed, updating affected peers", userAuth.UserId)
@@ -2456,10 +2450,7 @@ func (am *DefaultAccountManager) reconcileIPv6ForGroupChanges(ctx context.Contex
 }
 
 // ipv6ReconcileNeeded reports whether changes to the given groups trigger an IPv6
-// reconciliation. A reconciliation reassigns addresses across the whole account, and a
-// peer's address is visible to everyone that reaches it through any of its groups, so
-// callers that otherwise compute an affected-peers set must fall back to updating the
-// whole account.
+// reconciliation.
 func ipv6ReconcileNeeded(settings *types.Settings, groupIDs []string) bool {
 	for _, groupID := range groupIDs {
 		if slices.Contains(settings.IPv6EnabledGroups, groupID) {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1629,6 +1629,7 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 	var user *types.User
 	var change affectedpeers.Change
 	var snap *affectedpeers.Snapshot
+	var requiresAccountUpdate bool
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
 		user, err = transaction.GetUserByUserID(ctx, store.LockingStrengthNone, userAuth.UserId)
 		if err != nil {
@@ -1668,6 +1669,9 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 		}
 
 		allGroupChanges := slices.Concat(addNewGroups, removeOldGroups)
+		// The user's auto-groups changed, so the SSH rules authorizing them ship a new
+		// group -> user mapping even when no peer moves between groups.
+		change.UserGroupIDs = allGroupChanges
 
 		// Propagate changes to peers if group propagation is enabled
 		if settings.GroupsPropagationEnabled {
@@ -1692,16 +1696,9 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 
 			change.LinkGroups = allGroupChanges
 
-			// An IPv6 reconcile can change the peers' addresses, which are visible
-			// through ALL their group memberships, so seed the full walk instead of
-			// folding the peers alone.
-			for _, g := range allGroupChanges {
-				if slices.Contains(settings.IPv6EnabledGroups, g) {
-					change.ChangedPeerIDs = change.OutputPeerIDs
-					change.OutputPeerIDs = nil
-					break
-				}
-			}
+			// The reconciliation reassigns IPv6 addresses across the account, which
+			// every peer that can reach the reassigned ones observes.
+			requiresAccountUpdate = ipv6ReconcileNeeded(settings, allGroupChanges)
 
 			if err = am.reconcileIPv6ForGroupChanges(ctx, transaction, userAuth.AccountId, allGroupChanges); err != nil {
 				return fmt.Errorf("reconcile IPv6 for group changes: %w", err)
@@ -1711,16 +1708,6 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 				return fmt.Errorf("error incrementing network serial: %w", err)
 			}
 		}
-
-		// The user->group mapping shipped to SSH destination peers (GroupIDToUserIDs)
-		// changed for these groups even without peer propagation, so the destinations
-		// of SSH rules authorizing them must refresh.
-		sshDistributionGroups, sshPeerIDs, err := sshAuthorizedGroupConsumers(ctx, transaction, userAuth.AccountId, allGroupChanges)
-		if err != nil {
-			return err
-		}
-		change.DistributionGroupIDs = sshDistributionGroups
-		change.OutputPeerIDs = append(change.OutputPeerIDs, sshPeerIDs...)
 
 		if snap, err = affectedpeers.Load(ctx, transaction, userAuth.AccountId, change); err != nil {
 			return err
@@ -1762,6 +1749,12 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 		}
 	}
 
+	if requiresAccountUpdate {
+		log.WithContext(ctx).Tracef("user %s: JWT group membership changed, updating account peers", userAuth.UserId)
+		am.BufferUpdateAccountPeers(ctx, userAuth.AccountId, types.UpdateReason{Resource: types.UpdateResourceUser, Operation: types.UpdateOperationUpdate})
+		return nil
+	}
+
 	log.WithContext(ctx).Tracef("user %s: JWT group membership changed, updating affected peers", userAuth.UserId)
 	bgCtx := context.WithoutCancel(ctx)
 	go func() {
@@ -1775,53 +1768,6 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 	}()
 
 	return nil
-}
-
-// sshAuthorizedGroupConsumers returns the destination groups and destination peers of
-// enabled SSH rules whose AuthorizedGroups reference any of the changed groups. Their
-// network maps carry the user->group mapping for those groups.
-func sshAuthorizedGroupConsumers(ctx context.Context, transaction store.Store, accountID string, changedGroupIDs []string) ([]string, []string, error) {
-	if len(changedGroupIDs) == 0 {
-		return nil, nil, nil
-	}
-
-	policies, err := transaction.GetAccountPolicies(ctx, store.LockingStrengthNone, accountID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error getting account policies: %w", err)
-	}
-
-	changed := make(map[string]struct{}, len(changedGroupIDs))
-	for _, id := range changedGroupIDs {
-		changed[id] = struct{}{}
-	}
-
-	var groupIDs []string
-	var peerIDs []string
-	for _, policy := range policies {
-		if policy == nil || !policy.Enabled {
-			continue
-		}
-		for _, rule := range policy.Rules {
-			if !rule.Enabled || rule.Protocol != types.PolicyRuleProtocolNetbirdSSH {
-				continue
-			}
-			authorized := false
-			for groupID := range rule.AuthorizedGroups {
-				if _, ok := changed[groupID]; ok {
-					authorized = true
-					break
-				}
-			}
-			if !authorized {
-				continue
-			}
-			groupIDs = append(groupIDs, rule.Destinations...)
-			if rule.DestinationResource.Type == types.ResourceTypePeer && rule.DestinationResource.ID != "" {
-				peerIDs = append(peerIDs, rule.DestinationResource.ID)
-			}
-		}
-	}
-	return groupIDs, peerIDs, nil
 }
 
 // getAccountIDWithAuthorizationClaims retrieves an account ID using JWT Claims.
@@ -2502,28 +2448,25 @@ func (am *DefaultAccountManager) reconcileIPv6ForGroupChanges(ctx context.Contex
 		return fmt.Errorf("get account settings: %w", err)
 	}
 
-	if len(settings.IPv6EnabledGroups) == 0 {
-		return nil
-	}
-
-	enabledSet := make(map[string]struct{}, len(settings.IPv6EnabledGroups))
-	for _, gid := range settings.IPv6EnabledGroups {
-		enabledSet[gid] = struct{}{}
-	}
-
-	affected := false
-	for _, gid := range groupIDs {
-		if _, ok := enabledSet[gid]; ok {
-			affected = true
-			break
-		}
-	}
-
-	if !affected {
+	if !ipv6ReconcileNeeded(settings, groupIDs) {
 		return nil
 	}
 
 	return am.updatePeerIPv6Addresses(ctx, transaction, accountID, settings)
+}
+
+// ipv6ReconcileNeeded reports whether changes to the given groups trigger an IPv6
+// reconciliation. A reconciliation reassigns addresses across the whole account, and a
+// peer's address is visible to everyone that reaches it through any of its groups, so
+// callers that otherwise compute an affected-peers set must fall back to updating the
+// whole account.
+func ipv6ReconcileNeeded(settings *types.Settings, groupIDs []string) bool {
+	for _, groupID := range groupIDs {
+		if slices.Contains(settings.IPv6EnabledGroups, groupID) {
+			return true
+		}
+	}
+	return false
 }
 
 func (am *DefaultAccountManager) ensureIPv6Subnet(ctx context.Context, transaction store.Store, accountID string, settings *types.Settings, network *types.Network) error {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -33,6 +33,7 @@ import (
 	nbconfig "github.com/netbirdio/netbird/management/internals/server/config"
 	"github.com/netbirdio/netbird/management/server/account"
 	"github.com/netbirdio/netbird/management/server/activity"
+	"github.com/netbirdio/netbird/management/server/affectedpeers"
 	nbcache "github.com/netbirdio/netbird/management/server/cache"
 	nbcontext "github.com/netbirdio/netbird/management/server/context"
 	"github.com/netbirdio/netbird/management/server/geolocation"
@@ -1626,6 +1627,8 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 	var removeOldGroups []string
 	var hasChanges bool
 	var user *types.User
+	var change affectedpeers.Change
+	var snap *affectedpeers.Snapshot
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
 		user, err = transaction.GetUserByUserID(ctx, store.LockingStrengthNone, userAuth.UserId)
 		if err != nil {
@@ -1664,6 +1667,8 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 			return fmt.Errorf("error saving user: %w", err)
 		}
 
+		allGroupChanges := slices.Concat(addNewGroups, removeOldGroups)
+
 		// Propagate changes to peers if group propagation is enabled
 		if settings.GroupsPropagationEnabled {
 			peers, err := transaction.GetUserPeers(ctx, store.LockingStrengthNone, userAuth.AccountId, userAuth.UserId)
@@ -1672,6 +1677,7 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 			}
 
 			for _, peer := range peers {
+				change.OutputPeerIDs = append(change.OutputPeerIDs, peer.ID)
 				for _, g := range addNewGroups {
 					if err := transaction.AddPeerToGroup(ctx, userAuth.AccountId, peer.ID, g); err != nil {
 						return fmt.Errorf("error adding peer %s to group %s: %w", peer.ID, g, err)
@@ -1684,7 +1690,19 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 				}
 			}
 
-			allGroupChanges := slices.Concat(addNewGroups, removeOldGroups)
+			change.LinkGroups = allGroupChanges
+
+			// An IPv6 reconcile can change the peers' addresses, which are visible
+			// through ALL their group memberships, so seed the full walk instead of
+			// folding the peers alone.
+			for _, g := range allGroupChanges {
+				if slices.Contains(settings.IPv6EnabledGroups, g) {
+					change.ChangedPeerIDs = change.OutputPeerIDs
+					change.OutputPeerIDs = nil
+					break
+				}
+			}
+
 			if err = am.reconcileIPv6ForGroupChanges(ctx, transaction, userAuth.AccountId, allGroupChanges); err != nil {
 				return fmt.Errorf("reconcile IPv6 for group changes: %w", err)
 			}
@@ -1692,6 +1710,20 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 			if err = transaction.IncrementNetworkSerial(ctx, userAuth.AccountId); err != nil {
 				return fmt.Errorf("error incrementing network serial: %w", err)
 			}
+		}
+
+		// The user->group mapping shipped to SSH destination peers (GroupIDToUserIDs)
+		// changed for these groups even without peer propagation, so the destinations
+		// of SSH rules authorizing them must refresh.
+		sshDistributionGroups, sshPeerIDs, err := sshAuthorizedGroupConsumers(ctx, transaction, userAuth.AccountId, allGroupChanges)
+		if err != nil {
+			return err
+		}
+		change.DistributionGroupIDs = sshDistributionGroups
+		change.OutputPeerIDs = append(change.OutputPeerIDs, sshPeerIDs...)
+
+		if snap, err = affectedpeers.Load(ctx, transaction, userAuth.AccountId, change); err != nil {
+			return err
 		}
 
 		return nil
@@ -1730,22 +1762,66 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 		}
 	}
 
-	removedGroupAffectsPeers, err := areGroupChangesAffectPeers(ctx, am.Store, userAuth.AccountId, removeOldGroups)
-	if err != nil {
-		return err
-	}
-
-	newGroupsAffectsPeers, err := areGroupChangesAffectPeers(ctx, am.Store, userAuth.AccountId, addNewGroups)
-	if err != nil {
-		return err
-	}
-
-	if removedGroupAffectsPeers || newGroupsAffectsPeers {
-		log.WithContext(ctx).Tracef("user %s: JWT group membership changed, updating account peers", userAuth.UserId)
-		am.BufferUpdateAccountPeers(ctx, userAuth.AccountId, types.UpdateReason{Resource: types.UpdateResourceUser, Operation: types.UpdateOperationUpdate})
-	}
+	log.WithContext(ctx).Tracef("user %s: JWT group membership changed, updating affected peers", userAuth.UserId)
+	bgCtx := context.WithoutCancel(ctx)
+	go func() {
+		affectedPeerIDs := snap.Expand(bgCtx, userAuth.AccountId, change)
+		if len(affectedPeerIDs) == 0 {
+			return
+		}
+		if err := am.networkMapController.BufferUpdateAffectedPeers(bgCtx, userAuth.AccountId, affectedPeerIDs, types.UpdateReason{Resource: types.UpdateResourceUser, Operation: types.UpdateOperationUpdate}); err != nil {
+			log.WithContext(bgCtx).Errorf("failed to update affected peers after JWT group sync for account %s: %v", userAuth.AccountId, err)
+		}
+	}()
 
 	return nil
+}
+
+// sshAuthorizedGroupConsumers returns the destination groups and destination peers of
+// enabled SSH rules whose AuthorizedGroups reference any of the changed groups. Their
+// network maps carry the user->group mapping for those groups.
+func sshAuthorizedGroupConsumers(ctx context.Context, transaction store.Store, accountID string, changedGroupIDs []string) ([]string, []string, error) {
+	if len(changedGroupIDs) == 0 {
+		return nil, nil, nil
+	}
+
+	policies, err := transaction.GetAccountPolicies(ctx, store.LockingStrengthNone, accountID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting account policies: %w", err)
+	}
+
+	changed := make(map[string]struct{}, len(changedGroupIDs))
+	for _, id := range changedGroupIDs {
+		changed[id] = struct{}{}
+	}
+
+	var groupIDs []string
+	var peerIDs []string
+	for _, policy := range policies {
+		if policy == nil || !policy.Enabled {
+			continue
+		}
+		for _, rule := range policy.Rules {
+			if !rule.Enabled || rule.Protocol != types.PolicyRuleProtocolNetbirdSSH {
+				continue
+			}
+			authorized := false
+			for groupID := range rule.AuthorizedGroups {
+				if _, ok := changed[groupID]; ok {
+					authorized = true
+					break
+				}
+			}
+			if !authorized {
+				continue
+			}
+			groupIDs = append(groupIDs, rule.Destinations...)
+			if rule.DestinationResource.Type == types.ResourceTypePeer && rule.DestinationResource.ID != "" {
+				peerIDs = append(peerIDs, rule.DestinationResource.ID)
+			}
+		}
+	}
+	return groupIDs, peerIDs, nil
 }
 
 // getAccountIDWithAuthorizationClaims retrieves an account ID using JWT Claims.

--- a/management/server/affected_peers_jwt_test.go
+++ b/management/server/affected_peers_jwt_test.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	nbpeer "github.com/netbirdio/netbird/management/server/peer"
+	"github.com/netbirdio/netbird/management/server/store"
+	"github.com/netbirdio/netbird/management/server/types"
+	"github.com/netbirdio/netbird/shared/auth"
+)
+
+// TestAffectedPeers_SyncUserJWTGroups_OnlyAffectedPeersUpdated verifies that a JWT
+// auto-group change updates only the user's peers and the peers linked to the changed
+// group through policies, instead of fanning out to the whole account.
+func TestAffectedPeers_SyncUserJWTGroups_OnlyAffectedPeersUpdated(t *testing.T) {
+	manager, updateManager, account, _, peer2, peer3 := setupNetworkMapTest(t)
+	ctx := context.Background()
+	accountID := account.Id
+
+	key, err := wgtypes.GeneratePrivateKey()
+	require.NoError(t, err)
+	userPeer, _, _, _, err := manager.AddPeer(ctx, accountID, "", userID, &nbpeer.Peer{
+		Key:  key.PublicKey().String(),
+		Meta: nbpeer.PeerSystemMeta{Hostname: "user-peer"},
+	}, false)
+	require.NoError(t, err)
+
+	policies, err := manager.Store.GetAccountPolicies(ctx, store.LockingStrengthNone, accountID)
+	require.NoError(t, err)
+	for _, p := range policies {
+		require.NoError(t, manager.Store.DeletePolicy(ctx, accountID, p.ID))
+	}
+
+	account, err = manager.Store.GetAccount(ctx, accountID)
+	require.NoError(t, err)
+	account.Settings.JWTGroupsEnabled = true
+	account.Settings.JWTGroupsClaimName = "groups"
+	account.Settings.GroupsPropagationEnabled = true
+	require.NoError(t, manager.Store.SaveAccount(ctx, account))
+
+	require.NoError(t, manager.CreateGroup(ctx, accountID, userID, &types.Group{ID: "jwt-grp", Name: "jwt-linked", Issued: types.GroupIssuedJWT, Peers: []string{}}))
+	require.NoError(t, manager.CreateGroup(ctx, accountID, userID, &types.Group{ID: "jwt-dest", Name: "jwt-dest", Peers: []string{peer2.ID}}))
+
+	_, err = manager.SavePolicy(ctx, accountID, userID, &types.Policy{
+		Enabled: true,
+		Rules: []*types.PolicyRule{
+			{
+				Enabled:       true,
+				Sources:       []string{"jwt-grp"},
+				Destinations:  []string{"jwt-dest"},
+				Bidirectional: true,
+				Action:        types.PolicyTrafficActionAccept,
+			},
+		},
+	}, true)
+	require.NoError(t, err)
+
+	updUser := updateManager.CreateChannel(ctx, userPeer.ID)
+	upd2 := updateManager.CreateChannel(ctx, peer2.ID)
+	upd3 := updateManager.CreateChannel(ctx, peer3.ID)
+	t.Cleanup(func() {
+		updateManager.CloseChannel(ctx, userPeer.ID)
+		updateManager.CloseChannel(ctx, peer2.ID)
+		updateManager.CloseChannel(ctx, peer3.ID)
+	})
+
+	userAuth := auth.UserAuth{
+		AccountId: accountID,
+		UserId:    userID,
+		Groups:    []string{"jwt-linked"},
+	}
+
+	t.Run("adding JWT group updates only linked peers", func(t *testing.T) {
+		drainPeerUpdates(updUser)
+		drainPeerUpdates(upd2)
+		drainPeerUpdates(upd3)
+
+		require.NoError(t, manager.SyncUserJWTGroups(ctx, userAuth))
+
+		peerShouldReceiveUpdate(t, updUser)
+		peerShouldReceiveUpdate(t, upd2)
+		peerShouldNotReceiveUpdate(t, upd3)
+
+		user, err := manager.Store.GetUserByUserID(ctx, store.LockingStrengthNone, userID)
+		require.NoError(t, err)
+		assert.Contains(t, user.AutoGroups, "jwt-grp")
+	})
+
+	t.Run("removing JWT group updates only linked peers", func(t *testing.T) {
+		drainPeerUpdates(updUser)
+		drainPeerUpdates(upd2)
+		drainPeerUpdates(upd3)
+
+		userAuth.Groups = nil
+		require.NoError(t, manager.SyncUserJWTGroups(ctx, userAuth))
+
+		peerShouldReceiveUpdate(t, updUser)
+		peerShouldReceiveUpdate(t, upd2)
+		peerShouldNotReceiveUpdate(t, upd3)
+
+		user, err := manager.Store.GetUserByUserID(ctx, store.LockingStrengthNone, userID)
+		require.NoError(t, err)
+		assert.NotContains(t, user.AutoGroups, "jwt-grp")
+	})
+}

--- a/management/server/affected_peers_jwt_test.go
+++ b/management/server/affected_peers_jwt_test.go
@@ -8,11 +8,80 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
+	"github.com/netbirdio/netbird/management/server/affectedpeers"
 	nbpeer "github.com/netbirdio/netbird/management/server/peer"
 	"github.com/netbirdio/netbird/management/server/store"
 	"github.com/netbirdio/netbird/management/server/types"
 	"github.com/netbirdio/netbird/shared/auth"
 )
+
+// A user's auto-group change refreshes the destinations of the SSH rules authorizing
+// that group — they carry the group -> user mapping — even though no peer moved
+// between groups.
+func TestAffectedPeers_UserGroupChange_RefreshesSSHAuthorizedDestinations(t *testing.T) {
+	manager, s, accountID, peerIDs, groupIDs := setupAffectedPeersTest(t)
+	ctx := context.Background()
+
+	_, err := manager.SavePolicy(ctx, accountID, userID, &types.Policy{
+		Enabled: true,
+		Rules: []*types.PolicyRule{
+			{
+				Enabled:          true,
+				Sources:          []string{groupIDs[0]},
+				Destinations:     []string{groupIDs[1]},
+				Protocol:         types.PolicyRuleProtocolNetbirdSSH,
+				Action:           types.PolicyTrafficActionAccept,
+				AuthorizedGroups: map[string][]string{groupIDs[3]: {"root"}},
+			},
+		},
+	}, true)
+	require.NoError(t, err)
+
+	result := resolveAffected(t, s, accountID, affectedpeers.Change{UserGroupIDs: []string{groupIDs[3]}})
+	assert.ElementsMatch(t, []string{peerIDs[1]}, result,
+		"only the SSH rule's destination peers carry the changed group -> user mapping")
+
+	result = resolveAffected(t, s, accountID, affectedpeers.Change{UserGroupIDs: []string{groupIDs[4]}})
+	assert.Empty(t, result, "a group no SSH rule authorizes affects nobody")
+}
+
+// Creating, blocking or unblocking a user changes the account's allowed-user set, which
+// reaches only the destinations of the SSH rules that ship it.
+func TestAffectedPeers_AllowedUsersChange_RefreshesSSHDestinations(t *testing.T) {
+	manager, s, accountID, peerIDs, groupIDs := setupAffectedPeersTest(t)
+	ctx := context.Background()
+
+	// Ships the allowed-user set: an SSH rule naming no groups and no user.
+	_, err := manager.SavePolicy(ctx, accountID, userID, &types.Policy{
+		Enabled: true,
+		Rules: []*types.PolicyRule{{
+			Enabled:      true,
+			Sources:      []string{groupIDs[0]},
+			Destinations: []string{groupIDs[1]},
+			Protocol:     types.PolicyRuleProtocolNetbirdSSH,
+			Action:       types.PolicyTrafficActionAccept,
+		}},
+	}, true)
+	require.NoError(t, err)
+
+	// Does not ship it: an SSH rule that authorizes a specific group.
+	_, err = manager.SavePolicy(ctx, accountID, userID, &types.Policy{
+		Enabled: true,
+		Rules: []*types.PolicyRule{{
+			Enabled:          true,
+			Sources:          []string{groupIDs[2]},
+			Destinations:     []string{groupIDs[3]},
+			Protocol:         types.PolicyRuleProtocolNetbirdSSH,
+			Action:           types.PolicyTrafficActionAccept,
+			AuthorizedGroups: map[string][]string{groupIDs[0]: {"root"}},
+		}},
+	}, true)
+	require.NoError(t, err)
+
+	result := resolveAffected(t, s, accountID, affectedpeers.Change{AllowedUsersChanged: true})
+	assert.ElementsMatch(t, []string{peerIDs[1]}, result,
+		"only the destinations of the rule shipping the allowed-user set refresh")
+}
 
 // TestAffectedPeers_SyncUserJWTGroups_OnlyAffectedPeersUpdated verifies that a JWT
 // auto-group change updates only the user's peers and the peers linked to the changed

--- a/management/server/affected_peers_user_test.go
+++ b/management/server/affected_peers_user_test.go
@@ -1,0 +1,170 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/netbirdio/netbird/management/server/activity"
+	nbpeer "github.com/netbirdio/netbird/management/server/peer"
+	"github.com/netbirdio/netbird/management/server/store"
+	"github.com/netbirdio/netbird/management/server/types"
+)
+
+// A user update refreshes only the peers its auto-group change reaches, and a user
+// update that changes no group membership refreshes nobody.
+func TestAffectedPeers_SaveUser_OnlyAffectedPeersUpdated(t *testing.T) {
+	manager, updateManager, account, _, peer2, peer3 := setupNetworkMapTest(t)
+	ctx := context.Background()
+	accountID := account.Id
+
+	const targetUserID = "target-user"
+	require.NoError(t, manager.Store.SaveUser(ctx, &types.User{
+		Id: targetUserID, AccountID: accountID, Role: types.UserRoleUser,
+	}))
+
+	key, err := wgtypes.GeneratePrivateKey()
+	require.NoError(t, err)
+	targetPeer, _, _, _, err := manager.AddPeer(ctx, accountID, "", targetUserID, &nbpeer.Peer{
+		Key:  key.PublicKey().String(),
+		Meta: nbpeer.PeerSystemMeta{Hostname: "target-peer"},
+	}, false)
+	require.NoError(t, err)
+
+	policies, err := manager.Store.GetAccountPolicies(ctx, store.LockingStrengthNone, accountID)
+	require.NoError(t, err)
+	for _, p := range policies {
+		require.NoError(t, manager.Store.DeletePolicy(ctx, accountID, p.ID))
+	}
+
+	account, err = manager.Store.GetAccount(ctx, accountID)
+	require.NoError(t, err)
+	account.Settings.GroupsPropagationEnabled = true
+	require.NoError(t, manager.Store.SaveAccount(ctx, account))
+
+	require.NoError(t, manager.CreateGroup(ctx, accountID, userID, &types.Group{ID: "ug-linked", Name: "ug-linked"}))
+	require.NoError(t, manager.CreateGroup(ctx, accountID, userID, &types.Group{ID: "ug-dest", Name: "ug-dest", Peers: []string{peer2.ID}}))
+
+	_, err = manager.SavePolicy(ctx, accountID, userID, &types.Policy{
+		Enabled: true,
+		Rules: []*types.PolicyRule{
+			{
+				Enabled:       true,
+				Sources:       []string{"ug-linked"},
+				Destinations:  []string{"ug-dest"},
+				Bidirectional: true,
+				Action:        types.PolicyTrafficActionAccept,
+			},
+		},
+	}, true)
+	require.NoError(t, err)
+
+	updTarget := updateManager.CreateChannel(ctx, targetPeer.ID)
+	upd2 := updateManager.CreateChannel(ctx, peer2.ID)
+	upd3 := updateManager.CreateChannel(ctx, peer3.ID)
+	t.Cleanup(func() {
+		updateManager.CloseChannel(ctx, targetPeer.ID)
+		updateManager.CloseChannel(ctx, peer2.ID)
+		updateManager.CloseChannel(ctx, peer3.ID)
+	})
+
+	t.Run("auto group change updates only linked peers", func(t *testing.T) {
+		drainPeerUpdates(updTarget)
+		drainPeerUpdates(upd2)
+		drainPeerUpdates(upd3)
+
+		_, err := manager.SaveUser(ctx, accountID, activity.SystemInitiator, &types.User{
+			Id: targetUserID, AccountID: accountID, Role: types.UserRoleUser,
+			AutoGroups: []string{"ug-linked"},
+		})
+		require.NoError(t, err)
+
+		peerShouldReceiveUpdate(t, updTarget)
+		peerShouldReceiveUpdate(t, upd2)
+		peerShouldNotReceiveUpdate(t, upd3)
+	})
+
+	t.Run("update without group changes refreshes nobody", func(t *testing.T) {
+		drainPeerUpdates(updTarget)
+		drainPeerUpdates(upd2)
+		drainPeerUpdates(upd3)
+
+		_, err := manager.SaveUser(ctx, accountID, activity.SystemInitiator, &types.User{
+			Id: targetUserID, AccountID: accountID, Role: types.UserRoleUser,
+			AutoGroups: []string{"ug-linked"}, Name: "renamed",
+		})
+		require.NoError(t, err)
+
+		peerShouldNotReceiveUpdate(t, updTarget)
+		peerShouldNotReceiveUpdate(t, upd2)
+		peerShouldNotReceiveUpdate(t, upd3)
+
+		user, err := manager.Store.GetUserByUserID(ctx, store.LockingStrengthNone, targetUserID)
+		require.NoError(t, err)
+		assert.Equal(t, "renamed", user.Name)
+	})
+
+	t.Run("auto group change reassigning IPv6 refreshes the whole account", func(t *testing.T) {
+		account, err := manager.Store.GetAccount(ctx, accountID)
+		require.NoError(t, err)
+		account.Settings.IPv6EnabledGroups = []string{"ug-v6"}
+		require.NoError(t, manager.Store.SaveAccount(ctx, account))
+		require.NoError(t, manager.CreateGroup(ctx, accountID, userID, &types.Group{ID: "ug-v6", Name: "ug-v6"}))
+
+		drainPeerUpdates(updTarget)
+		drainPeerUpdates(upd2)
+		drainPeerUpdates(upd3)
+
+		_, err = manager.SaveUser(ctx, accountID, activity.SystemInitiator, &types.User{
+			Id: targetUserID, AccountID: accountID, Role: types.UserRoleUser,
+			AutoGroups: []string{"ug-linked", "ug-v6"}, Name: "renamed",
+		})
+		require.NoError(t, err)
+
+		// An IPv6 reassignment is visible to every peer that can reach the reassigned
+		// ones through any group, so peer3 refreshes even though it shares no policy.
+		peerShouldReceiveUpdate(t, updTarget)
+		peerShouldReceiveUpdate(t, upd2)
+		peerShouldReceiveUpdate(t, upd3)
+	})
+
+	t.Run("unblocking a user refreshes only the SSH rule destinations", func(t *testing.T) {
+		// An SSH rule that authorizes no group of its own ships the account's
+		// allowed-user set to its destinations, so those are the peers an unblock
+		// reaches — not the whole account.
+		_, err := manager.SavePolicy(ctx, accountID, userID, &types.Policy{
+			Enabled: true,
+			Rules: []*types.PolicyRule{{
+				Enabled:      true,
+				Sources:      []string{"ug-linked"},
+				Destinations: []string{"ug-dest"},
+				Protocol:     types.PolicyRuleProtocolNetbirdSSH,
+				Action:       types.PolicyTrafficActionAccept,
+			}},
+		}, true)
+		require.NoError(t, err)
+
+		blocked, err := manager.Store.GetUserByUserID(ctx, store.LockingStrengthNone, targetUserID)
+		require.NoError(t, err)
+		blocked.Blocked = true
+		require.NoError(t, manager.Store.SaveUser(ctx, blocked))
+
+		drainPeerUpdates(updTarget)
+		drainPeerUpdates(upd2)
+		drainPeerUpdates(upd3)
+
+		// Same auto-groups as the previous subtest left them, so no group change and
+		// no IPv6 reconciliation interferes: the unblock alone drives the refresh.
+		_, err = manager.SaveUser(ctx, accountID, activity.SystemInitiator, &types.User{
+			Id: targetUserID, AccountID: accountID, Role: types.UserRoleUser,
+			AutoGroups: []string{"ug-linked", "ug-v6"}, Name: "renamed",
+		})
+		require.NoError(t, err)
+
+		peerShouldReceiveUpdate(t, upd2)
+		peerShouldNotReceiveUpdate(t, upd3)
+	})
+}

--- a/management/server/affected_peers_user_test.go
+++ b/management/server/affected_peers_user_test.go
@@ -107,7 +107,7 @@ func TestAffectedPeers_SaveUser_OnlyAffectedPeersUpdated(t *testing.T) {
 		assert.Equal(t, "renamed", user.Name)
 	})
 
-	t.Run("auto group change reassigning IPv6 refreshes the whole account", func(t *testing.T) {
+	t.Run("auto group change reassigning IPv6 refreshes the changed peers and their observers", func(t *testing.T) {
 		account, err := manager.Store.GetAccount(ctx, accountID)
 		require.NoError(t, err)
 		account.Settings.IPv6EnabledGroups = []string{"ug-v6"}
@@ -124,11 +124,11 @@ func TestAffectedPeers_SaveUser_OnlyAffectedPeersUpdated(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// An IPv6 reassignment is visible to every peer that can reach the reassigned
-		// ones through any group, so peer3 refreshes even though it shares no policy.
+		// The reassigned peer refreshes with everyone it can reach: peer2 via the
+		// policy, but not peer3, which shares no group or policy with it.
 		peerShouldReceiveUpdate(t, updTarget)
 		peerShouldReceiveUpdate(t, upd2)
-		peerShouldReceiveUpdate(t, upd3)
+		peerShouldNotReceiveUpdate(t, upd3)
 	})
 
 	t.Run("unblocking a user refreshes only the SSH rule destinations", func(t *testing.T) {

--- a/management/server/affectedpeers/resolver.go
+++ b/management/server/affectedpeers/resolver.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
 
 	nbdns "github.com/netbirdio/netbird/dns"
 	rpservice "github.com/netbirdio/netbird/management/internals/modules/reverseproxy/service"
@@ -83,7 +84,7 @@ func (snap *Snapshot) loadCollections(ctx context.Context, s store.Store, accoun
 	hasGroupOrPeerChange := len(c.ChangedGroupIDs) > 0 || len(c.ChangedPeerIDs) > 0 || len(c.LinkGroups) > 0 || len(c.Resources) > 0
 	hasNetworkObject := len(c.Routers) > 0 || len(c.Resources) > 0 || len(c.Networks) > 0
 	// the resource<->router bridge can fire for any of these
-	needsRoutersResources := hasGroupOrPeerChange || len(c.PostureCheckIDs) > 0 || len(c.Policies) > 0 || hasNetworkObject
+	needsRoutersResources := hasGroupOrPeerChange || len(c.PostureCheckIDs) > 0 || len(c.Policies) > 0 || hasNetworkObject || len(c.UserGroupIDs) > 0 || c.AllowedUsersChanged
 
 	if needsRoutersResources {
 		if err := snap.loadPolicyRoutersResources(ctx, s, accountID); err != nil {
@@ -219,6 +220,18 @@ type Change struct {
 	// (correct when the peer's own attributes changed, e.g. IP/status).
 	OutputPeerIDs []string
 
+	// UserGroupIDs are groups whose USER membership changed (a user's auto-groups),
+	// as opposed to their peer membership. Peers ship the group -> user mapping only
+	// for the groups an SSH rule authorizes, so these refresh the destinations of the
+	// SSH rules authorizing them — independently of any peer moving between groups.
+	UserGroupIDs []string
+
+	// AllowedUsersChanged marks a change to the set of users allowed to open SSH
+	// sessions — a user was created, blocked or unblocked. That set is account-wide,
+	// and peers receive it through the SSH rules that name no group or user of their
+	// own, so those rules' destinations refresh.
+	AllowedUsersChanged bool
+
 	// LinkGroups are groups used ONLY to match policies/routes/routers and walk to the
 	// OPPOSITE side — they are never expanded to their own members. Use this when a
 	// peer's group membership changed: pass the peer in ChangedPeerIDs and its
@@ -240,6 +253,8 @@ func (c Change) isEmpty() bool {
 		len(c.Resources) == 0 &&
 		len(c.Networks) == 0 &&
 		len(c.PostureCheckIDs) == 0 &&
+		len(c.UserGroupIDs) == 0 &&
+		!c.AllowedUsersChanged &&
 		len(c.DistributionGroupIDs) == 0 &&
 		len(c.RemovedPeersByGroup) == 0 &&
 		len(c.LinkGroups) == 0 &&
@@ -358,6 +373,9 @@ func (r *resolver) walk() {
 		r.collectFromNetworkRouters()
 		r.collectFromProxyServices()
 	}
+
+	r.collectFromSSHAuthorizedGroups()
+	r.collectFromAllowedUsers()
 
 	r.collectFromChangedRoutes(r.change.Routes)
 	r.collectFromChangedRouters(r.change.Routers)
@@ -809,6 +827,59 @@ func (r *resolver) collectFromNameServers() {
 			r.foldOutputGroups(ns.Groups)
 		}
 	}
+}
+
+// collectFromSSHAuthorizedGroups folds the destinations of the enabled SSH rules that
+// authorize a group whose user membership changed. Those destination peers carry the
+// group -> user mapping for the groups they authorize, so they refresh even when no
+// peer moved between groups.
+func (r *resolver) collectFromSSHAuthorizedGroups() {
+	if len(r.change.UserGroupIDs) == 0 {
+		return
+	}
+
+	changed := toSet(r.change.UserGroupIDs)
+	for _, policy := range r.policies() {
+		for _, rule := range policy.Rules {
+			if !rule.Enabled || rule.Protocol != types.PolicyRuleProtocolNetbirdSSH {
+				continue
+			}
+			if !anyInSet(maps.Keys(rule.AuthorizedGroups), changed) {
+				continue
+			}
+			log.WithContext(r.ctx).Tracef("collectFromSSHAuthorizedGroups: rule %s authorizes a changed user group -> folding its destinations", rule.ID)
+			r.foldPolicySideForRule(policy, rule, sideDestination)
+		}
+	}
+}
+
+// collectFromAllowedUsers folds the destinations of the rules that make a peer carry
+// the account's allowed-user set, for a change to who is in that set.
+func (r *resolver) collectFromAllowedUsers() {
+	if !r.change.AllowedUsersChanged {
+		return
+	}
+
+	for _, policy := range r.policies() {
+		for _, rule := range policy.Rules {
+			if !rule.Enabled || !ruleShipsAllowedUsers(rule) {
+				continue
+			}
+			log.WithContext(r.ctx).Tracef("collectFromAllowedUsers: rule %s ships the allowed-user set -> folding its destinations", rule.ID)
+			r.foldPolicySideForRule(policy, rule, sideDestination)
+		}
+	}
+}
+
+// ruleShipsAllowedUsers reports whether a rule makes its destination peers carry the
+// account's allowed-user set. It mirrors the network map's SSH requirements except for
+// the destination peer's own SSH flag, which the snapshot does not hold — so it folds a
+// superset and never misses a peer.
+func ruleShipsAllowedUsers(rule *types.PolicyRule) bool {
+	if rule.Protocol == types.PolicyRuleProtocolNetbirdSSH {
+		return len(rule.AuthorizedGroups) == 0 && rule.AuthorizedUser == ""
+	}
+	return types.PolicyRuleImpliesLegacySSH(rule)
 }
 
 func (r *resolver) collectFromDNSSettings() {

--- a/management/server/affectedpeers/resolver_test.go
+++ b/management/server/affectedpeers/resolver_test.go
@@ -85,6 +85,8 @@ func TestChangeIsEmpty(t *testing.T) {
 	assert.False(t, Change{Resources: []*resourceTypes.NetworkResource{{ID: "r"}}}.isEmpty())
 	assert.False(t, Change{Networks: []*networkTypes.Network{{ID: "n"}}}.isEmpty())
 	assert.False(t, Change{PostureCheckIDs: []string{"pc"}}.isEmpty())
+	assert.False(t, Change{UserGroupIDs: []string{"g"}}.isEmpty())
+	assert.False(t, Change{AllowedUsersChanged: true}.isEmpty())
 }
 
 func TestPolicyReferencesPostureChecks(t *testing.T) {

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -593,7 +593,6 @@ func (am *DefaultAccountManager) SaveOrAddUsers(ctx context.Context, accountID, 
 		return nil, err
 	}
 
-	var requiresAccountUpdate bool
 	var snaps []*affectedpeers.Snapshot
 	var changes []affectedpeers.Change
 	var peersToExpire []*nbpeer.Peer
@@ -631,7 +630,7 @@ func (am *DefaultAccountManager) SaveOrAddUsers(ctx context.Context, accountID, 
 		}
 
 		err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
-			effect, updatedUser, userPeersToExpire, userEvents, err := am.processUserUpdate(
+			change, updatedUser, userPeersToExpire, userEvents, err := am.processUserUpdate(
 				ctx, transaction, groupsMap, accountID, initiatorUserID, initiatorUser, update, addIfNotExists, settings,
 			)
 			if err != nil {
@@ -643,14 +642,13 @@ func (am *DefaultAccountManager) SaveOrAddUsers(ctx context.Context, accountID, 
 				return fmt.Errorf("failed to save updated user %s: %w", update.Id, err)
 			}
 
-			snap, err := affectedpeers.Load(ctx, transaction, accountID, effect.change)
+			snap, err := affectedpeers.Load(ctx, transaction, accountID, change)
 			if err != nil {
 				return err
 			}
 
-			requiresAccountUpdate = requiresAccountUpdate || effect.requiresAccountUpdate
 			snaps = append(snaps, snap)
-			changes = append(changes, effect.change)
+			changes = append(changes, change)
 			usersToSave = append(usersToSave, updatedUser)
 			addUserEvents = append(addUserEvents, userEvents...)
 			peersToExpire = append(peersToExpire, userPeersToExpire...)
@@ -695,11 +693,7 @@ func (am *DefaultAccountManager) SaveOrAddUsers(ctx context.Context, accountID, 
 		if err = am.Store.IncrementNetworkSerial(ctx, accountID); err != nil {
 			return nil, fmt.Errorf("failed to increment network serial: %w", err)
 		}
-		if requiresAccountUpdate {
-			am.UpdateAccountPeers(ctx, accountID, types.UpdateReason{Resource: types.UpdateResourceUser, Operation: types.UpdateOperationUpdate})
-		} else {
-			go am.dispatchAffected(ctx, accountID, snaps, changes)
-		}
+		go am.dispatchAffected(ctx, accountID, snaps, changes)
 	}
 
 	return updatedUsersInfo, globalErr
@@ -770,31 +764,22 @@ func (am *DefaultAccountManager) prepareUserUpdateEvents(ctx context.Context, ac
 	return eventsToStore
 }
 
-// userUpdateEffect describes how a user update has to reach peers. Users only enter a
-// network map through the SSH rules, so the change resolves to those rules' peers —
-// except when the update triggers an IPv6 reconciliation, which reassigns addresses
-// across the account and so has to reach everyone.
-type userUpdateEffect struct {
-	change                affectedpeers.Change
-	requiresAccountUpdate bool
-}
-
 func (am *DefaultAccountManager) processUserUpdate(ctx context.Context, transaction store.Store, groupsMap map[string]*types.Group,
-	accountID, initiatorUserId string, initiatorUser, update *types.User, addIfNotExists bool, settings *types.Settings) (userUpdateEffect, *types.User, []*nbpeer.Peer, []func(), error) {
+	accountID, initiatorUserId string, initiatorUser, update *types.User, addIfNotExists bool, settings *types.Settings) (affectedpeers.Change, *types.User, []*nbpeer.Peer, []func(), error) {
 
-	var effect userUpdateEffect
+	var change affectedpeers.Change
 
 	if update == nil {
-		return effect, nil, nil, nil, status.Errorf(status.InvalidArgument, "provided user update is nil")
+		return change, nil, nil, nil, status.Errorf(status.InvalidArgument, "provided user update is nil")
 	}
 
 	oldUser, isNewUser, err := getUserOrCreateIfNotExists(ctx, transaction, accountID, update, addIfNotExists)
 	if err != nil {
-		return effect, nil, nil, nil, err
+		return change, nil, nil, nil, err
 	}
 
 	if err := validateUserUpdate(groupsMap, initiatorUser, oldUser, update); err != nil {
-		return effect, nil, nil, nil, err
+		return change, nil, nil, nil, err
 	}
 
 	// only auto groups, revoked status, and integration reference can be updated for now
@@ -815,13 +800,13 @@ func (am *DefaultAccountManager) processUserUpdate(ctx context.Context, transact
 	var transferredOwnerRole bool
 	result, err := handleOwnerRoleTransfer(ctx, transaction, initiatorUser, update)
 	if err != nil {
-		return effect, nil, nil, nil, err
+		return change, nil, nil, nil, err
 	}
 	transferredOwnerRole = result
 
 	userPeers, err := transaction.GetUserPeers(ctx, store.LockingStrengthNone, updatedUser.AccountID, update.Id)
 	if err != nil {
-		return effect, nil, nil, nil, err
+		return change, nil, nil, nil, err
 	}
 
 	var peersToExpire []*nbpeer.Peer
@@ -836,13 +821,24 @@ func (am *DefaultAccountManager) processUserUpdate(ctx context.Context, transact
 	// it maps into changes — including the All group that holds every active user.
 	// Otherwise only the auto-groups it joined or left do.
 	if isNewUser || oldUser.IsBlocked() != updatedUser.IsBlocked() {
-		effect.change.AllowedUsersChanged = true
-		effect.change.UserGroupIDs = slices.Concat(oldUser.AutoGroups, updatedUser.AutoGroups, allGroupIDs(groupsMap))
+		change.AllowedUsersChanged = true
+		change.UserGroupIDs = slices.Concat(oldUser.AutoGroups, updatedUser.AutoGroups, allGroupIDs(groupsMap))
 	} else {
-		effect.change.UserGroupIDs = slices.Concat(
+		change.UserGroupIDs = slices.Concat(
 			util.Difference(oldUser.AutoGroups, updatedUser.AutoGroups),
 			util.Difference(updatedUser.AutoGroups, oldUser.AutoGroups),
 		)
+	}
+
+	// The user's peers are the changed entity in every scenario the update can
+	// produce — group membership, IPv6 assignment, SSH mappings — so they refresh
+	// together with every peer they can connect to, like on a regular peer update.
+	// An update that changes neither the auto-groups nor the active-user set has no
+	// peer-visible effect and refreshes nobody.
+	if len(change.UserGroupIDs) > 0 || change.AllowedUsersChanged {
+		for _, peer := range userPeers {
+			change.ChangedPeerIDs = append(change.ChangedPeerIDs, peer.ID)
+		}
 	}
 
 	var removedGroups, addedGroups []string
@@ -852,36 +848,27 @@ func (am *DefaultAccountManager) processUserUpdate(ctx context.Context, transact
 		for _, peer := range userPeers {
 			for _, groupID := range removedGroups {
 				if err := transaction.RemovePeerFromGroup(ctx, peer.ID, groupID); err != nil {
-					return effect, nil, nil, nil, fmt.Errorf("failed to remove peer %s from group %s: %w", peer.ID, groupID, err)
+					return change, nil, nil, nil, fmt.Errorf("failed to remove peer %s from group %s: %w", peer.ID, groupID, err)
 				}
 			}
 			for _, groupID := range addedGroups {
 				if err := transaction.AddPeerToGroup(ctx, accountID, peer.ID, groupID); err != nil {
-					return effect, nil, nil, nil, fmt.Errorf("failed to add peer %s to group %s: %w", peer.ID, groupID, err)
+					return change, nil, nil, nil, fmt.Errorf("failed to add peer %s to group %s: %w", peer.ID, groupID, err)
 				}
 			}
 		}
 
 		allGroupChanges := slices.Concat(removedGroups, addedGroups)
-		if len(allGroupChanges) > 0 {
-			effect.change.LinkGroups = allGroupChanges
-			for _, peer := range userPeers {
-				effect.change.OutputPeerIDs = append(effect.change.OutputPeerIDs, peer.ID)
-			}
-		}
-
-		// The reconciliation reassigns IPv6 addresses across the account, which every
-		// peer that can reach the reassigned ones observes.
-		effect.requiresAccountUpdate = ipv6ReconcileNeeded(settings, allGroupChanges)
+		change.LinkGroups = allGroupChanges
 
 		if err := am.reconcileIPv6ForGroupChanges(ctx, transaction, accountID, allGroupChanges); err != nil {
-			return effect, nil, nil, nil, fmt.Errorf("reconcile IPv6 for group changes: %w", err)
+			return change, nil, nil, nil, fmt.Errorf("reconcile IPv6 for group changes: %w", err)
 		}
 	}
 
 	userEventsToAdd := am.prepareUserUpdateEvents(ctx, updatedUser.AccountID, initiatorUserId, oldUser, updatedUser, transferredOwnerRole, isNewUser, removedGroups, addedGroups, transaction)
 
-	return effect, updatedUser, peersToExpire, userEventsToAdd, nil
+	return change, updatedUser, peersToExpire, userEventsToAdd, nil
 }
 
 // allGroupIDs returns the ID of the account's All group, which every active user maps

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -593,7 +593,9 @@ func (am *DefaultAccountManager) SaveOrAddUsers(ctx context.Context, accountID, 
 		return nil, err
 	}
 
-	var updateAccountPeers bool
+	var requiresAccountUpdate bool
+	var snaps []*affectedpeers.Snapshot
+	var changes []affectedpeers.Change
 	var peersToExpire []*nbpeer.Peer
 	var addUserEvents []func()
 	var usersToSave = make([]*types.User, 0, len(updates))
@@ -629,20 +631,26 @@ func (am *DefaultAccountManager) SaveOrAddUsers(ctx context.Context, accountID, 
 		}
 
 		err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
-			_, updatedUser, userPeersToExpire, userEvents, err := am.processUserUpdate(
+			effect, updatedUser, userPeersToExpire, userEvents, err := am.processUserUpdate(
 				ctx, transaction, groupsMap, accountID, initiatorUserID, initiatorUser, update, addIfNotExists, settings,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to process update for user %s: %w", update.Id, err)
 			}
 
-			updateAccountPeers = true
-
 			err = transaction.SaveUser(ctx, updatedUser)
 			if err != nil {
 				return fmt.Errorf("failed to save updated user %s: %w", update.Id, err)
 			}
 
+			snap, err := affectedpeers.Load(ctx, transaction, accountID, effect.change)
+			if err != nil {
+				return err
+			}
+
+			requiresAccountUpdate = requiresAccountUpdate || effect.requiresAccountUpdate
+			snaps = append(snaps, snap)
+			changes = append(changes, effect.change)
 			usersToSave = append(usersToSave, updatedUser)
 			addUserEvents = append(addUserEvents, userEvents...)
 			peersToExpire = append(peersToExpire, userPeersToExpire...)
@@ -683,11 +691,15 @@ func (am *DefaultAccountManager) SaveOrAddUsers(ctx context.Context, accountID, 
 			log.WithContext(ctx).Errorf("failed update expired peers: %s", err)
 			return nil, err
 		}
-	} else if updateAccountPeers {
+	} else if len(usersToSave) > 0 {
 		if err = am.Store.IncrementNetworkSerial(ctx, accountID); err != nil {
 			return nil, fmt.Errorf("failed to increment network serial: %w", err)
 		}
-		am.UpdateAccountPeers(ctx, accountID, types.UpdateReason{Resource: types.UpdateResourceUser, Operation: types.UpdateOperationUpdate})
+		if requiresAccountUpdate {
+			am.UpdateAccountPeers(ctx, accountID, types.UpdateReason{Resource: types.UpdateResourceUser, Operation: types.UpdateOperationUpdate})
+		} else {
+			go am.dispatchAffected(ctx, accountID, snaps, changes)
+		}
 	}
 
 	return updatedUsersInfo, globalErr
@@ -758,20 +770,31 @@ func (am *DefaultAccountManager) prepareUserUpdateEvents(ctx context.Context, ac
 	return eventsToStore
 }
 
+// userUpdateEffect describes how a user update has to reach peers. Users only enter a
+// network map through the SSH rules, so the change resolves to those rules' peers —
+// except when the update triggers an IPv6 reconciliation, which reassigns addresses
+// across the account and so has to reach everyone.
+type userUpdateEffect struct {
+	change                affectedpeers.Change
+	requiresAccountUpdate bool
+}
+
 func (am *DefaultAccountManager) processUserUpdate(ctx context.Context, transaction store.Store, groupsMap map[string]*types.Group,
-	accountID, initiatorUserId string, initiatorUser, update *types.User, addIfNotExists bool, settings *types.Settings) (bool, *types.User, []*nbpeer.Peer, []func(), error) {
+	accountID, initiatorUserId string, initiatorUser, update *types.User, addIfNotExists bool, settings *types.Settings) (userUpdateEffect, *types.User, []*nbpeer.Peer, []func(), error) {
+
+	var effect userUpdateEffect
 
 	if update == nil {
-		return false, nil, nil, nil, status.Errorf(status.InvalidArgument, "provided user update is nil")
+		return effect, nil, nil, nil, status.Errorf(status.InvalidArgument, "provided user update is nil")
 	}
 
 	oldUser, isNewUser, err := getUserOrCreateIfNotExists(ctx, transaction, accountID, update, addIfNotExists)
 	if err != nil {
-		return false, nil, nil, nil, err
+		return effect, nil, nil, nil, err
 	}
 
 	if err := validateUserUpdate(groupsMap, initiatorUser, oldUser, update); err != nil {
-		return false, nil, nil, nil, err
+		return effect, nil, nil, nil, err
 	}
 
 	// only auto groups, revoked status, and integration reference can be updated for now
@@ -792,19 +815,34 @@ func (am *DefaultAccountManager) processUserUpdate(ctx context.Context, transact
 	var transferredOwnerRole bool
 	result, err := handleOwnerRoleTransfer(ctx, transaction, initiatorUser, update)
 	if err != nil {
-		return false, nil, nil, nil, err
+		return effect, nil, nil, nil, err
 	}
 	transferredOwnerRole = result
 
 	userPeers, err := transaction.GetUserPeers(ctx, store.LockingStrengthNone, updatedUser.AccountID, update.Id)
 	if err != nil {
-		return false, nil, nil, nil, err
+		return effect, nil, nil, nil, err
 	}
 
 	var peersToExpire []*nbpeer.Peer
 
 	if !oldUser.IsBlocked() && update.IsBlocked() {
 		peersToExpire = userPeers
+	}
+
+	// A user reaches a peer's network map only through the SSH rules: as part of a
+	// group -> user mapping, and as part of the account's allowed-user set. Creating,
+	// blocking or unblocking a user adds it to or removes it from both, so every group
+	// it maps into changes — including the All group that holds every active user.
+	// Otherwise only the auto-groups it joined or left do.
+	if isNewUser || oldUser.IsBlocked() != updatedUser.IsBlocked() {
+		effect.change.AllowedUsersChanged = true
+		effect.change.UserGroupIDs = slices.Concat(oldUser.AutoGroups, updatedUser.AutoGroups, allGroupIDs(groupsMap))
+	} else {
+		effect.change.UserGroupIDs = slices.Concat(
+			util.Difference(oldUser.AutoGroups, updatedUser.AutoGroups),
+			util.Difference(updatedUser.AutoGroups, oldUser.AutoGroups),
+		)
 	}
 
 	var removedGroups, addedGroups []string
@@ -814,26 +852,47 @@ func (am *DefaultAccountManager) processUserUpdate(ctx context.Context, transact
 		for _, peer := range userPeers {
 			for _, groupID := range removedGroups {
 				if err := transaction.RemovePeerFromGroup(ctx, peer.ID, groupID); err != nil {
-					return false, nil, nil, nil, fmt.Errorf("failed to remove peer %s from group %s: %w", peer.ID, groupID, err)
+					return effect, nil, nil, nil, fmt.Errorf("failed to remove peer %s from group %s: %w", peer.ID, groupID, err)
 				}
 			}
 			for _, groupID := range addedGroups {
 				if err := transaction.AddPeerToGroup(ctx, accountID, peer.ID, groupID); err != nil {
-					return false, nil, nil, nil, fmt.Errorf("failed to add peer %s to group %s: %w", peer.ID, groupID, err)
+					return effect, nil, nil, nil, fmt.Errorf("failed to add peer %s to group %s: %w", peer.ID, groupID, err)
 				}
 			}
 		}
 
 		allGroupChanges := slices.Concat(removedGroups, addedGroups)
+		if len(allGroupChanges) > 0 {
+			effect.change.LinkGroups = allGroupChanges
+			for _, peer := range userPeers {
+				effect.change.OutputPeerIDs = append(effect.change.OutputPeerIDs, peer.ID)
+			}
+		}
+
+		// The reconciliation reassigns IPv6 addresses across the account, which every
+		// peer that can reach the reassigned ones observes.
+		effect.requiresAccountUpdate = ipv6ReconcileNeeded(settings, allGroupChanges)
+
 		if err := am.reconcileIPv6ForGroupChanges(ctx, transaction, accountID, allGroupChanges); err != nil {
-			return false, nil, nil, nil, fmt.Errorf("reconcile IPv6 for group changes: %w", err)
+			return effect, nil, nil, nil, fmt.Errorf("reconcile IPv6 for group changes: %w", err)
 		}
 	}
 
-	updateAccountPeers := len(userPeers) > 0
 	userEventsToAdd := am.prepareUserUpdateEvents(ctx, updatedUser.AccountID, initiatorUserId, oldUser, updatedUser, transferredOwnerRole, isNewUser, removedGroups, addedGroups, transaction)
 
-	return updateAccountPeers, updatedUser, peersToExpire, userEventsToAdd, nil
+	return effect, updatedUser, peersToExpire, userEventsToAdd, nil
+}
+
+// allGroupIDs returns the ID of the account's All group, which every active user maps
+// into, as a slice so callers can concatenate it.
+func allGroupIDs(groupsMap map[string]*types.Group) []string {
+	for _, group := range groupsMap {
+		if group.IsGroupAll() {
+			return []string{group.ID}
+		}
+	}
+	return nil
 }
 
 // getUserOrCreateIfNotExists retrieves the existing user or creates a new one if it doesn't exist.


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Group membership and allowed-user changes now update only affected peers and SSH policy destinations, reducing unnecessary network updates.
  * JWT group additions and removals now reliably refresh associated users and policy-linked peers.
  * IPv6-related group changes trigger a complete peer update when address reassignment may affect connectivity.
* **Bug Fixes**
  * Improved synchronization of SSH access rules when authorized groups or account-wide allowed users change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->