### PR TITLE
[client] Delete NRPT rules by enumerating the registry instead of a rule count

### DIFF
--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -32,9 +32,15 @@ var (
 )
 
 const (
-	dnsPolicyConfigMatchPath    = `SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\DnsPolicyConfig\NetBird-Match`
+	// nrptKeyPrefix starts the name of every NRPT rule key this client creates.
+	// Older versions used different layouts under the same prefix: a single
+	// unsuffixed key, then one key per domain, now one key per batch of domains.
+	nrptKeyPrefix = "NetBird-Match"
+
+	dnsPolicyConfigRoot         = `SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\DnsPolicyConfig`
+	dnsPolicyConfigMatchPath    = dnsPolicyConfigRoot + `\` + nrptKeyPrefix
 	gpoDnsPolicyRoot            = `SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\DnsPolicyConfig`
-	gpoDnsPolicyConfigMatchPath = gpoDnsPolicyRoot + `\NetBird-Match`
+	gpoDnsPolicyConfigMatchPath = gpoDnsPolicyRoot + `\` + nrptKeyPrefix
 
 	dnsPolicyConfigVersionKey           = "Version"
 	dnsPolicyConfigVersionValue         = 2
@@ -73,7 +79,6 @@ type registryConfigurator struct {
 	guid            string
 	routingAll      bool
 	gpo             bool
-	nrptEntryCount  int
 	origNameservers []netip.Addr
 }
 
@@ -306,14 +311,9 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig, stateManager
 	}
 
 	if len(matchDomains) != 0 {
-		count, err := r.addDNSMatchPolicy(matchDomains, config.ServerIP)
-		// Update count even on error to ensure cleanup covers partially created rules
-		r.nrptEntryCount = count
-		if err != nil {
+		if err := r.addDNSMatchPolicy(matchDomains, config.ServerIP); err != nil {
 			return fmt.Errorf("add dns match policy: %w", err)
 		}
-	} else {
-		r.nrptEntryCount = 0
 	}
 
 	r.updateState(stateManager)
@@ -329,9 +329,8 @@ func (r *registryConfigurator) applyDNSConfig(config HostDNSConfig, stateManager
 
 func (r *registryConfigurator) updateState(stateManager *statemanager.Manager) {
 	if err := stateManager.UpdateState(&ShutdownState{
-		Guid:           r.guid,
-		GPO:            r.gpo,
-		NRPTEntryCount: r.nrptEntryCount,
+		Guid: r.guid,
+		GPO:  r.gpo,
 	}); err != nil {
 		log.Errorf("failed to update shutdown state: %s", err)
 	}
@@ -346,7 +345,7 @@ func (r *registryConfigurator) addDNSSetupForAll(ip netip.Addr) error {
 	return nil
 }
 
-func (r *registryConfigurator) addDNSMatchPolicy(domains []string, ip netip.Addr) (int, error) {
+func (r *registryConfigurator) addDNSMatchPolicy(domains []string, ip netip.Addr) error {
 	// if the gpo key is present, we need to put our DNS settings there, otherwise our config might be ignored
 	// see https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpnrpt/8cc31cb9-20cb-4140-9e85-3e08703b4745
 
@@ -363,19 +362,17 @@ func (r *registryConfigurator) addDNSMatchPolicy(domains []string, ip netip.Addr
 		gpoPath := fmt.Sprintf("%s-%d", gpoDnsPolicyConfigMatchPath, ruleIndex)
 
 		if err := r.configureDNSPolicy(localPath, batchDomains, ip); err != nil {
-			return ruleIndex, fmt.Errorf("configure DNS Local policy for rule %d: %w", ruleIndex, err)
+			return fmt.Errorf("configure DNS Local policy for rule %d: %w", ruleIndex, err)
 		}
-
-		// Increment immediately so the caller's cleanup path knows about this rule
-		ruleIndex++
 
 		if r.gpo {
 			if err := r.configureDNSPolicy(gpoPath, batchDomains, ip); err != nil {
-				return ruleIndex, fmt.Errorf("configure gpo DNS policy for rule %d: %w", ruleIndex-1, err)
+				return fmt.Errorf("configure gpo DNS policy for rule %d: %w", ruleIndex, err)
 			}
 		}
 
-		log.Debugf("added NRPT rule %d with %d domains", ruleIndex-1, len(batchDomains))
+		log.Debugf("added NRPT rule %d with %d domains", ruleIndex, len(batchDomains))
+		ruleIndex++
 	}
 
 	if r.gpo {
@@ -385,7 +382,7 @@ func (r *registryConfigurator) addDNSMatchPolicy(domains []string, ip netip.Addr
 	}
 
 	log.Infof("added %d NRPT rules for %d domains", ruleIndex, len(domains))
-	return ruleIndex, nil
+	return nil
 }
 
 func (r *registryConfigurator) configureDNSPolicy(policyPath string, domains []string, ip netip.Addr) error {
@@ -518,28 +515,28 @@ func (r *registryConfigurator) restoreHostDNS() error {
 	return nil
 }
 
+// removeDNSMatchPolicies deletes every NRPT rule this client may have created,
+// from the local and the GPO policy store. The rules are found by enumerating
+// the registry, the only authoritative record of what was written. Cleanup must
+// not depend on a rule count: the in-memory one is scoped to a single
+// registryConfigurator and the persisted one is deleted on every clean
+// disconnect, and a rule left behind keeps resolving names over an interface
+// that is gone, until reboot discards the volatile key.
 func (r *registryConfigurator) removeDNSMatchPolicies() error {
 	var merr *multierror.Error
 
-	// Try to remove the base entries (for backward compatibility)
-	if err := removeRegistryKeyFromDNSPolicyConfig(dnsPolicyConfigMatchPath); err != nil {
-		merr = multierror.Append(merr, fmt.Errorf("remove local base entry: %w", err))
-	}
-
-	if err := removeRegistryKeyFromDNSPolicyConfig(gpoDnsPolicyConfigMatchPath); err != nil {
-		merr = multierror.Append(merr, fmt.Errorf("remove GPO base entry: %w", err))
-	}
-
-	for i := 0; i < r.nrptEntryCount; i++ {
-		localPath := fmt.Sprintf("%s-%d", dnsPolicyConfigMatchPath, i)
-		gpoPath := fmt.Sprintf("%s-%d", gpoDnsPolicyConfigMatchPath, i)
-
-		if err := removeRegistryKeyFromDNSPolicyConfig(localPath); err != nil {
-			merr = multierror.Append(merr, fmt.Errorf("remove local entry %d: %w", i, err))
+	for _, root := range []string{dnsPolicyConfigRoot, gpoDnsPolicyRoot} {
+		names, err := listNRPTRuleKeys(root)
+		if err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("list rule keys under %s: %w", root, err))
+			continue
 		}
 
-		if err := removeRegistryKeyFromDNSPolicyConfig(gpoPath); err != nil {
-			merr = multierror.Append(merr, fmt.Errorf("remove GPO entry %d: %w", i, err))
+		for _, name := range names {
+			path := root + `\` + name
+			if err := removeRegistryKeyFromDNSPolicyConfig(path); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("remove entry %s: %w", path, err))
+			}
 		}
 	}
 
@@ -552,6 +549,33 @@ func (r *registryConfigurator) removeDNSMatchPolicies() error {
 
 func (r *registryConfigurator) restoreUncleanShutdownDNS() error {
 	return r.restoreHostDNS()
+}
+
+// listNRPTRuleKeys returns the names of our NRPT rule keys under a policy store
+// root. A root that cannot be opened holds nothing to clean up: the GPO store is
+// absent on a machine without DNS Client policy.
+func listNRPTRuleKeys(root string) ([]string, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, root, registry.ENUMERATE_SUB_KEYS)
+	if err != nil {
+		log.Debugf("failed to open HKEY_LOCAL_MACHINE\\%s: %v", root, err)
+		return nil, nil
+	}
+	defer closer(k)
+
+	names, err := k.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("read subkey names: %w", err)
+	}
+
+	var ruleKeys []string
+	for _, name := range names {
+		// registry key names are case insensitive
+		if strings.HasPrefix(strings.ToLower(name), strings.ToLower(nrptKeyPrefix)) {
+			ruleKeys = append(ruleKeys, name)
+		}
+	}
+
+	return ruleKeys, nil
 }
 
 func removeRegistryKeyFromDNSPolicyConfig(regKeyPath string) error {

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -552,13 +552,19 @@ func (r *registryConfigurator) restoreUncleanShutdownDNS() error {
 }
 
 // listNRPTRuleKeys returns the names of our NRPT rule keys under a policy store
-// root. A root that cannot be opened holds nothing to clean up: the GPO store is
-// absent on a machine without DNS Client policy.
+// root. An absent root holds nothing to clean up, which is the normal state of
+// the GPO store on a machine without DNS Client policy.
 func listNRPTRuleKeys(root string) ([]string, error) {
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, root, registry.ENUMERATE_SUB_KEYS)
-	if err != nil {
-		log.Debugf("failed to open HKEY_LOCAL_MACHINE\\%s: %v", root, err)
+	switch {
+	case errors.Is(err, registry.ErrNotExist), errors.Is(err, syscall.ERROR_PATH_NOT_FOUND):
+		// the GPO store is absent on a machine without DNS client policy
+		log.Debugf("HKEY_LOCAL_MACHINE\\%s does not exist", root)
 		return nil, nil
+	case err != nil:
+		// any other failure has to reach the caller: reporting no rules would
+		// report a successful cleanup while leaving the rules in place
+		return nil, fmt.Errorf("open HKEY_LOCAL_MACHINE\\%s: %w", root, err)
 	}
 	defer closer(k)
 

--- a/client/internal/dns/host_windows_test.go
+++ b/client/internal/dns/host_windows_test.go
@@ -25,7 +25,7 @@ func TestNRPTEntriesCleanupOnConfigChange(t *testing.T) {
 
 	// Create a test interface registry key so updateSearchDomains doesn't fail
 	testGUID := "{12345678-1234-1234-1234-123456789ABC}"
-	interfacePath := `SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\` + testGUID
+	interfacePath := interfaceConfigPath + `\` + testGUID
 	testKey, _, err := registry.CreateKey(registry.LOCAL_MACHINE, interfacePath, registry.SET_VALUE)
 	require.NoError(t, err, "Should create test interface registry key")
 	testKey.Close()
@@ -56,7 +56,7 @@ func TestNRPTEntriesCleanupOnConfigChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify 3 NRPT rules exist
-	assert.Equal(t, 3, cfg.nrptEntryCount, "Should create 3 NRPT rules for 125 domains")
+	assert.Equal(t, 3, countNRPTRuleKeys(t), "Should create 3 NRPT rules for 125 domains")
 	for i := 0; i < 3; i++ {
 		exists, err := registryKeyExists(fmt.Sprintf("%s-%d", dnsPolicyConfigMatchPath, i))
 		require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestNRPTEntriesCleanupOnConfigChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify first 2 NRPT rules exist
-	assert.Equal(t, 2, cfg.nrptEntryCount, "Should create 2 NRPT rules for 75 domains")
+	assert.Equal(t, 2, countNRPTRuleKeys(t), "Should create 2 NRPT rules for 75 domains")
 	for i := 0; i < 2; i++ {
 		exists, err := registryKeyExists(fmt.Sprintf("%s-%d", dnsPolicyConfigMatchPath, i))
 		require.NoError(t, err)
@@ -106,9 +106,65 @@ func registryKeyExists(path string) (bool, error) {
 	return true, nil
 }
 
+// TestNRPTCleanupWithoutRuleCount verifies that rules written by a previous run
+// are removed by a configurator that has no record of how many there are: an
+// unclean exit loses the in-memory count and a clean disconnect deletes the
+// persisted one, so cleanup cannot depend on either.
+func TestNRPTCleanupWithoutRuleCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping registry integration test in short mode")
+	}
+
+	defer cleanupRegistryKeys(t)
+	cleanupRegistryKeys(t)
+
+	testIP := netip.MustParseAddr("100.64.0.1")
+
+	// 75 domains produce two indexed rules, as the current layout does
+	domains := make([]string, 75)
+	for i := range domains {
+		domains[i] = fmt.Sprintf(".domain%d.com", i+1)
+	}
+
+	previousRun := &registryConfigurator{}
+	require.NoError(t, previousRun.addDNSMatchPolicy(domains, testIP))
+
+	// the unsuffixed key an older version would have written
+	require.NoError(t, previousRun.configureDNSPolicy(dnsPolicyConfigMatchPath, []string{".legacy.example.com"}, testIP))
+
+	// a policy owned by someone else, which cleanup must not touch
+	foreignPath := dnsPolicyConfigRoot + `\DnsPolicyConfigTestForeign`
+	foreignKey, _, err := registry.CreateKey(registry.LOCAL_MACHINE, foreignPath, registry.SET_VALUE)
+	require.NoError(t, err, "Should create foreign policy key")
+	foreignKey.Close()
+	defer func() {
+		_ = registry.DeleteKey(registry.LOCAL_MACHINE, foreignPath)
+	}()
+
+	require.Equal(t, 3, countNRPTRuleKeys(t), "Should have two indexed rules and the legacy one")
+
+	// a configurator that never applied a DNS config, as one built after a
+	// restart or from a shutdown state without a count is
+	freshRun := &registryConfigurator{}
+	require.NoError(t, freshRun.removeDNSMatchPolicies())
+
+	assert.Equal(t, 0, countNRPTRuleKeys(t), "Should remove every rule left by the previous run")
+
+	exists, err := registryKeyExists(foreignPath)
+	require.NoError(t, err)
+	assert.True(t, exists, "Should not remove a policy that is not ours")
+}
+
+func countNRPTRuleKeys(t *testing.T) int {
+	t.Helper()
+
+	names, err := listNRPTRuleKeys(dnsPolicyConfigRoot)
+	require.NoError(t, err, "Should list NRPT rule keys")
+	return len(names)
+}
+
 func cleanupRegistryKeys(*testing.T) {
-	// Clean up more entries to account for batching tests with many domains
-	cfg := &registryConfigurator{nrptEntryCount: 20}
+	cfg := &registryConfigurator{}
 	_ = cfg.removeDNSMatchPolicies()
 }
 
@@ -125,7 +181,7 @@ func TestNRPTDomainBatching(t *testing.T) {
 
 	// Create a test interface registry key so updateSearchDomains doesn't fail
 	testGUID := "{12345678-1234-1234-1234-123456789ABC}"
-	interfacePath := `SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\` + testGUID
+	interfacePath := interfaceConfigPath + `\` + testGUID
 	testKey, _, err := registry.CreateKey(registry.LOCAL_MACHINE, interfacePath, registry.SET_VALUE)
 	require.NoError(t, err, "Should create test interface registry key")
 	testKey.Close()
@@ -193,7 +249,7 @@ func TestNRPTDomainBatching(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify that exactly expectedRuleCount rules were created
-			assert.Equal(t, tc.expectedRuleCount, cfg.nrptEntryCount,
+			assert.Equal(t, tc.expectedRuleCount, countNRPTRuleKeys(t),
 				"Should create %d NRPT rules for %d domains", tc.expectedRuleCount, tc.domainCount)
 
 			// Verify all expected rules exist

--- a/client/internal/dns/unclean_shutdown_windows.go
+++ b/client/internal/dns/unclean_shutdown_windows.go
@@ -5,9 +5,8 @@ import (
 )
 
 type ShutdownState struct {
-	Guid           string
-	GPO            bool
-	NRPTEntryCount int
+	Guid string
+	GPO  bool
 }
 
 func (s *ShutdownState) Name() string {
@@ -16,9 +15,8 @@ func (s *ShutdownState) Name() string {
 
 func (s *ShutdownState) Cleanup() error {
 	manager := &registryConfigurator{
-		guid:           s.Guid,
-		gpo:            s.GPO,
-		nrptEntryCount: s.NRPTEntryCount,
+		guid: s.Guid,
+		gpo:  s.GPO,
 	}
 
 	if err := manager.restoreUncleanShutdownDNS(); err != nil {


### PR DESCRIPTION
## Describe your changes

NRPT rule cleanup on Windows deleted the indexed registry keys by counting them instead of reading what is actually there. That count lives only in memory and in the persisted shutdown state, and both can be absent: a configurator that never applied a DNS config starts at zero, and a clean disconnect deletes the state entry. In those cases the loop deletes nothing and any rule it skipped stays behind, keeping a namespace pointed at an interface that is gone until a reboot discards the volatile key. The registry is the authoritative record of what was written, so cleanup reads it.

- Delete the NRPT rules of both the local and the group policy store by enumerating the keys the client owns, rather than deriving their names from a count
- Cover the key layouts older versions wrote, which a count based on the current layout cannot
- Drop the rule count from the configurator and from the persisted shutdown state, since nothing needs it anymore
- Leave rules that belong to other products untouched
- Add tests for cleaning up rules a previous run wrote with no count available, and assert the existing NRPT tests against the registry rather than the counter

## Issue ticket number and link

Hardening of existing cleanup, no behavior change on the path where the count is intact.

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): internal cleanup behavior with no user facing surface

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows DNS policy cleanup to reliably remove all application-managed rules, including rules left behind after an unexpected shutdown or restart.
  * Preserved unrelated DNS policy entries during cleanup.
  * Improved handling of grouped and legacy policy entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->