### PR TITLE
[client] Reuse the profile's account for iOS SSO logins

### DIFF
--- a/client/internal/auth/device_flow.go
+++ b/client/internal/auth/device_flow.go
@@ -304,6 +304,16 @@ func (d *DeviceAuthorizationFlow) WaitToken(ctx context.Context, info AuthFlowIn
 				return TokenInfo{}, fmt.Errorf("validate access token failed with error: %v", err)
 			}
 
+			// Same as the PKCE flow: the account the token belongs to is what
+			// callers store to send back as the login_hint. Without it a client
+			// driven through the device flow — Android TV and tvOS — never binds
+			// an account to its profile and every later login goes out blind.
+			if email, err := parseEmailFromIDToken(tokenInfo.IDToken); err != nil {
+				log.Warnf("failed to parse email from ID token: %v", err)
+			} else {
+				tokenInfo.Email = email
+			}
+
 			log.Infof("device flow: user authorization confirmed after %d polls in %s", polls, time.Since(start).Round(time.Second))
 			return tokenInfo, err
 		}

--- a/client/ios/NetBirdSDK/login.go
+++ b/client/ios/NetBirdSDK/login.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/netbirdio/netbird/client/internal/auth"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
+	"github.com/netbirdio/netbird/client/mobile"
 	"github.com/netbirdio/netbird/client/system"
 )
 
@@ -284,12 +285,14 @@ func (a *Auth) login(urlOpener URLOpener, forceDeviceAuth bool, deviceName strin
 	}
 
 	jwtToken := ""
+	email := ""
 	if needsLogin {
 		tokenInfo, err := a.foregroundGetTokenInfo(authClient, urlOpener, forceDeviceAuth)
 		if err != nil {
 			return fmt.Errorf("interactive sso login failed: %v", err)
 		}
 		jwtToken = tokenInfo.GetTokenToUse()
+		email = tokenInfo.Email
 	}
 
 	err, isAuthError := authClient.Login(ctx, "", jwtToken)
@@ -299,6 +302,14 @@ func (a *Auth) login(urlOpener URLOpener, forceDeviceAuth bool, deviceName strin
 			return fmt.Errorf("authentication error: %v", err)
 		}
 		return fmt.Errorf("login failed: %v", err)
+	}
+
+	// Stored after Login, not before: a rejected token must not leave a hint
+	// pointing at an account that cannot be used.
+	if email != "" && a.cfgPath != "" {
+		if err := mobile.WriteProfileEmail(a.cfgPath, email); err != nil {
+			log.Warnf("failed to store profile account email: %v", err)
+		}
 	}
 
 	// Save the config before notifying success to ensure persistence completes
@@ -320,10 +331,24 @@ func (a *Auth) login(urlOpener URLOpener, forceDeviceAuth bool, deviceName strin
 	return nil
 }
 
+// profileLoginHint returns the stored account email for the profile at cfgPath,
+// so a re-login targets the account the profile already belongs to instead of
+// whatever session the shared browser cookie jar happens to hold.
+//
+// An empty hint is deliberate, not a fallback: a fresh profile leaves the
+// choice to the IdP. Switching accounts is done by switching or removing
+// profiles, not by logging out — logout keeps the email.
+func profileLoginHint(cfgPath string) string {
+	if cfgPath == "" {
+		return ""
+	}
+	return mobile.ReadProfileEmail(cfgPath)
+}
+
 const authInfoRequestTimeout = 30 * time.Second
 
 func (a *Auth) foregroundGetTokenInfo(authClient *auth.Auth, urlOpener URLOpener, forceDeviceAuth bool) (*auth.TokenInfo, error) {
-	oAuthFlow, err := authClient.GetOAuthFlow(a.ctx, forceDeviceAuth, "")
+	oAuthFlow, err := authClient.GetOAuthFlow(a.ctx, forceDeviceAuth, profileLoginHint(a.cfgPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OAuth flow: %v", err)
 	}

--- a/client/mobile/profile_state.go
+++ b/client/mobile/profile_state.go
@@ -78,8 +78,14 @@ func WriteProfileEmail(configPath string, email string) error {
 		return fmt.Errorf("resolve profile account path: %w", err)
 	}
 
+	// DirectWriteJson, not the atomic writers: those create a temp file and
+	// rename it over the target, which the tvOS App Group sandbox blocks. It is
+	// the same reason the config next to this file goes through
+	// DirectWriteOutConfig. The file is rewritten whole from one key, so losing
+	// atomicity costs nothing beyond a torn write on a crash mid-write, which
+	// reads back as "no email" and is recovered by the next login.
 	state := profilemanager.ProfileState{Email: email}
-	if err := util.WriteJsonWithRestrictedPermission(context.Background(), accountPath, state); err != nil {
+	if err := util.DirectWriteJson(context.Background(), accountPath, state); err != nil {
 		return fmt.Errorf("write profile account: %w", err)
 	}
 

--- a/util/file.go
+++ b/util/file.go
@@ -56,9 +56,9 @@ func WriteJson(ctx context.Context, file string, obj interface{}) error {
 }
 
 // DirectWriteJson writes JSON config object to a file creating parent directories if required without creating a temporary file
-func DirectWriteJson(ctx context.Context, file string, obj interface{}) error {
+func DirectWriteJson(ctx context.Context, file string, obj interface{}) (err error) {
 
-	_, _, err := prepareConfigFileDir(file)
+	_, _, err = prepareConfigFileDir(file)
 	if err != nil {
 		return err
 	}
@@ -68,11 +68,24 @@ func DirectWriteJson(ctx context.Context, file string, obj interface{}) error {
 		return err
 	}
 
+	// Named return so a failed Close is reported rather than logged and
+	// swallowed: the write is only durable once the file closes cleanly, and a
+	// caller told "written" would carry on with data that never landed.
 	defer func() {
-		err = targetFile.Close()
-		if err != nil {
-			log.Errorf("failed to close file %s: %v", file, err)
+		cerr := targetFile.Close()
+		if cerr == nil {
+			return
 		}
+		if err == nil {
+			// Returned, not logged: the caller reports it once.
+			err = cerr
+			return
+		}
+		// The body already failed and that error is the one the caller gets, so
+		// it is the one that explains the failure. This is then the only place
+		// the close failure can surface — at debug, per the logging rules for
+		// close errors on writes.
+		log.Debugf("failed to close file %s after %v: %v", file, err, cerr)
 	}()
 
 	// make it pretty


### PR DESCRIPTION
The iOS binding never recorded which account a profile belongs to, so every interactive login went to the IdP with no login_hint. With nothing to go on the IdP picks an account itself, which the host app could only work around by throwing the browser session away — and with it the IdP's trusted-device cookie, so every re-login asked for the OTP again.

Store the email the PKCE flow already parses out of the ID token, and pass it back as the hint on later flows. An empty hint stays meaningful: a fresh profile, or one that was logged out, deliberately leaves the choice to the IdP, which is how a profile changes accounts. The host app clears the stored email on logout for that reason — while it is on disk it would steer the next login straight back into the account just logged out of.

The email is keyed off the profile's config path rather than the active profile: Auth.login runs in a goroutine, so the active profile can change under a flow already in flight. It lands in <profile>.account.json next to the config. iOS gives every profile its own directory, so the engine's state.json cannot collide with it, but the write still goes through DirectWriteJson: the tvOS App Group sandbox blocks the temp-file+rename the atomic helpers use, the same reason the config itself goes through DirectWriteOutConfig.

Only NewAuth carries that path, and it is the constructor the interactive login uses. NewAuthWithConfig is left alone: it is handed a config rather than a profile, so it has nothing to attribute an account to, and since the engine's own loginToManagement replaced the Run() pre-flight it has no callers here.

ProfileAccountEmail and ClearProfileAccountEmail are exported for the host app, which owns the profile directory layout: it shows the bound account per profile and drops it on logout.

Mirrors 6155c94b, which did the same for Android.

## Describe your changes

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Interactive login now saves the authenticated account email to the local profile when available.
  * OAuth sign-in uses the saved email as a login hint, making repeat authentication more convenient.
  * Profile write issues are logged without interrupting an otherwise successful login.
  * Authentication now continues when account-email details cannot be read from the token.
  * Improved reliability when saving profile information, preventing secondary file-close issues from masking the original error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->