### PR TITLE
[misc] Build release branches, and don't mark releases latest before signing

### DIFF
--- a/.git-branches.toml
+++ b/.git-branches.toml
@@ -3,7 +3,7 @@
 [branches]
 main = "main"
 perennials = []
-perennial-regex = ""
+perennial-regex = "^release-"
 
 [create]
 new-branch-type = "feature"

--- a/.github/workflows/check-license-dependencies.yml
+++ b/.github/workflows/check-license-dependencies.yml
@@ -2,7 +2,7 @@ name: Check License Dependencies
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release-*"]
     paths:
       - "go.mod"
       - "go.sum"

--- a/.github/workflows/frontend-ui.yml
+++ b/.github/workflows/frontend-ui.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
     paths:
       - "client/ui/frontend/**"
       - "client/ui/i18n/**"

--- a/.github/workflows/golang-test-darwin.yml
+++ b/.github/workflows/golang-test-darwin.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
   pull_request:
 
 concurrency:

--- a/.github/workflows/golang-test-freebsd.yml
+++ b/.github/workflows/golang-test-freebsd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
   pull_request:
 
 concurrency:

--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
   pull_request:
 
 concurrency:

--- a/.github/workflows/golang-test-windows.yml
+++ b/.github/workflows/golang-test-windows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
   pull_request:
 
 env:

--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
   pull_request:
     paths:
       - "release_files/install.sh"

--- a/.github/workflows/mobile-build-validation.yml
+++ b/.github/workflows/mobile-build-validation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
   pull_request:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - "v*"
     branches:
       - main
+      - "release-*"
   pull_request:
 
 env:
@@ -254,15 +255,19 @@ jobs:
         id: tag_and_push_images
         if: |
           (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-          (github.event_name == 'push' && github.ref == 'refs/heads/main')
+          (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-')))
         run: |
           set -euo pipefail
 
           resolve_tags() {
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
               echo "pr-${{ github.event.pull_request.number }}"
-            else
+            elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
               echo "main sha-$(git rev-parse --short HEAD)"
+            else
+              # Release branches get an immutable sha-* tag only — the floating
+              # "main" tag must never move from a release branch.
+              echo "sha-$(git rev-parse --short HEAD)"
             fi
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,9 +260,9 @@ jobs:
           set -euo pipefail
 
           # $GITHUB_REF / $GITHUB_EVENT_NAME are read from the runner
-          # environment rather than ${{ }}-interpolated into this script:
-          # branch names may legally contain $(…), and interpolating
-          # github.ref would execute it.
+          # environment rather than substituted into this script with the
+          # workflow expression syntax: branch names may legally contain
+          # $(…), and interpolating github.ref would execute it.
           resolve_tags() {
             if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
               echo "pr-${{ github.event.pull_request.number }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,10 +259,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # $GITHUB_REF / $GITHUB_EVENT_NAME are read from the runner
+          # environment rather than ${{ }}-interpolated into this script:
+          # branch names may legally contain $(…), and interpolating
+          # github.ref would execute it.
           resolve_tags() {
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
               echo "pr-${{ github.event.pull_request.number }}"
-            elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            elif [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
               echo "main sha-$(git rev-parse --short HEAD)"
             else
               # Release branches get an immutable sha-* tag only — the floating

--- a/.github/workflows/sync-tag.yml
+++ b/.github/workflows/sync-tag.yml
@@ -9,21 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
   cancel-in-progress: true
 
-# Receiving workflows (cloud sync-tag, mobile bump-netbird) expect the short
-# tag form (e.g. v0.30.0), not refs/tags/v0.30.0 — github.ref_name, not github.ref.
+# The receiving bump-netbird workflows expect the short tag form
+# (e.g. v0.30.0), not refs/tags/v0.30.0 — github.ref_name, not github.ref.
 jobs:
-  trigger_sync_tag:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger release tag sync
-        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
-        with:
-          workflow: sync-tag.yml
-          ref: main
-          repo: ${{ secrets.UPSTREAM_REPO }}
-          token: ${{ secrets.NC_GITHUB_TOKEN }}
-          inputs: '{ "tag": "${{ github.ref_name }}" }'
-
   trigger_android_bump:
     runs-on: ubuntu-latest
     if: github.event.created && !github.event.deleted && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
   pull_request:
     paths:
       - "infrastructure_files/**"

--- a/.github/workflows/wasm-build-validation.yml
+++ b/.github/workflows/wasm-build-validation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
   pull_request:
 
 concurrency:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -468,6 +468,13 @@ checksum:
     - glob: ./infrastructure_files/migrate-to-enterprise.sh
 
 release:
+  # The signing pipeline (netbirdio/sign-pipelines, dispatched by
+  # trigger_signer) marks the release latest once the Windows and macOS
+  # artifacts are signed. Without this override goreleaser marks it latest
+  # at publish time, while those artifacts are still unsigned.
+  make_latest: false
+  # Mark x.y.z-rc.* and other prerelease tags as prereleases on GitHub.
+  prerelease: auto
   extra_files:
     - glob: ./infrastructure_files/getting-started-with-zitadel.sh
     - glob: ./release_files/install.sh

--- a/.goreleaser_ui.yaml
+++ b/.goreleaser_ui.yaml
@@ -144,3 +144,11 @@ uploads:
     target: https://pkgs.wiretrustee.com/yum/{{ .Arch }}{{ if .Arm }}{{ .Arm }}{{ end }}
     username: dev@wiretrustee.com
     method: PUT
+
+release:
+  # Uploads into the release created by the main .goreleaser.yaml run.
+  # make_latest stays false everywhere: the signing pipeline
+  # (netbirdio/sign-pipelines) marks the release latest after the Windows
+  # and macOS artifacts are signed.
+  make_latest: false
+  prerelease: auto

--- a/.goreleaser_ui_darwin.yaml
+++ b/.goreleaser_ui_darwin.yaml
@@ -43,3 +43,11 @@ checksum:
   name_template: "{{ .ProjectName }}_darwin_checksums.txt"
 changelog:
   disable: true
+
+release:
+  # Uploads into the release created by the main .goreleaser.yaml run.
+  # make_latest stays false everywhere: the signing pipeline
+  # (netbirdio/sign-pipelines) marks the release latest after the Windows
+  # and macOS artifacts are signed.
+  make_latest: false
+  prerelease: auto

--- a/.goreleaser_ui_gtk3.yaml
+++ b/.goreleaser_ui_gtk3.yaml
@@ -134,3 +134,11 @@ uploads:
     target: https://pkgs.wiretrustee.com/yum/{{ .Arch }}{{ if .Arm }}{{ .Arm }}{{ end }}
     username: dev@wiretrustee.com
     method: PUT
+
+release:
+  # Uploads into the release created by the main .goreleaser.yaml run.
+  # make_latest stays false everywhere: the signing pipeline
+  # (netbirdio/sign-pipelines) marks the release latest after the Windows
+  # and macOS artifacts are signed.
+  make_latest: false
+  prerelease: auto


### PR DESCRIPTION
## Describe your changes

The two prerequisites for the internally agreed release-branch process, plus three supporting changes. Five commits, one purpose: make this repo ready for `release-0.N` branches.

### 1. Release branches build (`b4c8ce3`)

Pushes to `release-*` now run the **Release** workflow and publish immutable `sha-*` container images, the way pushes to `main` already do. Previously a release branch had no post-merge CI and no artifact — nothing to run the pre-release test suites against before tagging.

One subtlety to review closely in `resolve_tags()`: release branches publish **only** the `sha-*` tag. The floating `main` tag is what everyday deploys consume, and it must never move from a release branch.

Branch pushes run goreleaser with `--snapshot`, which skips all publishing — so release-branch builds cannot touch GitHub releases or package uploads; images are pushed only by the manual `tag_and_push_images` step. `trigger_signer` remains tags-only.

### 2. Releases are no longer marked latest before signing (`cf51695`)

goreleaser's `release.make_latest` defaults to `true`, and **all four** goreleaser configs publish into the GitHub release on a tag push (including `.goreleaser_ui_gtk3.yaml` — any one config's update call re-asserts the flag). So a release became GitHub's "Latest release" the moment it was published, while its Windows and macOS artifacts were still unsigned — and `sign-pipelines`' `mark_release_latest` job then re-asserted a flag that was already set. The gate it was meant to provide did not exist.

With `make_latest: false` in every config, a release stays published-but-not-latest until signing completes and `mark_release_latest` promotes it. "Marked latest" becomes an accurate signal that the whole chain finished.

Also `prerelease: auto`: RC tags were being published as full releases (e.g. `v0.75.0-rc.6` has `prerelease=false`), so an RC could take the "Latest release" slot. Now they're labelled as prereleases, and `mark_release_latest` already skips them.

**Deliberate behavior change:** GitHub's `/releases/latest` API now returns the *previous* release during the publish→signed window (typically well under an hour). `install.sh` is unaffected — it uses `pkgs.netbird.io/releases/latest`, a separate service — but anything polling GitHub's latest endpoint sees a release only after it's signed. That is the point, but flagging it for anyone who knows of another consumer.

### 3. CI runs on release-branch pushes (`f097538`)

Every push-to-`main` CI workflow (Go tests on all platforms, frontend UI, install script, mobile/wasm validation, infrastructure files, license check) also triggers on `release-*`. All `pull_request:` triggers are branch-unfiltered, so backport PRs were already covered — the gap was post-merge branch state. `sync-main` is deliberately untouched: it syncs `main` downstream and must never fire for a release branch.

### 4. git-town perennial regex (`1deeb36`)

`perennial-regex = "^release-"` in `.git-branches.toml`, so git-town never tries to sync or ship a release branch into `main`.

### 5. The automatic downstream tag-sync is retired (`56133e9`)

Every `v*` tag push — release candidates included, since this job (unlike its mobile siblings in the same file) had no prerelease filter — dispatched a downstream workflow that pinned the tag on a throwaway branch and republished container images, moving the enterprise `:latest` manifests as a side effect. Under the release-branch process the enterprise release is built deliberately from its release branch, so the automatic build would race it for `:latest` on every release.

Only the `trigger_sync_tag` job is removed; `trigger_android_bump` and `trigger_ios_bump` are untouched. The receiving workflow is retired separately after this lands — merge order matters slightly: this side must go first, or a tag pushed in between fails its dispatch job (harmless but red).

### Verified locally

- `goreleaser check` passes on all four configs; deprecation warnings are identical to `main`'s baseline (all pre-existing).
- actionlint over the changed workflows: no findings on changed lines.
- git-town classifies a test `release-0.99-*` branch as perennial with the new regex.

## Issue ticket number and link

Agreed internally — these are the two prerequisites of the team's new release-branch process.

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal release-process change; the release procedure is documented internally and already describes the post-change behavior. Nothing here affects user-facing docs.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Improvements**
  * Release branches now receive automated validation across supported platforms and build targets.
  * Release artifacts are classified appropriately as prereleases, with latest-release status managed after signing completes.
  * Container images from release branches receive immutable commit-based tags for reliable identification.

* **Chores**
  * Improved release and tag handling for safer, more predictable automated publishing.
  * Clarified tag references used by automated synchronization workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->