### PR TITLE
[infrastructure] Detect community GHCR images during enterprise migration

### DIFF
--- a/infrastructure_files/migrate-to-enterprise.sh
+++ b/infrastructure_files/migrate-to-enterprise.sh
@@ -173,11 +173,11 @@ EOF
 # ---------------------------------------------------------------------------
 
 detect_combined_service() {
-  yq eval '.services | to_entries | map(select(.value.image | test("^netbirdio/netbird-server"))) | .[0].key // ""' "$COMPOSE_FILE"
+  yq eval '.services | to_entries | map(select(.value.image | test("^(ghcr\\.io/)?netbirdio/netbird-server([:@]|$)"))) | .[0].key // ""' "$COMPOSE_FILE"
 }
 
 detect_dashboard_service() {
-  yq eval '.services | to_entries | map(select(.value.image | test("^netbirdio/dashboard"))) | .[0].key // ""' "$COMPOSE_FILE"
+  yq eval '.services | to_entries | map(select(.value.image | test("^(ghcr\\.io/)?netbirdio/dashboard([:@]|$)"))) | .[0].key // ""' "$COMPOSE_FILE"
 }
 
 detect_config_yaml_host_path() {
@@ -661,12 +661,12 @@ init_migration() {
   COMPOSE_NETWORK=$(detect_compose_network)
 
   if [[ -z "$COMBINED_SERVICE" ]]; then
-    echo "Could not find a service running netbirdio/netbird-server* in $COMPOSE_FILE." > /dev/stderr
+    echo "Could not find a service running netbirdio/netbird-server or ghcr.io/netbirdio/netbird-server in $COMPOSE_FILE." > /dev/stderr
     echo "This script targets the community combined-server deployment." > /dev/stderr
     exit 1
   fi
   if [[ -z "$DASHBOARD_SERVICE" ]]; then
-    echo "Could not find a service running netbirdio/dashboard* in $COMPOSE_FILE." > /dev/stderr
+    echo "Could not find a service running netbirdio/dashboard or ghcr.io/netbirdio/dashboard in $COMPOSE_FILE." > /dev/stderr
     exit 1
   fi
   if [[ -z "$CONFIG_YAML_HOST" ]]; then


### PR DESCRIPTION


## Describe your changes
The migration wizard detected the community deployment only by the Docker Hub image prefix (netbirdio/netbird-server), so deployments installed from the ghcr.io mirror failed with "Could not find a service running netbirdio/netbird-server*".

This broadens the server and dashboard detection to also accept ghcr.io/netbirdio/... images. The regexes are anchored at the tag/digest separator so Enterprise images (netbird-server-cloud, dashboard-cloud) are still rejected, an already-migrated deployment must not be detected as a community one. Error messages updated to mention both forms.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why) - It is a script change which doesn't require any documentation change

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service detection for both local and `ghcr.io`-prefixed NetBird server and dashboard images.
  * Updated validation messages to clearly list all accepted image formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->