### PR TITLE
[client] Rename the GTK3 UI package so it can share the stable repos

### DIFF
--- a/.goreleaser_ui_gtk3.yaml
+++ b/.goreleaser_ui_gtk3.yaml
@@ -43,19 +43,17 @@ archives:
       - netbird-ui-gtk3
 
 nfpms:
-  # Same package_name as the GTK4 packages -- the two are mutually-exclusive
-  # alternatives served from separate repo paths (see uploads below); a given
-  # distro points at exactly one of them. The file names must still differ:
-  # the Debian pool is shared storage keyed by file name, so a default-named
-  # gtk3 .deb would overwrite the stable one.
+  # Mutually-exclusive alternative to the GTK4 netbird-ui package -- both
+  # ship the same /usr/bin/netbird-ui from the shared stable/yum repos, so
+  # this one carries its own name and conflicts with the GTK4 package.
   - maintainer: Netbird <dev@netbird.io>
     description: Netbird client UI.
     homepage: https://netbird.io/
     license: BSD-3-Clause
     vendor: NetBird
     id: netbird_ui_deb_gtk3
-    package_name: netbird-ui
-    file_name_template: "{{ .PackageName }}-gtk3_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    package_name: netbird-ui-gtk3
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     builds:
       - netbird-ui-gtk3
     formats:
@@ -67,6 +65,10 @@ nfpms:
         dst: /usr/share/applications/org.wails.netbird.desktop
       - src: client/ui/build/appicon.png
         dst: /usr/share/pixmaps/netbird.png
+    conflicts:
+      - netbird-ui
+    replaces:
+      - netbird-ui
     dependencies:
       - netbird (>= 0.75.0)
       - libgtk-3-0
@@ -79,8 +81,8 @@ nfpms:
     license: BSD-3-Clause
     vendor: NetBird
     id: netbird_ui_rpm_gtk3
-    package_name: netbird-ui
-    file_name_template: "{{ .PackageName }}-gtk3_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    package_name: netbird-ui-gtk3
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     builds:
       - netbird-ui-gtk3
     formats:
@@ -92,6 +94,10 @@ nfpms:
         dst: /usr/share/applications/org.wails.netbird.desktop
       - src: client/ui/build/appicon.png
         dst: /usr/share/pixmaps/netbird.png
+    # No `replaces` here: nfpm maps it to rpm Obsoletes, which would make
+    # dnf swap installed GTK4 netbird-ui packages for this one on upgrade.
+    conflicts:
+      - netbird-ui
     dependencies:
       - netbird >= 0.75.0
       - (gtk3 or libgtk-3-0)


### PR DESCRIPTION
## Describe your changes

With the uploads now targeting the same stable/yum paths as the GTK4 packages, two packages named netbird-ui with the same version and arch would collide in the repo indexes. Give the GTK3 variant its own package name and mark the two as conflicting alternatives.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
