### PR TITLE
Add NetworkManager VPN plugin for NetBird

### DIFF
--- a/client/networkmanager/.gitignore
+++ b/client/networkmanager/.gitignore
@@ -1,0 +1,7 @@
+bin
+properties/*.o
+properties/*.so
+properties/resources.c
+properties/resources-gtk3.c
+selinux/*.mod
+selinux/*.pp

--- a/client/networkmanager/Makefile
+++ b/client/networkmanager/Makefile
@@ -1,0 +1,80 @@
+GO ?= go
+
+LIBEXECDIR ?= /usr/libexec
+DBUS_SYSTEM_D ?= /etc/dbus-1/system.d
+UDEV_RULES_D ?= /usr/lib/udev/rules.d
+VPNSERVICEDIR ?= $(shell pkg-config --variable=vpnservicedir libnm 2>/dev/null)
+
+# libnm.pc does not export a "plugindir" variable; the real plugin directory
+# is libdir/NetworkManager (e.g. /usr/lib64/NetworkManager on Fedora).
+PLUGINDIR ?= $(shell pkg-config --variable=plugindir libnm 2>/dev/null)
+ifeq ($(PLUGINDIR),)
+PLUGINDIR := $(shell pkg-config --variable=libdir libnm 2>/dev/null)/NetworkManager
+endif
+
+GOFILES := $(shell find . -name '*.go')
+
+.PHONY: all properties install uninstall clean
+
+all: bin/nm-netbird-service bin/nm-netbird-auth-dialog properties
+
+bin/nm-netbird-service: $(GOFILES)
+	@mkdir -p bin
+	$(GO) build -o $@ ./cmd/nm-netbird-service
+
+bin/nm-netbird-auth-dialog: $(GOFILES)
+	@mkdir -p bin
+	$(GO) build -o $@ ./cmd/nm-netbird-auth-dialog
+
+ifeq ($(SKIP_PROPERTIES),1)
+properties:
+	@echo "skipping client/networkmanager/properties (SKIP_PROPERTIES=1)"
+else
+properties:
+	$(MAKE) -C properties
+endif
+
+install: all
+	install -d $(DESTDIR)$(LIBEXECDIR)
+	install -m 0755 bin/nm-netbird-service $(DESTDIR)$(LIBEXECDIR)/nm-netbird-service
+	install -m 0755 bin/nm-netbird-auth-dialog $(DESTDIR)$(LIBEXECDIR)/nm-netbird-auth-dialog
+	install -d $(DESTDIR)$(DBUS_SYSTEM_D)
+	install -m 0644 nm-netbird-service.conf $(DESTDIR)$(DBUS_SYSTEM_D)/nm-netbird-service.conf
+	install -d $(DESTDIR)$(UDEV_RULES_D)
+	install -m 0644 udev/71-nm-unmanaged-netbird.rules $(DESTDIR)$(UDEV_RULES_D)/71-nm-unmanaged-netbird.rules
+	-udevadm control --reload-rules 2>/dev/null
+	@test -n "$(VPNSERVICEDIR)" || { \
+		echo "error: could not determine libnm's VPN service directory (pkg-config --variable=vpnservicedir libnm)." >&2; \
+		echo "pass it explicitly: make install VPNSERVICEDIR=/path/to/NetworkManager/VPN" >&2; \
+		exit 1; \
+	}
+	install -d $(DESTDIR)$(VPNSERVICEDIR)
+	sed -e 's|@LIBEXECDIR@|$(LIBEXECDIR)|g' -e 's|@PLUGINDIR@|$(PLUGINDIR)|g' \
+		nm-netbird-service.name.in > $(DESTDIR)$(VPNSERVICEDIR)/nm-netbird-service.name
+ifneq ($(SKIP_PROPERTIES),1)
+	$(MAKE) -C properties install
+endif
+	@if command -v getenforce >/dev/null 2>&1 && [ "$$(getenforce)" = "Enforcing" ]; then \
+		echo; \
+		echo "SELinux is enforcing on this system: also run 'make -C selinux install'"; \
+		echo "(see README.md) or nm-netbird-service will fail to reach the netbird daemon."; \
+	fi
+
+# Undoes everything install did, including the udev rule that hides
+# netbird's tunnel interface from NetworkManager -- that behavior should
+# only apply while this plugin is actually installed, not linger after.
+uninstall:
+	rm -f $(DESTDIR)$(LIBEXECDIR)/nm-netbird-service
+	rm -f $(DESTDIR)$(LIBEXECDIR)/nm-netbird-auth-dialog
+	rm -f $(DESTDIR)$(DBUS_SYSTEM_D)/nm-netbird-service.conf
+	rm -f $(DESTDIR)$(UDEV_RULES_D)/71-nm-unmanaged-netbird.rules
+	-udevadm control --reload-rules 2>/dev/null
+	rm -f $(DESTDIR)$(VPNSERVICEDIR)/nm-netbird-service.name
+ifneq ($(SKIP_PROPERTIES),1)
+	$(MAKE) -C properties uninstall
+endif
+	@echo "note: the SELinux module (if installed) is separate: sudo semodule -r nm_netbird_local"
+
+clean:
+	rm -rf bin
+	$(MAKE) -C properties clean

--- a/client/networkmanager/README.md
+++ b/client/networkmanager/README.md
@@ -1,0 +1,151 @@
+# NetworkManager plugin for NetBird
+
+A NetworkManager VPN plugin so NetBird shows up as a native VPN connection
+type (`nmcli`, GNOME Settings, `nm-connection-editor`) instead of relying on
+`netbird-ui`. It is a thin control-plane front end: it drives the real
+`netbird` daemon's gRPC API to log in (including browser-based SSO) and to
+connect/disconnect, while the daemon itself keeps owning the tunnel
+interface, routes, DNS, and firewall exactly as it does today.
+
+Linux-only. Not part of a release; build and install it locally.
+
+## Layout
+
+- `cmd/nm-netbird-service` — the VPN service NetworkManager spawns per
+  active connection. Pure Go, implements
+  `org.freedesktop.NetworkManager.VPN.Plugin` directly over D-Bus.
+- `cmd/nm-netbird-auth-dialog` — the interactive helper NetworkManager
+  spawns in your desktop session for SSO login. Hand-written C/GTK4 (via
+  cgo) rather than a generated Go binding, since the latest `gotk4` release
+  fails to compile against current GLib.
+- `properties/` — the connection-editor plugin (`nm-connection-editor`/GNOME
+  Settings support), split into a toolkit-independent core `.so` and two
+  separate GTK3/GTK4 editor `.so`s, matching how NetworkManager's own
+  bundled plugins (openvpn, vpnc, ...) are structured. Both variants exist
+  because `nm-connection-editor` is still GTK3 on some distributions even
+  where GTK4 is the default elsewhere (GNOME Settings' own network panel is
+  GTK4) — the core plugin detects which toolkit is already loaded in the
+  host process and dlopen's the matching editor at runtime, never both.
+- `udev/` — marks netbird's tunnel interface unmanaged by NetworkManager,
+  see [Known issues](#known-issues).
+- `selinux/` — a local policy module needed on SELinux-enforcing systems
+  (Fedora and friends), see [SELinux](#selinux).
+
+## Prerequisites
+
+Go pieces need nothing beyond what building netbird already needs (the
+auth-dialog uses cgo against libgtk-4 directly, not a Go binding). The
+editor plugin additionally needs both GTK3 and GTK4 dev headers:
+
+```
+# Fedora
+sudo dnf install NetworkManager-libnm-devel gtk4-devel gtk3-devel glib2-devel
+
+# Debian/Ubuntu
+sudo apt install libnm-dev libgtk-4-dev libgtk-3-dev libglib2.0-dev
+```
+
+## Build and install
+
+```
+cd client/networkmanager
+make
+sudo make install
+```
+
+`make` fails loudly (not silently) if `libnm`/`gtk4`/`glib2` dev packages
+are missing. To build only the two Go binaries without those packages
+installed:
+
+```
+make SKIP_PROPERTIES=1
+sudo make install SKIP_PROPERTIES=1
+```
+
+`make install` installs:
+
+| What | Where |
+|---|---|
+| `nm-netbird-service`, `nm-netbird-auth-dialog` | `/usr/libexec` |
+| `libnm-vpn-plugin-netbird.so`, `libnm-vpn-plugin-netbird-editor.so` (GTK3), `libnm-gtk4-vpn-plugin-netbird-editor.so` (GTK4) | `libdir/NetworkManager` (e.g. `/usr/lib64/NetworkManager`) |
+| `nm-netbird-service.name` | libnm's `vpnservicedir` (e.g. `/usr/lib/NetworkManager/VPN`) |
+| `nm-netbird-service.conf` | `/etc/dbus-1/system.d` |
+| `71-nm-unmanaged-netbird.rules` | `/usr/lib/udev/rules.d` |
+
+`sudo make uninstall` removes all of the above, including the udev rule —
+that rule (see [Known issues](#known-issues)) is only meant to apply while
+this plugin is actually installed, not linger after. If you also installed
+the SELinux module, remove it separately: `sudo semodule -r nm_netbird_local`
+(or `sudo make -C selinux uninstall`).
+
+After installing for the first time, restart NetworkManager so it picks up
+the new plugin and D-Bus policy:
+
+```
+sudo systemctl restart NetworkManager
+```
+
+### SELinux
+
+On SELinux-enforcing systems (Fedora and derivatives), the targeted policy
+has no dedicated domain for this plugin the way it does for `nm-openvpn`,
+so `nm-netbird-service` runs under `NetworkManager_t` and is denied access
+to the netbird daemon's control socket by default. Without this, connecting
+fails with `dial unix /var/run/netbird.sock: connect: permission denied` in
+`journalctl -u NetworkManager`. `make install` detects `Enforcing` mode and
+prints a reminder; to fix it:
+
+```
+cd client/networkmanager/selinux
+make
+sudo make install
+```
+
+This installs a small local policy module (`selinux/nm_netbird_local.te`)
+granting exactly the two denied operations (reading/writing the daemon's
+socket file, and connecting to the daemon's process domain) — nothing
+broader. Inspect the `.te` file before installing it; it's short.
+
+## Usage
+
+Create a connection (SSO login, no setup key):
+
+```
+nmcli connection add type vpn vpn-type netbird ifname -- \
+  vpn.data "management-url=https://your-management-server:443" \
+  connection.id my-netbird
+nmcli connection up my-netbird
+```
+
+Or use the GTK4 editor via GNOME Settings / `nm-connection-editor` → Add
+VPN → NetBird, if `properties/` was built and installed.
+
+`vpn.data` keys map to `netbird up` flags: `management-url`, `admin-url`,
+`interface-name`, `hostname`, `mtu`, `wireguard-port`, `block-inbound`,
+`disable-server-routes`, `block-lan-access`, `disable-client-routes`,
+`disable-dns`, `disable-firewall`, `disable-ipv6`, `rosenpass-enabled`,
+`rosenpass-permissive`, `disable-auto-connect`, `network-monitor` (booleans
+are the strings `yes`/`no`). `setup-key` is a secret
+(`vpn.secrets`); leave it empty to use SSO instead.
+
+## Known issues
+
+- **NetworkManager may show netbird's tunnel interface (`wt0` by default)
+  as a second, bare device** in GNOME's network UI, since netbird creates
+  and manages it directly rather than through NetworkManager. The udev
+  rule in `udev/` marks it unmanaged to prevent this — if you changed
+  `interface-name` away from the default `wt0`, edit the rule to match.
+- **Disconnect through NetworkManager, not around it.** Once a connection
+  is active, use `nmcli connection down`/GNOME's network menu rather than
+  `netbird down` or `netbird-ui` directly. NetworkManager's VPN state
+  machine (`nm-vpn-connection.c`) unconditionally treats an unprompted
+  "stopped" report as a *failure* when it still believes the connection is
+  active — there is no D-Bus signal that means "stopped gracefully but you
+  didn't ask": it's a hard constraint of NM's model (the same thing would
+  happen if any VPN's underlying process died unexpectedly), not something
+  this plugin can special-case around. It still correctly syncs
+  NetworkManager's state either way; expect a "connection failed"
+  notification, not a stuck "connected" state, when bypassing NM this way.
+- No automated test suite: this is host-networking, D-Bus, and GTK
+  integration code that's only meaningfully verified against a real
+  daemon and a running NetworkManager/GNOME session.

--- a/client/networkmanager/authdialog/protocol.go
+++ b/client/networkmanager/authdialog/protocol.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+// Package authdialog implements the stdout half of the protocol
+// NetworkManager's secret-agent framework uses to talk to a VPN plugin's
+// auth-dialog helper: the helper writes secrets back as newline-delimited
+// key/value pairs, or a GKeyFile description when invoked in
+// --external-ui-mode.
+package authdialog
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/netbirdio/netbird/client/networkmanager/vpnplugin"
+)
+
+// noSecretKey is the sentinel key an auth-dialog writes with value "true" to
+// tell NetworkManager that no secret prompt is needed at all.
+const noSecretKey = "no-secret"
+
+// WriteSecrets writes the given secrets to stdout in the key/value protocol
+// NetworkManager expects back from an auth-dialog helper.
+func WriteSecrets(w io.Writer, secrets map[string]string) error {
+	bw := bufio.NewWriter(w)
+	for key, value := range secrets {
+		if _, err := fmt.Fprintf(bw, "%s\n%s\n", key, value); err != nil {
+			return err
+		}
+	}
+	if _, err := bw.WriteString("\n\n"); err != nil {
+		return err
+	}
+	return bw.Flush()
+}
+
+// WriteNoSecretsRequired tells NetworkManager no prompt is needed at all.
+func WriteNoSecretsRequired(w io.Writer) error {
+	return WriteSecrets(w, map[string]string{noSecretKey: "true"})
+}
+
+// WriteExternalUI writes the "[VPN Plugin UI]" GKeyFile description
+// NetworkManager's secret-agent framework expects when invoking the
+// auth-dialog with --external-ui-mode. Title and Description live directly
+// in the [VPN Plugin UI] group itself, not a separate section -- confirmed
+// against gnome-shell's actual parser (js/ui/components/networkAgent.js),
+// since getting this wrong produces an opaque "internal error" response
+// with no other diagnostic. The field is marked ShouldAsk=false since
+// nm-netbird-auth-dialog has already obtained everything it needs by
+// opening the browser itself; the agent should accept the given value
+// without prompting the user again.
+func WriteExternalUI(w io.Writer, title, description, secretKey string) error {
+	_, err := fmt.Fprintf(w,
+		"[VPN Plugin UI]\nVersion=2\nTitle=%s\nDescription=%s\n\n[%s]\nValue=yes\nLabel=NetBird SSO\nIsSecret=false\nShouldAsk=false\n",
+		title, description, secretKey)
+	return err
+}
+
+// ParseHints extracts the SecretsRequired hint values nm-netbird-service
+// encodes (see vpnplugin.HintVerificationURIPrefix/HintUserCodePrefix) out
+// of the auth-dialog's repeated --hint arguments.
+func ParseHints(hints []string) (verificationURI, userCode string) {
+	for _, hint := range hints {
+		switch {
+		case strings.HasPrefix(hint, vpnplugin.HintVerificationURIPrefix):
+			verificationURI = strings.TrimPrefix(hint, vpnplugin.HintVerificationURIPrefix)
+		case strings.HasPrefix(hint, vpnplugin.HintUserCodePrefix):
+			userCode = strings.TrimPrefix(hint, vpnplugin.HintUserCodePrefix)
+		}
+	}
+	return verificationURI, userCode
+}

--- a/client/networkmanager/cmd/nm-netbird-auth-dialog/dialog_linux.c
+++ b/client/networkmanager/cmd/nm-netbird-auth-dialog/dialog_linux.c
@@ -1,0 +1,127 @@
+#include "dialog_linux.h"
+
+#include <gtk/gtk.h>
+
+#include "_cgo_export.h"
+
+static GtkApplication *app = NULL;
+static GtkWidget *window = NULL;
+static GtkWidget *status_label = NULL;
+static char *dialog_url = NULL;
+
+static void
+on_open_clicked (GtkButton *button, gpointer user_data)
+{
+	gtk_widget_set_sensitive (GTK_WIDGET (button), FALSE);
+	gtk_label_set_text (GTK_LABEL (status_label), "Waiting on authentication in a browser...");
+	gtk_widget_set_visible (status_label, TRUE);
+	goOpenClicked ((char *) dialog_url);
+}
+
+static void
+on_cancel_clicked (GtkButton *button, gpointer user_data)
+{
+	goCancelled ();
+	gtk_window_close (GTK_WINDOW (window));
+}
+
+static gboolean
+on_close_request (GtkWindow *win, gpointer user_data)
+{
+	goCancelled ();
+	return FALSE;
+}
+
+static void
+activate (GtkApplication *gapp, gpointer user_data)
+{
+	const char **args = (const char **) user_data;
+	const char *name = args[0];
+	const char *url = args[1];
+	GtkWidget *box;
+	GtkWidget *message;
+	GtkWidget *buttons;
+	GtkWidget *open_button;
+	GtkWidget *cancel_button;
+	char *text;
+
+	window = GTK_WIDGET (gtk_application_window_new (gapp));
+	gtk_window_set_title (GTK_WINDOW (window), "NetBird VPN");
+	gtk_window_set_default_size (GTK_WINDOW (window), 420, -1);
+
+	box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
+	gtk_widget_set_margin_top (box, 18);
+	gtk_widget_set_margin_bottom (box, 18);
+	gtk_widget_set_margin_start (box, 18);
+	gtk_widget_set_margin_end (box, 18);
+
+	text = g_markup_printf_escaped (
+		"NetBird VPN connection <b>%s</b> requires authenticating in a browser.\n\n"
+		"Open the following link to continue:\n<a href=\"%s\">%s</a>",
+		name, url, url);
+	message = gtk_label_new (NULL);
+	gtk_label_set_markup (GTK_LABEL (message), text);
+	g_free (text);
+	gtk_label_set_wrap (GTK_LABEL (message), TRUE);
+	gtk_label_set_wrap_mode (GTK_LABEL (message), PANGO_WRAP_WORD_CHAR);
+	gtk_label_set_xalign (GTK_LABEL (message), 0);
+	gtk_label_set_selectable (GTK_LABEL (message), TRUE);
+	gtk_box_append (GTK_BOX (box), message);
+
+	status_label = gtk_label_new ("");
+	gtk_label_set_xalign (GTK_LABEL (status_label), 0);
+	gtk_widget_set_visible (status_label, FALSE);
+	gtk_box_append (GTK_BOX (box), status_label);
+
+	buttons = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+	gtk_widget_set_halign (buttons, GTK_ALIGN_CENTER);
+	cancel_button = gtk_button_new_with_label ("Cancel");
+	open_button = gtk_button_new_with_label ("Open in Browser");
+	gtk_widget_add_css_class (open_button, "suggested-action");
+	gtk_box_append (GTK_BOX (buttons), cancel_button);
+	gtk_box_append (GTK_BOX (buttons), open_button);
+	gtk_box_append (GTK_BOX (box), buttons);
+
+	gtk_window_set_child (GTK_WINDOW (window), box);
+
+	g_signal_connect (open_button, "clicked", G_CALLBACK (on_open_clicked), NULL);
+	g_signal_connect (cancel_button, "clicked", G_CALLBACK (on_cancel_clicked), NULL);
+	g_signal_connect (window, "close-request", G_CALLBACK (on_close_request), NULL);
+
+	gtk_window_present (GTK_WINDOW (window));
+}
+
+void
+netbird_dialog_run (const char *name, const char *url)
+{
+	const char *args[2];
+
+	dialog_url = g_strdup (url);
+	args[0] = name;
+	args[1] = url;
+
+#if GLIB_CHECK_VERSION (2, 74, 0)
+	app = gtk_application_new ("org.freedesktop.NetworkManager.netbird.AuthDialog", G_APPLICATION_DEFAULT_FLAGS);
+#else
+	app = gtk_application_new ("org.freedesktop.NetworkManager.netbird.AuthDialog", G_APPLICATION_FLAGS_NONE);
+#endif
+	g_signal_connect (app, "activate", G_CALLBACK (activate), args);
+	g_application_run (G_APPLICATION (app), 0, NULL);
+
+	g_object_unref (app);
+	g_free (dialog_url);
+}
+
+static gboolean
+close_window_idle (gpointer user_data)
+{
+	gtk_window_close (GTK_WINDOW (window));
+	return G_SOURCE_REMOVE;
+}
+
+void
+netbird_dialog_finish (int success)
+{
+	(void) success;
+	g_idle_add (close_window_idle, NULL);
+}

--- a/client/networkmanager/cmd/nm-netbird-auth-dialog/dialog_linux.h
+++ b/client/networkmanager/cmd/nm-netbird-auth-dialog/dialog_linux.h
@@ -1,0 +1,7 @@
+#ifndef NM_NETBIRD_AUTH_DIALOG_H
+#define NM_NETBIRD_AUTH_DIALOG_H
+
+void netbird_dialog_run (const char *name, const char *url);
+void netbird_dialog_finish (int success);
+
+#endif /* NM_NETBIRD_AUTH_DIALOG_H */

--- a/client/networkmanager/cmd/nm-netbird-auth-dialog/main.go
+++ b/client/networkmanager/cmd/nm-netbird-auth-dialog/main.go
@@ -1,0 +1,238 @@
+//go:build linux
+
+// Command nm-netbird-auth-dialog is the interactive helper NetworkManager
+// spawns, inside the user's desktop session, when nm-netbird-service raises
+// SecretsRequired for an SSO login. It shows a native GTK4 dialog (hand
+// written against libgtk-4 via cgo, not a generated Go binding, since the
+// latest gotk4 release fails to compile against this system's GLib) and
+// opens the verification URL with xdg-open on confirmation (inheriting the
+// session's DISPLAY/DBUS_SESSION_BUS_ADDRESS, unlike the root service).
+//
+// The acknowledgement is written back to NetworkManager right after Open is
+// clicked, not after login actually succeeds: NetworkManager's own
+// secrets-request has a hard timeout (observed around 25-40s) far shorter
+// than a real human SSO flow can take, so nm-netbird-service is the one
+// that waits out the actual login afterward, in a process NM isn't timing.
+// This dialog keeps showing progress in the meantime by independently
+// watching the daemon's status stream (rather than calling WaitSSOLogin
+// itself, which would race nm-netbird-service's own call for the same
+// login), closing gracefully once the daemon reports the tunnel is up.
+// Cancelling the dialog only stops this dialog's own wait; the connection
+// attempt already has its answer by then, so use the normal NetworkManager
+// disconnect action to abort it.
+package main
+
+/*
+#cgo pkg-config: gtk4
+#include <stdlib.h>
+#include "dialog_linux.h"
+*/
+import "C"
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/netbirdio/netbird/client/networkmanager/authdialog"
+	"github.com/netbirdio/netbird/client/networkmanager/nbdaemon"
+	nbproto "github.com/netbirdio/netbird/client/proto"
+)
+
+const ssoAckKey = "netbird-sso-acknowledged"
+
+var (
+	cancelMu     sync.Mutex
+	cancelWaitFn context.CancelFunc
+)
+
+func main() {
+	// NetworkManager's secret-agent framework closes this process's stderr
+	// (and, once it has our answer, stdin) right after spawning it, without
+	// ever reading from it. Any later write to that closed pipe -- ours or
+	// GTK/Mesa's own startup warnings -- raises SIGPIPE, which by default
+	// kills the whole process before it gets a chance to show anything.
+	signal.Ignore(syscall.SIGPIPE)
+
+	log.SetOutput(os.Stderr)
+
+	var hints []string
+	name := pflag.StringP("name", "n", "", "connection name")
+	uuid := pflag.StringP("uuid", "u", "", "connection UUID")
+	pflag.StringP("service", "s", "", "VPN service type")
+	externalUIMode := pflag.Bool("external-ui-mode", false, "describe the prompt via stdout instead of showing a window")
+	pflag.BoolP("allow-interaction", "i", false, "allow showing a UI")
+	pflag.Bool("reprompt", false, "force reprompting for secrets")
+	pflag.StringArrayVarP(&hints, "hint", "t", nil, "hint about which secret is needed, repeatable")
+	pflag.CommandLine.ParseErrorsAllowlist.UnknownFlags = true
+	pflag.Parse()
+
+	verificationURI, _ := authdialog.ParseHints(hints)
+	if verificationURI == "" {
+		if err := authdialog.WriteNoSecretsRequired(os.Stdout); err != nil {
+			log.Warnf("write no-secret response: %v", err)
+		}
+		return
+	}
+
+	release, err := acquireSingleInstance(*uuid)
+	if err != nil {
+		log.Warnf("single-instance lock: %v", err)
+	} else {
+		defer release()
+	}
+
+	ackOnOpen = func() {
+		if *externalUIMode {
+			if err := authdialog.WriteExternalUI(os.Stdout, "NetBird SSO Login",
+				"Open the link in your browser to sign in to NetBird.", ssoAckKey); err != nil {
+				log.Warnf("write external UI description: %v", err)
+			}
+		} else if err := authdialog.WriteSecrets(os.Stdout, map[string]string{ssoAckKey: "yes"}); err != nil {
+			log.Warnf("write ack secret: %v", err)
+		}
+
+		// The secret-agent reads this helper's stdout until EOF to know the
+		// answer is complete. Since this process keeps running past this
+		// point (to show "waiting..." and watch for login completion), the
+		// write above would otherwise sit unread indefinitely.
+		if err := os.Stdout.Close(); err != nil {
+			log.Warnf("close stdout: %v", err)
+		}
+	}
+
+	cName := C.CString(*name)
+	defer C.free(unsafe.Pointer(cName))
+	cURL := C.CString(verificationURI)
+	defer C.free(unsafe.Pointer(cURL))
+
+	C.netbird_dialog_run(cName, cURL)
+}
+
+// acquireSingleInstance ensures at most one nm-netbird-auth-dialog runs at a
+// time for a given connection UUID. NetworkManager's own secrets-request
+// timeout does not cascade a cancel down to an already-spawned auth-dialog
+// helper when it gives up waiting, so a helper whose login the user
+// abandoned (or that got stuck) can outlive the connection attempt that
+// spawned it; retrying the same connection then spawns a second, unrelated
+// helper alongside the still-running one, which has been observed to
+// confuse the secret agent's per-connection request tracking. Killing any
+// stale instance for the same UUID up front, rather than relying on a
+// timeout, closes that race regardless of how quickly the user retries.
+func acquireSingleInstance(uuid string) (release func(), err error) {
+	noop := func() {}
+	if uuid == "" {
+		return noop, nil
+	}
+
+	dir := os.Getenv("XDG_RUNTIME_DIR")
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	dir = filepath.Join(dir, "nm-netbird-auth-dialog")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return noop, fmt.Errorf("create lock dir: %w", err)
+	}
+	path := filepath.Join(dir, uuid+".pid")
+
+	if data, readErr := os.ReadFile(path); readErr == nil {
+		if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid != os.Getpid() {
+			if proc, findErr := os.FindProcess(pid); findErr == nil && proc.Signal(syscall.Signal(0)) == nil {
+				log.Warnf("killing stale auth-dialog (pid %d) for the same connection", pid)
+				_ = proc.Kill()
+			}
+		}
+	}
+
+	if err := os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		return noop, fmt.Errorf("write lock file: %w", err)
+	}
+
+	return func() { _ = os.Remove(path) }, nil
+}
+
+// ackOnOpen writes NetworkManager's acknowledgement; set in main once flags
+// are parsed, since //export functions can't take extra arguments.
+var ackOnOpen func()
+
+//export goOpenClicked
+func goOpenClicked(curl *C.char) {
+	url := C.GoString(curl)
+	if err := exec.Command("xdg-open", url).Start(); err != nil {
+		log.Warnf("xdg-open %s: %v", url, err)
+	}
+
+	ackOnOpen()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelMu.Lock()
+	cancelWaitFn = cancel
+	cancelMu.Unlock()
+
+	go func() {
+		err := watchUntilLoggedIn(ctx)
+		if err != nil {
+			log.Warnf("watch login status: %v", err)
+		}
+
+		success := C.int(0)
+		if err == nil {
+			success = 1
+		}
+		C.netbird_dialog_finish(success)
+	}()
+}
+
+//export goCancelled
+func goCancelled() {
+	cancelMu.Lock()
+	cancel := cancelWaitFn
+	cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// watchUntilLoggedIn subscribes to the daemon's status stream and returns
+// once login has progressed past NeedsLogin, or reports an error on
+// LoginFailed or context cancellation. It does not call WaitSSOLogin
+// itself, since nm-netbird-service already does and the daemon may not
+// support two concurrent waiters for the same login.
+func watchUntilLoggedIn(ctx context.Context) error {
+	conn, err := nbdaemon.Dial()
+	if err != nil {
+		return fmt.Errorf("dial netbird daemon: %w", err)
+	}
+	defer conn.Close()
+
+	client := nbproto.NewDaemonServiceClient(conn)
+	stream, err := client.SubscribeStatus(ctx, &nbproto.StatusRequest{})
+	if err != nil {
+		return fmt.Errorf("subscribe status: %w", err)
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+
+		switch resp.Status {
+		case "Connecting", "Connected":
+			return nil
+		case "LoginFailed", "SessionExpired":
+			return fmt.Errorf("netbird status: %s", resp.Status)
+		}
+	}
+}

--- a/client/networkmanager/cmd/nm-netbird-service/main.go
+++ b/client/networkmanager/cmd/nm-netbird-service/main.go
@@ -1,0 +1,86 @@
+//go:build linux
+
+// Command nm-netbird-service is the NetworkManager VPN service plugin
+// NetworkManager spawns per active "netbird" connection. It implements
+// org.freedesktop.NetworkManager.VPN.Plugin and drives the real netbird
+// daemon's gRPC API to connect and disconnect.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/client/networkmanager/vpnplugin"
+)
+
+func main() {
+	busName := flag.String("bus-name", "", "D-Bus name to claim for this VPN plugin instance")
+	debug := flag.Bool("debug", false, "enable debug logging")
+	persist := flag.Bool("persist", false, "keep running after Disconnect instead of exiting")
+	flag.Parse()
+
+	if *debug {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	if err := run(*busName, *persist); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(busName string, persist bool) error {
+	if busName == "" {
+		return fmt.Errorf("missing required --bus-name")
+	}
+
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return fmt.Errorf("connect system bus: %w", err)
+	}
+	defer conn.Close()
+
+	reply, err := conn.RequestName(busName, dbus.NameFlagDoNotQueue)
+	if err != nil {
+		return fmt.Errorf("request bus name %s: %w", busName, err)
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		return fmt.Errorf("bus name %s is already owned", busName)
+	}
+
+	plugin := vpnplugin.New(conn, persist)
+	if err := plugin.Export(); err != nil {
+		return fmt.Errorf("export VPN plugin object: %w", err)
+	}
+
+	waitForShutdown(plugin)
+	return nil
+}
+
+func waitForShutdown(plugin *vpnplugin.Plugin) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+
+	select {
+	case s := <-sig:
+		log.Debugf("received signal %v, disconnecting", s)
+		if err := plugin.Disconnect(); err != nil {
+			log.Warnf("disconnect: %v", err)
+		}
+		// Exit on signal regardless of --persist: the process is being
+		// killed either way, persist only governs voluntary exit after a
+		// D-Bus-initiated Disconnect.
+		select {
+		case <-plugin.Quit():
+		case <-time.After(15 * time.Second):
+			log.Warn("timed out waiting for netbird down during shutdown")
+		}
+	case <-plugin.Quit():
+	}
+}

--- a/client/networkmanager/nbdaemon/dial.go
+++ b/client/networkmanager/nbdaemon/dial.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+// Package nbdaemon dials the netbird daemon's gRPC control socket, shared by
+// nm-netbird-service and nm-netbird-auth-dialog since both need to talk to
+// it independently (the latter to wait out the SSO login from the user's
+// own session).
+package nbdaemon
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	"github.com/netbirdio/netbird/client/internal/daemonaddr"
+)
+
+// DefaultAddr is the netbird daemon's default control socket on Linux,
+// mirroring client/cmd/root.go's default.
+const DefaultAddr = "unix:///var/run/netbird.sock"
+
+// Dial connects to the netbird daemon over its control socket, using the
+// same address resolution and dial options as the netbird CLI/UI.
+func Dial() (*grpc.ClientConn, error) {
+	addr := daemonaddr.ResolveUnixDaemonAddr(DefaultAddr)
+	target, opts := daemonaddr.DialTarget(addr)
+
+	conn, err := grpc.NewClient(target, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("dial netbird daemon: %w", err)
+	}
+	return conn, nil
+}

--- a/client/networkmanager/nm-netbird-service.conf
+++ b/client/networkmanager/nm-netbird-service.conf
@@ -1,0 +1,13 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="root">
+    <allow own="org.freedesktop.NetworkManager.netbird"/>
+    <allow send_destination="org.freedesktop.NetworkManager.netbird"/>
+    <allow send_interface="org.freedesktop.NetworkManager.VPN.Plugin"/>
+  </policy>
+  <policy context="default">
+    <deny own="org.freedesktop.NetworkManager.netbird"/>
+    <deny send_destination="org.freedesktop.NetworkManager.netbird"/>
+  </policy>
+</busconfig>

--- a/client/networkmanager/nm-netbird-service.name.in
+++ b/client/networkmanager/nm-netbird-service.name.in
@@ -1,0 +1,13 @@
+[VPN Connection]
+name=netbird
+service=org.freedesktop.NetworkManager.netbird
+program=@LIBEXECDIR@/nm-netbird-service
+supports-multiple-connections=true
+
+[libnm]
+plugin=@PLUGINDIR@/libnm-vpn-plugin-netbird.so
+
+[GNOME]
+auth-dialog=@LIBEXECDIR@/nm-netbird-auth-dialog
+supports-external-ui-mode=true
+supports-hints=true

--- a/client/networkmanager/properties/Makefile
+++ b/client/networkmanager/properties/Makefile
@@ -1,0 +1,100 @@
+PKG_CONFIG ?= pkg-config
+CC ?= gcc
+REQUIRED_PKGS := libnm gmodule-2.0 gtk4 gtk+-3.0
+
+CORE_NAME := libnm-vpn-plugin-netbird.so
+EDITOR_GTK4_NAME := libnm-gtk4-vpn-plugin-netbird-editor.so
+EDITOR_GTK3_NAME := libnm-vpn-plugin-netbird-editor.so
+
+# libnm.pc does not export a "plugindir" variable; the real plugin directory
+# is libdir/NetworkManager (e.g. /usr/lib64/NetworkManager on Fedora).
+PLUGINDIR ?= $(shell $(PKG_CONFIG) --variable=plugindir libnm 2>/dev/null)
+ifeq ($(PLUGINDIR),)
+PLUGINDIR := $(shell $(PKG_CONFIG) --variable=libdir libnm 2>/dev/null)/NetworkManager
+endif
+
+LIBNM_CFLAGS := $(shell $(PKG_CONFIG) --cflags libnm 2>/dev/null)
+LIBNM_LIBS := $(shell $(PKG_CONFIG) --libs libnm 2>/dev/null)
+GMODULE_CFLAGS := $(shell $(PKG_CONFIG) --cflags gmodule-2.0 2>/dev/null)
+GMODULE_LIBS := $(shell $(PKG_CONFIG) --libs gmodule-2.0 2>/dev/null)
+GTK4_CFLAGS := $(shell $(PKG_CONFIG) --cflags gtk4 2>/dev/null)
+GTK4_LIBS := $(shell $(PKG_CONFIG) --libs gtk4 2>/dev/null)
+GTK3_CFLAGS := $(shell $(PKG_CONFIG) --cflags gtk+-3.0 2>/dev/null)
+GTK3_LIBS := $(shell $(PKG_CONFIG) --libs gtk+-3.0 2>/dev/null)
+
+CFLAGS += -fPIC -Wall -DPLUGINDIR='"$(PLUGINDIR)"'
+
+.PHONY: all check-deps install uninstall clean
+
+all: check-deps $(CORE_NAME) $(EDITOR_GTK4_NAME) $(EDITOR_GTK3_NAME)
+
+check-deps:
+	@$(PKG_CONFIG) --exists $(REQUIRED_PKGS) || { \
+		echo "error: missing build dependencies for the NetBird NetworkManager editor plugin ($(REQUIRED_PKGS))." >&2; \
+		echo "install them first, e.g. on Fedora:" >&2; \
+		echo "  sudo dnf install NetworkManager-libnm-devel glib2-devel gtk4-devel gtk3-devel" >&2; \
+		echo "or on Debian/Ubuntu:" >&2; \
+		echo "  sudo apt install libnm-dev libglib2.0-dev libgtk-4-dev libgtk-3-dev" >&2; \
+		exit 1; \
+	}
+	@test -n "$(PLUGINDIR)" || { \
+		echo "error: could not determine libnm's plugin directory (libdir/NetworkManager)." >&2; \
+		echo "pass it explicitly: make PLUGINDIR=/path/to/NetworkManager" >&2; \
+		exit 1; \
+	}
+
+# Core plugin: toolkit-independent on purpose. NetworkManager and GNOME
+# Shell's own secret-agent both load this .so directly (not just
+# nm-connection-editor), so it must not link GTK -- doing so previously broke
+# GNOME Shell's SecretsRequired handling by loading a second GTK stack
+# inside its Wayland compositor process. It picks and dlopen's whichever of
+# the two editor .so's below matches the GTK toolkit already loaded in the
+# host process (nm-connection-editor is still GTK3 on some distributions
+# even where GTK4 is the default elsewhere; GNOME Settings' network panel is
+# GTK4), matching how NetworkManager's own bundled plugins do this.
+nm-netbird-editor-plugin.o: nm-netbird-editor-plugin.c
+	$(CC) $(CFLAGS) $(LIBNM_CFLAGS) $(GMODULE_CFLAGS) -c -o $@ $<
+
+$(CORE_NAME): nm-netbird-editor-plugin.o
+	$(CC) -shared -o $@ $^ $(LIBNM_LIBS) $(GMODULE_LIBS)
+
+resources.c: gresource.xml nm-netbird-dialog.ui
+	glib-compile-resources --generate-source --target=$@ --sourcedir=. gresource.xml
+
+nm-netbird-editor.o: nm-netbird-editor.c
+	$(CC) $(CFLAGS) $(LIBNM_CFLAGS) $(GTK4_CFLAGS) -c -o $@ $<
+
+resources.o: resources.c
+	$(CC) $(CFLAGS) $(GTK4_CFLAGS) -c -o $@ $<
+
+$(EDITOR_GTK4_NAME): nm-netbird-editor.o resources.o
+	$(CC) -shared -o $@ $^ $(LIBNM_LIBS) $(GTK4_LIBS)
+
+resources-gtk3.c: gresource-gtk3.xml nm-netbird-dialog-gtk3.ui
+	glib-compile-resources --generate-source --target=$@ --sourcedir=. gresource-gtk3.xml
+
+nm-netbird-editor-gtk3.o: nm-netbird-editor-gtk3.c
+	$(CC) $(CFLAGS) $(LIBNM_CFLAGS) $(GTK3_CFLAGS) -c -o $@ $<
+
+resources-gtk3.o: resources-gtk3.c
+	$(CC) $(CFLAGS) $(GTK3_CFLAGS) -c -o $@ $<
+
+$(EDITOR_GTK3_NAME): nm-netbird-editor-gtk3.o resources-gtk3.o
+	$(CC) -shared -o $@ $^ $(LIBNM_LIBS) $(GTK3_LIBS)
+
+install: all
+	install -d $(DESTDIR)$(PLUGINDIR)
+	install -m 0644 $(CORE_NAME) $(DESTDIR)$(PLUGINDIR)/$(CORE_NAME)
+	install -m 0644 $(EDITOR_GTK4_NAME) $(DESTDIR)$(PLUGINDIR)/$(EDITOR_GTK4_NAME)
+	install -m 0644 $(EDITOR_GTK3_NAME) $(DESTDIR)$(PLUGINDIR)/$(EDITOR_GTK3_NAME)
+
+uninstall:
+	rm -f $(DESTDIR)$(PLUGINDIR)/$(CORE_NAME)
+	rm -f $(DESTDIR)$(PLUGINDIR)/$(EDITOR_GTK4_NAME)
+	rm -f $(DESTDIR)$(PLUGINDIR)/$(EDITOR_GTK3_NAME)
+
+clean:
+	rm -f nm-netbird-editor-plugin.o nm-netbird-editor.o nm-netbird-editor-gtk3.o \
+		resources.o resources-gtk3.o \
+		$(CORE_NAME) $(EDITOR_GTK4_NAME) $(EDITOR_GTK3_NAME) \
+		resources.c resources-gtk3.c

--- a/client/networkmanager/properties/gresource-gtk3.xml
+++ b/client/networkmanager/properties/gresource-gtk3.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/freedesktop/network-manager-netbird">
+    <file preprocess="xml-stripblanks">nm-netbird-dialog-gtk3.ui</file>
+  </gresource>
+</gresources>

--- a/client/networkmanager/properties/gresource.xml
+++ b/client/networkmanager/properties/gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/freedesktop/network-manager-netbird">
+    <file preprocess="xml-stripblanks">nm-netbird-dialog.ui</file>
+  </gresource>
+</gresources>

--- a/client/networkmanager/properties/nm-netbird-dialog-gtk3.ui
+++ b/client/networkmanager/properties/nm-netbird-dialog-gtk3.ui
@@ -1,0 +1,426 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkAdjustment" id="mtu_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">9000</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">100</property>
+  </object>
+  <object class="GtkAdjustment" id="wireguard_port_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">65535</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">100</property>
+  </object>
+  <object class="GtkSizeGroup" id="label_size_group">
+    <property name="mode">horizontal</property>
+    <widgets>
+      <widget name="management_url_label"/>
+      <widget name="setup_key_label"/>
+      <widget name="management_url_hint_spacer"/>
+      <widget name="setup_key_hint_spacer"/>
+    </widgets>
+  </object>
+  <object class="GtkSizeGroup" id="advanced_label_size_group">
+    <property name="mode">horizontal</property>
+    <widgets>
+      <widget name="admin_url_label"/>
+      <widget name="interface_name_label"/>
+      <widget name="hostname_label"/>
+      <widget name="mtu_label"/>
+      <widget name="wireguard_port_label"/>
+    </widgets>
+  </object>
+  <object class="GtkBox" id="netbird-vbox">
+    <property name="visible">true</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">12</property>
+    <property name="margin_start">12</property>
+    <property name="margin_end">12</property>
+    <property name="margin_top">12</property>
+    <property name="margin_bottom">12</property>
+    <child>
+      <object class="GtkBox" id="main_box">
+        <property name="visible">true</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">true</property>
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="management_url_label">
+                <property name="visible">true</property>
+                <property name="label" translatable="yes">Management URL</property>
+                <property name="halign">start</property>
+              </object>
+              <packing>
+                <property name="expand">false</property>
+                <property name="fill">false</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="management_url_entry">
+                <property name="visible">true</property>
+              </object>
+              <packing>
+                <property name="expand">true</property>
+                <property name="fill">true</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">false</property>
+            <property name="fill">false</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">true</property>
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="management_url_hint_spacer">
+                <property name="visible">true</property>
+              </object>
+              <packing>
+                <property name="expand">false</property>
+                <property name="fill">false</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="management_url_hint_label">
+                <property name="visible">true</property>
+                <property name="label" translatable="yes">Leave empty to use NetBird's hosted management service.</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="wrap">true</property>
+                <attributes>
+                  <attribute name="scale" value="0.83"/>
+                </attributes>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">true</property>
+                <property name="fill">true</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">false</property>
+            <property name="fill">false</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">true</property>
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="setup_key_label">
+                <property name="visible">true</property>
+                <property name="label" translatable="yes">Setup key</property>
+                <property name="halign">start</property>
+              </object>
+              <packing>
+                <property name="expand">false</property>
+                <property name="fill">false</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="setup_key_entry">
+                <property name="visible">true</property>
+                <property name="visibility">false</property>
+                <property name="input-purpose">password</property>
+              </object>
+              <packing>
+                <property name="expand">true</property>
+                <property name="fill">true</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">false</property>
+            <property name="fill">false</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">true</property>
+        <property name="orientation">horizontal</property>
+        <property name="spacing">12</property>
+        <child>
+          <object class="GtkLabel" id="setup_key_hint_spacer">
+            <property name="visible">true</property>
+          </object>
+          <packing>
+            <property name="expand">false</property>
+            <property name="fill">false</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="setup_key_hint_label">
+            <property name="visible">true</property>
+            <property name="label" translatable="yes">Leave the setup key empty to sign in with your browser (SSO) instead.</property>
+            <property name="halign">start</property>
+            <property name="xalign">0</property>
+            <property name="wrap">true</property>
+            <attributes>
+              <attribute name="scale" value="0.83"/>
+            </attributes>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">true</property>
+            <property name="fill">true</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkExpander" id="advanced_expander">
+        <property name="visible">true</property>
+        <property name="label" translatable="yes">Advanced</property>
+        <child>
+          <object class="GtkBox" id="advanced_box">
+            <property name="visible">true</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
+            <property name="margin_top">6</property>
+            <child>
+              <object class="GtkBox" id="advanced_fields_box">
+                <property name="visible">true</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">true</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="admin_url_label">
+                        <property name="visible">true</property>
+                        <property name="label" translatable="yes">Admin URL</property>
+                        <property name="halign">start</property>
+                      </object>
+                      <packing>
+                        <property name="expand">false</property>
+                        <property name="fill">false</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="admin_url_entry">
+                        <property name="visible">true</property>
+                      </object>
+                      <packing>
+                        <property name="expand">true</property>
+                        <property name="fill">true</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">true</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="interface_name_label">
+                        <property name="visible">true</property>
+                        <property name="label" translatable="yes">Interface name</property>
+                        <property name="halign">start</property>
+                      </object>
+                      <packing>
+                        <property name="expand">false</property>
+                        <property name="fill">false</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="interface_name_entry">
+                        <property name="visible">true</property>
+                        <property name="placeholder-text">(automatic)</property>
+                      </object>
+                      <packing>
+                        <property name="expand">true</property>
+                        <property name="fill">true</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">true</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="hostname_label">
+                        <property name="visible">true</property>
+                        <property name="label" translatable="yes">Hostname</property>
+                        <property name="halign">start</property>
+                      </object>
+                      <packing>
+                        <property name="expand">false</property>
+                        <property name="fill">false</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="hostname_entry">
+                        <property name="visible">true</property>
+                        <property name="placeholder-text">(automatic)</property>
+                      </object>
+                      <packing>
+                        <property name="expand">true</property>
+                        <property name="fill">true</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">true</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="mtu_label">
+                        <property name="visible">true</property>
+                        <property name="label" translatable="yes">MTU (0 = automatic)</property>
+                        <property name="halign">start</property>
+                      </object>
+                      <packing>
+                        <property name="expand">false</property>
+                        <property name="fill">false</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="mtu_spin">
+                        <property name="visible">true</property>
+                        <property name="adjustment">mtu_adjustment</property>
+                        <property name="numeric">true</property>
+                      </object>
+                      <packing>
+                        <property name="expand">true</property>
+                        <property name="fill">true</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">true</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="wireguard_port_label">
+                        <property name="visible">true</property>
+                        <property name="label" translatable="yes">WireGuard port (0 = automatic)</property>
+                        <property name="halign">start</property>
+                      </object>
+                      <packing>
+                        <property name="expand">false</property>
+                        <property name="fill">false</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="wireguard_port_spin">
+                        <property name="visible">true</property>
+                        <property name="adjustment">wireguard_port_adjustment</property>
+                        <property name="numeric">true</property>
+                      </object>
+                      <packing>
+                        <property name="expand">true</property>
+                        <property name="fill">true</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="checks_box">
+                <property name="visible">true</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkCheckButton" id="block_inbound_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Block inbound connections</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_server_routes_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Disable routes received from the management server</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="block_lan_access_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Block access to the local network while connected</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_client_routes_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Disable advertising local routes to peers</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_dns_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Disable NetBird's DNS management</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_firewall_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Disable NetBird's firewall management</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_ipv6_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Disable IPv6</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="rosenpass_enabled_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Enable Rosenpass (post-quantum secure tunnel)</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="rosenpass_permissive_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Accept non-Rosenpass peers too</property>
+                    <property name="margin_start">24</property>
+                    <property name="sensitive">false</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_auto_connect_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Do not connect automatically when the daemon starts</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="network_monitor_check">
+                    <property name="visible">true</property>
+                    <property name="label" translatable="yes">Monitor network changes and reconnect automatically</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/client/networkmanager/properties/nm-netbird-dialog.ui
+++ b/client/networkmanager/properties/nm-netbird-dialog.ui
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <object class="GtkAdjustment" id="mtu_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">9000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">100</property>
+  </object>
+  <object class="GtkAdjustment" id="wireguard_port_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">65535</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">100</property>
+  </object>
+  <object class="GtkSizeGroup" id="label_size_group">
+    <property name="mode">horizontal</property>
+    <widgets>
+      <widget name="management_url_label"/>
+      <widget name="setup_key_label"/>
+      <widget name="management_url_hint_spacer"/>
+      <widget name="setup_key_hint_spacer"/>
+    </widgets>
+  </object>
+  <object class="GtkSizeGroup" id="advanced_label_size_group">
+    <property name="mode">horizontal</property>
+    <widgets>
+      <widget name="admin_url_label"/>
+      <widget name="interface_name_label"/>
+      <widget name="hostname_label"/>
+      <widget name="mtu_label"/>
+      <widget name="wireguard_port_label"/>
+    </widgets>
+  </object>
+  <object class="GtkBox" id="netbird-vbox">
+    <property name="orientation">vertical</property>
+    <property name="spacing">12</property>
+    <property name="margin-start">12</property>
+    <property name="margin-end">12</property>
+    <property name="margin-top">12</property>
+    <property name="margin-bottom">12</property>
+    <child>
+      <object class="GtkBox" id="main_box">
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="management_url_label">
+                <property name="label" translatable="yes">Management URL</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEntry" id="management_url_entry">
+                <property name="hexpand">true</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="management_url_hint_spacer"/>
+            </child>
+            <child>
+              <object class="GtkLabel" id="management_url_hint_label">
+                <property name="label" translatable="yes">Leave empty to use NetBird's hosted management service.</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="hexpand">true</property>
+                <property name="wrap">true</property>
+                <attributes>
+                  <attribute name="scale" value="0.83"/>
+                </attributes>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="setup_key_label">
+                <property name="label" translatable="yes">Setup key</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEntry" id="setup_key_entry">
+                <property name="hexpand">true</property>
+                <property name="visibility">false</property>
+                <property name="input-purpose">password</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">horizontal</property>
+        <property name="spacing">12</property>
+        <child>
+          <object class="GtkLabel" id="setup_key_hint_spacer"/>
+        </child>
+        <child>
+          <object class="GtkLabel" id="setup_key_hint_label">
+            <property name="label" translatable="yes">Leave the setup key empty to sign in with your browser (SSO) instead.</property>
+            <property name="halign">start</property>
+            <property name="xalign">0</property>
+            <property name="hexpand">true</property>
+            <property name="wrap">true</property>
+            <attributes>
+              <attribute name="scale" value="0.83"/>
+            </attributes>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkExpander" id="advanced_expander">
+        <property name="label" translatable="yes">Advanced</property>
+        <child>
+          <object class="GtkBox" id="advanced_box">
+            <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
+            <property name="margin-top">6</property>
+            <child>
+              <object class="GtkBox" id="advanced_fields_box">
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="admin_url_label">
+                        <property name="label" translatable="yes">Admin URL</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="admin_url_entry">
+                        <property name="hexpand">true</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="interface_name_label">
+                        <property name="label" translatable="yes">Interface name</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="interface_name_entry">
+                        <property name="hexpand">true</property>
+                        <property name="placeholder-text">(automatic)</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="hostname_label">
+                        <property name="label" translatable="yes">Hostname</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="hostname_entry">
+                        <property name="hexpand">true</property>
+                        <property name="placeholder-text">(automatic)</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="mtu_label">
+                        <property name="label" translatable="yes">MTU (0 = automatic)</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="mtu_spin">
+                        <property name="adjustment">mtu_adjustment</property>
+                        <property name="numeric">true</property>
+                        <property name="hexpand">true</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="wireguard_port_label">
+                        <property name="label" translatable="yes">WireGuard port (0 = automatic)</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="wireguard_port_spin">
+                        <property name="adjustment">wireguard_port_adjustment</property>
+                        <property name="numeric">true</property>
+                        <property name="hexpand">true</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="checks_box">
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkCheckButton" id="block_inbound_check">
+                    <property name="label" translatable="yes">Block inbound connections</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_server_routes_check">
+                    <property name="label" translatable="yes">Disable routes received from the management server</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="block_lan_access_check">
+                    <property name="label" translatable="yes">Block access to the local network while connected</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_client_routes_check">
+                    <property name="label" translatable="yes">Disable advertising local routes to peers</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_dns_check">
+                    <property name="label" translatable="yes">Disable NetBird's DNS management</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_firewall_check">
+                    <property name="label" translatable="yes">Disable NetBird's firewall management</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_ipv6_check">
+                    <property name="label" translatable="yes">Disable IPv6</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="rosenpass_enabled_check">
+                    <property name="label" translatable="yes">Enable Rosenpass (post-quantum secure tunnel)</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="rosenpass_permissive_check">
+                    <property name="label" translatable="yes">Accept non-Rosenpass peers too</property>
+                    <property name="margin-start">24</property>
+                    <property name="sensitive">false</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_auto_connect_check">
+                    <property name="label" translatable="yes">Do not connect automatically when the daemon starts</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="network_monitor_check">
+                    <property name="label" translatable="yes">Monitor network changes and reconnect automatically</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/client/networkmanager/properties/nm-netbird-editor-gtk3.c
+++ b/client/networkmanager/properties/nm-netbird-editor-gtk3.c
@@ -1,0 +1,320 @@
+#include "nm-netbird-editor.h"
+
+#include <gtk/gtk.h>
+
+#include "nm-netbird-service-defines.h"
+
+struct _NetbirdEditor {
+	GObject parent;
+
+	GtkBuilder *builder;
+	GtkWidget *widget;
+
+	GtkWidget *management_url_entry;
+	GtkWidget *setup_key_entry;
+	GtkWidget *admin_url_entry;
+	GtkWidget *interface_name_entry;
+	GtkWidget *hostname_entry;
+	GtkWidget *mtu_spin;
+	GtkWidget *wireguard_port_spin;
+	GtkWidget *block_inbound_check;
+	GtkWidget *disable_server_routes_check;
+	GtkWidget *block_lan_access_check;
+	GtkWidget *disable_client_routes_check;
+	GtkWidget *disable_dns_check;
+	GtkWidget *disable_firewall_check;
+	GtkWidget *disable_ipv6_check;
+	GtkWidget *rosenpass_enabled_check;
+	GtkWidget *rosenpass_permissive_check;
+	GtkWidget *disable_auto_connect_check;
+	GtkWidget *network_monitor_check;
+};
+
+static void netbird_editor_iface_init (NMVpnEditorInterface *iface_class);
+
+G_DEFINE_TYPE_EXTENDED (NetbirdEditor, netbird_editor, G_TYPE_OBJECT, 0,
+                        G_IMPLEMENT_INTERFACE (NM_TYPE_VPN_EDITOR, netbird_editor_iface_init))
+
+static gboolean
+is_data_item_yes (NMSettingVpn *s_vpn, const char *key)
+{
+	return g_strcmp0 (nm_setting_vpn_get_data_item (s_vpn, key), NM_NETBIRD_VALUE_YES) == 0;
+}
+
+static void
+set_entry_text (GtkWidget *entry, const char *value)
+{
+	gtk_entry_set_text (GTK_ENTRY (entry), value ? value : "");
+}
+
+static void
+init_widgets_from_connection (NetbirdEditor *self, NMConnection *connection)
+{
+	NMSettingVpn *s_vpn;
+	const char *value;
+
+	s_vpn = nm_connection_get_setting_vpn (connection);
+	if (!s_vpn) {
+		return;
+	}
+
+	set_entry_text (self->management_url_entry, nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_MANAGEMENT_URL));
+	set_entry_text (self->setup_key_entry, nm_setting_vpn_get_secret (s_vpn, NM_NETBIRD_KEY_SETUP_KEY));
+	set_entry_text (self->admin_url_entry, nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_ADMIN_URL));
+	set_entry_text (self->interface_name_entry, nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_INTERFACE_NAME));
+	set_entry_text (self->hostname_entry, nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_HOSTNAME));
+
+	value = nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_MTU);
+	gtk_spin_button_set_value (GTK_SPIN_BUTTON (self->mtu_spin), value ? g_ascii_strtod (value, NULL) : 0);
+
+	value = nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_WIREGUARD_PORT);
+	gtk_spin_button_set_value (GTK_SPIN_BUTTON (self->wireguard_port_spin), value ? g_ascii_strtod (value, NULL) : 0);
+
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->block_inbound_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_BLOCK_INBOUND));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->disable_server_routes_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_SERVER_ROUTES));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->block_lan_access_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_BLOCK_LAN_ACCESS));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->disable_client_routes_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_CLIENT_ROUTES));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->disable_dns_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_DNS));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->disable_firewall_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_FIREWALL));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->disable_ipv6_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_IPV6));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->rosenpass_enabled_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_ROSENPASS_ENABLED));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->rosenpass_permissive_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_ROSENPASS_PERMISSIVE));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->disable_auto_connect_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_AUTO_CONNECT));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (self->network_monitor_check),
+	                               is_data_item_yes (s_vpn, NM_NETBIRD_KEY_NETWORK_MONITOR));
+
+	gtk_widget_set_sensitive (self->rosenpass_permissive_check,
+	                          gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->rosenpass_enabled_check)));
+}
+
+static void
+rosenpass_enabled_toggled_cb (GtkToggleButton *button, gpointer user_data)
+{
+	NetbirdEditor *self = NETBIRD_EDITOR (user_data);
+
+	gtk_widget_set_sensitive (self->rosenpass_permissive_check, gtk_toggle_button_get_active (button));
+	g_signal_emit_by_name (self, "changed");
+}
+
+static void
+emit_changed_cb (GtkWidget *widget, gpointer user_data)
+{
+	g_signal_emit_by_name (NETBIRD_EDITOR (user_data), "changed");
+}
+
+static void
+connect_changed_signals (NetbirdEditor *self)
+{
+	GtkWidget *entries[] = {
+		self->management_url_entry,
+		self->setup_key_entry,
+		self->admin_url_entry,
+		self->interface_name_entry,
+		self->hostname_entry,
+	};
+	GtkWidget *checks[] = {
+		self->block_inbound_check,
+		self->disable_server_routes_check,
+		self->block_lan_access_check,
+		self->disable_client_routes_check,
+		self->disable_dns_check,
+		self->disable_firewall_check,
+		self->disable_ipv6_check,
+		self->rosenpass_enabled_check,
+		self->rosenpass_permissive_check,
+		self->disable_auto_connect_check,
+		self->network_monitor_check,
+	};
+	GtkWidget *spins[] = { self->mtu_spin, self->wireguard_port_spin };
+	guint ii;
+
+	for (ii = 0; ii < G_N_ELEMENTS (entries); ii++) {
+		g_signal_connect (entries[ii], "changed", G_CALLBACK (emit_changed_cb), self);
+	}
+	for (ii = 0; ii < G_N_ELEMENTS (checks); ii++) {
+		g_signal_connect (checks[ii], "toggled", G_CALLBACK (emit_changed_cb), self);
+	}
+	for (ii = 0; ii < G_N_ELEMENTS (spins); ii++) {
+		g_signal_connect (spins[ii], "value-changed", G_CALLBACK (emit_changed_cb), self);
+	}
+}
+
+static void
+add_optional_data_item (NMSettingVpn *s_vpn, const char *key, const char *value)
+{
+	if (value && value[0]) {
+		nm_setting_vpn_add_data_item (s_vpn, key, value);
+	}
+}
+
+static void
+add_bool_data_item (NMSettingVpn *s_vpn, const char *key, gboolean active)
+{
+	nm_setting_vpn_add_data_item (s_vpn, key, active ? NM_NETBIRD_VALUE_YES : NM_NETBIRD_VALUE_NO);
+}
+
+static void
+add_optional_int_data_item (NMSettingVpn *s_vpn, const char *key, GtkWidget *spin)
+{
+	int value;
+
+	value = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (spin));
+	if (value != 0) {
+		char *text = g_strdup_printf ("%d", value);
+		nm_setting_vpn_add_data_item (s_vpn, key, text);
+		g_free (text);
+	}
+}
+
+static gboolean
+update_connection (NMVpnEditor *iface, NMConnection *connection, GError **error)
+{
+	NetbirdEditor *self = NETBIRD_EDITOR (iface);
+	NMSettingVpn *s_vpn;
+	const char *setup_key;
+
+	s_vpn = NM_SETTING_VPN (nm_setting_vpn_new ());
+	g_object_set (s_vpn, NM_SETTING_VPN_SERVICE_TYPE, NM_VPN_SERVICE_TYPE_NETBIRD, NULL);
+
+	/* Left empty, this means the same thing "normal" (non-self-managed)
+	 * setup means in netbird-ui: use NetBird's own hosted management
+	 * service (api.netbird.io) instead of a self-hosted one. */
+	add_optional_data_item (s_vpn, NM_NETBIRD_KEY_MANAGEMENT_URL,
+	                         gtk_entry_get_text (GTK_ENTRY (self->management_url_entry)));
+
+	setup_key = gtk_entry_get_text (GTK_ENTRY (self->setup_key_entry));
+	if (setup_key && setup_key[0]) {
+		nm_setting_vpn_add_secret (s_vpn, NM_NETBIRD_KEY_SETUP_KEY, setup_key);
+		nm_setting_set_secret_flags (NM_SETTING (s_vpn), NM_NETBIRD_KEY_SETUP_KEY,
+		                              NM_SETTING_SECRET_FLAG_AGENT_OWNED, NULL);
+	}
+
+	add_optional_data_item (s_vpn, NM_NETBIRD_KEY_ADMIN_URL,
+	                         gtk_entry_get_text (GTK_ENTRY (self->admin_url_entry)));
+	add_optional_data_item (s_vpn, NM_NETBIRD_KEY_INTERFACE_NAME,
+	                         gtk_entry_get_text (GTK_ENTRY (self->interface_name_entry)));
+	add_optional_data_item (s_vpn, NM_NETBIRD_KEY_HOSTNAME,
+	                         gtk_entry_get_text (GTK_ENTRY (self->hostname_entry)));
+
+	add_optional_int_data_item (s_vpn, NM_NETBIRD_KEY_MTU, self->mtu_spin);
+	add_optional_int_data_item (s_vpn, NM_NETBIRD_KEY_WIREGUARD_PORT, self->wireguard_port_spin);
+
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_BLOCK_INBOUND,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->block_inbound_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_SERVER_ROUTES,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->disable_server_routes_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_BLOCK_LAN_ACCESS,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->block_lan_access_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_CLIENT_ROUTES,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->disable_client_routes_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_DNS,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->disable_dns_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_FIREWALL,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->disable_firewall_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_IPV6,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->disable_ipv6_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_ROSENPASS_ENABLED,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->rosenpass_enabled_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_ROSENPASS_PERMISSIVE,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->rosenpass_permissive_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_AUTO_CONNECT,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->disable_auto_connect_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_NETWORK_MONITOR,
+	                     gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->network_monitor_check)));
+
+	nm_connection_add_setting (connection, NM_SETTING (s_vpn));
+	return TRUE;
+}
+
+static GObject *
+get_widget (NMVpnEditor *iface)
+{
+	return G_OBJECT (NETBIRD_EDITOR (iface)->widget);
+}
+
+static void
+netbird_editor_iface_init (NMVpnEditorInterface *iface_class)
+{
+	iface_class->get_widget = get_widget;
+	iface_class->update_connection = update_connection;
+}
+
+static void
+netbird_editor_init (NetbirdEditor *self)
+{
+}
+
+static void
+dispose (GObject *object)
+{
+	NetbirdEditor *self = NETBIRD_EDITOR (object);
+
+	g_clear_object (&self->widget);
+	g_clear_object (&self->builder);
+
+	G_OBJECT_CLASS (netbird_editor_parent_class)->dispose (object);
+}
+
+static void
+netbird_editor_class_init (NetbirdEditorClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+	object_class->dispose = dispose;
+}
+
+NMVpnEditor *
+nm_vpn_editor_factory_netbird (NMVpnEditorPlugin *plugin, NMConnection *connection, GError **error)
+{
+	NetbirdEditor *self;
+	GtkBuilder *builder;
+
+	builder = gtk_builder_new ();
+	if (!gtk_builder_add_from_resource (builder, "/org/freedesktop/network-manager-netbird/nm-netbird-dialog-gtk3.ui", error)) {
+		g_object_unref (builder);
+		return NULL;
+	}
+
+	self = g_object_new (NETBIRD_TYPE_EDITOR, NULL);
+	self->builder = builder;
+
+	self->widget = GTK_WIDGET (gtk_builder_get_object (builder, "netbird-vbox"));
+	g_object_ref_sink (self->widget);
+
+	self->management_url_entry = GTK_WIDGET (gtk_builder_get_object (builder, "management_url_entry"));
+	gtk_entry_set_placeholder_text (GTK_ENTRY (self->management_url_entry), NM_NETBIRD_DEFAULT_MANAGEMENT_URL);
+	self->setup_key_entry = GTK_WIDGET (gtk_builder_get_object (builder, "setup_key_entry"));
+	self->admin_url_entry = GTK_WIDGET (gtk_builder_get_object (builder, "admin_url_entry"));
+	self->interface_name_entry = GTK_WIDGET (gtk_builder_get_object (builder, "interface_name_entry"));
+	self->hostname_entry = GTK_WIDGET (gtk_builder_get_object (builder, "hostname_entry"));
+	self->mtu_spin = GTK_WIDGET (gtk_builder_get_object (builder, "mtu_spin"));
+	self->wireguard_port_spin = GTK_WIDGET (gtk_builder_get_object (builder, "wireguard_port_spin"));
+	self->block_inbound_check = GTK_WIDGET (gtk_builder_get_object (builder, "block_inbound_check"));
+	self->disable_server_routes_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_server_routes_check"));
+	self->block_lan_access_check = GTK_WIDGET (gtk_builder_get_object (builder, "block_lan_access_check"));
+	self->disable_client_routes_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_client_routes_check"));
+	self->disable_dns_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_dns_check"));
+	self->disable_firewall_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_firewall_check"));
+	self->disable_ipv6_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_ipv6_check"));
+	self->rosenpass_enabled_check = GTK_WIDGET (gtk_builder_get_object (builder, "rosenpass_enabled_check"));
+	self->rosenpass_permissive_check = GTK_WIDGET (gtk_builder_get_object (builder, "rosenpass_permissive_check"));
+	self->disable_auto_connect_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_auto_connect_check"));
+	self->network_monitor_check = GTK_WIDGET (gtk_builder_get_object (builder, "network_monitor_check"));
+
+	init_widgets_from_connection (self, connection);
+
+	g_signal_connect (self->rosenpass_enabled_check, "toggled", G_CALLBACK (rosenpass_enabled_toggled_cb), self);
+	connect_changed_signals (self);
+
+	return NM_VPN_EDITOR (self);
+}

--- a/client/networkmanager/properties/nm-netbird-editor-plugin.c
+++ b/client/networkmanager/properties/nm-netbird-editor-plugin.c
@@ -1,0 +1,158 @@
+#include "nm-netbird-editor-plugin.h"
+
+#include <gmodule.h>
+
+#include "nm-netbird-service-defines.h"
+
+#ifndef NETBIRD_EDITOR_MODULE_PATH_GTK3
+#define NETBIRD_EDITOR_MODULE_PATH_GTK3 PLUGINDIR "/libnm-vpn-plugin-netbird-editor.so"
+#endif
+
+#ifndef NETBIRD_EDITOR_MODULE_PATH_GTK4
+#define NETBIRD_EDITOR_MODULE_PATH_GTK4 PLUGINDIR "/libnm-gtk4-vpn-plugin-netbird-editor.so"
+#endif
+
+#define NETBIRD_EDITOR_FACTORY_SYMBOL "nm_vpn_editor_factory_netbird"
+
+typedef NMVpnEditor *(*NetbirdEditorFactoryFunc) (NMVpnEditorPlugin *plugin, NMConnection *connection, GError **error);
+
+/* nm-connection-editor (network-manager-applet) is still a GTK3 process on
+ * some distributions even where GTK4 is otherwise the default, while GNOME
+ * Settings' own network panel is GTK4. Loading a GTK4-linked editor module
+ * into a GTK3 host process (or vice versa) corrupts the GObject type
+ * registry, since both toolkits define types with the same names (GtkWidget,
+ * GtkEditable, ...). gtk_container_add was removed in GTK4, so its presence
+ * in the running process is a reliable way to tell which toolkit is already
+ * loaded and pick the matching editor module. */
+static gboolean
+gtk3_is_loaded (void)
+{
+	GModule *self_module;
+	gpointer symbol;
+
+	self_module = g_module_open (NULL, G_MODULE_BIND_LAZY);
+	if (!self_module)
+		return FALSE;
+
+	return g_module_symbol (self_module, "gtk_container_add", &symbol);
+}
+
+static const char *
+editor_module_path (void)
+{
+	if (gtk3_is_loaded ())
+		return NETBIRD_EDITOR_MODULE_PATH_GTK3;
+	return NETBIRD_EDITOR_MODULE_PATH_GTK4;
+}
+
+enum {
+	PROP_NAME = 1,
+	PROP_DESCRIPTION,
+	PROP_SERVICE,
+};
+
+struct _NetbirdEditorPlugin {
+	GObject parent;
+	GModule *editor_module;
+};
+
+static void netbird_editor_plugin_iface_init (NMVpnEditorPluginInterface *iface_class);
+
+G_DEFINE_TYPE_EXTENDED (NetbirdEditorPlugin, netbird_editor_plugin, G_TYPE_OBJECT, 0,
+                        G_IMPLEMENT_INTERFACE (NM_TYPE_VPN_EDITOR_PLUGIN, netbird_editor_plugin_iface_init))
+
+static NMVpnEditor *
+get_editor (NMVpnEditorPlugin *plugin, NMConnection *connection, GError **error)
+{
+	NetbirdEditorPlugin *self = NETBIRD_EDITOR_PLUGIN (plugin);
+	NetbirdEditorFactoryFunc factory;
+
+	if (!self->editor_module) {
+		const char *module_path = editor_module_path ();
+
+		self->editor_module = g_module_open (module_path, G_MODULE_BIND_LOCAL);
+		if (!self->editor_module) {
+			g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+			             "cannot load netbird editor module %s: %s",
+			             module_path, g_module_error ());
+			return NULL;
+		}
+	}
+
+	if (!g_module_symbol (self->editor_module, NETBIRD_EDITOR_FACTORY_SYMBOL, (gpointer *) &factory)) {
+		g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+		             "cannot find %s in netbird editor module: %s",
+		             NETBIRD_EDITOR_FACTORY_SYMBOL, g_module_error ());
+		return NULL;
+	}
+
+	return factory (plugin, connection, error);
+}
+
+static guint32
+get_capabilities (NMVpnEditorPlugin *plugin)
+{
+	return NM_VPN_EDITOR_PLUGIN_CAPABILITY_NONE;
+}
+
+static void
+netbird_editor_plugin_iface_init (NMVpnEditorPluginInterface *iface_class)
+{
+	iface_class->get_editor = get_editor;
+	iface_class->get_capabilities = get_capabilities;
+}
+
+static void
+netbird_editor_plugin_init (NetbirdEditorPlugin *self)
+{
+}
+
+static void
+dispose (GObject *object)
+{
+	NetbirdEditorPlugin *self = NETBIRD_EDITOR_PLUGIN (object);
+
+	g_clear_pointer (&self->editor_module, g_module_close);
+
+	G_OBJECT_CLASS (netbird_editor_plugin_parent_class)->dispose (object);
+}
+
+static void
+get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
+{
+	switch (prop_id) {
+	case PROP_NAME:
+		g_value_set_string (value, "NetBird");
+		break;
+	case PROP_DESCRIPTION:
+		g_value_set_string (value, "NetBird VPN client");
+		break;
+	case PROP_SERVICE:
+		g_value_set_string (value, NM_DBUS_SERVICE_NETBIRD);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+netbird_editor_plugin_class_init (NetbirdEditorPluginClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+	object_class->dispose = dispose;
+	object_class->get_property = get_property;
+
+	g_object_class_override_property (object_class, PROP_NAME, NM_VPN_EDITOR_PLUGIN_NAME);
+	g_object_class_override_property (object_class, PROP_DESCRIPTION, NM_VPN_EDITOR_PLUGIN_DESCRIPTION);
+	g_object_class_override_property (object_class, PROP_SERVICE, NM_VPN_EDITOR_PLUGIN_SERVICE);
+}
+
+G_MODULE_EXPORT NMVpnEditorPlugin *
+nm_vpn_editor_plugin_factory (GError **error)
+{
+	if (error)
+		*error = NULL;
+	return g_object_new (NETBIRD_TYPE_EDITOR_PLUGIN, NULL);
+}

--- a/client/networkmanager/properties/nm-netbird-editor-plugin.h
+++ b/client/networkmanager/properties/nm-netbird-editor-plugin.h
@@ -1,0 +1,10 @@
+#ifndef NM_NETBIRD_EDITOR_PLUGIN_H
+#define NM_NETBIRD_EDITOR_PLUGIN_H
+
+#include <glib-object.h>
+#include <NetworkManager.h>
+
+#define NETBIRD_TYPE_EDITOR_PLUGIN (netbird_editor_plugin_get_type ())
+G_DECLARE_FINAL_TYPE (NetbirdEditorPlugin, netbird_editor_plugin, NETBIRD, EDITOR_PLUGIN, GObject)
+
+#endif /* NM_NETBIRD_EDITOR_PLUGIN_H */

--- a/client/networkmanager/properties/nm-netbird-editor.c
+++ b/client/networkmanager/properties/nm-netbird-editor.c
@@ -1,0 +1,320 @@
+#include "nm-netbird-editor.h"
+
+#include <gtk/gtk.h>
+
+#include "nm-netbird-service-defines.h"
+
+struct _NetbirdEditor {
+	GObject parent;
+
+	GtkBuilder *builder;
+	GtkWidget *widget;
+
+	GtkWidget *management_url_entry;
+	GtkWidget *setup_key_entry;
+	GtkWidget *admin_url_entry;
+	GtkWidget *interface_name_entry;
+	GtkWidget *hostname_entry;
+	GtkWidget *mtu_spin;
+	GtkWidget *wireguard_port_spin;
+	GtkWidget *block_inbound_check;
+	GtkWidget *disable_server_routes_check;
+	GtkWidget *block_lan_access_check;
+	GtkWidget *disable_client_routes_check;
+	GtkWidget *disable_dns_check;
+	GtkWidget *disable_firewall_check;
+	GtkWidget *disable_ipv6_check;
+	GtkWidget *rosenpass_enabled_check;
+	GtkWidget *rosenpass_permissive_check;
+	GtkWidget *disable_auto_connect_check;
+	GtkWidget *network_monitor_check;
+};
+
+static void netbird_editor_iface_init (NMVpnEditorInterface *iface_class);
+
+G_DEFINE_TYPE_EXTENDED (NetbirdEditor, netbird_editor, G_TYPE_OBJECT, 0,
+                        G_IMPLEMENT_INTERFACE (NM_TYPE_VPN_EDITOR, netbird_editor_iface_init))
+
+static gboolean
+is_data_item_yes (NMSettingVpn *s_vpn, const char *key)
+{
+	return g_strcmp0 (nm_setting_vpn_get_data_item (s_vpn, key), NM_NETBIRD_VALUE_YES) == 0;
+}
+
+static void
+set_entry_text (GtkWidget *entry, const char *value)
+{
+	gtk_editable_set_text (GTK_EDITABLE (entry), value ? value : "");
+}
+
+static void
+init_widgets_from_connection (NetbirdEditor *self, NMConnection *connection)
+{
+	NMSettingVpn *s_vpn;
+	const char *value;
+
+	s_vpn = nm_connection_get_setting_vpn (connection);
+	if (!s_vpn) {
+		return;
+	}
+
+	set_entry_text (self->management_url_entry, nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_MANAGEMENT_URL));
+	set_entry_text (self->setup_key_entry, nm_setting_vpn_get_secret (s_vpn, NM_NETBIRD_KEY_SETUP_KEY));
+	set_entry_text (self->admin_url_entry, nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_ADMIN_URL));
+	set_entry_text (self->interface_name_entry, nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_INTERFACE_NAME));
+	set_entry_text (self->hostname_entry, nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_HOSTNAME));
+
+	value = nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_MTU);
+	gtk_spin_button_set_value (GTK_SPIN_BUTTON (self->mtu_spin), value ? g_ascii_strtod (value, NULL) : 0);
+
+	value = nm_setting_vpn_get_data_item (s_vpn, NM_NETBIRD_KEY_WIREGUARD_PORT);
+	gtk_spin_button_set_value (GTK_SPIN_BUTTON (self->wireguard_port_spin), value ? g_ascii_strtod (value, NULL) : 0);
+
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->block_inbound_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_BLOCK_INBOUND));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->disable_server_routes_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_SERVER_ROUTES));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->block_lan_access_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_BLOCK_LAN_ACCESS));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->disable_client_routes_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_CLIENT_ROUTES));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->disable_dns_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_DNS));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->disable_firewall_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_FIREWALL));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->disable_ipv6_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_IPV6));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->rosenpass_enabled_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_ROSENPASS_ENABLED));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->rosenpass_permissive_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_ROSENPASS_PERMISSIVE));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->disable_auto_connect_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_DISABLE_AUTO_CONNECT));
+	gtk_check_button_set_active (GTK_CHECK_BUTTON (self->network_monitor_check),
+	                              is_data_item_yes (s_vpn, NM_NETBIRD_KEY_NETWORK_MONITOR));
+
+	gtk_widget_set_sensitive (self->rosenpass_permissive_check,
+	                          gtk_check_button_get_active (GTK_CHECK_BUTTON (self->rosenpass_enabled_check)));
+}
+
+static void
+rosenpass_enabled_toggled_cb (GtkCheckButton *button, gpointer user_data)
+{
+	NetbirdEditor *self = NETBIRD_EDITOR (user_data);
+
+	gtk_widget_set_sensitive (self->rosenpass_permissive_check, gtk_check_button_get_active (button));
+	g_signal_emit_by_name (self, "changed");
+}
+
+static void
+emit_changed_cb (GtkWidget *widget, gpointer user_data)
+{
+	g_signal_emit_by_name (NETBIRD_EDITOR (user_data), "changed");
+}
+
+static void
+connect_changed_signals (NetbirdEditor *self)
+{
+	GtkWidget *entries[] = {
+		self->management_url_entry,
+		self->setup_key_entry,
+		self->admin_url_entry,
+		self->interface_name_entry,
+		self->hostname_entry,
+	};
+	GtkWidget *checks[] = {
+		self->block_inbound_check,
+		self->disable_server_routes_check,
+		self->block_lan_access_check,
+		self->disable_client_routes_check,
+		self->disable_dns_check,
+		self->disable_firewall_check,
+		self->disable_ipv6_check,
+		self->rosenpass_enabled_check,
+		self->rosenpass_permissive_check,
+		self->disable_auto_connect_check,
+		self->network_monitor_check,
+	};
+	GtkWidget *spins[] = { self->mtu_spin, self->wireguard_port_spin };
+	guint ii;
+
+	for (ii = 0; ii < G_N_ELEMENTS (entries); ii++) {
+		g_signal_connect (entries[ii], "changed", G_CALLBACK (emit_changed_cb), self);
+	}
+	for (ii = 0; ii < G_N_ELEMENTS (checks); ii++) {
+		g_signal_connect (checks[ii], "toggled", G_CALLBACK (emit_changed_cb), self);
+	}
+	for (ii = 0; ii < G_N_ELEMENTS (spins); ii++) {
+		g_signal_connect (spins[ii], "value-changed", G_CALLBACK (emit_changed_cb), self);
+	}
+}
+
+static void
+add_optional_data_item (NMSettingVpn *s_vpn, const char *key, const char *value)
+{
+	if (value && value[0]) {
+		nm_setting_vpn_add_data_item (s_vpn, key, value);
+	}
+}
+
+static void
+add_bool_data_item (NMSettingVpn *s_vpn, const char *key, gboolean active)
+{
+	nm_setting_vpn_add_data_item (s_vpn, key, active ? NM_NETBIRD_VALUE_YES : NM_NETBIRD_VALUE_NO);
+}
+
+static void
+add_optional_int_data_item (NMSettingVpn *s_vpn, const char *key, GtkWidget *spin)
+{
+	int value;
+
+	value = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (spin));
+	if (value != 0) {
+		char *text = g_strdup_printf ("%d", value);
+		nm_setting_vpn_add_data_item (s_vpn, key, text);
+		g_free (text);
+	}
+}
+
+static gboolean
+update_connection (NMVpnEditor *iface, NMConnection *connection, GError **error)
+{
+	NetbirdEditor *self = NETBIRD_EDITOR (iface);
+	NMSettingVpn *s_vpn;
+	const char *setup_key;
+
+	s_vpn = NM_SETTING_VPN (nm_setting_vpn_new ());
+	g_object_set (s_vpn, NM_SETTING_VPN_SERVICE_TYPE, NM_VPN_SERVICE_TYPE_NETBIRD, NULL);
+
+	/* Left empty, this means the same thing "normal" (non-self-managed)
+	 * setup means in netbird-ui: use NetBird's own hosted management
+	 * service (api.netbird.io) instead of a self-hosted one. */
+	add_optional_data_item (s_vpn, NM_NETBIRD_KEY_MANAGEMENT_URL,
+	                         gtk_editable_get_text (GTK_EDITABLE (self->management_url_entry)));
+
+	setup_key = gtk_editable_get_text (GTK_EDITABLE (self->setup_key_entry));
+	if (setup_key && setup_key[0]) {
+		nm_setting_vpn_add_secret (s_vpn, NM_NETBIRD_KEY_SETUP_KEY, setup_key);
+		nm_setting_set_secret_flags (NM_SETTING (s_vpn), NM_NETBIRD_KEY_SETUP_KEY,
+		                              NM_SETTING_SECRET_FLAG_AGENT_OWNED, NULL);
+	}
+
+	add_optional_data_item (s_vpn, NM_NETBIRD_KEY_ADMIN_URL,
+	                         gtk_editable_get_text (GTK_EDITABLE (self->admin_url_entry)));
+	add_optional_data_item (s_vpn, NM_NETBIRD_KEY_INTERFACE_NAME,
+	                         gtk_editable_get_text (GTK_EDITABLE (self->interface_name_entry)));
+	add_optional_data_item (s_vpn, NM_NETBIRD_KEY_HOSTNAME,
+	                         gtk_editable_get_text (GTK_EDITABLE (self->hostname_entry)));
+
+	add_optional_int_data_item (s_vpn, NM_NETBIRD_KEY_MTU, self->mtu_spin);
+	add_optional_int_data_item (s_vpn, NM_NETBIRD_KEY_WIREGUARD_PORT, self->wireguard_port_spin);
+
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_BLOCK_INBOUND,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->block_inbound_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_SERVER_ROUTES,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->disable_server_routes_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_BLOCK_LAN_ACCESS,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->block_lan_access_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_CLIENT_ROUTES,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->disable_client_routes_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_DNS,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->disable_dns_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_FIREWALL,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->disable_firewall_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_IPV6,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->disable_ipv6_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_ROSENPASS_ENABLED,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->rosenpass_enabled_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_ROSENPASS_PERMISSIVE,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->rosenpass_permissive_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_DISABLE_AUTO_CONNECT,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->disable_auto_connect_check)));
+	add_bool_data_item (s_vpn, NM_NETBIRD_KEY_NETWORK_MONITOR,
+	                     gtk_check_button_get_active (GTK_CHECK_BUTTON (self->network_monitor_check)));
+
+	nm_connection_add_setting (connection, NM_SETTING (s_vpn));
+	return TRUE;
+}
+
+static GObject *
+get_widget (NMVpnEditor *iface)
+{
+	return G_OBJECT (NETBIRD_EDITOR (iface)->widget);
+}
+
+static void
+netbird_editor_iface_init (NMVpnEditorInterface *iface_class)
+{
+	iface_class->get_widget = get_widget;
+	iface_class->update_connection = update_connection;
+}
+
+static void
+netbird_editor_init (NetbirdEditor *self)
+{
+}
+
+static void
+dispose (GObject *object)
+{
+	NetbirdEditor *self = NETBIRD_EDITOR (object);
+
+	g_clear_object (&self->widget);
+	g_clear_object (&self->builder);
+
+	G_OBJECT_CLASS (netbird_editor_parent_class)->dispose (object);
+}
+
+static void
+netbird_editor_class_init (NetbirdEditorClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+	object_class->dispose = dispose;
+}
+
+NMVpnEditor *
+nm_vpn_editor_factory_netbird (NMVpnEditorPlugin *plugin, NMConnection *connection, GError **error)
+{
+	NetbirdEditor *self;
+	GtkBuilder *builder;
+
+	builder = gtk_builder_new ();
+	if (!gtk_builder_add_from_resource (builder, "/org/freedesktop/network-manager-netbird/nm-netbird-dialog.ui", error)) {
+		g_object_unref (builder);
+		return NULL;
+	}
+
+	self = g_object_new (NETBIRD_TYPE_EDITOR, NULL);
+	self->builder = builder;
+
+	self->widget = GTK_WIDGET (gtk_builder_get_object (builder, "netbird-vbox"));
+	g_object_ref_sink (self->widget);
+
+	self->management_url_entry = GTK_WIDGET (gtk_builder_get_object (builder, "management_url_entry"));
+	gtk_entry_set_placeholder_text (GTK_ENTRY (self->management_url_entry), NM_NETBIRD_DEFAULT_MANAGEMENT_URL);
+	self->setup_key_entry = GTK_WIDGET (gtk_builder_get_object (builder, "setup_key_entry"));
+	self->admin_url_entry = GTK_WIDGET (gtk_builder_get_object (builder, "admin_url_entry"));
+	self->interface_name_entry = GTK_WIDGET (gtk_builder_get_object (builder, "interface_name_entry"));
+	self->hostname_entry = GTK_WIDGET (gtk_builder_get_object (builder, "hostname_entry"));
+	self->mtu_spin = GTK_WIDGET (gtk_builder_get_object (builder, "mtu_spin"));
+	self->wireguard_port_spin = GTK_WIDGET (gtk_builder_get_object (builder, "wireguard_port_spin"));
+	self->block_inbound_check = GTK_WIDGET (gtk_builder_get_object (builder, "block_inbound_check"));
+	self->disable_server_routes_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_server_routes_check"));
+	self->block_lan_access_check = GTK_WIDGET (gtk_builder_get_object (builder, "block_lan_access_check"));
+	self->disable_client_routes_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_client_routes_check"));
+	self->disable_dns_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_dns_check"));
+	self->disable_firewall_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_firewall_check"));
+	self->disable_ipv6_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_ipv6_check"));
+	self->rosenpass_enabled_check = GTK_WIDGET (gtk_builder_get_object (builder, "rosenpass_enabled_check"));
+	self->rosenpass_permissive_check = GTK_WIDGET (gtk_builder_get_object (builder, "rosenpass_permissive_check"));
+	self->disable_auto_connect_check = GTK_WIDGET (gtk_builder_get_object (builder, "disable_auto_connect_check"));
+	self->network_monitor_check = GTK_WIDGET (gtk_builder_get_object (builder, "network_monitor_check"));
+
+	init_widgets_from_connection (self, connection);
+
+	g_signal_connect (self->rosenpass_enabled_check, "toggled", G_CALLBACK (rosenpass_enabled_toggled_cb), self);
+	connect_changed_signals (self);
+
+	return NM_VPN_EDITOR (self);
+}

--- a/client/networkmanager/properties/nm-netbird-editor.h
+++ b/client/networkmanager/properties/nm-netbird-editor.h
@@ -1,0 +1,12 @@
+#ifndef NM_NETBIRD_EDITOR_H
+#define NM_NETBIRD_EDITOR_H
+
+#include <glib-object.h>
+#include <NetworkManager.h>
+
+#define NETBIRD_TYPE_EDITOR (netbird_editor_get_type ())
+G_DECLARE_FINAL_TYPE (NetbirdEditor, netbird_editor, NETBIRD, EDITOR, GObject)
+
+NMVpnEditor *nm_vpn_editor_factory_netbird (NMVpnEditorPlugin *plugin, NMConnection *connection, GError **error);
+
+#endif /* NM_NETBIRD_EDITOR_H */

--- a/client/networkmanager/properties/nm-netbird-service-defines.h
+++ b/client/networkmanager/properties/nm-netbird-service-defines.h
@@ -1,0 +1,34 @@
+#ifndef NM_NETBIRD_SERVICE_DEFINES_H
+#define NM_NETBIRD_SERVICE_DEFINES_H
+
+#define NM_DBUS_SERVICE_NETBIRD "org.freedesktop.NetworkManager.netbird"
+#define NM_VPN_SERVICE_TYPE_NETBIRD "org.freedesktop.NetworkManager.netbird"
+
+/* Must match profilemanager.DefaultManagementURL
+ * (client/internal/profilemanager/config.go), the project-wide default the
+ * daemon itself falls back to when no management URL is configured. */
+#define NM_NETBIRD_DEFAULT_MANAGEMENT_URL "https://api.netbird.io:443"
+
+#define NM_NETBIRD_KEY_MANAGEMENT_URL "management-url"
+#define NM_NETBIRD_KEY_ADMIN_URL "admin-url"
+#define NM_NETBIRD_KEY_SETUP_KEY "setup-key"
+#define NM_NETBIRD_KEY_INTERFACE_NAME "interface-name"
+#define NM_NETBIRD_KEY_HOSTNAME "hostname"
+#define NM_NETBIRD_KEY_MTU "mtu"
+#define NM_NETBIRD_KEY_WIREGUARD_PORT "wireguard-port"
+#define NM_NETBIRD_KEY_BLOCK_INBOUND "block-inbound"
+#define NM_NETBIRD_KEY_DISABLE_SERVER_ROUTES "disable-server-routes"
+#define NM_NETBIRD_KEY_BLOCK_LAN_ACCESS "block-lan-access"
+#define NM_NETBIRD_KEY_DISABLE_CLIENT_ROUTES "disable-client-routes"
+#define NM_NETBIRD_KEY_DISABLE_DNS "disable-dns"
+#define NM_NETBIRD_KEY_DISABLE_FIREWALL "disable-firewall"
+#define NM_NETBIRD_KEY_DISABLE_IPV6 "disable-ipv6"
+#define NM_NETBIRD_KEY_ROSENPASS_ENABLED "rosenpass-enabled"
+#define NM_NETBIRD_KEY_ROSENPASS_PERMISSIVE "rosenpass-permissive"
+#define NM_NETBIRD_KEY_DISABLE_AUTO_CONNECT "disable-auto-connect"
+#define NM_NETBIRD_KEY_NETWORK_MONITOR "network-monitor"
+
+#define NM_NETBIRD_VALUE_YES "yes"
+#define NM_NETBIRD_VALUE_NO "no"
+
+#endif /* NM_NETBIRD_SERVICE_DEFINES_H */

--- a/client/networkmanager/selinux/Makefile
+++ b/client/networkmanager/selinux/Makefile
@@ -1,0 +1,16 @@
+MODULE := nm_netbird_local
+
+.PHONY: install uninstall clean
+
+$(MODULE).pp: $(MODULE).te
+	checkmodule -M -m -o $(MODULE).mod $(MODULE).te
+	semodule_package -o $(MODULE).pp -m $(MODULE).mod
+
+install: $(MODULE).pp
+	semodule -i $(MODULE).pp
+
+uninstall:
+	semodule -r $(MODULE)
+
+clean:
+	rm -f $(MODULE).mod $(MODULE).pp

--- a/client/networkmanager/selinux/nm-netbird-local.te
+++ b/client/networkmanager/selinux/nm-netbird-local.te
@@ -1,0 +1,21 @@
+module nm_netbird_local 1.1;
+
+require {
+	type NetworkManager_t;
+	type var_run_t;
+	type unconfined_service_t;
+	class sock_file { getattr write };
+	class unix_stream_socket connectto;
+}
+
+# nm-netbird-service runs under NetworkManager_t (NetworkManager execs VPN
+# plugin programs directly, and there is no dedicated SELinux domain for
+# this plugin the way there is for nm-openvpn). It needs to dial the
+# netbird daemon's control socket at /var/run/netbird.sock, which the
+# targeted policy does not allow NetworkManager_t to do by default.
+allow NetworkManager_t var_run_t:sock_file { getattr write };
+
+# The netbird daemon's systemd unit sets no SELinux type, so it runs as
+# unconfined_service_t; connecting to its listening socket needs an
+# explicit connectto allow rule for the same reason as above.
+allow NetworkManager_t unconfined_service_t:unix_stream_socket connectto;

--- a/client/networkmanager/udev/71-nm-unmanaged-netbird.rules
+++ b/client/networkmanager/udev/71-nm-unmanaged-netbird.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add|change", ENV{INTERFACE}=="wt0", ENV{NM_UNMANAGED}="1"

--- a/client/networkmanager/vpnplugin/daemon.go
+++ b/client/networkmanager/vpnplugin/daemon.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package vpnplugin
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/netbirdio/netbird/client/networkmanager/nbdaemon"
+	nbproto "github.com/netbirdio/netbird/client/proto"
+)
+
+// daemonClient wraps a gRPC connection to the netbird daemon.
+type daemonClient struct {
+	conn   *grpc.ClientConn
+	client nbproto.DaemonServiceClient
+}
+
+// dialDaemon connects to the netbird daemon over its control socket.
+func dialDaemon(ctx context.Context) (*daemonClient, error) {
+	conn, err := nbdaemon.Dial()
+	if err != nil {
+		return nil, err
+	}
+	return &daemonClient{conn: conn, client: nbproto.NewDaemonServiceClient(conn)}, nil
+}
+
+func (d *daemonClient) Close() error {
+	return d.conn.Close()
+}
+
+func (d *daemonClient) setConfig(ctx context.Context, req *nbproto.SetConfigRequest) error {
+	_, err := d.client.SetConfig(ctx, req)
+	return err
+}
+
+func (d *daemonClient) login(ctx context.Context, req *nbproto.LoginRequest) (*nbproto.LoginResponse, error) {
+	return d.client.Login(ctx, req)
+}
+
+func (d *daemonClient) waitSSOLogin(ctx context.Context, userCode string) error {
+	_, err := d.client.WaitSSOLogin(ctx, &nbproto.WaitSSOLoginRequest{UserCode: userCode})
+	return err
+}
+
+func (d *daemonClient) up(ctx context.Context) error {
+	_, err := d.client.Up(ctx, &nbproto.UpRequest{Async: true})
+	return err
+}
+
+func (d *daemonClient) down(ctx context.Context) error {
+	_, err := d.client.Down(ctx, &nbproto.DownRequest{})
+	return err
+}
+
+func (d *daemonClient) subscribeStatus(ctx context.Context) (nbproto.DaemonService_SubscribeStatusClient, error) {
+	return d.client.SubscribeStatus(ctx, &nbproto.StatusRequest{GetFullPeerStatus: true})
+}
+
+func (d *daemonClient) getConfig(ctx context.Context) (*nbproto.GetConfigResponse, error) {
+	return d.client.GetConfig(ctx, &nbproto.GetConfigRequest{})
+}

--- a/client/networkmanager/vpnplugin/gateway.go
+++ b/client/networkmanager/vpnplugin/gateway.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package vpnplugin
+
+import (
+	"encoding/binary"
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+// defaultIPv4Gateway returns the host's current default IPv4 gateway, in
+// the network-byte-order form NetworkManager's VPN plugin D-Bus API
+// documents for the Config signal's "gateway" key
+// (NM_VPN_PLUGIN_CONFIG_EXT_GATEWAY). NetworkManager hard-requires this key
+// to accept a VPN's Config reply at all -- it uses it to pin a route to the
+// VPN's own endpoints via the pre-existing gateway, bypassing the tunnel.
+func defaultIPv4Gateway() (uint32, bool) {
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
+	if err != nil {
+		return 0, false
+	}
+
+	for _, route := range routes {
+		if !isDefaultDst(route.Dst) || route.Gw == nil {
+			continue
+		}
+		gw := route.Gw.To4()
+		if gw == nil {
+			continue
+		}
+		return binary.BigEndian.Uint32(gw), true
+	}
+	return 0, false
+}
+
+// isDefaultDst reports whether dst represents the default route (0.0.0.0/0):
+// either a nil destination, or an explicit zero-length-prefix network,
+// depending on how the platform's route table represents it.
+func isDefaultDst(dst *net.IPNet) bool {
+	if dst == nil {
+		return true
+	}
+	ones, _ := dst.Mask.Size()
+	return ones == 0
+}

--- a/client/networkmanager/vpnplugin/iface.go
+++ b/client/networkmanager/vpnplugin/iface.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+// Package vpnplugin implements NetworkManager's VPN plugin D-Bus contract
+// (org.freedesktop.NetworkManager.VPN.Plugin) directly over godbus, and
+// drives the real netbird daemon's gRPC API to do the actual connect/
+// disconnect work.
+package vpnplugin
+
+import "github.com/godbus/dbus/v5"
+
+const (
+	// PluginInterface is the well-known, toolkit-independent interface every
+	// NetworkManager VPN service plugin implements, regardless of its own
+	// D-Bus bus name.
+	PluginInterface = "org.freedesktop.NetworkManager.VPN.Plugin"
+
+	// PluginObjectPath is the fixed object path every VPN plugin instance
+	// exports the interface at; the caller is disambiguated by bus name, not
+	// by path.
+	PluginObjectPath dbus.ObjectPath = "/org/freedesktop/NetworkManager/VPN/Plugin"
+
+	// ServiceName is the VPN service-type string this plugin registers under
+	// in nm-netbird-service.name (vpn.service-type on a matching connection).
+	// NetworkManager passes the actual per-instance bus name to claim via
+	// --bus-name; it is not necessarily this exact string once multiple
+	// simultaneous connections are active.
+	ServiceName = "org.freedesktop.NetworkManager.netbird"
+)
+
+// serviceState mirrors NetworkManager's NMVpnServiceState enum, used by the
+// plugin's StateChanged signal.
+type serviceState uint32
+
+const (
+	stateUnknown  serviceState = 0
+	stateInit     serviceState = 1
+	stateShutdown serviceState = 2
+	stateStarting serviceState = 3
+	stateStarted  serviceState = 4
+	stateStopping serviceState = 5
+	stateStopped  serviceState = 6
+)
+
+// pluginFailure mirrors NetworkManager's NMVpnPluginFailure enum, used by
+// the plugin's Failure signal.
+type pluginFailure uint32
+
+const (
+	failureLoginFailed   pluginFailure = 0
+	failureConnectFailed pluginFailure = 1
+	failureBadIPConfig   pluginFailure = 2
+)
+
+const (
+	signalStateChanged    = PluginInterface + ".StateChanged"
+	signalSecretsRequired = PluginInterface + ".SecretsRequired"
+	signalConfig          = PluginInterface + ".Config"
+	signalIP4Config       = PluginInterface + ".Ip4Config"
+	signalFailure         = PluginInterface + ".Failure"
+
+	// Well-known keys in the Config/Ip4Config signal payloads, per libnm's
+	// nm-vpn-dbus-interface.h.
+	configKeyTunDev        = "tundev"
+	configKeyHasIP4        = "has-ip4"
+	ip4ConfigKeyAddress    = "address"
+	ip4ConfigKeyPrefix     = "prefix"
+	ip4ConfigKeyNeverDflt  = "never-default"
+	ip4ConfigDefaultPrefix = 32
+
+	// configKeyExtGateway is NM_VPN_PLUGIN_CONFIG_EXT_GATEWAY: the host's
+	// real external gateway, used by NetworkManager to route to the VPN's
+	// own endpoints without looping through the tunnel. It belongs in the
+	// Config signal, not Ip4Config, and NetworkManager hard-rejects a
+	// Config reply without it.
+	configKeyExtGateway = "gateway"
+)
+
+// Hint prefixes used in the SecretsRequired signal's "secrets" array, which
+// NetworkManager forwards to the auth-dialog helper as repeated --hint
+// arguments. Exported so cmd/nm-netbird-auth-dialog can parse them without
+// duplicating the convention.
+const (
+	HintVerificationURIPrefix = "netbird-verification-uri:"
+	HintUserCodePrefix        = "netbird-user-code:"
+)
+
+// netbird daemon status strings (internal.StatusType's values), duplicated
+// here as plain constants to avoid pulling the netbird agent's full internal
+// package into this plugin's binary just for four string comparisons.
+const (
+	netbirdStatusIdle           = "Idle"
+	netbirdStatusConnected      = "Connected"
+	netbirdStatusLoginFailed    = "LoginFailed"
+	netbirdStatusSessionExpired = "SessionExpired"
+)

--- a/client/networkmanager/vpnplugin/plugin.go
+++ b/client/networkmanager/vpnplugin/plugin.go
@@ -1,0 +1,360 @@
+//go:build linux
+
+package vpnplugin
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+	log "github.com/sirupsen/logrus"
+
+	nbproto "github.com/netbirdio/netbird/client/proto"
+)
+
+// Plugin implements org.freedesktop.NetworkManager.VPN.Plugin over godbus,
+// driving the netbird daemon's gRPC API to connect and disconnect.
+type Plugin struct {
+	conn    *dbus.Conn
+	persist bool
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	daemon *daemonClient
+	ssoAck chan struct{}
+
+	quitOnce sync.Once
+	quit     chan struct{}
+}
+
+// New builds a Plugin bound to an already-connected system bus connection.
+// persist controls whether the process should keep running after
+// Disconnect, mirroring nm-openvpn-service's --persist flag.
+func New(conn *dbus.Conn, persist bool) *Plugin {
+	return &Plugin{conn: conn, persist: persist, quit: make(chan struct{})}
+}
+
+// Export publishes the plugin object at PluginObjectPath on the bus
+// connection it was created with.
+func (p *Plugin) Export() error {
+	return p.conn.Export(p, PluginObjectPath, PluginInterface)
+}
+
+// Quit is closed when the plugin decides the process should exit: after a
+// successful Disconnect, unless persist was requested.
+func (p *Plugin) Quit() <-chan struct{} {
+	return p.quit
+}
+
+// Connect is called by NetworkManager to bring the VPN connection up.
+func (p *Plugin) Connect(connection map[string]map[string]dbus.Variant) *dbus.Error {
+	return p.connect(connection)
+}
+
+// ConnectInteractive is Connect's variant for interactive activations; this
+// plugin does not vary its behavior based on the extra "details" argument.
+func (p *Plugin) ConnectInteractive(connection map[string]map[string]dbus.Variant, _ map[string]dbus.Variant) *dbus.Error {
+	return p.connect(connection)
+}
+
+// NeedSecrets always reports that no secrets are required upfront: SSO
+// login, when needed, is requested dynamically mid-Connect via the
+// SecretsRequired signal instead.
+func (p *Plugin) NeedSecrets(_ map[string]map[string]dbus.Variant) (string, *dbus.Error) {
+	return "", nil
+}
+
+// NewSecrets is called once the auth-dialog helper has acknowledged an SSO
+// prompt raised via SecretsRequired, unblocking the waiting connect
+// goroutine.
+func (p *Plugin) NewSecrets(_ map[string]map[string]dbus.Variant) *dbus.Error {
+	p.mu.Lock()
+	ack := p.ssoAck
+	p.ssoAck = nil
+	p.mu.Unlock()
+
+	if ack != nil {
+		close(ack)
+	}
+	return nil
+}
+
+// Disconnect tears down the active connection attempt, if any, and brings
+// the netbird daemon down while leaving it logged in.
+func (p *Plugin) Disconnect() *dbus.Error {
+	p.mu.Lock()
+	cancel := p.cancel
+	daemon := p.daemon
+	p.cancel = nil
+	p.daemon = nil
+	p.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	p.emitStateChanged(stateStopping)
+
+	go func() {
+		if daemon != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if err := daemon.down(ctx); err != nil {
+				log.Warnf("netbird down: %v", err)
+			}
+			cancel()
+			if err := daemon.Close(); err != nil {
+				log.Debugf("close netbird daemon connection: %v", err)
+			}
+		}
+		p.stop()
+	}()
+
+	return nil
+}
+
+func (p *Plugin) connect(connection map[string]map[string]dbus.Variant) *dbus.Error {
+	data, secrets := extractVPNStrings(connection)
+	cfg, err := parseSettings(data, secrets)
+	if err != nil {
+		return dbus.MakeFailedError(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	p.mu.Lock()
+	oldCancel, oldDaemon := p.cancel, p.daemon
+	p.cancel, p.daemon = cancel, nil
+	p.mu.Unlock()
+
+	if oldCancel != nil {
+		oldCancel()
+	}
+	if oldDaemon != nil {
+		if err := oldDaemon.Close(); err != nil {
+			log.Debugf("close previous netbird daemon connection: %v", err)
+		}
+	}
+
+	go p.runConnect(ctx, cfg)
+	return nil
+}
+
+func (p *Plugin) runConnect(ctx context.Context, cfg *settings) {
+	p.emitStateChanged(stateStarting)
+
+	daemon, err := dialDaemon(ctx)
+	if err != nil {
+		p.fail(failureConnectFailed, err)
+		return
+	}
+	p.mu.Lock()
+	p.daemon = daemon
+	p.mu.Unlock()
+
+	if err := daemon.setConfig(ctx, cfg.setConfigRequest()); err != nil {
+		log.Debugf("netbird SetConfig: %v", err)
+	}
+
+	loginResp, err := daemon.login(ctx, cfg.loginRequest())
+	if err != nil {
+		p.fail(failureLoginFailed, fmt.Errorf("login: %w", err))
+		return
+	}
+
+	if loginResp.NeedsSSOLogin {
+		if err := p.waitForSSO(ctx, daemon, loginResp); err != nil {
+			p.fail(failureLoginFailed, fmt.Errorf("SSO login: %w", err))
+			return
+		}
+	}
+
+	if err := daemon.up(ctx); err != nil {
+		p.fail(failureConnectFailed, fmt.Errorf("up: %w", err))
+		return
+	}
+
+	p.watchStatus(ctx, daemon, cfg)
+}
+
+// waitForSSO emits SecretsRequired with the SSO verification URL and blocks
+// until nm-netbird-auth-dialog acknowledges it via NewSecrets, then waits
+// for the actual login to complete. The ack only means the browser was
+// opened, not that login succeeded: NetworkManager's own secrets-request
+// has a hard timeout (observed around 25-40s) far shorter than a real
+// human SSO flow can take, so the auth-dialog must answer quickly and this
+// long wait has to happen here instead, in a process NM isn't timing.
+func (p *Plugin) waitForSSO(ctx context.Context, daemon *daemonClient, resp *nbproto.LoginResponse) error {
+	ack := make(chan struct{})
+	p.mu.Lock()
+	p.ssoAck = ack
+	p.mu.Unlock()
+
+	message := fmt.Sprintf("Open the following link in your browser to sign in to NetBird:\n%s", resp.VerificationURIComplete)
+	hints := []string{
+		HintVerificationURIPrefix + resp.VerificationURIComplete,
+		HintUserCodePrefix + resp.UserCode,
+	}
+	if err := p.conn.Emit(PluginObjectPath, signalSecretsRequired, message, hints); err != nil {
+		return fmt.Errorf("emit SecretsRequired: %w", err)
+	}
+
+	select {
+	case <-ack:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return daemon.waitSSOLogin(ctx, resp.UserCode)
+}
+
+func (p *Plugin) watchStatus(ctx context.Context, daemon *daemonClient, cfg *settings) {
+	stream, err := daemon.subscribeStatus(ctx)
+	if err != nil {
+		p.fail(failureConnectFailed, fmt.Errorf("subscribe status: %w", err))
+		return
+	}
+
+	activated := false
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			p.fail(failureConnectFailed, fmt.Errorf("status stream: %w", err))
+			return
+		}
+
+		switch resp.Status {
+		case netbirdStatusConnected:
+			if !activated {
+				p.reportConnected(ctx, daemon, cfg, resp)
+				activated = true
+			}
+		case netbirdStatusIdle:
+			if activated {
+				// The daemon went idle on its own (e.g. `netbird down` run
+				// directly, bypassing NetworkManager entirely): stop like
+				// Disconnect would, so NetworkManager's own active-connection
+				// state doesn't go stale believing we're still connected.
+				p.stop()
+				return
+			}
+		case netbirdStatusLoginFailed, netbirdStatusSessionExpired:
+			p.fail(failureLoginFailed, fmt.Errorf("netbird status: %s", resp.Status))
+			return
+		}
+	}
+}
+
+func (p *Plugin) reportConnected(ctx context.Context, daemon *daemonClient, cfg *settings, resp *nbproto.StatusResponse) {
+	tundev := cfg.interfaceName
+	if tundev == "" {
+		if gcfg, err := daemon.getConfig(ctx); err != nil {
+			log.Debugf("GetConfig: %v", err)
+		} else {
+			tundev = gcfg.InterfaceName
+		}
+	}
+
+	// Config must be emitted before Ip4Config: NetworkManager treats an
+	// Ip4Config that arrives before any Config as a legacy combined
+	// message and demands the (config-level) gateway key inside it
+	// instead, failing this same "no VPN gateway address received" check
+	// a different way.
+	configValues := map[string]dbus.Variant{
+		configKeyTunDev: dbus.MakeVariant(tundev),
+		configKeyHasIP4: dbus.MakeVariant(true),
+	}
+	// NetworkManager hard-rejects a Config reply without this: it is the
+	// host's real external gateway, not anything netbird-specific, used to
+	// route to the VPN's own endpoints without looping through the tunnel.
+	if gw, ok := defaultIPv4Gateway(); ok {
+		configValues[configKeyExtGateway] = dbus.MakeVariant(gw)
+	} else {
+		log.Warnf("could not determine the host's default IPv4 gateway; NetworkManager will likely reject this connection")
+	}
+
+	if err := p.conn.Emit(PluginObjectPath, signalConfig, configValues); err != nil {
+		log.Debugf("emit Config signal: %v", err)
+	}
+
+	if addr, prefix, ok := localPeerAddress(resp); ok {
+		if err := p.conn.Emit(PluginObjectPath, signalIP4Config, map[string]dbus.Variant{
+			ip4ConfigKeyAddress:   dbus.MakeVariant(addr),
+			ip4ConfigKeyPrefix:    dbus.MakeVariant(uint32(prefix)),
+			ip4ConfigKeyNeverDflt: dbus.MakeVariant(true),
+		}); err != nil {
+			log.Debugf("emit Ip4Config signal: %v", err)
+		}
+	}
+
+	p.emitStateChanged(stateStarted)
+}
+
+func (p *Plugin) fail(reason pluginFailure, err error) {
+	log.Warnf("netbird VPN plugin: %v", err)
+	if emitErr := p.conn.Emit(PluginObjectPath, signalFailure, uint32(reason)); emitErr != nil {
+		log.Debugf("emit Failure signal: %v", emitErr)
+	}
+	p.stop()
+}
+
+func (p *Plugin) emitStateChanged(state serviceState) {
+	if err := p.conn.Emit(PluginObjectPath, signalStateChanged, uint32(state)); err != nil {
+		log.Debugf("emit StateChanged signal: %v", err)
+	}
+}
+
+// stop reports the terminal stopped state and, unless persist was
+// requested, lets the process exit. Every path that ends the connection
+// without going through NetworkManager's own Disconnect call (an external
+// `netbird down`, a login failure, a lost status stream) must still reach
+// this, or NetworkManager's active-connection state goes stale believing
+// the tunnel is still up.
+func (p *Plugin) stop() {
+	p.emitStateChanged(stateStopped)
+	if !p.persist {
+		p.quitOnce.Do(func() { close(p.quit) })
+	}
+}
+
+func extractVPNStrings(connection map[string]map[string]dbus.Variant) (data, secrets map[string]string) {
+	vpn := connection["vpn"]
+	data, _ = vpn["data"].Value().(map[string]string)
+	secrets, _ = vpn["secrets"].Value().(map[string]string)
+	return data, secrets
+}
+
+// localPeerAddress extracts the local peer's overlay IPv4 address from a
+// status snapshot, returning it in the network-byte-order form NetworkManager's
+// VPN plugin D-Bus API documents for Ip4Config's "address" key, along with
+// its prefix length.
+func localPeerAddress(resp *nbproto.StatusResponse) (uint32, int, bool) {
+	if resp.FullStatus == nil || resp.FullStatus.LocalPeerState == nil {
+		return 0, 0, false
+	}
+
+	raw := resp.FullStatus.LocalPeerState.IP
+	if raw == "" {
+		return 0, 0, false
+	}
+
+	prefix, err := netip.ParsePrefix(raw)
+	if err != nil {
+		addr, addrErr := netip.ParseAddr(raw)
+		if addrErr != nil {
+			return 0, 0, false
+		}
+		prefix = netip.PrefixFrom(addr, ip4ConfigDefaultPrefix)
+	}
+	if !prefix.Addr().Is4() {
+		return 0, 0, false
+	}
+
+	b := prefix.Addr().As4()
+	return binary.BigEndian.Uint32(b[:]), prefix.Bits(), true
+}

--- a/client/networkmanager/vpnplugin/settings.go
+++ b/client/networkmanager/vpnplugin/settings.go
@@ -1,0 +1,172 @@
+//go:build linux
+
+package vpnplugin
+
+import (
+	"fmt"
+	"strconv"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/netbirdio/netbird/client/internal/profilemanager"
+	nbproto "github.com/netbirdio/netbird/client/proto"
+)
+
+// vpn.data / vpn.secrets keys understood by this plugin. Kept in sync by
+// convention with client/networkmanager/properties/nm-netbird-service-defines.h,
+// which the GTK4 editor plugin uses to read/write the same connection.
+const (
+	keyManagementURL       = "management-url"
+	keyAdminURL            = "admin-url"
+	keySetupKey            = "setup-key" // secret
+	keyInterfaceName       = "interface-name"
+	keyHostname            = "hostname"
+	keyMTU                 = "mtu"
+	keyWireguardPort       = "wireguard-port"
+	keyBlockInbound        = "block-inbound"
+	keyDisableServerRoutes = "disable-server-routes"
+	keyBlockLANAccess      = "block-lan-access"
+	keyDisableClientRoutes = "disable-client-routes"
+	keyDisableDNS          = "disable-dns"
+	keyDisableFirewall     = "disable-firewall"
+	keyDisableIPv6         = "disable-ipv6"
+	keyRosenpassEnabled    = "rosenpass-enabled"
+	keyRosenpassPermissive = "rosenpass-permissive"
+	keyDisableAutoConnect  = "disable-auto-connect"
+	keyNetworkMonitor      = "network-monitor"
+
+	boolTrue = "yes"
+)
+
+// settings is the parsed form of a netbird NM connection's vpn.data/
+// vpn.secrets, ready to translate into netbird daemon RPC requests.
+type settings struct {
+	managementURL string
+	adminURL      string
+	setupKey      string
+	interfaceName string
+	hostname      string
+	mtu           int64
+	wireguardPort int64
+
+	blockInbound        bool
+	disableServerRoutes bool
+	blockLANAccess      bool
+	disableClientRoutes bool
+	disableDNS          bool
+	disableFirewall     bool
+	disableIPv6         bool
+	rosenpassEnabled    bool
+	rosenpassPermissive bool
+	disableAutoConnect  bool
+	networkMonitor      bool
+}
+
+// parseSettings builds a settings value from a connection's vpn.data and
+// vpn.secrets string maps, as delivered by NetworkManager's Connect/
+// ConnectInteractive D-Bus calls.
+func parseSettings(data, secrets map[string]string) (*settings, error) {
+	managementURL := data[keyManagementURL]
+	if managementURL == "" {
+		managementURL = profilemanager.DefaultManagementURL
+	}
+
+	mtu, err := parseOptionalInt(data[keyMTU])
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", keyMTU, err)
+	}
+	wireguardPort, err := parseOptionalInt(data[keyWireguardPort])
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", keyWireguardPort, err)
+	}
+
+	return &settings{
+		managementURL: managementURL,
+		adminURL:      data[keyAdminURL],
+		setupKey:      secrets[keySetupKey],
+		interfaceName: data[keyInterfaceName],
+		hostname:      data[keyHostname],
+		mtu:           mtu,
+		wireguardPort: wireguardPort,
+
+		blockInbound:        data[keyBlockInbound] == boolTrue,
+		disableServerRoutes: data[keyDisableServerRoutes] == boolTrue,
+		blockLANAccess:      data[keyBlockLANAccess] == boolTrue,
+		disableClientRoutes: data[keyDisableClientRoutes] == boolTrue,
+		disableDNS:          data[keyDisableDNS] == boolTrue,
+		disableFirewall:     data[keyDisableFirewall] == boolTrue,
+		disableIPv6:         data[keyDisableIPv6] == boolTrue,
+		rosenpassEnabled:    data[keyRosenpassEnabled] == boolTrue,
+		rosenpassPermissive: data[keyRosenpassPermissive] == boolTrue,
+		disableAutoConnect:  data[keyDisableAutoConnect] == boolTrue,
+		networkMonitor:      data[keyNetworkMonitor] == boolTrue,
+	}, nil
+}
+
+func parseOptionalInt(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	return strconv.ParseInt(value, 10, 64)
+}
+
+// setConfigRequest builds the SetConfig RPC request for these settings.
+func (s *settings) setConfigRequest() *nbproto.SetConfigRequest {
+	req := &nbproto.SetConfigRequest{
+		ManagementUrl:       s.managementURL,
+		AdminURL:            s.adminURL,
+		BlockInbound:        proto.Bool(s.blockInbound),
+		DisableServerRoutes: proto.Bool(s.disableServerRoutes),
+		BlockLanAccess:      proto.Bool(s.blockLANAccess),
+		DisableClientRoutes: proto.Bool(s.disableClientRoutes),
+		DisableDns:          proto.Bool(s.disableDNS),
+		DisableFirewall:     proto.Bool(s.disableFirewall),
+		DisableIpv6:         proto.Bool(s.disableIPv6),
+		RosenpassEnabled:    proto.Bool(s.rosenpassEnabled),
+		RosenpassPermissive: proto.Bool(s.rosenpassPermissive),
+		DisableAutoConnect:  proto.Bool(s.disableAutoConnect),
+		NetworkMonitor:      proto.Bool(s.networkMonitor),
+	}
+	if s.interfaceName != "" {
+		req.InterfaceName = proto.String(s.interfaceName)
+	}
+	if s.wireguardPort != 0 {
+		req.WireguardPort = proto.Int64(s.wireguardPort)
+	}
+	if s.mtu != 0 {
+		req.Mtu = proto.Int64(s.mtu)
+	}
+	return req
+}
+
+// loginRequest builds the Login RPC request for these settings.
+func (s *settings) loginRequest() *nbproto.LoginRequest {
+	req := &nbproto.LoginRequest{
+		SetupKey:            s.setupKey,
+		ManagementUrl:       s.managementURL,
+		AdminURL:            s.adminURL,
+		Hostname:            s.hostname,
+		IsUnixDesktopClient: true,
+		BlockInbound:        proto.Bool(s.blockInbound),
+		DisableServerRoutes: proto.Bool(s.disableServerRoutes),
+		BlockLanAccess:      proto.Bool(s.blockLANAccess),
+		DisableClientRoutes: proto.Bool(s.disableClientRoutes),
+		DisableDns:          proto.Bool(s.disableDNS),
+		DisableFirewall:     proto.Bool(s.disableFirewall),
+		DisableIpv6:         proto.Bool(s.disableIPv6),
+		RosenpassEnabled:    proto.Bool(s.rosenpassEnabled),
+		RosenpassPermissive: proto.Bool(s.rosenpassPermissive),
+		DisableAutoConnect:  proto.Bool(s.disableAutoConnect),
+		NetworkMonitor:      proto.Bool(s.networkMonitor),
+	}
+	if s.interfaceName != "" {
+		req.InterfaceName = proto.String(s.interfaceName)
+	}
+	if s.wireguardPort != 0 {
+		req.WireguardPort = proto.Int64(s.wireguardPort)
+	}
+	if s.mtu != 0 {
+		req.Mtu = proto.Int64(s.mtu)
+	}
+	return req
+}


### PR DESCRIPTION
netbird-ui (client/ui) is a standalone Wails tray app: it does not integrate with NetworkManager, so NetBird connections cannot appear alongside other VPNs in nmcli, GNOME Settings, or nm-connection-editor, and cannot be driven by anything that talks to NetworkManager directly.

Add a NetworkManager VPN plugin, self-contained under client/networkmanager/ and built independently via its own Makefile (the same way client/ui already has its own Taskfile outside the root build), that makes NetBird a first-class NetworkManager VPN type. It is a thin control-plane front end: nm-netbird-service implements org.freedesktop.NetworkManager.VPN.Plugin directly over D-Bus and drives the existing netbird daemon's own gRPC control API (SetConfig, Login, Up, Down, SubscribeStatus) to connect, disconnect, and authenticate, including browser-based SSO; the daemon keeps owning the WireGuard interface, routing, DNS, and firewall exactly as it does today. nm-netbird-auth-dialog is the interactive helper NetworkManager spawns in the user's desktop session for SSO login, built against GTK3 and GTK4 (selected at runtime to match whichever toolkit nm-connection-editor or GNOME Settings already has loaded, the same pattern NetworkManager's own bundled plugins such as openvpn use) via cgo rather than a generated Go binding, since the current gotk4 release does not compile against this system's GLib. properties/ is the connection-editor plugin exposing the netbird up flag set (management URL, setup key, and boolean flags such as block-inbound/disable-server-routes/block-lan-access) through nmcli, GNOME Settings, and nm-connection-editor.

udev/ marks netbird's tunnel interface unmanaged so it does not also show up as a second, unconfigured device, and selinux/ carries the local policy module needed on SELinux-enforcing systems to let the VPN service reach the daemon's control socket.

## Describe your changes

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux NetworkManager integration for NetBird VPN connections.
  * Added GTK3 and GTK4 connection editors with management, routing, DNS, firewall, IPv6, Rosenpass, MTU, and auto-connect settings.
  * Added browser-based SSO authentication dialogs.
  * Added VPN lifecycle management, status monitoring, and daemon communication.
  * Added installation, uninstall, SELinux, udev, and build tooling.

* **Documentation**
  * Added Linux setup, usage, prerequisites, supported settings, and known limitations documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->