### PR TITLE
[infrastructure] Exempt Crowdin service PRs from title and docs checks

### DIFF
--- a/.github/workflows/docs-ack.yml
+++ b/.github/workflows/docs-ack.yml
@@ -12,6 +12,8 @@ jobs:
   docs-ack:
     name: Require docs PR URL or explicit "not needed"
     runs-on: ubuntu-latest
+    # Crowdin's translation-sync service PRs are auto-generated without the PR template.
+    if: github.event.pull_request.user.login != 'netbirddev'
 
     steps:
       - name: Read PR body

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   check-title:
     runs-on: ubuntu-latest
+    # Crowdin's translation-sync service PRs are auto-generated with a fixed title.
+    if: github.event.pull_request.user.login != 'netbirddev'
     steps:
       - name: Validate PR title prefix
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Describe your changes

Crowdin's translation-sync service PRs (author `netbirddev`, e.g. #7167) are auto-generated with a fixed title and no PR template, so they permanently fail the PR Title Check and Docs Acknowledgement workflows. Skip both jobs when the PR author is the sync bot. The jobs still run and report a skipped conclusion, which satisfies branch protection.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] This change does **not** modify the public API, gRPC protocols, functionality behavior, CLI / service flags, or introduce a new feature — **OR** I have discussed it with the NetBird team beforehand (link the issue / Slack thread in the description). See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#discuss-changes-with-the-netbird-team-first).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (CI-only workflow condition)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation acknowledgement checks to accommodate automatically generated pull requests.
  * Updated pull request title validation to handle automatically generated pull requests.
  * Existing documentation and title validation remains unchanged for other pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->