### PR TITLE
[client, android] Keep account email on logout, drop it on profile removal

### DIFF
--- a/client/android/login.go
+++ b/client/android/login.go
@@ -204,8 +204,9 @@ func (a *Auth) foregroundGetTokenInfo(authClient *auth.Auth, urlOpener URLOpener
 		return nil, fmt.Errorf("failed to get OAuth flow: %v", err)
 	}
 
-	// An empty hint is deliberate, not a fallback: a fresh or logged-out profile
-	// leaves the choice to the IdP, which is how accounts get switched.
+	// An empty hint is deliberate, not a fallback: a fresh profile leaves the
+	// choice to the IdP. Switching accounts is done by switching or removing
+	// profiles, not by logging out — logout keeps the email.
 	if a.cfgPath != "" {
 		if hint := readProfileEmail(a.cfgPath); hint != "" {
 			if setter, ok := oAuthFlow.(loginHintSetter); ok {

--- a/client/android/profile_manager.go
+++ b/client/android/profile_manager.go
@@ -22,7 +22,8 @@ type Profile struct {
 	ID   string
 	Name string
 	// Email is the account this profile last logged in with, "" if it never
-	// completed an SSO login or was logged out. See profile_state.go.
+	// completed an SSO login. Kept across logouts; cleared when the profile is
+	// removed. See profile_state.go.
 	Email    string
 	IsActive bool
 }
@@ -200,11 +201,9 @@ func (pm *ProfileManager) LogoutProfile(id string) error {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
-	// Not fatal: a stale hint costs an account switch, not the logout itself.
-	if err := removeProfileEmail(configPath); err != nil {
-		log.Warnf("failed to clear stored account email for profile %s: %v", id, err)
-	}
-
+	// The stored account email is kept on purpose, matching the desktop and CLI
+	// logout semantics: the next login passes it as the login_hint so the IdP
+	// preselects the account. Removing the profile is what deletes it.
 	log.Infof("logged out from profile: %s", id)
 	return nil
 }
@@ -224,9 +223,22 @@ func (pm *ProfileManager) RenameProfile(id string, newName string) error {
 
 // RemoveProfile deletes a profile
 func (pm *ProfileManager) RemoveProfile(id string) error {
+	configPath, err := pm.getProfileConfigPath(id)
+	if err != nil {
+		return err
+	}
+
 	// Use ServiceManager (removes profile from profiles/ directory)
 	if err := pm.serviceMgr.RemoveProfile(profilemanager.ID(id), androidUsername); err != nil {
 		return fmt.Errorf("failed to remove profile: %w", err)
+	}
+
+	// The account file is this package's, not the ServiceManager's, so it must
+	// go here. The default profile has a fixed filename, so a recreated one
+	// would otherwise inherit the deleted profile's email as its login_hint.
+	// Not fatal: the profile itself is gone.
+	if err := removeProfileEmail(configPath); err != nil {
+		log.Warnf("failed to remove stored account email for profile %s: %v", id, err)
 	}
 
 	log.Infof("removed profile: %s", id)

--- a/client/android/profile_state.go
+++ b/client/android/profile_state.go
@@ -90,10 +90,10 @@ func writeProfileEmail(configPath string, email string) error {
 	return nil
 }
 
-// removeProfileEmail drops the stored account email. Called on logout: while the
-// email is on disk it goes out as a login_hint, which would steer the next login
-// straight back into the account just logged out of. Mirrors the desktop UI's
-// RemoveProfileState call.
+// removeProfileEmail drops the stored account email. Called on profile removal,
+// not on logout: a logged-out profile keeps its email so the next login passes
+// it as the login_hint, matching the desktop and CLI semantics. Mirrors the
+// desktop UI's RemoveProfileState call.
 func removeProfileEmail(configPath string) error {
 	accountPath, err := profileAccountPathFor(configPath)
 	if err != nil {

--- a/client/android/profile_state_test.go
+++ b/client/android/profile_state_test.go
@@ -127,10 +127,10 @@ func TestWriteThenReadProfileEmail(t *testing.T) {
 		t.Fatalf("remove: %v", err)
 	}
 	if got := readProfileEmail(configPath); got != "" {
-		t.Errorf("expected no email after logout, got %q", got)
+		t.Errorf("expected no email after removal, got %q", got)
 	}
 
-	// Logout may run on a never-logged-in profile, so a second remove must pass.
+	// Removal may run on a never-logged-in profile, so a second remove must pass.
 	if err := removeProfileEmail(configPath); err != nil {
 		t.Fatalf("second remove should be a no-op: %v", err)
 	}


### PR DESCRIPTION
## Describe your changes

Align Android logout semantics with the desktop UI and CLI: logging out no longer deletes the stored account email, so the next login passes it as the OIDC login_hint and the IdP preselects the account. Removing the profile is now the operation that deletes the email; previously RemoveProfile left the account file behind, which the fixed-name default profile would have inherited on recreation.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the remembered email address after logout to improve account sign-in hints.
  * Removed stored email information only when a profile is deleted.
  * Improved cleanup handling when removing profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->