### PR TITLE
[infrastructure] Let a suite outside this repo use the e2e harness

### DIFF
--- a/e2e/harness/Dockerfile.client
+++ b/e2e/harness/Dockerfile.client
@@ -20,5 +20,9 @@ ENV NETBIRD_BIN="/usr/local/bin/netbird" \
     NB_ENABLE_CAPTURE="false" \
     NB_ENTRYPOINT_SERVICE_TIMEOUT="30"
 ENTRYPOINT [ "/usr/local/bin/netbird-entrypoint.sh" ]
-COPY client/netbird-entrypoint.sh /usr/local/bin/netbird-entrypoint.sh
+# --chmod because the build context is not always a git checkout. A suite in
+# another module builds from this module's extracted copy in the module cache,
+# where every file is 0444 — the cache drops the executable bit git records — and
+# a bare COPY then produces an entrypoint the runtime cannot exec.
+COPY --chmod=0755 client/netbird-entrypoint.sh /usr/local/bin/netbird-entrypoint.sh
 COPY --from=builder /out/netbird /usr/local/bin/netbird

--- a/e2e/harness/client.go
+++ b/e2e/harness/client.go
@@ -61,7 +61,7 @@ func StartClient(ctx context.Context, c *Combined, setupKey string, opts ...Clie
 		opt(&o)
 	}
 
-	root, err := repoRoot()
+	root, err := repoRoot(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/harness/client.go
+++ b/e2e/harness/client.go
@@ -32,11 +32,35 @@ type Client struct {
 	container testcontainers.Container
 }
 
+// clientOptions is what the ClientOption values assemble.
+type clientOptions struct {
+	name string
+}
+
+// ClientOption adjusts how StartClient runs the agent.
+type ClientOption func(*clientOptions)
+
+// WithClientName names the agent, which sets both its network alias and its
+// container hostname. The hostname matters beyond addressing: the agent reports
+// it to management at registration, so it is the name the peer appears under in
+// the API.
+//
+// Required to run more than one agent against the same server — the default name
+// is shared, and two containers cannot hold the same alias on one network.
+func WithClientName(name string) ClientOption {
+	return func(o *clientOptions) { o.name = name }
+}
+
 // StartClient builds the client image and runs it on the combined server's
 // network, joining via the given setup key. The image entrypoint brings the
 // daemon up automatically; callers wait for connectivity with WaitConnected /
 // WaitProxyPeer.
-func StartClient(ctx context.Context, c *Combined, setupKey string) (*Client, error) {
+func StartClient(ctx context.Context, c *Combined, setupKey string, opts ...ClientOption) (*Client, error) {
+	o := clientOptions{name: clientAlias}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	root, err := repoRoot()
 	if err != nil {
 		return nil, err
@@ -47,9 +71,13 @@ func StartClient(ctx context.Context, c *Combined, setupKey string) (*Client, er
 	}
 
 	req := testcontainers.ContainerRequest{
-		Image:          clientImage,
+		Image: clientImage,
+		// The agent reports the container's hostname to management, so this is
+		// the name the peer is addressable by in the API as well as on the
+		// network. The entrypoint takes no hostname flag of its own.
+		Hostname:       o.name,
 		Networks:       []string{c.network.Name},
-		NetworkAliases: map[string][]string{c.network.Name: {clientAlias}},
+		NetworkAliases: map[string][]string{c.network.Name: {o.name}},
 		Env: map[string]string{
 			"NB_MANAGEMENT_URL": combinedExposedURL,
 			"NB_SETUP_KEY":      setupKey,

--- a/e2e/harness/combined.go
+++ b/e2e/harness/combined.go
@@ -61,10 +61,67 @@ type Combined struct {
 	workDir string
 }
 
+// combinedOptions is what the CombinedOption values assemble.
+type combinedOptions struct {
+	geolocation bool
+	env         map[string]string
+}
+
+// CombinedOption adjusts how StartCombined boots the server. The defaults suit a
+// suite that only drives the API; the options exist for the ones that need more
+// of the product than that.
+type CombinedOption func(*combinedOptions)
+
+// WithGeolocation leaves the GeoLite database download enabled. It is off by
+// default because the download adds startup latency that most suites get nothing
+// for. A suite asserting on location-based posture checks needs it: management
+// evaluates those rules against the database, and without it the rule fails
+// instead of passing without having been checked.
+func WithGeolocation() CombinedOption {
+	return func(o *combinedOptions) { o.geolocation = true }
+}
+
+// WithServerEnv adds environment variables to the combined container, overriding
+// the defaults on a key collision. For settings this harness does not model
+// directly, so a suite needing one does not have to fork the harness to get it.
+func WithServerEnv(env map[string]string) CombinedOption {
+	return func(o *combinedOptions) {
+		if o.env == nil {
+			o.env = map[string]string{}
+		}
+		for k, v := range env {
+			o.env[k] = v
+		}
+	}
+}
+
+// combinedEnv is the combined container's environment: setup-PAT enabled so the
+// caller can mint an admin token through /api/setup, geolocation off unless the
+// suite asked for it, and whatever the suite added on top.
+func combinedEnv(o combinedOptions) map[string]string {
+	env := map[string]string{
+		"NB_SETUP_PAT_ENABLED": "true",
+	}
+	if !o.geolocation {
+		// Skip the GeoLite DB download — it blocks startup and agent-network
+		// ingest doesn't use geolocation.
+		env["NB_DISABLE_GEOLOCATION"] = "true"
+	}
+	for k, v := range o.env {
+		env[k] = v
+	}
+	return env
+}
+
 // StartCombined builds the combined server from its multistage Dockerfile and
 // boots it with setup-PAT enabled on a fresh shared network, returning once the
 // API is serving. The caller still owns minting the admin PAT via Bootstrap.
-func StartCombined(ctx context.Context) (*Combined, error) {
+func StartCombined(ctx context.Context, opts ...CombinedOption) (*Combined, error) {
+	var o combinedOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	root, err := repoRoot()
 	if err != nil {
 		return nil, err
@@ -88,7 +145,7 @@ func StartCombined(ctx context.Context) (*Combined, error) {
 		return nil, fmt.Errorf("create work dir: %w", err)
 	}
 
-	cfg := fmt.Sprintf(combinedConfigYAML, combinedExposedURL, containerIssuer)
+	cfg := fmt.Sprintf(combinedConfigYAML, combinedExposedURL, !o.geolocation, containerIssuer)
 	if err := os.WriteFile(filepath.Join(workDir, "config.yaml"), []byte(cfg), 0o644); err != nil { //nolint:gosec // non-secret config, bind-mounted and read by the container
 		_ = net.Remove(ctx)
 		return nil, fmt.Errorf("write combined config: %w", err)
@@ -112,13 +169,8 @@ func StartCombined(ctx context.Context) (*Combined, error) {
 		ExposedPorts:   []string{combinedHTTPPort},
 		Networks:       []string{net.Name},
 		NetworkAliases: map[string][]string{net.Name: {combinedAlias}},
-		Env: map[string]string{
-			"NB_SETUP_PAT_ENABLED": "true",
-			// Skip the GeoLite DB download — it blocks startup and agent-network
-			// ingest doesn't use geolocation.
-			"NB_DISABLE_GEOLOCATION": "true",
-		},
-		Cmd: []string{"--config", "/nb/config.yaml"},
+		Env:            combinedEnv(o),
+		Cmd:            []string{"--config", "/nb/config.yaml"},
 		HostConfigModifier: func(hc *container.HostConfig) {
 			hc.Binds = append(hc.Binds, workDir+":/nb")
 		},

--- a/e2e/harness/combined.go
+++ b/e2e/harness/combined.go
@@ -122,7 +122,7 @@ func StartCombined(ctx context.Context, opts ...CombinedOption) (*Combined, erro
 		opt(&o)
 	}
 
-	root, err := repoRoot()
+	root, err := repoRoot(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/harness/config.go
+++ b/e2e/harness/config.go
@@ -15,6 +15,11 @@ package harness
 // server is required to load it — a broken path or malformed file fails startup
 // rather than silently falling back to the compiled-in rates, and TestMain then
 // fails with the container logs.
+//
+// disableGeoliteUpdate is a parameter rather than a fixed true because a suite
+// that exercises geolocation needs the database: management can only evaluate a
+// location rule with GeoLite loaded, and a rule it cannot evaluate fails rather
+// than passing vacuously. See WithGeolocation.
 const combinedConfigYAML = `server:
   listenAddress: ":8080"
   exposedAddress: "%s"
@@ -25,7 +30,7 @@ const combinedConfigYAML = `server:
   authSecret: "e2e-relay-secret"
   dataDir: "/nb/data"
   disableAnonymousMetrics: true
-  disableGeoliteUpdate: true
+  disableGeoliteUpdate: %t
   auth:
     issuer: "%s"
   store:

--- a/e2e/harness/options_test.go
+++ b/e2e/harness/options_test.go
@@ -1,0 +1,136 @@
+//go:build e2e
+
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The options exist so a suite can ask for a deployment this harness would not
+// otherwise give it. What they configure is a container environment and a config
+// file, both assembled before anything is started, so they are checkable without
+// Docker — which is the point: a wiring mistake here would otherwise only show up
+// as a puzzling failure minutes into a container run.
+
+func TestCombinedEnvGeolocation(t *testing.T) {
+	var off combinedOptions
+	if got := combinedEnv(off)["NB_DISABLE_GEOLOCATION"]; got != "true" {
+		t.Errorf("geolocation should be off by default, NB_DISABLE_GEOLOCATION = %q", got)
+	}
+
+	var on combinedOptions
+	WithGeolocation()(&on)
+	if _, set := combinedEnv(on)["NB_DISABLE_GEOLOCATION"]; set {
+		t.Error("WithGeolocation must leave NB_DISABLE_GEOLOCATION unset, so the server downloads the database")
+	}
+	if combinedEnv(on)["NB_SETUP_PAT_ENABLED"] != "true" {
+		t.Error("the setup PAT must stay enabled whatever else is configured; Bootstrap depends on it")
+	}
+}
+
+// The config file carries the same decision as the environment variable, and the
+// server needs both to agree: disableGeoliteUpdate suppresses the download even
+// when geolocation itself is enabled.
+func TestCombinedConfigGeolocation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts []CombinedOption
+		want string
+	}{
+		{name: "default", want: "disableGeoliteUpdate: true"},
+		{name: "with geolocation", opts: []CombinedOption{WithGeolocation()}, want: "disableGeoliteUpdate: false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var o combinedOptions
+			for _, opt := range tc.opts {
+				opt(&o)
+			}
+			cfg := fmt.Sprintf(combinedConfigYAML, combinedExposedURL, !o.geolocation, containerIssuer)
+			if !strings.Contains(cfg, tc.want) {
+				t.Errorf("config should contain %q, got:\n%s", tc.want, cfg)
+			}
+			// The issuer is the last verb; a mis-ordered argument list would put
+			// the boolean here instead and the server would fail to start.
+			if !strings.Contains(cfg, `issuer: "`+containerIssuer+`"`) {
+				t.Errorf("issuer not rendered, got:\n%s", cfg)
+			}
+		})
+	}
+}
+
+func TestWithServerEnvOverrides(t *testing.T) {
+	var o combinedOptions
+	WithServerEnv(map[string]string{"NB_LOG_LEVEL": "debug"})(&o)
+	WithServerEnv(map[string]string{"NB_SETUP_PAT_ENABLED": "false"})(&o)
+
+	env := combinedEnv(o)
+	if env["NB_LOG_LEVEL"] != "debug" {
+		t.Errorf("added variable missing, NB_LOG_LEVEL = %q", env["NB_LOG_LEVEL"])
+	}
+	if env["NB_SETUP_PAT_ENABLED"] != "false" {
+		t.Errorf("a suite must be able to override a default, NB_SETUP_PAT_ENABLED = %q", env["NB_SETUP_PAT_ENABLED"])
+	}
+}
+
+// Two agents on one network cannot share an alias, so the name has to reach both
+// the alias and the hostname. The hostname is the one management records, so it is
+// also what the peer is addressable by through the API.
+func TestWithClientName(t *testing.T) {
+	o := clientOptions{name: clientAlias}
+	if o.name != "client" {
+		t.Fatalf("unexpected default client name %q", o.name)
+	}
+
+	WithClientName("peer2")(&o)
+	if o.name != "peer2" {
+		t.Errorf("WithClientName did not take, name = %q", o.name)
+	}
+}
+
+// repoRoot has to recognise this module rather than merely finding a go.mod, or a
+// suite in another module gets its own root and a build context without the
+// component Dockerfiles in it.
+func TestIsModule(t *testing.T) {
+	dir := t.TempDir()
+	other := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(other, []byte("module example.com/other\n\ngo 1.25\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if isModule(other, modulePath) {
+		t.Error("another module's go.mod must not be taken for this repo")
+	}
+
+	ours := filepath.Join(dir, "ours.mod")
+	if err := os.WriteFile(ours, []byte("// a comment\n\nmodule "+modulePath+"\n\ngo 1.25\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isModule(ours, modulePath) {
+		t.Error("this repo's go.mod was not recognised")
+	}
+
+	if isModule(filepath.Join(dir, "absent.mod"), modulePath) {
+		t.Error("a missing go.mod must not report a match")
+	}
+}
+
+// Running from inside the repo, repoRoot finds it by walking up — the module
+// lookup is only the fallback, and this asserts the walk still wins so an
+// in-repo run never depends on the module cache.
+func TestRepoRootFindsThisRepo(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("repoRoot: %v", err)
+	}
+	if !isModule(filepath.Join(root, "go.mod"), modulePath) {
+		t.Errorf("repoRoot returned %s, which is not this module", root)
+	}
+	for _, f := range []string{combinedDockerfile, clientDockerfile} {
+		if _, err := os.Stat(filepath.Join(root, f)); err != nil {
+			t.Errorf("%s is not present under the reported root %s: %v", f, root, err)
+		}
+	}
+}

--- a/e2e/harness/options_test.go
+++ b/e2e/harness/options_test.go
@@ -3,11 +3,15 @@
 package harness
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The options exist so a suite can ask for a deployment this harness would not
@@ -18,18 +22,15 @@ import (
 
 func TestCombinedEnvGeolocation(t *testing.T) {
 	var off combinedOptions
-	if got := combinedEnv(off)["NB_DISABLE_GEOLOCATION"]; got != "true" {
-		t.Errorf("geolocation should be off by default, NB_DISABLE_GEOLOCATION = %q", got)
-	}
+	assert.Equal(t, "true", combinedEnv(off)["NB_DISABLE_GEOLOCATION"],
+		"geolocation should be off by default")
 
 	var on combinedOptions
 	WithGeolocation()(&on)
-	if _, set := combinedEnv(on)["NB_DISABLE_GEOLOCATION"]; set {
-		t.Error("WithGeolocation must leave NB_DISABLE_GEOLOCATION unset, so the server downloads the database")
-	}
-	if combinedEnv(on)["NB_SETUP_PAT_ENABLED"] != "true" {
-		t.Error("the setup PAT must stay enabled whatever else is configured; Bootstrap depends on it")
-	}
+	assert.NotContains(t, combinedEnv(on), "NB_DISABLE_GEOLOCATION",
+		"WithGeolocation must leave NB_DISABLE_GEOLOCATION unset, so the server downloads the database")
+	assert.Equal(t, "true", combinedEnv(on)["NB_SETUP_PAT_ENABLED"],
+		"the setup PAT must stay enabled whatever else is configured; Bootstrap depends on it")
 }
 
 // The config file carries the same decision as the environment variable, and the
@@ -50,14 +51,10 @@ func TestCombinedConfigGeolocation(t *testing.T) {
 				opt(&o)
 			}
 			cfg := fmt.Sprintf(combinedConfigYAML, combinedExposedURL, !o.geolocation, containerIssuer)
-			if !strings.Contains(cfg, tc.want) {
-				t.Errorf("config should contain %q, got:\n%s", tc.want, cfg)
-			}
+			assert.Contains(t, cfg, tc.want, "geolocation not rendered as expected")
 			// The issuer is the last verb; a mis-ordered argument list would put
 			// the boolean here instead and the server would fail to start.
-			if !strings.Contains(cfg, `issuer: "`+containerIssuer+`"`) {
-				t.Errorf("issuer not rendered, got:\n%s", cfg)
-			}
+			assert.Contains(t, cfg, `issuer: "`+containerIssuer+`"`, "issuer not rendered")
 		})
 	}
 }
@@ -68,12 +65,8 @@ func TestWithServerEnvOverrides(t *testing.T) {
 	WithServerEnv(map[string]string{"NB_SETUP_PAT_ENABLED": "false"})(&o)
 
 	env := combinedEnv(o)
-	if env["NB_LOG_LEVEL"] != "debug" {
-		t.Errorf("added variable missing, NB_LOG_LEVEL = %q", env["NB_LOG_LEVEL"])
-	}
-	if env["NB_SETUP_PAT_ENABLED"] != "false" {
-		t.Errorf("a suite must be able to override a default, NB_SETUP_PAT_ENABLED = %q", env["NB_SETUP_PAT_ENABLED"])
-	}
+	assert.Equal(t, "debug", env["NB_LOG_LEVEL"], "added variable missing")
+	assert.Equal(t, "false", env["NB_SETUP_PAT_ENABLED"], "a suite must be able to override a default")
 }
 
 // Two agents on one network cannot share an alias, so the name has to reach both
@@ -81,14 +74,10 @@ func TestWithServerEnvOverrides(t *testing.T) {
 // also what the peer is addressable by through the API.
 func TestWithClientName(t *testing.T) {
 	o := clientOptions{name: clientAlias}
-	if o.name != "client" {
-		t.Fatalf("unexpected default client name %q", o.name)
-	}
+	require.Equal(t, "client", o.name, "unexpected default client name")
 
 	WithClientName("peer2")(&o)
-	if o.name != "peer2" {
-		t.Errorf("WithClientName did not take, name = %q", o.name)
-	}
+	assert.Equal(t, "peer2", o.name, "WithClientName did not take")
 }
 
 // repoRoot has to recognise this module rather than merely finding a go.mod, or a
@@ -96,41 +85,77 @@ func TestWithClientName(t *testing.T) {
 // component Dockerfiles in it.
 func TestIsModule(t *testing.T) {
 	dir := t.TempDir()
+
 	other := filepath.Join(dir, "go.mod")
-	if err := os.WriteFile(other, []byte("module example.com/other\n\ngo 1.25\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if isModule(other, modulePath) {
-		t.Error("another module's go.mod must not be taken for this repo")
-	}
+	require.NoError(t, os.WriteFile(other, []byte("module example.com/other\n\ngo 1.25\n"), 0o600))
+	assert.False(t, isModule(other, modulePath), "another module's go.mod must not be taken for this repo")
 
 	ours := filepath.Join(dir, "ours.mod")
-	if err := os.WriteFile(ours, []byte("// a comment\n\nmodule "+modulePath+"\n\ngo 1.25\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if !isModule(ours, modulePath) {
-		t.Error("this repo's go.mod was not recognised")
-	}
+	require.NoError(t, os.WriteFile(ours, []byte("// a comment\n\nmodule "+modulePath+"\n\ngo 1.25\n"), 0o600))
+	assert.True(t, isModule(ours, modulePath), "this repo's go.mod was not recognised")
 
-	if isModule(filepath.Join(dir, "absent.mod"), modulePath) {
-		t.Error("a missing go.mod must not report a match")
-	}
+	assert.False(t, isModule(filepath.Join(dir, "absent.mod"), modulePath),
+		"a missing go.mod must not report a match")
 }
 
 // Running from inside the repo, repoRoot finds it by walking up — the module
-// lookup is only the fallback, and this asserts the walk still wins so an
-// in-repo run never depends on the module cache.
+// lookup is only the fallback, and this asserts the walk still wins so an in-repo
+// run never depends on the module cache.
 func TestRepoRootFindsThisRepo(t *testing.T) {
-	root, err := repoRoot()
-	if err != nil {
-		t.Fatalf("repoRoot: %v", err)
-	}
-	if !isModule(filepath.Join(root, "go.mod"), modulePath) {
-		t.Errorf("repoRoot returned %s, which is not this module", root)
-	}
+	root, err := repoRoot(context.Background())
+	require.NoError(t, err)
+	assert.True(t, isModule(filepath.Join(root, "go.mod"), modulePath),
+		"repoRoot returned %s, which is not this module", root)
+
 	for _, f := range []string{combinedDockerfile, clientDockerfile} {
-		if _, err := os.Stat(filepath.Join(root, f)); err != nil {
-			t.Errorf("%s is not present under the reported root %s: %v", f, root, err)
-		}
+		_, err := os.Stat(filepath.Join(root, f))
+		assert.NoError(t, err, "%s is not present under the reported root %s", f, root)
 	}
+}
+
+// A caller that vendors its dependencies puts the go command in automatic vendor
+// mode, where `go list -m -f {{.Dir}}` succeeds and reports an EMPTY directory:
+// vendor/ holds packages, not module source. Without -mod=readonly the lookup
+// would come back empty and the harness would report a missing module for a
+// dependency that is present.
+func TestModuleDirResolvesUnderVendorMode(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("no go tool on PATH")
+	}
+	ctx := context.Background()
+
+	base := t.TempDir()
+	dep := filepath.Join(base, "dep")
+	main := filepath.Join(base, "main")
+	require.NoError(t, os.MkdirAll(dep, 0o750))
+	require.NoError(t, os.MkdirAll(main, 0o750))
+
+	// A local replacement rather than a real dependency, so this needs no network.
+	require.NoError(t, os.WriteFile(filepath.Join(dep, "go.mod"),
+		[]byte("module example.com/dep\n\ngo 1.25\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dep, "dep.go"),
+		[]byte("package dep\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(main, "go.mod"),
+		[]byte("module example.com/main\n\ngo 1.25\n\nrequire example.com/dep v0.0.0\n\nreplace example.com/dep v0.0.0 => ../dep\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(main, "main.go"),
+		[]byte("package main\n\nimport _ \"example.com/dep\"\n\nfunc main() {}\n"), 0o600))
+
+	t.Chdir(main)
+	vendor := exec.CommandContext(ctx, "go", "mod", "vendor")
+	out, err := vendor.CombinedOutput()
+	require.NoError(t, err, "go mod vendor: %s", out)
+
+	dir, err := moduleDir(ctx, "example.com/dep")
+	require.NoError(t, err, "the module must still resolve with a vendor directory present")
+	assert.Equal(t, dep, dir, "resolved the wrong directory")
+}
+
+// A cancelled context has to stop the lookup rather than leaving the caller
+// waiting on a subprocess it has already given up on.
+func TestModuleDirHonoursContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := moduleDir(ctx, modulePath)
+	assert.Error(t, err, "a cancelled context must fail the lookup")
 }

--- a/e2e/harness/options_test.go
+++ b/e2e/harness/options_test.go
@@ -157,5 +157,5 @@ func TestModuleDirHonoursContext(t *testing.T) {
 	cancel()
 
 	_, err := moduleDir(ctx, modulePath)
-	assert.Error(t, err, "a cancelled context must fail the lookup")
+	assert.ErrorIs(t, err, context.Canceled, "a cancelled context must stop the lookup")
 }

--- a/e2e/harness/paths.go
+++ b/e2e/harness/paths.go
@@ -3,27 +3,75 @@
 package harness
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
-// repoRoot walks up from the working directory to the module root (the
-// directory holding go.mod), so the Docker build context is correct no matter
-// which package the test runs from.
+// modulePath is this module, used both to recognise the repo when walking up
+// from the working directory and to locate it when the suite lives elsewhere.
+const modulePath = "github.com/netbirdio/netbird"
+
+// repoRoot returns the directory the component Dockerfiles are built from.
+//
+// Walking up from the working directory finds it for any test inside this repo,
+// no matter which package it runs from. A suite in another module gets a
+// different answer that way — its own module root, where combined/Dockerfile
+// does not exist — so the ancestor has to be this module and not merely some
+// module. When it is not, the build context is the extracted module directory of
+// whichever version that suite depends on, which is the right one: the server it
+// tests against is then built from the same revision as the client library it
+// was compiled with.
 func repoRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
 	for {
-		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+		if isModule(filepath.Join(dir, "go.mod"), modulePath) {
 			return dir, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", fmt.Errorf("go.mod not found above %s", dir)
+			break
 		}
 		dir = parent
 	}
+	return moduleDir()
+}
+
+// isModule reports whether the go.mod at path declares the given module.
+func isModule(path, want string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "module "); ok {
+			return strings.TrimSpace(rest) == want
+		}
+	}
+	return false
+}
+
+// moduleDir asks the go tool where this module's source is, which for a
+// dependent module is its extracted copy in the module cache. The cache is
+// read-only, and a Docker build context is only ever read.
+func moduleDir() (string, error) {
+	cmd := exec.CommandContext(context.Background(), "go", "list", "-m", "-f", "{{.Dir}}", modulePath)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("locate %s: %w", modulePath, err)
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return "", fmt.Errorf("locate %s: the go tool reported no directory; run `go mod download %s`", modulePath, modulePath)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		return "", fmt.Errorf("locate %s: %w", modulePath, err)
+	}
+	return dir, nil
 }

--- a/e2e/harness/paths.go
+++ b/e2e/harness/paths.go
@@ -25,7 +25,7 @@ const modulePath = "github.com/netbirdio/netbird"
 // whichever version that suite depends on, which is the right one: the server it
 // tests against is then built from the same revision as the client library it
 // was compiled with.
-func repoRoot() (string, error) {
+func repoRoot(ctx context.Context) (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -40,7 +40,7 @@ func repoRoot() (string, error) {
 		}
 		dir = parent
 	}
-	return moduleDir()
+	return moduleDir(ctx, modulePath)
 }
 
 // isModule reports whether the go.mod at path declares the given module.
@@ -57,21 +57,28 @@ func isModule(path, want string) bool {
 	return false
 }
 
-// moduleDir asks the go tool where this module's source is, which for a
-// dependent module is its extracted copy in the module cache. The cache is
-// read-only, and a Docker build context is only ever read.
-func moduleDir() (string, error) {
-	cmd := exec.CommandContext(context.Background(), "go", "list", "-m", "-f", "{{.Dir}}", modulePath)
+// moduleDir asks the go tool where a module's source is, which for a dependent
+// module is its extracted copy in the module cache. The cache is read-only, and
+// a Docker build context is only ever read.
+//
+// -mod=readonly is required rather than cosmetic. A caller that vendors its
+// dependencies puts the go command in automatic vendor mode, where this lookup
+// succeeds with an EMPTY directory — vendor/ holds packages, not module source,
+// so there is nothing to report. Asking in readonly mode resolves against the
+// module graph instead, which answers for both a cached module and a local
+// replacement, and neither writes to go.mod.
+func moduleDir(ctx context.Context, module string) (string, error) {
+	cmd := exec.CommandContext(ctx, "go", "list", "-mod=readonly", "-m", "-f", "{{.Dir}}", module)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("locate %s: %w", modulePath, err)
+		return "", fmt.Errorf("locate %s: %w", module, err)
 	}
 	dir := strings.TrimSpace(string(out))
 	if dir == "" {
-		return "", fmt.Errorf("locate %s: the go tool reported no directory; run `go mod download %s`", modulePath, modulePath)
+		return "", fmt.Errorf("locate %s: the go tool reported no directory; run `go mod download %s`", module, module)
 	}
 	if _, err := os.Stat(dir); err != nil {
-		return "", fmt.Errorf("locate %s: %w", modulePath, err)
+		return "", fmt.Errorf("locate %s: %w", module, err)
 	}
 	return dir, nil
 }

--- a/e2e/harness/proxy.go
+++ b/e2e/harness/proxy.go
@@ -43,7 +43,7 @@ type Proxy struct {
 // or override any NB_PROXY_* var (e.g. NB_PROXY_TUNNEL_CACHE_TTL for tests that
 // need a short authorization-cache window).
 func StartProxy(ctx context.Context, c *Combined, proxyToken string, envOverrides ...map[string]string) (*Proxy, error) {
-	root, err := repoRoot()
+	root, err := repoRoot(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes

`e2e/harness` documents itself as feature-agnostic — *"any suite can ask for a live management server (with an admin PAT minted through the unauthenticated /api/setup bootstrap) and, later, a proxy and client"* — but three details assume the caller lives in this repo. The terraform provider's acceptance suite wants exactly what the package advertises, and today it cannot use it, so it would have to carry a second harness for the same product.

**This does add exported API.** Three option constructors and two variadic parameters, all additive — no existing call site changes, and `StartCombined(ctx)` / `StartClient(ctx, c, key)` compile and behave exactly as before. Nothing outside `e2e/` is touched, and the package is behind the `e2e` build tag so it is absent from normal builds.

| Added | |
| --- | --- |
| `harness.CombinedOption` | option type for `StartCombined` |
| `harness.WithGeolocation()` | keep the GeoLite download |
| `harness.WithServerEnv(map[string]string)` | add/override combined container env |
| `harness.ClientOption` | option type for `StartClient` |
| `harness.WithClientName(string)` | name an agent (alias + hostname) |

### The three problems

**`repoRoot` found any `go.mod`, not this one.** It walked up from the working directory and used the first module root as the Docker build context. From another module that is the caller's own root, where `combined/Dockerfile.multistage` does not exist. It now requires the ancestor to be this module, and falls back to asking the go tool where this module's source is. For a dependent that is the extracted module directory of the version it pins — which is the right context, because the server it tests against is then built from the same revision as the client library it was compiled against.

**Geolocation was off unconditionally**, in both the container environment and `disableGeoliteUpdate`. That is correct for agent-network ingest, which does not use it, but a suite asserting on location-based posture checks needs the database: management evaluates those rules against it, and a rule it cannot evaluate fails rather than passing without having been checked.

```go
srv, err := harness.StartCombined(ctx, harness.WithGeolocation())
srv, err := harness.StartCombined(ctx, harness.WithServerEnv(map[string]string{"NB_LOG_LEVEL": "debug"}))
```

`WithServerEnv` is the general escape hatch, so a suite needing a setting the harness does not model does not have to fork it.

**`StartClient` pinned one network alias and set no hostname.** A second agent cannot start — the alias collides — and the peer's name was whatever the container happened to get. Both matter to a suite whose fixtures address peers by name, since management records the container hostname at registration and that is the name the peer appears under in the API:

```go
c1, _ := harness.StartClient(ctx, srv, key, harness.WithClientName("peer1"))
c2, _ := harness.StartClient(ctx, srv, key, harness.WithClientName("peer2"))
```

## Issue ticket number and link

Not filed. This is test-only: no product behaviour, no protocol, no CLI or service flag, and no package outside `e2e/`. The exported surface added is listed above and is entirely additive. If the additive-exported-API-on-a-test-helper case still wants a ticket first, say so and I will open one before you spend review time.

## Stack



### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

&gt; By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Test-helper internals with no user-facing surface. The behaviour is documented where it is used — on the exported options and in the package doc comment.

### Docs PR URL (required if "docs added" is checked)

n/a

## How this was tested

`e2e/harness/options_test.go` covers the wiring without Docker, because that is what the options are: a container environment and a config file, both assembled before anything starts. A mistake there would otherwise surface as a puzzling failure minutes into a container run.

`TestModuleDirResolvesUnderVendorMode` earns its place: a caller that vendors puts the go command in automatic vendor mode, where the lookup succeeds with an **empty** `Dir`, and the harness then reports a missing module for a dependency that is present. It fails without `-mod=readonly` with exactly that misleading error, which I checked both ways.

**The full suite is green in CI.** [Agent Network E2E run 31569967715](https://github.com/netbirdio/netbird/actions/runs/31569967715) on this branch: **30 tests, all passing, zero failures.**

```
ok  github.com/netbirdio/netbird/e2e/agentnetwork  699.023s
ok  github.com/netbirdio/netbird/e2e/harness         0.021s
```

22 of those are the existing `e2e/agentnetwork` suite, unchanged by this PR — `TestProvidersMatrix` (356s), the six guardrail tests, the pricing and attribution tests, `TestProviderSkipTLSVerification`, `TestVLLMProvider`, and the settings-bootstrap pair. They call `StartCombined(ctx)` and `StartClient(ctx, c, key)` with no options, so they are what covers the unchanged defaults. The other 8 are the new `options_test.go`.

This run had to be dispatched by hand: `agent-network-e2e.yml` triggers only on `schedule` and `workflow_dispatch`, never on `pull_request`, so a PR touching this suite gets no automated coverage of it.

For the record on what I could and could not run locally: my sandbox cannot pull from Docker Hub (the blob CDN returns 403), so `nginx:alpine` is unavailable and the 12 data-plane tests that need a mock vLLM upstream all failed there — identically on `main`, at the same point, before and after this change. I ran the rest against locally-built component images via `NB_E2E_{COMBINED,CLIENT,PROXY}_IMAGE`, with the per-test outcome identical before and after. The CI run above is what actually clears those 12.

## Who wants this

[netbirdio/terraform-provider-netbird#198](https://github.com/netbirdio/terraform-provider-netbird/pull/198) is the consumer: it drops a compose file and a hand-written SQL seed in favour of this harness. Its acceptance suite is green against a deployment started through these options — **129 tests run, 2 skipped, 0 failed** (the two skips are cloud-only SCIM tests that skip unconditionally), including the peer fixtures that need `WithClientName` and the geolocation posture checks that need `WithGeolocation`.

That PR is open rather than draft, and only its `go.mod` waits on this: it currently pins a pseudo-version of this branch, which it replaces once this merges.



## Summary by CodeRabbit

- **New Features**
  - Added configurable test environments with optional geolocation data downloads.
  - Added support for custom server environment variables.
  - Added configurable client names for container hostnames and network aliases.
  - Improved automatic discovery of the project source directory.

- **Bug Fixes**
  - Kept generated configuration and container settings consistent.
  - Improved validation when project files or module information are missing.
  - Improved handling of cancelled operations.

- **Tests**
  - Added coverage for geolocation, environment overrides, client naming, module detection, vendored dependencies, and repository discovery.
