### PR TITLE
[client] Remove installer registry handlers for autostart Run keys

### DIFF
--- a/client/installer.nsis
+++ b/client/installer.nsis
@@ -22,8 +22,6 @@
 !define UI_REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\${UI_APP_EXE}"
 !define UI_UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${UI_APP_NAME}"
 
-!define AUTOSTART_REG_KEY "Software\Microsoft\Windows\CurrentVersion\Run"
-
 !define NETBIRD_DATA_DIR "$COMMONPROGRAMDATA\Netbird"
 
 Unicode True
@@ -228,13 +226,6 @@ WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "Publisher" "${COMP_NAME}"
 
 WriteRegStr ${REG_ROOT} "${UI_REG_APP_PATH}" "" "$INSTDIR\${UI_APP_EXE}"
 
-; Autostart is owned by the UI's per-user setting (HKCU\...\Run via Wails),
-; not the installer. Drop the machine-wide entry older installers wrote so the
-; toggle is the single source of truth. HKCU is left untouched -- it may hold
-; the user's own toggle state, which must survive upgrades.
-DetailPrint "Removing installer-managed autostart registry entry if present..."
-DeleteRegValue HKLM "${AUTOSTART_REG_KEY}" "${APP_NAME}"
-
 EnVar::SetHKLM
 EnVar::AddValueEx "path" "$INSTDIR"
 
@@ -298,15 +289,6 @@ ExecWait '"$INSTDIR\${MAIN_APP_EXE}" service uninstall'
 
 DetailPrint "Terminating Netbird UI process..."
 ExecWait `taskkill /im ${UI_APP_EXE}.exe /f`
-
-; Remove autostart registry entries
-DetailPrint "Removing autostart registry entries if they exist..."
-; Legacy machine-wide entry written by older installers.
-DeleteRegValue HKLM "${AUTOSTART_REG_KEY}" "${APP_NAME}"
-; Per-user entry the UI toggle writes via Wails (value name is the lowercase
-; app-name slug). Uninstall removes the app, so drop it too.
-DeleteRegValue HKCU "${AUTOSTART_REG_KEY}" "${APP_NAME}"
-DeleteRegValue HKCU "${AUTOSTART_REG_KEY}" "netbird"
 
 ; Handle data deletion based on checkbox
 DetailPrint "Checking if user requested data deletion..."


### PR DESCRIPTION
## Describe your changes

The NSIS installer deleted HKLM/HKCU CurrentVersion\Run values it never writes, which matches common AV heuristics for unwanted Run-key manipulation and is suspected to contribute to Windows Defender and third-party antivirus false positives on the installer.

Drop all autostart registry deletions from both the install and uninstall sections so the installer only touches keys it creates itself. Cleanup of the legacy machine-wide entry written by old installers is left to documentation.

Extends the approach of the closed PR #6735, which only removed the per-user deletion on uninstall.


Leftover entries can be removed manually (value names are case-insensitive, one command per hive is enough):

- legacy machine-wide entry written by old (pre-Wails) installers
reg delete "HKLM\Software\Microsoft\Windows\CurrentVersion\Run" /v Netbird /f
 
- per-user entry written by the UI autostart toggle (left behind after uninstall)
reg delete "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" /v Netbird /f

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated uninstallation behavior so existing machine-wide and per-user autostart registry entries are preserved.
  * Other installation and uninstallation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->