### PR TITLE
[client] Pass stored email as login hint from UI and keep it on logout

### DIFF
--- a/client/internal/profilemanager/state.go
+++ b/client/internal/profilemanager/state.go
@@ -87,9 +87,10 @@ func (pm *ProfileManager) SetActiveProfileState(state *ProfileState) error {
 
 // RemoveProfileState deletes the per-profile state file (which holds the
 // account email used for the SSO login hint and the UI display). Called after
-// a successful logout so a logged-out profile no longer shows a stale account
-// email. The state file only stores the email, so deleting it is equivalent to
-// clearing it; the next SSO login recreates it. A missing file is not an error.
+// profile removal; logout keeps the file so the next login can pass the email
+// as the login_hint. The state file only stores the email, so deleting it is
+// equivalent to clearing it; the next SSO login recreates it. A missing file
+// is not an error.
 func (pm *ProfileManager) RemoveProfileState(profileName string) error {
 	configDir, err := getConfigDir()
 	if err != nil {

--- a/client/ui/authsession/service.go
+++ b/client/ui/authsession/service.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
 
+	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
 )
 
@@ -60,9 +61,17 @@ func (s *Session) RequestExtend(ctx context.Context, p ExtendStartParams) (Exten
 
 	// a request from the UI implies a graphical session, which the daemon cannot detect itself
 	req := &proto.RequestExtendAuthSessionRequest{HasGraphicalSession: true}
-	if p.Hint != "" {
-		h := p.Hint
-		req.Hint = &h
+	hint := p.Hint
+	if hint == "" {
+		pm := profilemanager.NewProfileManager()
+		if active, perr := pm.GetActiveProfile(); perr == nil {
+			if state, serr := pm.GetProfileState(active.ID); serr == nil {
+				hint = state.Email
+			}
+		}
+	}
+	if hint != "" {
+		req.Hint = &hint
 	}
 
 	resp, err := cli.RequestExtendAuthSession(ctx, req)

--- a/client/ui/authsession/service.go
+++ b/client/ui/authsession/service.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
 
@@ -64,10 +65,12 @@ func (s *Session) RequestExtend(ctx context.Context, p ExtendStartParams) (Exten
 	hint := p.Hint
 	if hint == "" {
 		pm := profilemanager.NewProfileManager()
-		if active, perr := pm.GetActiveProfile(); perr == nil {
-			if state, serr := pm.GetProfileState(active.ID); serr == nil {
-				hint = state.Email
-			}
+		if active, perr := pm.GetActiveProfile(); perr != nil {
+			log.Debugf("failed to get active profile for login hint: %v", perr)
+		} else if state, serr := pm.GetProfileState(active.ID); serr != nil {
+			log.Debugf("failed to get profile state for login hint: %v", serr)
+		} else {
+			hint = state.Email
 		}
 	}
 	if hint != "" {

--- a/client/ui/services/connection.go
+++ b/client/ui/services/connection.go
@@ -123,8 +123,16 @@ func (s *Connection) Login(ctx context.Context, p LoginParams) (LoginResult, err
 	if p.PreSharedKey != "" {
 		req.OptionalPreSharedKey = ptrStr(p.PreSharedKey)
 	}
-	if p.Hint != "" {
-		req.Hint = ptrStr(p.Hint)
+	hint := p.Hint
+	if hint == "" && profileID != "" {
+		if state, serr := profilemanager.NewProfileManager().GetProfileState(profilemanager.ID(profileID)); serr == nil {
+			hint = state.Email
+		} else {
+			log.Debugf("failed to get profile state for login hint: %v", serr)
+		}
+	}
+	if hint != "" {
+		req.Hint = ptrStr(hint)
 	}
 
 	resp, err := cli.Login(ctx, req)
@@ -228,16 +236,6 @@ func (s *Connection) Logout(ctx context.Context, p LogoutParams) error {
 		return s.classifyDaemonError(err)
 	}
 
-	// The daemon runs as root and can't reach the user-owned per-profile state
-	// file holding the account email (see Profiles.List), so clear the stale
-	// email here; the next SSO login recreates it.
-	if p.ProfileName != "" {
-		if err := profilemanager.NewProfileManager().RemoveProfileState(p.ProfileName); err != nil {
-			// Non-fatal: the logout itself succeeded.
-			log.Warnf("failed to remove profile state for %s: %v", p.ProfileName, err)
-		}
-	}
-
 	return nil
 }
 
@@ -261,7 +259,7 @@ func (s *Connection) waitSSOLogin(ctx context.Context, p WaitSSOParams) (string,
 
 	// Persist the account email the same way the CLI does after its own
 	// WaitSSOLogin: the daemon returns it but cannot store it, since it runs as
-	// root and the per-profile state file is user-owned (see Logout below).
+	// root and the per-profile state file is user-owned (see Profiles.List).
 	// Without this the profile has no email, so Profiles.List shows no account
 	// and later logins and session extends go out without a login_hint —
 	// leaving the IdP to guess which account was meant.

--- a/client/ui/services/profile.go
+++ b/client/ui/services/profile.go
@@ -162,8 +162,9 @@ func (s *Profiles) Remove(ctx context.Context, p ProfileRef) error {
 	}
 
 	// The daemon deletes what it owns but runs as root, so it leaves the
-	// user-owned state file holding the account email behind (same split as
-	// Connection.Logout). Legacy profiles are keyed by name rather than by a
+	// user-owned state file holding the account email behind. Logout keeps the
+	// email on purpose so later logins can pass it as the login_hint; profile
+	// removal is what deletes it. Legacy profiles are keyed by name rather than by a
 	// generated ID, so a recreated profile of the same name would inherit the
 	// deleted one's email and offer it as the login_hint.
 	//


### PR DESCRIPTION
## Describe your changes

Follow the CLI pattern: the Wails UI now reads the account email from the user-owned profile state file and passes it as the OIDC login_hint on login and session extend, since the daemon-side fallback runs as root and cannot see the user's state file. Logout no longer deletes the stored email, so a later login preselects the account at the IdP; profile removal remains the operation that deletes it.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login and session extension can automatically use the active profile’s stored email when no hint is provided.
  * Explicit login and session hints remain supported.

* **Bug Fixes**
  * Logging out now preserves profile email state for future SSO sign-in.
  * Removing a profile still deletes its associated state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->