### PR TITLE
[doc] Point translation contributions at Crowdin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,7 @@ aligns with our security standards and design expectations.
         - [Test suite](#test-suite)
     - [Checklist before submitting a PR](#checklist-before-submitting-a-pr)
     - [When we close a PR](#when-we-close-a-pr)
+    - [Translations](#translations)
     - [Other project repositories](#other-project-repositories)
     - [Contributor License Agreement](#contributor-license-agreement)
 
@@ -611,6 +612,17 @@ We would rather redirect early than let a PR sit. We may close one if:
 A closed PR is not a rejected idea. Take it back to the
 [discussion](https://github.com/netbirdio/netbird/discussions), settle the
 approach, and reopen the work from there.
+
+## Translations
+
+Desktop UI translations are not contributed through pull requests. Translate on
+[Crowdin](https://crowdin.com/project/netbird) instead: no ticket needed, just
+join the project and pick your language. Crowdin syncs with this repository and
+opens the service PRs itself, so hand-edited locale files would conflict with
+the next sync. Style, terminology, and review guidance live in
+[client/ui/i18n/TRANSLATING.md](client/ui/i18n/TRANSLATING.md). To request a
+language the project does not offer yet, ask on the Crowdin project page or in
+a [discussion](https://github.com/netbirdio/netbird/discussions).
 
 ## Other project repositories
 

--- a/client/ui/i18n/TRANSLATING.md
+++ b/client/ui/i18n/TRANSLATING.md
@@ -2,9 +2,22 @@
 
 A short brief for translating the desktop UI — for any translator, human or AI agent (*"you"* = whoever's translating).
 
-**Drive an agent with:** *"Read `i18n/TRANSLATING.md` and translate the UI to Russian"* — or *"…and review the existing German translation."*
+**Translations are managed on Crowdin: <https://crowdin.com/project/netbird>.** Join the project, pick your language, and translate in the editor. Each string carries a context note (the `description` from the source file) telling you what it is and where it shows up, and the project's glossary, style guide, and QA checks are generated from this document.
 
-> 💡 **The one habit that matters most:** read each key's `description` before translating it. Labels are terse and ambiguous on their own; the `description` tells you what the string is, where it shows up, what to keep verbatim, and what it actually means.
+> 💡 **The one habit that matters most:** read each string's context before translating it. Labels are terse and ambiguous on their own; the context tells you what the string is, where it shows up, what to keep verbatim, and what it actually means.
+
+---
+
+## How contributions flow
+
+```
+i18n/locales/en/common.json ──sync──▶ Crowdin ──service PR──▶ i18n/locales/<code>/common.json
+```
+
+- `i18n/locales/en/common.json` is the source of truth. New and changed strings sync to Crowdin automatically (see `crowdin.yml` in the repository root).
+- Crowdin opens and updates a service pull request with the translated bundles. Maintainers review and merge it; key parity, key order, and file shape are guaranteed by the export.
+- Don't hand-edit `i18n/locales/<code>/common.json` in your own PRs: the next sync would conflict with or overwrite your changes. Translate on Crowdin instead.
+- Missing your language? Request it on the Crowdin project page or in a [GitHub discussion](https://github.com/netbirdio/netbird/discussions). When a language first ships, a maintainer adds its row to `i18n/locales/_index.json` (`{"code","displayName"` = native name`,"englishName"}`), which puts it in the app's language picker.
 
 ---
 
@@ -30,25 +43,6 @@ A **business zero-trust VPN** — an encrypted **overlay mesh** between a compan
 
 ---
 
-## The files
-
-```
-i18n/locales/_index.json         shipped-language list
-i18n/locales/en/common.json      source of truth — message + description
-i18n/locales/<code>/common.json  a target — message only
-```
-
-Chrome-extension JSON, each key → `{ "message", "description" }`. You translate the **`message`**.
-
-| ✅ Do | ❌ Don't |
-|---|---|
-| Keep **every key** from `en`, in the same order | Translate, rename, reorder, drop, or add keys (they're identifiers; the set grows over time) |
-| Put **only `message`** in target bundles | Copy `description` into a target bundle |
-| Give every key a non-empty `message` | Leave keys missing or empty |
-| Save valid UTF-8 JSON, no BOM | Add trailing commas or break the JSON |
-
----
-
 ## Hard rules — get these exactly right
 
 These are the usual ways a translation *breaks the app*, not just reads oddly.
@@ -58,7 +52,7 @@ These are the usual ways a translation *breaks the app*, not just reads oddly.
 | Copy `{placeholders}` verbatim — `{version}`, `{count}`, `{name}`… | Translate the word inside the braces (`{verbleibend}` breaks it) |
 | Reposition a placeholder so the sentence flows | Drop or duplicate a placeholder |
 | Preserve every `\n`, leading/trailing space, and trailing `...` | Trim "invisible" spaces or the `...` (they're load-bearing) |
-| Keep `®` in WireGuard® and quotes around `{name}` | Strip punctuation the description flags |
+| Keep `®` in WireGuard® and quotes around `{name}` | Strip punctuation the context flags |
 
 **Plurals:** the app has only a *one / other* split — the singular key fires only when `count == 1`; the `{count}` key covers everything else (0, 2, 5, 100…). Languages with more than two forms (ru, pl, uk) can't be fully correct here — use the form that fits the widest range (Russian genitive plural: `минут` / `часов` / `дней`). Don't invent extra keys or cram multiple forms into one string. When no single form fits every value — a unit label after a number field, say — reach for a number-agnostic form (an abbreviation, or wording that reads the same for 1 and 100) instead of forcing a plural the *one / other* split can't supply.
 
@@ -78,12 +72,14 @@ When a brand sits beside a common noun, keep its exact spelling but join them th
 
 > **Use the word that language's IT users actually say.** Translate when a natural, common term exists; keep the English term *only* when the literal translation would be awkward or no one in that field really uses it.
 
-Apply each term **consistently** — same English term → same translation everywhere — and keep a term once you've settled it. Whether a term stays English or takes a native word is **language-dependent**: a technical loanword (e.g. *Daemon*, *Handshake*) often stays, an everyday word (e.g. *Latency*, *Public key*) usually localizes, and some (*Exit Node*, *Peer*) go either way depending on the language. Decide per term with the rule above — a foreign origin alone is no reason to keep English. **Your main reference is the existing bundles:** match how a term was already rendered for your language rather than re-deciding it.
+Apply each term **consistently** — same English term → same translation everywhere — and keep a term once you've settled it. Whether a term stays English or takes a native word is **language-dependent**: a technical loanword (e.g. *Daemon*, *Handshake*) often stays, an everyday word (e.g. *Latency*, *Public key*) usually localizes, and some (*Exit Node*, *Peer*) go either way depending on the language. Decide per term with the rule above — a foreign origin alone is no reason to keep English. **Your main reference is the existing translation:** match how a term was already rendered for your language rather than re-deciding it.
 
 Two checks before you commit a term:
 
 - **Prefer established localized wording.** If a widely used tool in this space (for example WireGuard) ships your language, its wording for a shared term such as *handshake* is what users already expect — look at the translated app, not just English docs. For generic UI verbs and formal address, follow your OS vendor's style guide (Microsoft / Apple / Google).
 - **Watch for false friends.** A literal translation can collide with a *different* established term in your field — confirm your word doesn't already mean something else in this domain before using it.
+
+These tiers are mirrored in the Crowdin project glossary, so the editor highlights them inline. When you settle a new Tier C term for your language, add its translation to the glossary entry so it sticks for everyone who comes after you.
 
 ---
 
@@ -98,7 +94,7 @@ Two checks before you commit a term:
 
 Where it reads naturally, aim to keep each string **roughly the same length** as the English — the UI is tight and over-long strings can wrap or truncate. It's a soft preference, not a rule: if your language simply needs more words, use them.
 
-A few habits that keep a bundle reading like one product rather than a word-for-word port:
+A few habits that keep a translation reading like one product rather than a word-for-word port:
 
 - **Translate meaning, not words.** Render what a string *does*. An idiom or an awkward source phrase should become natural in your language, not a literal calque.
 - **Keep one voice within a family.** Sibling strings — the connection states, every settings *help* caption, every "… Failed" title — should share a grammatical form. If one member sounds wrong in that form, re-voice the whole family rather than leave one odd sibling.
@@ -107,27 +103,26 @@ A few habits that keep a bundle reading like one product rather than a word-for-
 
 ---
 
-## Procedure
+## Reviewing a language
 
-**New language** — read `en/common.json` *with* descriptions → settle your Tier C terms → write `i18n/locales/<code>/common.json` (same keys and order as `en`, `message` only, placeholders & brands preserved) → add a row to `_index.json` (`{"code","displayName"` = native name`,"englishName"}`) → run the QA list. Use the locale-code style the existing entries use (e.g. `fr`, `pt`, `zh-CN`).
+**On Crowdin:** proofread in the editor — context, glossary highlights, and QA flags sit inline next to each string.
 
-**Review (de / hu / …)** — read source and target side by side; for each key check glossary conformance (e.g. de `Exit-Node` → `Exit Node`, hu `Kilépő csomópont` → `Exit Node`), placeholder/`\n` integrity, consistency, tone, and that the meaning matches the English `description`. Fix in place, then report what you changed (especially term standardizations) so a native speaker can sanity-check.
+**In the repo** — e.g. driving an AI agent with *"Read `i18n/TRANSLATING.md` and review the existing German translation"* — read source and target side by side; for each key check glossary conformance (e.g. de `Exit-Node` → `Exit Node`, hu `Kilépő csomópont` → `Exit Node`), placeholder/`\n` integrity, consistency, tone, and that the meaning matches the English `description`. Report what you found, and apply the fixes **on Crowdin** — direct edits to the locale files are overwritten by the next sync.
 
 ---
 
 ## QA before you finish
 
-- [ ] Valid JSON · **every `en` key** present, same order · **no `description`** fields
 - [ ] Every `{placeholder}`, `\n`, and intentional space preserved · `...` / `… Failed` / `{name}` quotes kept
-- [ ] Tier A/B left intact · Tier C applied consistently (and matching the existing bundle for your language)
+- [ ] Tier A/B left intact · Tier C applied consistently (and matching the existing translation for your language)
 - [ ] Buttons & tray short · locale punctuation and capitalization applied
-- [ ] New language added to `_index.json`
+- [ ] Crowdin QA flags resolved (variables, glossary terms, punctuation)
 - [ ] **Tested in the running app** ↓
 
 ---
 
 ## Test it in the app
 
-A bundle can pass every check above and still read wrong on screen. **Run the app, switch to your language, and click through the real surfaces** — tray menu, main window, every Settings tab, the dialogs. Watch for text overflow or truncation, labels that are technically right but wrong *for what the control does*, leaked placeholders, and terms that drift between screens.
+A translation can pass every check above and still read wrong on screen. **Run the app, switch to your language, and click through the real surfaces** — tray menu, main window, every Settings tab, the dialogs. Watch for text overflow or truncation, labels that are technically right but wrong *for what the control does*, leaked placeholders, and terms that drift between screens.
 
 How to run the app and switch language: see the project README. Can't run it (e.g. a headless agent)? Say so in your summary — don't silently skip this step.

--- a/client/ui/i18n/TRANSLATING.md
+++ b/client/ui/i18n/TRANSLATING.md
@@ -2,7 +2,7 @@
 
 A short brief for translating the desktop UI — for any translator, human or AI agent (*"you"* = whoever's translating).
 
-**Translations are managed on Crowdin: <https://crowdin.com/project/netbird>.** Join the project, pick your language, and translate in the editor. Each string carries a context note (the `description` from the source file) telling you what it is and where it shows up, and the project's glossary, style guide, and QA checks are generated from this document.
+**Translations are managed on Crowdin: <https://crowdin.com/project/netbird>.** Join the project, pick your language, and translate in the editor. Each string carries a context note (the `description` from the source file) telling you what it is and where it shows up, and the project's glossary, style guide, and QA checks mirror this document.
 
 > 💡 **The one habit that matters most:** read each string's context before translating it. Labels are terse and ambiguous on their own; the context tells you what the string is, where it shows up, what to keep verbatim, and what it actually means.
 
@@ -10,14 +10,16 @@ A short brief for translating the desktop UI — for any translator, human or AI
 
 ## How contributions flow
 
-```
+```text
 i18n/locales/en/common.json ──sync──▶ Crowdin ──service PR──▶ i18n/locales/<code>/common.json
 ```
 
 - `i18n/locales/en/common.json` is the source of truth. New and changed strings sync to Crowdin automatically (see `crowdin.yml` in the repository root).
-- Crowdin opens and updates a service pull request with the translated bundles. Maintainers review and merge it; key parity, key order, and file shape are guaranteed by the export.
+- Crowdin opens and updates a service pull request with the translated bundles, keeping the source's file shape and key order. Keys nobody has translated yet are left out of the export; the app falls back to English for them at runtime. Maintainers review and merge that PR.
 - Don't hand-edit `i18n/locales/<code>/common.json` in your own PRs: the next sync would conflict with or overwrite your changes. Translate on Crowdin instead.
-- Missing your language? Request it on the Crowdin project page or in a [GitHub discussion](https://github.com/netbirdio/netbird/discussions). When a language first ships, a maintainer adds its row to `i18n/locales/_index.json` (`{"code","displayName"` = native name`,"englishName"}`), which puts it in the app's language picker.
+- Missing your language? Request it on the Crowdin project page or in a [GitHub discussion](https://github.com/netbirdio/netbird/discussions). When a language first ships, a maintainer adds its row to `i18n/locales/_index.json` with `code`, `displayName` (the native name), and `englishName`, which puts it in the app's language picker.
+
+**Prefer translating with an AI agent?** That still works: drive it with *"Read `i18n/TRANSLATING.md` and translate the UI to Russian"* as before, but deliver the result to Crowdin instead of a pull request. Download your language's file from the Crowdin editor, let the agent translate it, and upload it back (the editor's offline translation flow). Crowdin runs its QA checks on upload, and the next service PR carries the strings into the repo.
 
 ---
 


### PR DESCRIPTION
## Describe your changes

Follow-up to #7155. Now that UI translations are managed on Crowdin (https://crowdin.com/project/netbird), update the contributor docs to match:

- `client/ui/i18n/TRANSLATING.md`: the procedure sections (hand-writing a bundle, key parity, `_index.json` steps, the QA items Crowdin now automates) are replaced by the Crowdin workflow and a "How contributions flow" overview. The style, terminology, and review guidance stays; the Crowdin glossary and style guide are generated from it. Direct locale-file edits are now discouraged since the sync would overwrite them.
- `CONTRIBUTING.md`: new "Translations" section pointing translators at Crowdin (no ticket needed) and at TRANSLATING.md, so translation contributors don't get funneled into the ticket-first PR flow.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

This PR is itself the documentation change (in-repo contributor docs); no netbirdio/docs page covers UI translation contributions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for submitting desktop UI translations through Crowdin instead of pull requests.
  * Updated translation instructions with source synchronization, glossary and quality checks, review workflows, and in-app validation steps.
  * Added links for translation guidance and requesting additional languages.
  * Clarified language onboarding and advised against directly editing locale files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->