### PR TITLE
[client] Clear stale installer result before starting update

### DIFF
--- a/client/internal/updater/installer/installer_common.go
+++ b/client/internal/updater/installer/installer_common.go
@@ -43,7 +43,7 @@ func NewWithDir(tempDir string) *Installer {
 func (u *Installer) RunInstallation(ctx context.Context, targetVersion string) (err error) {
 	resultHandler := NewResultHandler(u.tempDir)
 	if err := resultHandler.ClearStaleResult(); err != nil {
-		log.Warnf("failed to clear stale installer result: %v", err)
+		log.Warnf("clear stale installer result: %v", err)
 	}
 
 	defer func() {

--- a/client/internal/updater/installer/installer_common.go
+++ b/client/internal/updater/installer/installer_common.go
@@ -42,6 +42,9 @@ func NewWithDir(tempDir string) *Installer {
 // This will run by the original service process
 func (u *Installer) RunInstallation(ctx context.Context, targetVersion string) (err error) {
 	resultHandler := NewResultHandler(u.tempDir)
+	if err := resultHandler.ClearStaleResult(); err != nil {
+		log.Warnf("failed to clear stale installer result: %v", err)
+	}
 
 	defer func() {
 		if err != nil {

--- a/client/internal/updater/installer/result.go
+++ b/client/internal/updater/installer/result.go
@@ -54,6 +54,12 @@ func (rh *ResultHandler) GetErrorResultReason() string {
 	return ""
 }
 
+// ClearStaleResult removes a result file left over from a previous installation
+// attempt so result watchers cannot read an outdated outcome for the current attempt.
+func (rh *ResultHandler) ClearStaleResult() error {
+	return rh.cleanup()
+}
+
 func (rh *ResultHandler) WriteSuccess() error {
 	result := Result{
 		Success:    true,


### PR DESCRIPTION
## Describe your changes

The installer result file could survive a previous update attempt (e.g. when the updater wrote it after the restarted daemon already ran its startup check). A new install attempt left the old file in place, so the GUI progress window's first GetInstallerResult poll read the outdated result: a stale success made the GUI quit mid-install, which cancelled the TriggerUpdate context and aborted the artifact verification; a stale error surfaced a bogus failure dialog for a succeeding update.

Remove any leftover result file at the start of RunInstallation, before the download begins, so result watchers only see the current attempt's outcome.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability by removing leftover results from previous installation attempts before starting a new one.
  * Installations now continue even if cleanup encounters an issue, with a warning recorded for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->