### PR TITLE
[client] Add Windows DNS configuration to the debug bundle

### DIFF
--- a/client/anonymize/anonymize.go
+++ b/client/anonymize/anonymize.go
@@ -305,6 +305,12 @@ func (a *Anonymizer) AnonymizeDomain(domain string) string {
 		return domain
 	}
 
+	// A reverse zone names an address prefix, so it follows the address rules,
+	// which also keeps its digit labels intact.
+	if zone, ok := a.anonymizeReverseZone(baseDomain); ok {
+		return withTrailingDot(zone, hasDot)
+	}
+
 	if suffix := protectedSuffix(baseDomain); suffix != "" {
 		if a.level < LevelStrict || baseDomain == suffix || suffix == infraDomain {
 			return domain
@@ -405,6 +411,10 @@ func (a *Anonymizer) AnonymizeString(str string) string {
 	ipv4Regex := regexp.MustCompile(`\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b`)
 	ipv6Regex := regexp.MustCompile(`\b([0-9a-fA-F:]+:+[0-9a-fA-F]{0,4})(?:%[0-9a-zA-Z]+)?(?:\/[0-9]{1,3})?(?::[0-9]{1,5})?\b`)
 
+	// Reverse zones go first and are then held out of the passes below: their
+	// labels are digits, which the address patterns would otherwise consume.
+	str, restoreZones := a.replaceReverseZones(str)
+
 	str = ipv4Regex.ReplaceAllStringFunc(str, a.AnonymizeIPString)
 	str = ipv6Regex.ReplaceAllStringFunc(str, a.AnonymizeIPString)
 
@@ -425,7 +435,7 @@ func (a *Anonymizer) AnonymizeString(str string) string {
 		str = wgKeyRegex.ReplaceAllStringFunc(str, a.AnonymizeWGKey)
 	}
 
-	return str
+	return restoreZones(str)
 }
 
 // sortedDomains returns the domain mappings longest-first, so a full-FQDN

--- a/client/anonymize/reverse_zone.go
+++ b/client/anonymize/reverse_zone.go
@@ -1,0 +1,174 @@
+package anonymize
+
+import (
+	"encoding/hex"
+	"net/netip"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	reverseZoneSuffixV4 = ".in-addr.arpa"
+	reverseZoneSuffixV6 = ".ip6.arpa"
+
+	v6Nibbles = 32
+	v4Octets  = 4
+)
+
+// reverseZoneRegexes match a reverse zone or a full reverse name in free text.
+// They are applied before the address passes of AnonymizeString, whose IPv4
+// pattern would otherwise consume the digit labels of a zone and replace parts
+// of it with unrelated addresses.
+var reverseZoneRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`(?:[0-9]{1,3}\.){1,4}in-addr\.arpa\b`),
+	regexp.MustCompile(`(?:[0-9a-fA-F]\.){1,32}ip6\.arpa\b`),
+}
+
+// anonymizeReverseZone maps a reverse zone to the zone of the anonymized form
+// of the prefix it encodes, so it follows the address rules rather than the
+// domain ones: the zone of an address that is preserved is preserved too, and
+// the zone of one that is replaced names the replacement. This keeps a reverse
+// zone recognizable as such, and consistent with the addresses it belongs to
+// elsewhere in the same output. It reports false for anything that is not a
+// reverse zone.
+func (a *Anonymizer) anonymizeReverseZone(domain string) (string, bool) {
+	prefix, labelCount, suffix, ok := parseReverseZone(domain)
+	if !ok {
+		return "", false
+	}
+
+	anonymized := a.AnonymizeIP(prefix)
+	if anonymized == prefix {
+		return domain, true
+	}
+
+	return reverseZoneName(anonymized, labelCount) + suffix, true
+}
+
+// replaceReverseZones anonymizes every reverse zone in str and swaps each one
+// for a placeholder, returning a function that puts the anonymized zones back.
+// The placeholders carry no dots, digits or colons, so no later pass matches
+// them.
+func (a *Anonymizer) replaceReverseZones(str string) (string, func(string) string) {
+	var zones []string
+
+	for _, re := range reverseZoneRegexes {
+		str = re.ReplaceAllStringFunc(str, func(match string) string {
+			zone, ok := a.anonymizeReverseZone(match)
+			if !ok {
+				return match
+			}
+
+			zones = append(zones, zone)
+			return reverseZonePlaceholder(len(zones) - 1)
+		})
+	}
+
+	if len(zones) == 0 {
+		return str, func(s string) string { return s }
+	}
+
+	return str, func(s string) string {
+		for i, zone := range zones {
+			s = strings.ReplaceAll(s, reverseZonePlaceholder(i), zone)
+		}
+		return s
+	}
+}
+
+func reverseZonePlaceholder(index int) string {
+	return "\x00reversezone" + strconv.Itoa(index) + "\x00"
+}
+
+// parseReverseZone turns a reverse zone into the address of the prefix its
+// labels spell backwards, padding the absent low-order part with zeroes, and
+// returns the label count and zone suffix so the name can be rebuilt.
+func parseReverseZone(domain string) (netip.Addr, int, string, bool) {
+	lower := strings.ToLower(domain)
+
+	switch {
+	case strings.HasSuffix(lower, reverseZoneSuffixV4):
+		labels := strings.Split(strings.TrimSuffix(lower, reverseZoneSuffixV4), ".")
+		addr, ok := reverseZoneAddrV4(labels)
+		return addr, len(labels), reverseZoneSuffixV4, ok
+	case strings.HasSuffix(lower, reverseZoneSuffixV6):
+		labels := strings.Split(strings.TrimSuffix(lower, reverseZoneSuffixV6), ".")
+		addr, ok := reverseZoneAddrV6(labels)
+		return addr, len(labels), reverseZoneSuffixV6, ok
+	default:
+		return netip.Addr{}, 0, "", false
+	}
+}
+
+func reverseZoneAddrV4(labels []string) (netip.Addr, bool) {
+	if len(labels) == 0 || len(labels) > v4Octets {
+		return netip.Addr{}, false
+	}
+
+	var octets [v4Octets]byte
+	for i, label := range labels {
+		octet, err := strconv.ParseUint(label, 10, 8)
+		if err != nil {
+			return netip.Addr{}, false
+		}
+		octets[len(labels)-1-i] = byte(octet)
+	}
+
+	return netip.AddrFrom4(octets), true
+}
+
+func reverseZoneAddrV6(labels []string) (netip.Addr, bool) {
+	if len(labels) == 0 || len(labels) > v6Nibbles {
+		return netip.Addr{}, false
+	}
+
+	nibbles := make([]byte, 0, v6Nibbles)
+	for i := len(labels) - 1; i >= 0; i-- {
+		if len(labels[i]) != 1 || !isHexDigit(labels[i][0]) {
+			return netip.Addr{}, false
+		}
+		nibbles = append(nibbles, labels[i][0])
+	}
+	for len(nibbles) < v6Nibbles {
+		nibbles = append(nibbles, '0')
+	}
+
+	var groups []string
+	for i := 0; i < len(nibbles); i += 4 {
+		groups = append(groups, string(nibbles[i:i+4]))
+	}
+
+	addr, err := netip.ParseAddr(strings.Join(groups, ":"))
+	if err != nil {
+		return netip.Addr{}, false
+	}
+
+	return addr, true
+}
+
+// reverseZoneName spells the first labelCount labels of addr backwards, the
+// inverse of parseReverseZone, without the zone suffix.
+func reverseZoneName(addr netip.Addr, labelCount int) string {
+	labels := make([]string, 0, labelCount)
+
+	if addr.Is4() {
+		octets := addr.As4()
+		for i := labelCount - 1; i >= 0; i-- {
+			labels = append(labels, strconv.Itoa(int(octets[i])))
+		}
+		return strings.Join(labels, ".")
+	}
+
+	address := addr.As16()
+	nibbles := hex.EncodeToString(address[:])
+	for i := labelCount - 1; i >= 0; i-- {
+		labels = append(labels, string(nibbles[i]))
+	}
+
+	return strings.Join(labels, ".")
+}
+
+func isHexDigit(c byte) bool {
+	return c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F'
+}

--- a/client/anonymize/reverse_zone_test.go
+++ b/client/anonymize/reverse_zone_test.go
@@ -1,0 +1,171 @@
+package anonymize
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newLeveledAnonymizer(level Level) *Anonymizer {
+	a := NewAnonymizer(DefaultAddresses())
+	a.SetLevel(level)
+	return a
+}
+
+// TestAnonymizeDomainReverseZone covers reverse zones going through the address
+// rules instead of the domain ones, so a zone stays a zone and an address that
+// is preserved keeps the zone that names it.
+func TestAnonymizeDomainReverseZone(t *testing.T) {
+	// 100.64.0.0/10 is the overlay range, which is CGNAT: preserved at the
+	// default level and replaced from the internal pool at the strict one
+	const overlayZone = "64.100.in-addr.arpa"
+
+	t.Run("overlay zone preserved at the default level", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+		assert.Equal(t, overlayZone, a.AnonymizeDomain(overlayZone), "should keep the zone of a preserved address")
+	})
+
+	t.Run("private zone preserved at the default level", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+		assert.Equal(t, "168.192.in-addr.arpa", a.AnonymizeDomain("168.192.in-addr.arpa"), "should keep the zone of a private address")
+	})
+
+	t.Run("overlay zone replaced at the strict level", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelStrict)
+
+		got := a.AnonymizeDomain(overlayZone)
+		require.True(t, strings.HasSuffix(got, reverseZoneSuffixV4), "should stay a reverse zone, got %q", got)
+		assert.NotEqual(t, overlayZone, got, "should replace the encoded prefix")
+		assert.Len(t, strings.Split(strings.TrimSuffix(got, reverseZoneSuffixV4), "."), 2,
+			"should keep the label count, got %q", got)
+	})
+
+	t.Run("public zone replaced at the default level", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+
+		got := a.AnonymizeDomain("113.0.203.in-addr.arpa")
+		require.True(t, strings.HasSuffix(got, reverseZoneSuffixV4), "should stay a reverse zone, got %q", got)
+		assert.NotEqual(t, "113.0.203.in-addr.arpa", got, "should replace a public prefix")
+	})
+
+	t.Run("zone of an address keeps that address mapping", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+
+		anonymizedAddr := a.AnonymizeIPString("203.0.113.7")
+		got := a.AnonymizeDomain("7.113.0.203.in-addr.arpa")
+
+		octets := strings.Split(anonymizedAddr, ".")
+		want := octets[3] + "." + octets[2] + "." + octets[1] + "." + octets[0] + reverseZoneSuffixV4
+		assert.Equal(t, want, got, "should name the same replacement as the address itself")
+	})
+
+	t.Run("ipv6 nibble labels stay single digits", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+
+		zone := "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0" + reverseZoneSuffixV6
+		got := a.AnonymizeDomain(zone)
+
+		require.True(t, strings.HasSuffix(got, reverseZoneSuffixV6), "should stay a reverse zone, got %q", got)
+		labels := strings.Split(strings.TrimSuffix(got, reverseZoneSuffixV6), ".")
+		assert.Len(t, labels, 28, "should keep every nibble label, got %q", got)
+		for _, label := range labels {
+			assert.Len(t, label, 1, "nibble label %q should stay a single digit", label)
+		}
+	})
+
+	t.Run("trailing dot is kept", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+		assert.Equal(t, "64.100.in-addr.arpa.", a.AnonymizeDomain("64.100.in-addr.arpa."), "should keep the trailing dot")
+	})
+
+	t.Run("a domain that only looks like a zone is anonymized as a domain", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+
+		got := a.AnonymizeDomain("not-a-zone.in-addr.arpa")
+		assert.NotContains(t, got, "in-addr.arpa", "should fall back to domain anonymization")
+	})
+}
+
+// TestAnonymizeStringReverseZone verifies that a zone inside free text, such as
+// a DNS log line, is not chewed up by the address passes. The IPv4 pattern
+// matches any run of dotted digits, which a reverse zone is made of.
+func TestAnonymizeStringReverseZone(t *testing.T) {
+	t.Run("ipv6 zone survives the address passes", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+
+		zone := "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0" + reverseZoneSuffixV6
+		got := a.AnonymizeString("question: domain=" + zone + " type=PTR")
+
+		assert.Contains(t, got, "type=PTR", "should keep the rest of the line")
+		assert.NotContains(t, got, "198.51.100", "should not rewrite nibble labels as an address")
+
+		labels := strings.Split(strings.TrimSuffix(strings.TrimPrefix(got, "question: domain="), reverseZoneSuffixV6+" type=PTR"), ".")
+		assert.Len(t, labels, 28, "should keep every nibble label, got %q", got)
+	})
+
+	t.Run("preserved ipv4 zone is untouched", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+
+		line := "reverse zone 64.100.in-addr.arpa registered"
+		assert.Equal(t, line, a.AnonymizeString(line), "should keep the zone of a preserved address")
+	})
+
+	t.Run("public ipv4 zone is replaced consistently", func(t *testing.T) {
+		a := newLeveledAnonymizer(LevelDefault)
+
+		got := a.AnonymizeString("zone 113.0.203.in-addr.arpa and address 203.0.113.7")
+		assert.NotContains(t, got, "113.0.203.in-addr.arpa", "should replace the zone")
+		assert.NotContains(t, got, "203.0.113.7", "should replace the address")
+		assert.Contains(t, got, reverseZoneSuffixV4, "should keep the zone suffix")
+	})
+}
+
+func TestParseReverseZone(t *testing.T) {
+	tests := []struct {
+		name   string
+		zone   string
+		addr   string
+		labels int
+	}{
+		{name: "v4 two labels", zone: "0.100" + reverseZoneSuffixV4, addr: "100.0.0.0", labels: 2},
+		{name: "v4 three labels", zone: "1.168.192" + reverseZoneSuffixV4, addr: "192.168.1.0", labels: 3},
+		{name: "v4 full address", zone: "7.113.0.203" + reverseZoneSuffixV4, addr: "203.0.113.7", labels: 4},
+		{
+			name:   "v6 prefix",
+			zone:   "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0" + reverseZoneSuffixV6,
+			addr:   "2::",
+			labels: 28,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, labels, suffix, ok := parseReverseZone(tc.zone)
+			require.True(t, ok, "should decode the reverse zone")
+			assert.Equal(t, tc.addr, addr.String(), "should decode to the encoded prefix")
+			assert.Equal(t, tc.labels, labels, "should count the labels")
+			assert.Equal(t, tc.zone, reverseZoneName(addr, labels)+suffix, "should re-encode to the original zone")
+		})
+	}
+}
+
+func TestParseReverseZoneRejectsNonZones(t *testing.T) {
+	tests := []string{
+		"example.com",
+		"in-addr.arpa",
+		"x.100" + reverseZoneSuffixV4,
+		"256" + reverseZoneSuffixV4,
+		"1.2.3.4.5" + reverseZoneSuffixV4,
+		"ab" + reverseZoneSuffixV6,
+		"g" + reverseZoneSuffixV6,
+	}
+
+	for _, zone := range tests {
+		t.Run(zone, func(t *testing.T) {
+			_, _, _, ok := parseReverseZone(zone)
+			assert.False(t, ok, "should reject %q", zone)
+		})
+	}
+}

--- a/client/internal/debug/debug.go
+++ b/client/internal/debug/debug.go
@@ -51,6 +51,7 @@ nftables.txt: Anonymized nftables rules with packet counters across all families
 sysctls.txt: Forwarding, reverse-path filter, source-validation, and conntrack accounting sysctl values that the NetBird client may read or modify, if --system-info flag was provided (Linux only).
 resolv.conf: DNS resolver configuration from /etc/resolv.conf (Unix systems only), if --system-info flag was provided.
 scutil_dns.txt: DNS configuration from scutil --dns (macOS only), if --system-info flag was provided.
+dns_windows.txt: Anonymized NRPT rules and policy table in effect, DNS client policy, and per-interface and per-adapter DNS configuration (Windows only), if --system-info flag was provided.
 resolved_domains.txt: Anonymized resolved domain IP addresses from the status recorder.
 config.txt: Anonymized configuration information of the NetBird client.
 network_map.json: Anonymized sync response containing peer configurations, routes, DNS settings, and firewall rules.
@@ -236,6 +237,13 @@ scutil_dns.txt (macOS only):
 - Contains detailed DNS configuration from scutil --dns
 - Shows DNS configuration for all network interfaces
 - Includes search domains, nameservers, and DNS resolver settings
+- All IP addresses and domain names are anonymized
+
+dns_windows.txt (Windows only):
+- Lists the NRPT rules of both policy stores, the local one and the group policy one, marking the rules the client created
+- Follows them with the policy table the resolver has loaded, which differs from the rules while a change has not been picked up yet
+- Includes the DNS client group policy, the global TCP/IP and Dnscache parameters, and the DNS values of every interface that has any
+- Ends with the resolver configuration in effect per adapter, from GetAdaptersAddresses
 - All IP addresses and domain names are anonymized
 `
 

--- a/client/internal/debug/debug_nonunix.go
+++ b/client/internal/debug/debug_nonunix.go
@@ -1,4 +1,4 @@
-//go:build !unix
+//go:build !unix && !windows
 
 package debug
 

--- a/client/internal/debug/debug_windows.go
+++ b/client/internal/debug/debug_windows.go
@@ -1,0 +1,405 @@
+//go:build windows
+
+package debug
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+
+	nbdns "github.com/netbirdio/netbird/client/internal/dns"
+)
+
+const dnsInfoFileName = "dns_windows.txt"
+
+const (
+	gpoDNSClientRoot = `SOFTWARE\Policies\Microsoft\Windows NT\DNSClient`
+	tcpipParamsPath  = `SYSTEM\CurrentControlSet\Services\Tcpip\Parameters`
+	dnscacheParams   = `SYSTEM\CurrentControlSet\Services\Dnscache\Parameters`
+)
+
+// interfaceDNSValues are the per-interface values that decide how a name is
+// resolved and registered. Everything the DNS host manager writes is in here,
+// so a bundle shows both what we set and what it replaced.
+var interfaceDNSValues = []string{
+	"NameServer",
+	"DhcpNameServer",
+	"Domain",
+	"DhcpDomain",
+	"SearchList",
+	"RegistrationEnabled",
+	"DisableDynamicUpdate",
+	"MaxNumberOfAddressesToRegister",
+	"EnableDHCP",
+}
+
+// addDNSInfo collects and adds DNS configuration information to the archive
+func (g *BundleGenerator) addDNSInfo() error {
+	var sb strings.Builder
+
+	sb.WriteString("Windows DNS configuration\n")
+	sb.WriteString("=========================\n")
+
+	adapters, adaptersErr := adapterAddresses()
+
+	g.writeNRPTRules(&sb, "NRPT rules, local policy store", nbdns.DNSPolicyConfigRoot)
+	g.writeNRPTRules(&sb, "NRPT rules, group policy store", nbdns.GPODNSPolicyConfigRoot)
+	g.writeEffectiveNRPTPolicies(&sb)
+	g.writeRegistryKey(&sb, "DNS client group policy", gpoDNSClientRoot)
+	g.writeRegistryKey(&sb, "Global TCP/IP parameters", tcpipParamsPath)
+	g.writeRegistryKey(&sb, "Dnscache parameters", dnscacheParams)
+	g.writeInterfaceDNS(&sb, "Per-interface DNS, IPv4", nbdns.InterfaceConfigPath, adapterNames(adapters))
+	g.writeInterfaceDNS(&sb, "Per-interface DNS, IPv6", nbdns.InterfaceConfigPathV6, adapterNames(adapters))
+	g.writeAdapterDNS(&sb, adapters, adaptersErr)
+
+	if err := g.addFileToZip(strings.NewReader(sb.String()), dnsInfoFileName); err != nil {
+		return fmt.Errorf("add DNS info to zip: %w", err)
+	}
+
+	return nil
+}
+
+// writeNRPTRules lists every rule in a policy store, ours and any other
+// product's, since a foreign rule for the same namespace decides resolution
+// just as ours does. Rules the client wrote are marked.
+func (g *BundleGenerator) writeNRPTRules(sb *strings.Builder, title, root string) {
+	writeSection(sb, title, root)
+
+	names, err := subKeyNames(root)
+	if err != nil {
+		fmt.Fprintf(sb, "error: %v\n", err)
+		return
+	}
+
+	if len(names) == 0 {
+		sb.WriteString("no rules\n")
+		return
+	}
+
+	for _, name := range names {
+		owner := ""
+		if strings.HasPrefix(strings.ToLower(name), strings.ToLower(nbdns.NRPTKeyPrefix)) {
+			owner = "  (netbird)"
+		}
+		fmt.Fprintf(sb, "%s%s\n", name, owner)
+		g.writeValues(sb, root+`\`+name, nil, "  ")
+	}
+}
+
+// writeEffectiveNRPTPolicies reports the table the resolver answers from, which
+// the registry cannot show: a rule is written before it is loaded, and it keeps
+// being enforced after its key is gone until the resolver reloads its policy.
+func (g *BundleGenerator) writeEffectiveNRPTPolicies(sb *strings.Builder) {
+	writeSection(sb, "NRPT policy table in effect", nrptPolicyClass+"."+nrptPolicyMethod+" in "+nrptPolicyNamespace)
+
+	entries, err := effectiveNRPTPolicies()
+	if err != nil {
+		fmt.Fprintf(sb, "error: %v\n", err)
+		return
+	}
+
+	if len(entries) == 0 {
+		sb.WriteString("no policies\n")
+		return
+	}
+
+	for _, entry := range entries {
+		fmt.Fprintf(sb, "%s\n", g.anonymizeValue("Namespace", entry.namespace))
+		for _, value := range entry.values {
+			fmt.Fprintf(sb, "  %s: %s\n", value.name, g.anonymizeValue(value.name, value.value))
+		}
+	}
+}
+
+// writeInterfaceDNS reports the DNS values of every interface that has any, so
+// the netbird interface can be compared against the physical ones. The registry
+// keys the values by GUID, so each is named from the adapter list; a GUID with
+// no adapter is a leftover key of an interface that no longer exists.
+func (g *BundleGenerator) writeInterfaceDNS(sb *strings.Builder, title, root string, names map[string]string) {
+	writeSection(sb, title, root)
+
+	guids, err := subKeyNames(root)
+	if err != nil {
+		fmt.Fprintf(sb, "error: %v\n", err)
+		return
+	}
+
+	var reported int
+	for _, guid := range guids {
+		var iface strings.Builder
+		g.writeValues(&iface, root+`\`+guid, interfaceDNSValues, "  ")
+		if iface.Len() == 0 {
+			continue
+		}
+
+		name, ok := names[strings.ToLower(guid)]
+		if !ok {
+			name = "no adapter with this GUID"
+		}
+
+		reported++
+		fmt.Fprintf(sb, "%s (%s)\n%s", guid, name, iface.String())
+	}
+
+	if reported == 0 {
+		sb.WriteString("no interface holds DNS values\n")
+	}
+}
+
+// writeRegistryKey reports the values of a single key, without its subkeys.
+func (g *BundleGenerator) writeRegistryKey(sb *strings.Builder, title, path string) {
+	writeSection(sb, title, path)
+
+	var values strings.Builder
+	g.writeValues(&values, path, nil, "")
+	if values.Len() == 0 {
+		sb.WriteString("no values\n")
+		return
+	}
+
+	sb.WriteString(values.String())
+}
+
+// writeValues renders the values of a key. A nil names list reports every
+// value, otherwise only those named and present.
+func (g *BundleGenerator) writeValues(sb *strings.Builder, path string, names []string, indent string) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, path, registry.QUERY_VALUE)
+	if err != nil {
+		// an absent key is the normal state for the GPO store and for
+		// interfaces without DNS settings
+		log.Debugf("open HKEY_LOCAL_MACHINE\\%s: %v", path, err)
+		return
+	}
+	defer closeKey(k)
+
+	if names == nil {
+		names, err = k.ReadValueNames(-1)
+		if err != nil {
+			fmt.Fprintf(sb, "%serror: read value names: %v\n", indent, err)
+			return
+		}
+	}
+
+	for _, name := range names {
+		value, err := readRegistryValue(k, name)
+		if err != nil {
+			continue
+		}
+
+		fmt.Fprintf(sb, "%s%s: %s\n", indent, name, g.anonymizeValue(name, value))
+	}
+}
+
+// anonymizeValue redacts a registry value according to what its name says it
+// holds. Domains and addresses are handled per entry rather than by the string
+// pass: the pass only replaces domains something else in the bundle already
+// seeded, and its address regex would eat the digit labels of a reverse zone.
+func (g *BundleGenerator) anonymizeValue(name, value string) string {
+	if !g.anonymize || value == "" {
+		return value
+	}
+
+	switch {
+	case holdsDomains(name):
+		return joinValueEntries(splitValueEntries(value), g.anonymizeDomain)
+	case holdsAddresses(name):
+		return joinValueEntries(splitValueEntries(value), g.anonymizer.AnonymizeIPString)
+	default:
+		return g.anonymizer.AnonymizeString(value)
+	}
+}
+
+// holdsDomains reports whether a value name holds domains: the domain list of
+// an NRPT rule (Name) or of the policy table (Namespace), a search list, the
+// DNS suffix values of the TCP/IP and policy keys, which all end in "Domain"
+// (Domain, DhcpDomain, NV Domain, ICSDomain), and a proxy host name.
+func holdsDomains(name string) bool {
+	lower := strings.ToLower(name)
+	return lower == "name" || lower == "namespace" || lower == "searchlist" ||
+		strings.HasSuffix(lower, "domain") || strings.HasSuffix(lower, "proxyname")
+}
+
+// holdsAddresses reports whether a value name holds DNS server addresses
+// (NameServer, DhcpNameServer, GenericDNSServers, NameServers).
+func holdsAddresses(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.Contains(lower, "nameserver") || strings.Contains(lower, "dnsserver")
+}
+
+// adapterNames maps adapter GUIDs, as the registry keys the interfaces, to the
+// names an operator sees.
+func adapterNames(adapters []*windows.IpAdapterAddresses) map[string]string {
+	names := make(map[string]string, len(adapters))
+	for _, adapter := range adapters {
+		guid := windows.BytePtrToString(adapter.AdapterName)
+		names[strings.ToLower(guid)] = windows.UTF16PtrToString(adapter.FriendlyName)
+	}
+	return names
+}
+
+// writeAdapterDNS reports the resolver configuration in effect per adapter,
+// which is what the resolver uses for a name no NRPT rule matches.
+func (g *BundleGenerator) writeAdapterDNS(sb *strings.Builder, adapters []*windows.IpAdapterAddresses, err error) {
+	writeSection(sb, "Adapter DNS configuration", "GetAdaptersAddresses")
+
+	if err != nil {
+		fmt.Fprintf(sb, "error: %v\n", err)
+		return
+	}
+
+	for _, adapter := range adapters {
+		name := windows.UTF16PtrToString(adapter.FriendlyName)
+		suffix := g.anonymizeDomain(windows.UTF16PtrToString(adapter.DnsSuffix))
+
+		fmt.Fprintf(sb, "%s (index %d, oper status %d)\n", name, adapter.IfIndex, adapter.OperStatus)
+		fmt.Fprintf(sb, "  DNS suffix: %s\n", suffix)
+
+		var servers []string
+		for server := adapter.FirstDnsServerAddress; server != nil; server = server.Next {
+			ip := server.Address.IP()
+			if ip == nil {
+				continue
+			}
+
+			address := ip.String()
+			if g.anonymize {
+				address = g.anonymizer.AnonymizeIPString(address)
+			}
+			servers = append(servers, address)
+		}
+
+		fmt.Fprintf(sb, "  DNS servers: %s\n", strings.Join(servers, ", "))
+	}
+}
+
+// anonymizeDomain anonymizes a single domain, keeping the leading dot an NRPT
+// match domain carries.
+func (g *BundleGenerator) anonymizeDomain(entry string) string {
+	if !g.anonymize {
+		return entry
+	}
+
+	domain, dot := strings.CutPrefix(entry, ".")
+	if domain == "" {
+		return entry
+	}
+
+	anonymized := g.anonymizer.AnonymizeDomain(domain)
+	if dot {
+		anonymized = "." + anonymized
+	}
+	return anonymized
+}
+
+// splitValueEntries splits a registry value that holds a list. The separator
+// differs per value: a REG_MULTI_SZ arrives joined with ", ", a SearchList is
+// comma separated and a NameServer may use commas or spaces.
+func splitValueEntries(value string) []string {
+	return strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';' || r == ' ' || r == '\t'
+	})
+}
+
+func joinValueEntries(entries []string, anonymize func(string) string) string {
+	for i, entry := range entries {
+		entries[i] = anonymize(entry)
+	}
+	return strings.Join(entries, ", ")
+}
+
+func writeSection(sb *strings.Builder, title, source string) {
+	fmt.Fprintf(sb, "\n%s\n%s\n%s\n", title, strings.Repeat("-", len(title)), source)
+}
+
+func subKeyNames(root string) ([]string, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, root, registry.ENUMERATE_SUB_KEYS)
+	if err != nil {
+		return nil, fmt.Errorf("open HKEY_LOCAL_MACHINE\\%s: %w", root, err)
+	}
+	defer closeKey(k)
+
+	names, err := k.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("read subkey names: %w", err)
+	}
+
+	return names, nil
+}
+
+// readRegistryValue renders a value as text regardless of its type, so an
+// unexpected type in a policy key still shows up instead of being dropped.
+func readRegistryValue(k registry.Key, name string) (string, error) {
+	_, valueType, err := k.GetValue(name, nil)
+	if err != nil {
+		return "", fmt.Errorf("get value %s: %w", name, err)
+	}
+
+	switch valueType {
+	case registry.SZ, registry.EXPAND_SZ:
+		value, _, err := k.GetStringValue(name)
+		if err != nil {
+			return "", fmt.Errorf("get string value %s: %w", name, err)
+		}
+		return value, nil
+	case registry.MULTI_SZ:
+		values, _, err := k.GetStringsValue(name)
+		if err != nil {
+			return "", fmt.Errorf("get strings value %s: %w", name, err)
+		}
+		return strings.Join(values, ", "), nil
+	case registry.DWORD, registry.QWORD:
+		value, _, err := k.GetIntegerValue(name)
+		if err != nil {
+			return "", fmt.Errorf("get integer value %s: %w", name, err)
+		}
+		return fmt.Sprintf("%d (0x%x)", value, value), nil
+	case registry.BINARY:
+		value, _, err := k.GetBinaryValue(name)
+		if err != nil {
+			return "", fmt.Errorf("get binary value %s: %w", name, err)
+		}
+		return hex.EncodeToString(value), nil
+	default:
+		return fmt.Sprintf("<unhandled registry type %d>", valueType), nil
+	}
+}
+
+// adapterAddresses returns the adapter list including DNS servers. The call
+// reports the size it needs, so grow the buffer and retry until it fits.
+func adapterAddresses() ([]*windows.IpAdapterAddresses, error) {
+	const flags = windows.GAA_FLAG_SKIP_ANYCAST | windows.GAA_FLAG_SKIP_MULTICAST
+
+	size := uint32(15000)
+	for range 3 {
+		buf := make([]byte, size)
+		first := (*windows.IpAdapterAddresses)(unsafe.Pointer(&buf[0]))
+
+		err := windows.GetAdaptersAddresses(windows.AF_UNSPEC, flags, 0, first, &size)
+		if errors.Is(err, windows.ERROR_BUFFER_OVERFLOW) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("GetAdaptersAddresses: %w", err)
+		}
+
+		var adapters []*windows.IpAdapterAddresses
+		for adapter := first; adapter != nil; adapter = adapter.Next {
+			adapters = append(adapters, adapter)
+		}
+		return adapters, nil
+	}
+
+	return nil, fmt.Errorf("GetAdaptersAddresses: buffer kept growing")
+}
+
+func closeKey(k registry.Key) {
+	if err := k.Close(); err != nil {
+		log.Debugf("close registry key: %v", err)
+	}
+}

--- a/client/internal/debug/debug_windows.go
+++ b/client/internal/debug/debug_windows.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/netip"
 	"strings"
 	"unsafe"
 
@@ -41,7 +42,28 @@ var interfaceDNSValues = []string{
 
 // addDNSInfo collects and adds DNS configuration information to the archive
 func (g *BundleGenerator) addDNSInfo() error {
+	if err := g.addFileToZip(strings.NewReader(g.collectDNSInfo()), dnsInfoFileName); err != nil {
+		return fmt.Errorf("add DNS info to zip: %w", err)
+	}
+
+	return nil
+}
+
+// collectDNSInfo renders the report. Everything below it reaches the platform
+// through COM and through lazily resolved procedures, which panic when a
+// procedure is missing rather than returning an error, and a debug bundle is not
+// allowed to take the daemon down. The panic is contained here, and whatever was
+// collected before it is kept and reported with it.
+func (g *BundleGenerator) collectDNSInfo() (content string) {
 	var sb strings.Builder
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("collecting Windows DNS configuration panicked: %v", r)
+			fmt.Fprintf(&sb, "\nerror: collection stopped: %v\n", r)
+		}
+		content = sb.String()
+	}()
 
 	sb.WriteString("Windows DNS configuration\n")
 	sb.WriteString("=========================\n")
@@ -58,11 +80,7 @@ func (g *BundleGenerator) addDNSInfo() error {
 	g.writeInterfaceDNS(&sb, "Per-interface DNS, IPv6", nbdns.InterfaceConfigPathV6, adapterNames(adapters))
 	g.writeAdapterDNS(&sb, adapters, adaptersErr)
 
-	if err := g.addFileToZip(strings.NewReader(sb.String()), dnsInfoFileName); err != nil {
-		return fmt.Errorf("add DNS info to zip: %w", err)
-	}
-
-	return nil
+	return sb.String()
 }
 
 // writeNRPTRules lists every rule in a policy store, ours and any other
@@ -170,10 +188,14 @@ func (g *BundleGenerator) writeRegistryKey(sb *strings.Builder, title, path stri
 // value, otherwise only those named and present.
 func (g *BundleGenerator) writeValues(sb *strings.Builder, path string, names []string, indent string) {
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, path, registry.QUERY_VALUE)
-	if err != nil {
+	switch {
+	case errors.Is(err, registry.ErrNotExist), errors.Is(err, windows.ERROR_PATH_NOT_FOUND):
 		// an absent key is the normal state for the GPO store and for
 		// interfaces without DNS settings
-		log.Debugf("open HKEY_LOCAL_MACHINE\\%s: %v", path, err)
+		log.Debugf("HKEY_LOCAL_MACHINE\\%s does not exist", path)
+		return
+	case err != nil:
+		fmt.Fprintf(sb, "%serror: open HKEY_LOCAL_MACHINE\\%s: %v\n", indent, path, err)
 		return
 	}
 	defer closeKey(k)
@@ -188,7 +210,15 @@ func (g *BundleGenerator) writeValues(sb *strings.Builder, path string, names []
 
 	for _, name := range names {
 		value, err := readRegistryValue(k, name)
-		if err != nil {
+		switch {
+		case errors.Is(err, registry.ErrNotExist):
+			// the caller asks for a fixed set of values, most of which a
+			// given interface does not carry
+			continue
+		case err != nil:
+			// report rather than omit: a value that is there but cannot be
+			// read reads as unset otherwise
+			fmt.Fprintf(sb, "%s%s: error: %v\n", indent, name, err)
 			continue
 		}
 
@@ -262,16 +292,16 @@ func (g *BundleGenerator) writeAdapterDNS(sb *strings.Builder, adapters []*windo
 
 		var servers []string
 		for server := adapter.FirstDnsServerAddress; server != nil; server = server.Next {
-			ip := server.Address.IP()
-			if ip == nil {
+			addr, ok := netip.AddrFromSlice(server.Address.IP())
+			if !ok {
 				continue
 			}
 
-			address := ip.String()
+			addr = addr.Unmap()
 			if g.anonymize {
-				address = g.anonymizer.AnonymizeIPString(address)
+				addr = g.anonymizer.AnonymizeIP(addr)
 			}
-			servers = append(servers, address)
+			servers = append(servers, addr.String())
 		}
 
 		fmt.Fprintf(sb, "  DNS servers: %s\n", strings.Join(servers, ", "))
@@ -372,7 +402,16 @@ func readRegistryValue(k registry.Key, name string) (string, error) {
 
 // adapterAddresses returns the adapter list including DNS servers. The call
 // reports the size it needs, so grow the buffer and retry until it fits.
-func adapterAddresses() ([]*windows.IpAdapterAddresses, error) {
+func adapterAddresses() (adapters []*windows.IpAdapterAddresses, err error) {
+	// GetAdaptersAddresses is resolved on first use and panics when it is
+	// missing, so this reports it as an error and leaves the rest of the
+	// report intact.
+	defer func() {
+		if r := recover(); r != nil {
+			adapters, err = nil, fmt.Errorf("GetAdaptersAddresses: %v", r)
+		}
+	}()
+
 	const flags = windows.GAA_FLAG_SKIP_ANYCAST | windows.GAA_FLAG_SKIP_MULTICAST
 
 	size := uint32(15000)
@@ -388,7 +427,6 @@ func adapterAddresses() ([]*windows.IpAdapterAddresses, error) {
 			return nil, fmt.Errorf("GetAdaptersAddresses: %w", err)
 		}
 
-		var adapters []*windows.IpAdapterAddresses
 		for adapter := first; adapter != nil; adapter = adapter.Next {
 			adapters = append(adapters, adapter)
 		}

--- a/client/internal/debug/debug_windows_test.go
+++ b/client/internal/debug/debug_windows_test.go
@@ -1,0 +1,146 @@
+//go:build windows
+
+package debug
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/anonymize"
+)
+
+func newDNSValueGenerator(level anonymize.Level) *BundleGenerator {
+	anonymizer := anonymize.NewAnonymizer(anonymize.DefaultAddresses())
+	anonymizer.SetLevel(level)
+
+	return &BundleGenerator{
+		anonymize:      true,
+		anonymizeLevel: level,
+		anonymizer:     anonymizer,
+	}
+}
+
+// TestAnonymizeValueByName covers the value kinds of the DNS registry keys. The
+// names decide the treatment, because the string pass alone replaces only
+// domains another part of the bundle already seeded.
+func TestAnonymizeValueByName(t *testing.T) {
+	tests := []struct {
+		name      string
+		valueName string
+		value     string
+		assert    func(t *testing.T, got string)
+	}{
+		{
+			name:      "NRPT match domains keep the leading dot",
+			valueName: "Name",
+			value:     ".internal.example.com, .corp.example.org",
+			assert: func(t *testing.T, got string) {
+				t.Helper()
+				for _, entry := range strings.Split(got, ", ") {
+					assert.True(t, strings.HasPrefix(entry, "."), "entry %q should keep its leading dot", entry)
+					assert.NotContains(t, entry, "example", "entry %q should not keep the original domain", entry)
+				}
+			},
+		},
+		{
+			name:      "any value name ending in Domain is treated as a domain",
+			valueName: "ICSDomain",
+			value:     "mshome.net",
+			assert: func(t *testing.T, got string) {
+				t.Helper()
+				assert.NotContains(t, got, "mshome", "should anonymize a domain suffix value")
+			},
+		},
+		{
+			name:      "search list is a comma separated domain list",
+			valueName: "SearchList",
+			value:     "corp.example.com,branch.example.com",
+			assert: func(t *testing.T, got string) {
+				t.Helper()
+				assert.NotContains(t, got, "example", "should anonymize every search domain")
+				assert.Len(t, strings.Split(got, ", "), 2, "should keep both search domains")
+			},
+		},
+		{
+			name:      "name servers are anonymized as addresses",
+			valueName: "DhcpNameServer",
+			value:     "203.0.113.10 8.8.8.8",
+			assert: func(t *testing.T, got string) {
+				t.Helper()
+				assert.NotContains(t, got, "203.0.113.10", "should anonymize a public resolver address")
+				// well-known resolvers stay readable at every level
+				assert.Contains(t, got, "8.8.8.8", "should keep a well-known resolver address")
+			},
+		},
+		{
+			name:      "opaque values are left to the string pass",
+			valueName: "DataBasePath",
+			value:     `%SystemRoot%\System32\drivers\etc`,
+			assert: func(t *testing.T, got string) {
+				t.Helper()
+				assert.Equal(t, `%SystemRoot%\System32\drivers\etc`, got, "should not alter a path")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := newDNSValueGenerator(anonymize.LevelDefault)
+			tc.assert(t, g.anonymizeValue(tc.valueName, tc.value))
+		})
+	}
+}
+
+// TestParseNRPTPolicyTable parses the MOF text of the policy table out
+// parameters, as the provider on a client with one NRPT rule renders it.
+func TestParseNRPTPolicyTable(t *testing.T) {
+	const text = `[abstract]
+class __PARAMETERS
+{
+	[Out, EmbeddedInstance("DnsClientPolicyConfiguration"): ToSubClass, ID(2): DisableOverride ToInstance] DnsClientPolicyConfiguration cmdletOutput[] = {
+instance of DnsClientPolicyConfiguration
+{
+	DirectAccessProxyType = "NoProxy";
+	DirectAccessQueryIPsecRequired = FALSE;
+	NameEncoding = "Utf8WithoutMapping";
+	Namespace = ".0.100.in-addr.arpa";
+}, 
+instance of DnsClientPolicyConfiguration
+{
+	DirectAccessProxyType = "NoProxy";
+	NameEncoding = "Utf8WithoutMapping";
+	NameServers = {"100.0.255.254", "100.0.255.253"};
+	Namespace = ".nb.internal";
+}};
+	[in] boolean Effective;
+	[out] uint32 ReturnValue = 0;
+};
+`
+
+	entries := parseNRPTPolicyTable(text)
+	require.Len(t, entries, 2, "should parse both embedded instances")
+
+	assert.Equal(t, ".0.100.in-addr.arpa", entries[0].namespace, "should read the namespace of the first instance")
+	assert.Equal(t, ".nb.internal", entries[1].namespace, "should read the namespace of the second instance")
+
+	assert.Equal(t, []registryValue{
+		{name: "DirectAccessProxyType", value: "NoProxy"},
+		{name: "DirectAccessQueryIPsecRequired", value: "FALSE"},
+		{name: "NameEncoding", value: "Utf8WithoutMapping"},
+	}, entries[0].values, "should keep the remaining values in order")
+
+	assert.Contains(t, entries[1].values, registryValue{name: "NameServers", value: "100.0.255.254, 100.0.255.253"},
+		"should flatten a MOF array")
+
+	for _, value := range entries[1].values {
+		assert.NotContains(t, value.name, "ReturnValue", "should not read the class level parameters as values")
+	}
+}
+
+func TestParseNRPTPolicyTableEmpty(t *testing.T) {
+	assert.Empty(t, parseNRPTPolicyTable(""), "should parse no entries from empty text")
+	assert.Empty(t, parseNRPTPolicyTable("class __PARAMETERS\n{\n};\n"), "should parse no entries from a table with no instances")
+}

--- a/client/internal/debug/nrpt_windows.go
+++ b/client/internal/debug/nrpt_windows.go
@@ -32,12 +32,18 @@ const (
 	nrptPolicyTimeout = 15 * time.Second
 )
 
-// COM initialization results that mean the calling thread is already usable.
+// COM initialization results that leave the calling thread usable: S_FALSE for
+// a thread this process already initialized, RPC_E_CHANGED_MODE for one that
+// belongs to another apartment.
 const (
-	sFalse           = 0x00000001
-	rpcEChangedMode  = 0x80010106
-	nrptQueryTimeout = "timed out"
+	sFalse          = 0x00000001
+	rpcEChangedMode = 0x80010106
 )
+
+// nrptQueryInFlight admits one read of the policy table at a time. A provider
+// that stops answering keeps its goroutine and the OS thread that goroutine
+// pinned, so a later bundle reports that instead of pinning another one.
+var nrptQueryInFlight = make(chan struct{}, 1)
 
 // nrptPolicyEntry is one namespace of the effective policy table, holding the
 // values of an embedded DnsClientPolicyConfiguration instance in the order the
@@ -62,8 +68,18 @@ func effectiveNRPTPolicies() ([]nrptPolicyEntry, error) {
 		err  error
 	}
 
+	select {
+	case nrptQueryInFlight <- struct{}{}:
+	default:
+		return nil, errors.New("an earlier read of the policy table has not returned")
+	}
+
 	done := make(chan result, 1)
 	go func() {
+		// the slot is released here rather than by the caller, so a read that
+		// outlives the timeout holds it until the provider answers
+		defer func() { <-nrptQueryInFlight }()
+
 		text, err := nrptPolicyTableText()
 		done <- result{text: text, err: err}
 	}()
@@ -75,7 +91,7 @@ func effectiveNRPTPolicies() ([]nrptPolicyEntry, error) {
 		}
 		return parseNRPTPolicyTable(res.text), nil
 	case <-time.After(nrptPolicyTimeout):
-		return nil, errors.New(nrptQueryTimeout)
+		return nil, errors.New("read of the policy table timed out")
 	}
 }
 
@@ -95,10 +111,13 @@ func nrptPolicyTableText() (text string, err error) {
 		}
 	}()
 
-	if err := coInitialize(); err != nil {
+	owns, err := coInitialize()
+	if err != nil {
 		return "", err
 	}
-	defer ole.CoUninitialize()
+	if owns {
+		defer ole.CoUninitialize()
+	}
 
 	locator, err := oleutil.CreateObject("WbemScripting.SWbemLocator")
 	if err != nil {
@@ -242,25 +261,29 @@ func unquoteMOFValue(value string) string {
 	return strings.Trim(value, `"`)
 }
 
-func coInitialize() error {
+// coInitialize prepares the calling thread for COM and reports whether this
+// call owns the initialization, which decides whether it may be balanced with
+// CoUninitialize. S_FALSE took a reference on a thread this process had already
+// initialized and so has to be released, while RPC_E_CHANGED_MODE took none:
+// the thread belongs to another apartment, which is usable but is not ours to
+// uninitialize.
+func coInitialize() (bool, error) {
 	err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
 	if err == nil {
-		return nil
+		return true, nil
 	}
 
-	// An already initialized thread reports S_FALSE, and one initialized in
-	// another apartment reports RPC_E_CHANGED_MODE. Both are usable, and
-	// neither owns the uninitialize call, which is balanced per successful
-	// initialization.
 	var oleErr *ole.OleError
 	if errors.As(err, &oleErr) {
 		switch oleErr.Code() {
-		case sFalse, rpcEChangedMode:
-			return nil
+		case sFalse:
+			return true, nil
+		case rpcEChangedMode:
+			return false, nil
 		}
 	}
 
-	return fmt.Errorf("initialize COM: %w", err)
+	return false, fmt.Errorf("initialize COM: %w", err)
 }
 
 // dispatchCall calls a COM method that returns an object.

--- a/client/internal/debug/nrpt_windows.go
+++ b/client/internal/debug/nrpt_windows.go
@@ -1,0 +1,294 @@
+//go:build windows
+
+package debug
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/go-ole/go-ole"
+	"github.com/go-ole/go-ole/oleutil"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// The NRPT policy table is reachable through the CIM class that backs
+	// Get-DnsClientNrptPolicy. Unlike the rules in the registry, the table is
+	// what the resolver currently has loaded, which is the only way to tell an
+	// applied rule from one that is merely written, in either direction.
+	nrptPolicyNamespace = `root\Microsoft\Windows\DNS`
+	nrptPolicyClass     = "PS_DnsClientNrptPolicy"
+	nrptPolicyMethod    = "Get"
+
+	// The class has no instances, so the table comes from the out parameters
+	// of a static method call, rendered as MOF text: the embedded instances
+	// arrive as a safe array of objects, which cannot be read back through the
+	// COM bindings, and the text form carries all of them.
+	nrptPolicyInstanceKeyword = "instance of DnsClientPolicyConfiguration"
+
+	nrptPolicyTimeout = 15 * time.Second
+)
+
+// COM initialization results that mean the calling thread is already usable.
+const (
+	sFalse           = 0x00000001
+	rpcEChangedMode  = 0x80010106
+	nrptQueryTimeout = "timed out"
+)
+
+// nrptPolicyEntry is one namespace of the effective policy table, holding the
+// values of an embedded DnsClientPolicyConfiguration instance in the order the
+// provider reported them.
+type nrptPolicyEntry struct {
+	namespace string
+	values    []registryValue
+}
+
+// registryValue is a name and its rendered value, shared by the registry and
+// policy table readers so both anonymize by value name the same way.
+type registryValue struct {
+	name  string
+	value string
+}
+
+// effectiveNRPTPolicies reads the effective NRPT table. The call is bounded
+// because a WMI provider can block indefinitely and a debug bundle must not.
+func effectiveNRPTPolicies() ([]nrptPolicyEntry, error) {
+	type result struct {
+		text string
+		err  error
+	}
+
+	done := make(chan result, 1)
+	go func() {
+		text, err := nrptPolicyTableText()
+		done <- result{text: text, err: err}
+	}()
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			return nil, res.err
+		}
+		return parseNRPTPolicyTable(res.text), nil
+	case <-time.After(nrptPolicyTimeout):
+		return nil, errors.New(nrptQueryTimeout)
+	}
+}
+
+// nrptPolicyTableText calls the policy table method and returns the MOF text of
+// its out parameters.
+func nrptPolicyTableText() (text string, err error) {
+	// COM is per thread, and the collection is short lived, so the thread is
+	// pinned for the duration rather than initialized for the process.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	defer func() {
+		// The COM call chain is dynamically typed, so a provider that answers
+		// with an unexpected shape must not take the daemon down with it.
+		if r := recover(); r != nil {
+			err = fmt.Errorf("read NRPT policy table: %v", r)
+		}
+	}()
+
+	if err := coInitialize(); err != nil {
+		return "", err
+	}
+	defer ole.CoUninitialize()
+
+	locator, err := oleutil.CreateObject("WbemScripting.SWbemLocator")
+	if err != nil {
+		return "", fmt.Errorf("create WMI locator: %w", err)
+	}
+	defer locator.Release()
+
+	dispatch, err := locator.QueryInterface(ole.IID_IDispatch)
+	if err != nil {
+		return "", fmt.Errorf("query WMI locator interface: %w", err)
+	}
+	defer dispatch.Release()
+
+	service, err := dispatchCall(dispatch, "ConnectServer", nil, nrptPolicyNamespace)
+	if err != nil {
+		return "", fmt.Errorf("connect to %s: %w", nrptPolicyNamespace, err)
+	}
+	defer service.Release()
+
+	inParams, err := spawnMethodInParams(service)
+	if err != nil {
+		return "", err
+	}
+	defer inParams.Release()
+
+	// The effective table is the merge of the local and the group policy
+	// store, which is what the resolver answers from.
+	if _, err := oleutil.PutProperty(inParams, "Effective", true); err != nil {
+		return "", fmt.Errorf("set Effective parameter: %w", err)
+	}
+
+	outParams, err := dispatchCall(service, "ExecMethod", nrptPolicyClass, nrptPolicyMethod, inParams)
+	if err != nil {
+		return "", fmt.Errorf("call %s.%s: %w", nrptPolicyClass, nrptPolicyMethod, err)
+	}
+	defer outParams.Release()
+
+	textVariant, err := oleutil.CallMethod(outParams, "GetObjectText_")
+	if err != nil {
+		return "", fmt.Errorf("render policy table: %w", err)
+	}
+	defer func() {
+		if err := textVariant.Clear(); err != nil {
+			log.Debugf("clear policy table variant: %v", err)
+		}
+	}()
+
+	return textVariant.ToString(), nil
+}
+
+// spawnMethodInParams builds the in parameters instance the method needs. The
+// provider rejects the call without one, even when every parameter is optional.
+func spawnMethodInParams(service *ole.IDispatch) (*ole.IDispatch, error) {
+	class, err := dispatchCall(service, "Get", nrptPolicyClass)
+	if err != nil {
+		return nil, fmt.Errorf("get class %s: %w", nrptPolicyClass, err)
+	}
+	defer class.Release()
+
+	methods, err := dispatchProperty(class, "Methods_")
+	if err != nil {
+		return nil, fmt.Errorf("get class methods: %w", err)
+	}
+	defer methods.Release()
+
+	method, err := dispatchCall(methods, "Item", nrptPolicyMethod)
+	if err != nil {
+		return nil, fmt.Errorf("get method %s: %w", nrptPolicyMethod, err)
+	}
+	defer method.Release()
+
+	params, err := dispatchProperty(method, "InParameters")
+	if err != nil {
+		return nil, fmt.Errorf("get method parameters: %w", err)
+	}
+	defer params.Release()
+
+	inParams, err := dispatchCall(params, "SpawnInstance_")
+	if err != nil {
+		return nil, fmt.Errorf("spawn parameter instance: %w", err)
+	}
+
+	return inParams, nil
+}
+
+// parseNRPTPolicyTable pulls the embedded instances out of the MOF text. Each
+// instance is a namespace of the table, with one name and value per line.
+func parseNRPTPolicyTable(text string) []nrptPolicyEntry {
+	var entries []nrptPolicyEntry
+	var current *nrptPolicyEntry
+
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(line), ";"))
+
+		switch {
+		case strings.HasPrefix(line, nrptPolicyInstanceKeyword):
+			entries = append(entries, nrptPolicyEntry{})
+			current = &entries[len(entries)-1]
+			continue
+		case strings.HasPrefix(line, "}"):
+			// closes an instance, and the array with the last one, so the
+			// class level parameters that follow are not read as values
+			current = nil
+			continue
+		case current == nil, line == "{":
+			continue
+		}
+
+		name, value, ok := strings.Cut(line, " = ")
+		if !ok {
+			continue
+		}
+
+		value = unquoteMOFValue(value)
+		if name == "Namespace" {
+			current.namespace = value
+			continue
+		}
+
+		current.values = append(current.values, registryValue{name: name, value: value})
+	}
+
+	return entries
+}
+
+// unquoteMOFValue renders a MOF scalar or array as plain text: "a" becomes a,
+// and {"a", "b"} becomes a, b.
+func unquoteMOFValue(value string) string {
+	value = strings.TrimSpace(value)
+
+	if inner, ok := strings.CutPrefix(value, "{"); ok {
+		value = strings.TrimSuffix(inner, "}")
+
+		entries := strings.Split(value, ",")
+		for i, entry := range entries {
+			entries[i] = strings.Trim(strings.TrimSpace(entry), `"`)
+		}
+		return strings.Join(entries, ", ")
+	}
+
+	return strings.Trim(value, `"`)
+}
+
+func coInitialize() error {
+	err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
+	if err == nil {
+		return nil
+	}
+
+	// An already initialized thread reports S_FALSE, and one initialized in
+	// another apartment reports RPC_E_CHANGED_MODE. Both are usable, and
+	// neither owns the uninitialize call, which is balanced per successful
+	// initialization.
+	var oleErr *ole.OleError
+	if errors.As(err, &oleErr) {
+		switch oleErr.Code() {
+		case sFalse, rpcEChangedMode:
+			return nil
+		}
+	}
+
+	return fmt.Errorf("initialize COM: %w", err)
+}
+
+// dispatchCall calls a COM method that returns an object.
+func dispatchCall(dispatch *ole.IDispatch, method string, params ...any) (*ole.IDispatch, error) {
+	variant, err := oleutil.CallMethod(dispatch, method, params...)
+	if err != nil {
+		return nil, err
+	}
+
+	object := variant.ToIDispatch()
+	if object == nil {
+		return nil, fmt.Errorf("%s returned no object", method)
+	}
+
+	return object, nil
+}
+
+// dispatchProperty reads a COM property that holds an object.
+func dispatchProperty(dispatch *ole.IDispatch, property string) (*ole.IDispatch, error) {
+	variant, err := oleutil.GetProperty(dispatch, property)
+	if err != nil {
+		return nil, err
+	}
+
+	object := variant.ToIDispatch()
+	if object == nil {
+		return nil, fmt.Errorf("property %s holds no object", property)
+	}
+
+	return object, nil
+}

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -31,10 +31,28 @@ var (
 	dnsFlushResolverCacheFn = dnsapi.NewProc("DnsFlushResolverCache")
 )
 
+// Registry locations of the host DNS configuration this package programs,
+// exported so a diagnostic reader reports the same locations that are written.
 const (
-	dnsPolicyConfigMatchPath    = `SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\DnsPolicyConfig\NetBird-Match`
-	gpoDnsPolicyRoot            = `SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\DnsPolicyConfig`
-	gpoDnsPolicyConfigMatchPath = gpoDnsPolicyRoot + `\NetBird-Match`
+	// NRPTKeyPrefix starts the name of every NRPT rule key this client creates.
+	NRPTKeyPrefix = "NetBird-Match"
+
+	// DNSPolicyConfigRoot holds the NRPT rules of the local policy store.
+	DNSPolicyConfigRoot = `SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\DnsPolicyConfig`
+
+	// GPODNSPolicyConfigRoot holds the NRPT rules of the group policy store,
+	// which takes precedence over the local one when it is present.
+	GPODNSPolicyConfigRoot = `SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\DnsPolicyConfig`
+
+	// InterfaceConfigPath and InterfaceConfigPathV6 hold the per-interface DNS
+	// settings, keyed by interface GUID, in separate hives per address family.
+	InterfaceConfigPath   = `SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces`
+	InterfaceConfigPathV6 = `SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\Interfaces`
+)
+
+const (
+	dnsPolicyConfigMatchPath    = DNSPolicyConfigRoot + `\` + NRPTKeyPrefix
+	gpoDnsPolicyConfigMatchPath = GPODNSPolicyConfigRoot + `\` + NRPTKeyPrefix
 
 	dnsPolicyConfigVersionKey           = "Version"
 	dnsPolicyConfigVersionValue         = 2
@@ -45,8 +63,6 @@ const (
 
 	nrptMaxDomainsPerRule = 50
 
-	interfaceConfigPath           = `SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces`
-	interfaceConfigPathV6         = `SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\Interfaces`
 	interfaceConfigNameServerKey  = "NameServer"
 	interfaceConfigDhcpNameSrvKey = "DhcpNameServer"
 	interfaceConfigSearchListKey  = "SearchList"
@@ -84,7 +100,7 @@ func newHostManager(wgInterface WGIface) (*registryConfigurator, error) {
 	}
 
 	var useGPO bool
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, gpoDnsPolicyRoot, registry.QUERY_VALUE)
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, GPODNSPolicyConfigRoot, registry.QUERY_VALUE)
 	if err != nil {
 		log.Debugf("failed to open GPO DNS policy root: %v", err)
 	} else {
@@ -123,7 +139,7 @@ func (r *registryConfigurator) captureOriginalNameservers() ([]netip.Addr, error
 	seen := make(map[netip.Addr]struct{})
 	var out []netip.Addr
 	var merr *multierror.Error
-	for _, root := range []string{interfaceConfigPath, interfaceConfigPathV6} {
+	for _, root := range []string{InterfaceConfigPath, InterfaceConfigPathV6} {
 		addrs, err := r.captureFromTcpipRoot(root)
 		if err != nil {
 			merr = multierror.Append(merr, fmt.Errorf("%s: %w", root, err))
@@ -496,7 +512,7 @@ func (r *registryConfigurator) deleteInterfaceRegistryKeyProperty(propertyKey st
 }
 
 func (r *registryConfigurator) getInterfaceRegistryKey() (registry.Key, error) {
-	regKeyPath := interfaceConfigPath + "\\" + r.guid
+	regKeyPath := InterfaceConfigPath + "\\" + r.guid
 	regKey, err := registry.OpenKey(registry.LOCAL_MACHINE, regKeyPath, registry.SET_VALUE)
 	if err != nil {
 		return regKey, fmt.Errorf("open HKEY_LOCAL_MACHINE\\%s: %w", regKeyPath, err)

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-jose/go-jose/v4 v4.1.4
+	github.com/go-ole/go-ole v1.3.0
 	github.com/gobwas/ws v1.4.0
 	github.com/goccy/go-yaml v1.18.0
 	github.com/godbus/dbus/v5 v5.2.2
@@ -199,7 +200,6 @@ require (
 	github.com/go-ldap/ldap/v3 v3.4.13 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect


### PR DESCRIPTION
## Describe your changes

Windows was the one platform whose debug bundle carried no DNS configuration at all, while Unix contributes resolv.conf and macOS contributes scutil output. Diagnosing a name resolution problem there meant asking the reporter to run registry and PowerShell commands by hand, and the answers were not comparable between reports. The bundle now collects the same picture itself, through the registry and iphlpapi rather than by shelling out.

- Add dns_windows.txt to the bundle with the NRPT rules of both the local and the group policy store, the rules the client created marked as such, and rules from other products kept visible since they decide resolution too
- Include the NRPT policy table the resolver currently has loaded, which differs from the written rules while a change has not been picked up, in either direction
- Include the DNS client group policy, the global TCP/IP and Dnscache parameters, the DNS values of every interface that has any, and the resolver configuration in effect per adapter
- Name each interface registry key by its adapter, so a GUID is readable and a key whose adapter no longer exists stands out
- Export the registry locations the DNS host manager writes, so the reader reports the same locations rather than its own copies
- Anonymize each value by what its name says it holds, rather than relying on the string pass, which only replaces domains another part of the bundle already contributed
- Handle reverse DNS zones in the anonymizer: a zone names an address prefix, so it now follows the address rules and keeps its label shape, where before the arpa suffix was treated as a customer domain and the digit labels of an ip6.arpa zone were partly rewritten as addresses by the address pass

`go-ole` moves from an indirect to a direct dependency. It is already in the module graph through the WMI package, at the same version.

## Issue ticket number and link

Diagnostics only, no behavior change to the client itself.

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): the bundle README describes the new file, and the contents are for support rather than users

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Windows debug bundles now include DNS diagnostics covering resolver policies, NRPT rules, registry settings, and adapter configuration.
  - Reverse DNS zones for IPv4 and IPv6 are anonymized while preserving labels, prefixes, and trailing dots.

- **Bug Fixes**
  - Invalid or non-reverse DNS zones remain unchanged during anonymization.
  - Windows DNS diagnostics preserve partial results when individual data sources cannot be accessed.

- **Documentation**
  - Documented the Windows DNS diagnostics file and its anonymized contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->