### PR TITLE
fix(proxy): revalidate OIDC session cookies via ValidateSession

### DIFF
--- a/proxy/internal/auth/middleware.go
+++ b/proxy/internal/auth/middleware.go
@@ -316,6 +316,8 @@ func (mw *Middleware) handleOAuthCallbackError(w http.ResponseWriter, r *http.Re
 
 // forwardWithSessionCookie checks for a valid session cookie and, if found,
 // sets the user identity on the request context and forwards to the next handler.
+// OIDC cookies are revalidated via management ValidateSession so blocked/pending
+// users (and stale group membership) cannot ride a previously minted JWT until TTL.
 func (mw *Middleware) forwardWithSessionCookie(w http.ResponseWriter, r *http.Request, host string, config DomainConfig, next http.Handler) bool {
 	cookie, err := r.Cookie(auth.SessionCookieName)
 	if err != nil {
@@ -325,6 +327,36 @@ func (mw *Middleware) forwardWithSessionCookie(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return false
 	}
+
+	if method == string(auth.MethodOIDC) && mw.sessionValidator != nil {
+		result, err := mw.validateSessionToken(r.Context(), host, cookie.Value, config.SessionPublicKey, auth.MethodOIDC)
+		if err != nil {
+			if errors.Is(err, errValidationUnavailable) {
+				http.Error(w, "authentication service unavailable", http.StatusBadGateway)
+				return true
+			}
+			clearSessionCookie(w)
+			return false
+		}
+		if !result.Valid {
+			mw.logger.WithFields(log.Fields{
+				"domain":        host,
+				"denied_reason": result.DeniedReason,
+				"user_id":       result.UserID,
+			}).Debug("Session cookie validation denied")
+			clearSessionCookie(w)
+			return false
+		}
+		userID = result.UserID
+		email = result.UserEmail
+		if len(result.Groups) > 0 {
+			groups = result.Groups
+		}
+		if len(result.GroupNames) > 0 {
+			groupNames = result.GroupNames
+		}
+	}
+
 	if cd := proxy.CapturedDataFromContext(r.Context()); cd != nil {
 		cd.SetUserID(userID)
 		cd.SetUserEmail(email)
@@ -334,6 +366,19 @@ func (mw *Middleware) forwardWithSessionCookie(w http.ResponseWriter, r *http.Re
 	}
 	next.ServeHTTP(w, r)
 	return true
+}
+
+// clearSessionCookie expires the proxy session cookie so a denied JWT cannot be replayed.
+func clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     auth.SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
 }
 
 // forwardWithTunnelPeer is the OIDC fast-path for requests originating on the

--- a/proxy/internal/auth/middleware_test.go
+++ b/proxy/internal/auth/middleware_test.go
@@ -264,6 +264,112 @@ func TestProtect_ValidSessionCookiePassesThrough(t *testing.T) {
 	assert.Equal(t, "authenticated", rec.Body.String())
 }
 
+// stubSessionStatusValidator drives ValidateSession for the OIDC cookie hot path.
+type stubSessionStatusValidator struct {
+	called bool
+	valid  bool
+}
+
+func (s *stubSessionStatusValidator) ValidateSession(_ context.Context, _ *proto.ValidateSessionRequest, _ ...grpc.CallOption) (*proto.ValidateSessionResponse, error) {
+	s.called = true
+	return &proto.ValidateSessionResponse{
+		Valid:     s.valid,
+		UserId:    "oidc-user",
+		UserEmail: "user@example.com",
+	}, nil
+}
+
+func (s *stubSessionStatusValidator) ValidateTunnelPeer(context.Context, *proto.ValidateTunnelPeerRequest, ...grpc.CallOption) (*proto.ValidateTunnelPeerResponse, error) {
+	return nil, errors.New("not used in this test")
+}
+
+func TestProtect_OIDCSessionCookieRevalidatedViaManagement(t *testing.T) {
+	validator := &stubSessionStatusValidator{valid: true}
+	mw := NewMiddleware(log.StandardLogger(), validator, nil)
+	kp := generateTestKeyPair(t)
+
+	scheme := &stubScheme{method: auth.MethodOIDC, promptID: "oidc"}
+	require.NoError(t, mw.AddDomain("example.com", []Scheme{scheme}, kp.PublicKey, time.Hour, "", "", nil, false))
+
+	token, err := sessionkey.SignToken(kp.PrivateKey, "oidc-user", "user@example.com", "example.com", auth.MethodOIDC, nil, nil, time.Hour)
+	require.NoError(t, err)
+
+	var backendCalled bool
+	handler := mw.Protect(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		backendCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.True(t, validator.called, "OIDC cookie must call ValidateSession")
+	assert.True(t, backendCalled)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestProtect_OIDCSessionCookieDeniedClearsCookie(t *testing.T) {
+	validator := &stubSessionStatusValidator{valid: false}
+	mw := NewMiddleware(log.StandardLogger(), validator, nil)
+	kp := generateTestKeyPair(t)
+
+	scheme := &stubScheme{method: auth.MethodOIDC, promptID: "oidc"}
+	require.NoError(t, mw.AddDomain("example.com", []Scheme{scheme}, kp.PublicKey, time.Hour, "", "", nil, false))
+
+	token, err := sessionkey.SignToken(kp.PrivateKey, "oidc-user", "user@example.com", "example.com", auth.MethodOIDC, nil, nil, time.Hour)
+	require.NoError(t, err)
+
+	var backendCalled bool
+	handler := mw.Protect(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		backendCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.True(t, validator.called, "OIDC cookie must call ValidateSession")
+	assert.False(t, backendCalled, "denied status must not reach the backend")
+	cleared := false
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == auth.SessionCookieName && c.MaxAge < 0 {
+			cleared = true
+		}
+	}
+	assert.True(t, cleared, "denied cookie must be cleared")
+}
+
+func TestProtect_PINSessionCookieSkipsValidateSession(t *testing.T) {
+	validator := &stubSessionStatusValidator{valid: false}
+	mw := NewMiddleware(log.StandardLogger(), validator, nil)
+	kp := generateTestKeyPair(t)
+
+	scheme := &stubScheme{method: auth.MethodPIN, promptID: "pin"}
+	require.NoError(t, mw.AddDomain("example.com", []Scheme{scheme}, kp.PublicKey, time.Hour, "", "", nil, false))
+
+	token, err := sessionkey.SignToken(kp.PrivateKey, "pin-user", "", "example.com", auth.MethodPIN, nil, nil, time.Hour)
+	require.NoError(t, err)
+
+	var backendCalled bool
+	handler := mw.Protect(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		backendCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.False(t, validator.called, "PIN cookies must not hit ValidateSession")
+	assert.True(t, backendCalled)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
 // TestProtect_SessionCookieGroupsPropagate verifies the cookie path lifts the
 // JWT's groups claim into CapturedData so policy-aware middlewares can
 // authorise without an extra management round-trip.


### PR DESCRIPTION
## Summary
- Follow-up to #7105 / triage discussion [#7109](https://github.com/netbirdio/netbird/discussions/7109).
- Management `ValidateSession` now denies pending/blocked users, but `forwardWithSessionCookie` still accepted a locally valid Ed25519 JWT without calling it.
- OIDC cookies now go through the existing `validateSessionToken` → gRPC path; denied cookies are cleared. PIN cookies remain local-only.

## Test plan
- [x] `go test ./proxy/internal/auth/ -run 'SessionCookie|OIDCSession|PINSession'`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * OIDC sessions are now revalidated before requests proceed.
  * Validated identity and group information is used when available.
  * Invalid or denied sessions are cleared and redirected to authentication.
  * Infrastructure validation failures return an appropriate error.
* **Bug Fixes**
  * PIN-based sessions continue to access the backend without OIDC validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->