### PR TITLE
[infrastructure] Fix Crowdin export paths and export options

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,8 +1,11 @@
+skip_untranslated_strings: true
+skip_untranslated_files: true
+import_eq_suggestions: true
+
 files:
   - source: /client/ui/i18n/locales/en/common.json
-    translation: /client/ui/i18n/locales/%locale%/common.json
+    translation: /client/ui/i18n/locales/%two_letters_code%/common.json
     type: chrome
     languages_mapping:
-      locale:
-        es-ES: es
-        pt-BR: pt
+      two_letters_code:
+        zh-CN: zh-CN


### PR DESCRIPTION
## Describe your changes

The first Crowdin sync after #7155 exported bundles to wrong directories (`de-DE/`, `fr-FR/`, `ja-JP/`...) because `%locale%` resolves to the full locale code, not the plain codes the repo uses (see the now-closed #7157). Only the explicitly mapped es/pt and the coincidentally matching zh-CN came out right, which also means only those three languages had their existing translations imported.

- Switch the translation pattern to `%two_letters_code%`, which matches every repo directory except zh-CN, and override that one via `languages_mapping`.
- `skip_untranslated_strings` / `skip_untranslated_files`: don't export English filler for untranslated keys or create all-English bundles for languages with no translations yet (the app falls back to English per key at runtime).
- `import_eq_suggestions`: import repo translations that are identical to the English source (brand names, acronyms) instead of treating those keys as untranslated.

After merge, a re-sync should import the remaining existing bundles (de, fr, hu, it, ja, ru) and regenerate the service PR with correct paths.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (Crowdin-only configuration file)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Untranslated strings and files are now skipped during translation workflows.
  * Equivalent translation suggestions can now be imported.
  * Updated translation path handling and simplified language mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->