### PR TITLE
[infrastructure] getting-started.sh: env-driven non-interactive install

### DIFF
--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -111,6 +111,59 @@ check_nb_domain() {
   return 0
 }
 
+# Non-interactive configuration
+# ------------------------------
+# Every prompt below can be pre-answered with an environment variable, so the
+# script runs unattended (cloud-init, CI, Terraform, curl | bash). resolve()
+# is the single place that decides env var vs prompt vs default; the read_*
+# helpers stay pure prompts.
+#
+# Supported env vars:
+#   NETBIRD_DOMAIN                    domain/FQDN (required)
+#   NETBIRD_LETSENCRYPT_EMAIL         ACME email (required for built-in Traefik)
+#   NETBIRD_AGENT_NETWORK             true enables the agent-network preset
+#   NETBIRD_REVERSE_PROXY_TYPE        0-5 (default 0 = built-in Traefik)
+#   NETBIRD_ENABLE_PROXY              true/false (default false)
+#   NETBIRD_ENABLE_CROWDSEC           true/false (default false)
+#   NETBIRD_TRAEFIK_EXTERNAL_NETWORK  external-Traefik network (type 1)
+#   NETBIRD_TRAEFIK_ENTRYPOINT        external-Traefik entrypoint (type 1, default websecure)
+#   NETBIRD_TRAEFIK_CERTRESOLVER      external-Traefik cert resolver (type 1)
+#   NETBIRD_BIND_LOCALHOST_ONLY       true/false (default true, types 2-5)
+#   NETBIRD_EXTERNAL_PROXY_NETWORK    docker network to join (types 2-4)
+#   NETBIRD_NON_INTERACTIVE           true forces unattended mode even with a TTY
+
+# tty_available succeeds only when we may prompt: never when the operator has
+# set NETBIRD_NON_INTERACTIVE=true, otherwise only when /dev/tty can actually
+# be opened. A PTY can be attached in automation (CI runners, some
+# provisioners), so the env override is the authoritative signal and the
+# /dev/tty probe is the fallback. /dev/tty is a world-rw device node even with
+# no terminal, so a permission test ([ -r ]) is not enough - we must open it.
+tty_available() {
+  [[ "${NETBIRD_NON_INTERACTIVE:-}" == "true" ]] && return 1
+  { true < /dev/tty; } 2>/dev/null
+}
+
+# resolve ENV_VAR_NAME DEFAULT PROMPT_FN [prompt args...]
+#   env var set and non-empty -> its value
+#   interactive               -> PROMPT_FN "$@" (prompt behavior unchanged)
+#   otherwise                 -> DEFAULT, or abort when DEFAULT is "required"
+resolve() {
+  local env_name="$1" default="$2" prompt_fn="$3"
+  shift 3
+  local env_value="${!env_name:-}"
+  if [[ -n "$env_value" ]]; then
+    echo "$env_value"
+  elif tty_available; then
+    "$prompt_fn" "$@"
+  elif [[ "$default" == "required" ]]; then
+    echo "$env_name is required for a non-interactive install." > /dev/stderr
+    exit 1
+  else
+    echo "$default"
+  fi
+  return 0
+}
+
 read_nb_domain() {
   READ_NETBIRD_DOMAIN=""
   echo -n "Enter the domain you want to use for NetBird (e.g. netbird.my-domain.com): " > /dev/stderr
@@ -383,7 +436,14 @@ initialize_default_values() {
 }
 
 configure_domain() {
+  # Domain is validated (not a free-form value), so it keeps its own guard
+  # rather than going through resolve(): a valid NETBIRD_DOMAIN is used as-is,
+  # otherwise we prompt, or abort when there is no terminal to prompt on.
   if ! check_nb_domain "$NETBIRD_DOMAIN"; then
+    if ! tty_available; then
+      echo "NETBIRD_DOMAIN is required for a non-interactive install." > /dev/stderr
+      exit 1
+    fi
     NETBIRD_DOMAIN=$(read_nb_domain)
   fi
 
@@ -411,11 +471,7 @@ apply_agent_network_preset() {
   ENABLE_PROXY="true"
   ENABLE_CROWDSEC="false"
 
-  if [[ -n "${NETBIRD_LETSENCRYPT_EMAIL}" ]]; then
-    TRAEFIK_ACME_EMAIL="${NETBIRD_LETSENCRYPT_EMAIL}"
-  else
-    TRAEFIK_ACME_EMAIL=$(read_traefik_acme_email)
-  fi
+  TRAEFIK_ACME_EMAIL=$(resolve NETBIRD_LETSENCRYPT_EMAIL required read_traefik_acme_email)
 
   echo "" > /dev/stderr
   echo "Agent-network preset enabled (NETBIRD_AGENT_NETWORK=true):" > /dev/stderr
@@ -437,35 +493,35 @@ configure_reverse_proxy() {
     return 0
   fi
 
-  # Prompt for reverse proxy type
-  REVERSE_PROXY_TYPE=$(read_reverse_proxy_type)
+  # Reverse proxy type (env NETBIRD_REVERSE_PROXY_TYPE, else prompt, else 0)
+  REVERSE_PROXY_TYPE=$(resolve NETBIRD_REVERSE_PROXY_TYPE 0 read_reverse_proxy_type)
 
   # Handle built-in Traefik prompts (option 0)
   if [[ "$REVERSE_PROXY_TYPE" == "0" ]]; then
-    TRAEFIK_ACME_EMAIL=$(read_traefik_acme_email)
-    ENABLE_PROXY=$(read_enable_proxy)
+    TRAEFIK_ACME_EMAIL=$(resolve NETBIRD_LETSENCRYPT_EMAIL required read_traefik_acme_email)
+    ENABLE_PROXY=$(resolve NETBIRD_ENABLE_PROXY false read_enable_proxy)
     if [[ "$ENABLE_PROXY" == "true" ]]; then
-      ENABLE_CROWDSEC=$(read_enable_crowdsec)
+      ENABLE_CROWDSEC=$(resolve NETBIRD_ENABLE_CROWDSEC false read_enable_crowdsec)
     fi
   fi
 
   # Handle external Traefik-specific prompts (option 1)
   if [[ "$REVERSE_PROXY_TYPE" == "1" ]]; then
-    TRAEFIK_EXTERNAL_NETWORK=$(read_traefik_network)
-    TRAEFIK_ENTRYPOINT=$(read_traefik_entrypoint)
-    TRAEFIK_CERTRESOLVER=$(read_traefik_certresolver)
+    TRAEFIK_EXTERNAL_NETWORK=$(resolve NETBIRD_TRAEFIK_EXTERNAL_NETWORK "" read_traefik_network)
+    TRAEFIK_ENTRYPOINT=$(resolve NETBIRD_TRAEFIK_ENTRYPOINT websecure read_traefik_entrypoint)
+    TRAEFIK_CERTRESOLVER=$(resolve NETBIRD_TRAEFIK_CERTRESOLVER "" read_traefik_certresolver)
   fi
 
   # Handle port binding for external proxy options (2-5)
   if [[ "$REVERSE_PROXY_TYPE" -ge 2 ]]; then
-    BIND_LOCALHOST_ONLY=$(read_port_binding_preference)
+    BIND_LOCALHOST_ONLY=$(resolve NETBIRD_BIND_LOCALHOST_ONLY true read_port_binding_preference)
   fi
 
   # Handle Docker network prompts for external proxies (options 2-4)
   case "$REVERSE_PROXY_TYPE" in
-    2) EXTERNAL_PROXY_NETWORK=$(read_proxy_docker_network "Nginx") ;;
-    3) EXTERNAL_PROXY_NETWORK=$(read_proxy_docker_network "Nginx Proxy Manager") ;;
-    4) EXTERNAL_PROXY_NETWORK=$(read_proxy_docker_network "Caddy") ;;
+    2) EXTERNAL_PROXY_NETWORK=$(resolve NETBIRD_EXTERNAL_PROXY_NETWORK "" read_proxy_docker_network "Nginx") ;;
+    3) EXTERNAL_PROXY_NETWORK=$(resolve NETBIRD_EXTERNAL_PROXY_NETWORK "" read_proxy_docker_network "Nginx Proxy Manager") ;;
+    4) EXTERNAL_PROXY_NETWORK=$(resolve NETBIRD_EXTERNAL_PROXY_NETWORK "" read_proxy_docker_network "Caddy") ;;
     *) ;; # No network prompt for other options
   esac
   return 0
@@ -643,8 +699,13 @@ start_services_and_show_instructions() {
     print_post_setup_instructions
 
     echo ""
-    echo -n "Press Enter when your reverse proxy is configured (or Ctrl+C to exit)... "
-    read -r < /dev/tty
+    if tty_available; then
+      echo -n "Press Enter when your reverse proxy is configured (or Ctrl+C to exit)... "
+      read -r < /dev/tty
+    else
+      echo "Non-interactive mode: starting NetBird containers now. Finish configuring"
+      echo "your reverse proxy using the instructions above so it can reach them."
+    fi
 
     echo -e "$MSG_STARTING_SERVICES"
     $DOCKER_COMPOSE_COMMAND up -d


### PR DESCRIPTION
# getting-started.sh: env-driven non-interactive install

## Problem

`infrastructure_files/getting-started.sh` can only be run fully unattended in **one** mode: `NETBIRD_AGENT_NETWORK=true`. Every other path reaches an interactive `read ... < /dev/tty` prompt.

The worst offender is `read_traefik_acme_email` (built-in Traefik / reverse-proxy type `0`, the default and recommended option). It reads `/dev/tty` with **no env-var fallback** and **recurses on empty input**. When the script runs with no controlling terminal — cloud-init, CI, Terraform `remote-exec`, `curl … | bash` from an automation context — the `/dev/tty` open fails, the value is empty, and the function recurses until the shell **crashes (SIGSEGV)**. The result is a hung or silently misconfigured deploy (no ACME email set), which is exactly what we hit building a one-click cloud deploy.

Interestingly, `getting-started-enterprise.sh` already solved this for its email prompt (`read_letsencrypt_email` checks `NETBIRD_LETSENCRYPT_EMAIL` first). This PR brings the same env-first pattern to `getting-started.sh`, generalized so every prompt can be pre-answered.

## What changed

Two small helpers, and the `read_*` functions are left **completely untouched** (they remain pure prompts — verified byte-for-byte identical to `main`):

- **`resolve ENV_VAR DEFAULT PROMPT_FN [args...]`** — the single place that decides how a value is obtained: env var if set → prompt if interactive → otherwise the default, or abort when the default is the literal `required`. Only the call sites change, e.g.:
  ```bash
  REVERSE_PROXY_TYPE=$(resolve NETBIRD_REVERSE_PROXY_TYPE 0        read_reverse_proxy_type)
  TRAEFIK_ACME_EMAIL=$(resolve NETBIRD_LETSENCRYPT_EMAIL  required read_traefik_acme_email)
  ENABLE_PROXY=$(resolve       NETBIRD_ENABLE_PROXY       false    read_enable_proxy)
  ```
- **`tty_available`** — decides whether we may prompt. `NETBIRD_NON_INTERACTIVE=true` forces unattended mode; otherwise it *opens* `/dev/tty` (a `[ -r ]` test is insufficient — the device node is world-rw even with no terminal). The explicit override matters because a PTY can be attached in automation (CI runners, some provisioners), where the `/dev/tty` probe alone would still prompt and hang.

| Env var | Value used for | Headless default |
|---|---|---|
| `NETBIRD_DOMAIN` | domain (validated) | required → exit 1 |
| `NETBIRD_LETSENCRYPT_EMAIL` | ACME email | required (built-in Traefik) → exit 1 |
| `NETBIRD_REVERSE_PROXY_TYPE` | reverse-proxy choice | `0` (built-in Traefik) |
| `NETBIRD_ENABLE_PROXY` | enable NetBird Proxy | `false` |
| `NETBIRD_ENABLE_CROWDSEC` | enable CrowdSec | `false` |
| `NETBIRD_TRAEFIK_EXTERNAL_NETWORK` / `NETBIRD_TRAEFIK_ENTRYPOINT` / `NETBIRD_TRAEFIK_CERTRESOLVER` | external-Traefik options | empty / `websecure` / empty |
| `NETBIRD_BIND_LOCALHOST_ONLY` | localhost-only port binding | `true` |
| `NETBIRD_EXTERNAL_PROXY_NETWORK` | external proxy docker network | empty |
| `NETBIRD_NON_INTERACTIVE` | force unattended even with a TTY | — |

Boolean env vars take `true`/`false` (used verbatim). The external-proxy "Press Enter to continue" pause is also skipped when headless.

**Interactive behavior is unchanged when a terminal is present.**

## Example (unattended)

```bash
curl -fsSL https://pkgs.netbird.io/getting-started.sh \
  | NETBIRD_DOMAIN=netbird.example.com \
    NETBIRD_LETSENCRYPT_EMAIL=admin@example.com \
    bash
```

## Testing

Ran in `ubuntu:24.04` (bash 5.2) with `docker`/`docker-compose`/`curl`/`openssl`/`jq` stubbed. Headless cases run under `setsid` (no controlling terminal, reproducing cloud-init); interactive and PTY-override cases run under `script` (a real pty). A per-case timeout turns any hang into a failure. **24/24 assertions pass:**

- **Standard** preset, domain+email via env → completes, correct ACME email, proxy off, standard dashboard.
- **Agent-network** preset via env → completes, `NETBIRD_AGENT_NETWORK_ONLY=true`, `NB_PROXY_PRIVATE=true`.
- **Standard + proxy + CrowdSec** via env → both services rendered.
- **Missing email / missing domain, no tty** → fail fast (exit 1) with a clear message, **no hang**.
- **Agent-network, missing email, no tty** → fail fast.
- **Interactive regression (real pty, no env vars)** → prompts work, typed email applied.
- **PTY attached + `NETBIRD_NON_INTERACTIVE=true`** → completes without prompting (override honored).
- **Control (PTY, no override, missing email)** → hangs, demonstrating the gap the override closes.

Controls: the **unmodified** script on the missing-email/no-tty case exits **139 (SIGSEGV)**; the no-override PTY case hangs — both confirm the bug and that the fix resolves it. `shellcheck`: **0 new findings** (identical before/after).

## Documentation

- [ ] I added/updated documentation
- [x] Documentation is **not needed** — this is a bug fix; the supported env vars are self-documented in the script header. Happy to open a `netbirdio/docs` note on self-hosting env vars if the maintainers prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for unattended setup using environment variables and predefined defaults.
  * Added automatic detection of terminal availability during configuration.
  * External-proxy deployments can now start without interactive confirmation.

* **Bug Fixes**
  * Configuration now stops with clear failures when required domain or certificate email values are missing.
  * Setup consistently applies environment-provided values for proxy, security, networking, and binding settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->