### PR TITLE
[client] Fix credentials for the gtk3 package uploads

### DIFF
--- a/.goreleaser_ui_gtk3.yaml
+++ b/.goreleaser_ui_gtk3.yaml
@@ -112,6 +112,13 @@ uploads:
   # The gtk3 packages reuse the netbird-ui package name, so they live in
   # dedicated repo paths (deb distribution `gtk3`, yum path `yum-gtk3`) that
   # legacy distros point their repo config at.
+  #
+  # GoReleaser derives the credential env var from the upload name, so these
+  # would look for UPLOAD_DEBIAN-GTK3_SECRET / UPLOAD_YUM-GTK3_SECRET. The
+  # release workflow only exports UPLOAD_DEBIAN_SECRET / UPLOAD_YUM_SECRET, and
+  # a missing secret is a silent skip rather than a failure -- the packages
+  # reached the GitHub release but never the package repositories. Point
+  # `password` at the exported vars so both uploads authenticate.
   - name: debian-gtk3
     skip: "{{ .Env.SKIP_PUBLISH }}"
     ids:
@@ -119,6 +126,7 @@ uploads:
     mode: archive
     target: https://pkgs.wiretrustee.com/debian/pool/{{ .ArtifactName }};deb.distribution=gtk3;deb.component=main;deb.architecture={{ if .Arm }}armhf{{ else }}{{ .Arch }}{{ end }};deb.package=
     username: dev@wiretrustee.com
+    password: "{{ .Env.UPLOAD_DEBIAN_SECRET }}"
     method: PUT
 
   - name: yum-gtk3
@@ -128,4 +136,5 @@ uploads:
     mode: archive
     target: https://pkgs.wiretrustee.com/yum-gtk3/{{ .Arch }}{{ if .Arm }}{{ .Arm }}{{ end }}
     username: dev@wiretrustee.com
+    password: "{{ .Env.UPLOAD_YUM_SECRET }}"
     method: PUT


### PR DESCRIPTION
## Describe your changes

GoReleaser derives the upload credential env var from the upload name, so the `debian-gtk3` and `yum-gtk3` uploads looked for UPLOAD_DEBIAN-GTK3_SECRET and UPLOAD_YUM-GTK3_SECRET. The release workflow only exports UPLOAD_DEBIAN_SECRET and UPLOAD_YUM_SECRET.

A missing secret is a silent skip rather than a failure, so the release job stayed green while both uploads were dropped: the packages reached the GitHub release but never the package repositories, leaving pkgs.netbird.io/debian dists/gtk3 and pkgs.netbird.io/yum-gtk3 unpublished.

Set `password` explicitly on both uploads so they authenticate with the secrets the workflow already exports. No new secret or env var is needed.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GTK3 Debian and Yum package uploads by using the correct publishing credentials.
  * Prevented release uploads from failing when upload-specific secrets are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->