### PR TITLE
[infrastructure] Add Crowdin configuration for UI translation sync

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,3 +2,7 @@ files:
   - source: /client/ui/i18n/locales/en/common.json
     translation: /client/ui/i18n/locales/%locale%/common.json
     type: chrome
+    languages_mapping:
+      locale:
+        es-ES: es
+        pt-BR: pt

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,8 @@
+files:
+  - source: /client/ui/i18n/locales/en/common.json
+    translation: /client/ui/i18n/locales/%locale%/common.json
+    type: chrome
+    languages_mapping:
+      locale:
+        es-ES: es
+        pt-BR: pt

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,7 +2,3 @@ files:
   - source: /client/ui/i18n/locales/en/common.json
     translation: /client/ui/i18n/locales/%locale%/common.json
     type: chrome
-    languages_mapping:
-      locale:
-        es-ES: es
-        pt-BR: pt


### PR DESCRIPTION
## Describe your changes

Adds a `crowdin.yml` so the Crowdin GitHub integration can sync the desktop UI locale bundles. The integration is connected but has been syncing zero files because it expects this configuration file in the repository root.

- Source: `client/ui/i18n/locales/en/common.json` (Chrome JSON, `description` fields become translator context)
- Translations: `client/ui/i18n/locales/%locale%/common.json`
- Maps Crowdin's `es-ES`/`pt-BR` locale codes to the repo's `es`/`pt` directories

No runtime behavior changes; the file is only read by Crowdin.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (Crowdin-only configuration file, translator workflow is documented in `client/ui/i18n/TRANSLATING.md`)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localization configuration for generating Spanish and Brazilian Portuguese translations from the English locale.
  * Enabled Chrome-compatible localization file formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->