### PR TITLE
[client] Skip IPv6 route tests when the default nexthop is unusable

### DIFF
--- a/client/internal/routemanager/systemops/v6route_linux_test.go
+++ b/client/internal/routemanager/systemops/v6route_linux_test.go
@@ -5,6 +5,7 @@ package systemops
 import (
 	"errors"
 	"net"
+	"net/netip"
 	"syscall"
 	"testing"
 
@@ -29,6 +30,7 @@ func ensureIPv6DefaultRoute(t *testing.T) {
 	}
 	if err := netlink.RouteAdd(route); err != nil {
 		if errors.Is(err, syscall.EEXIST) {
+			requireUsableIPv6Nexthop(t)
 			return
 		}
 		t.Skipf("install IPv6 fallback default route: %v", err)
@@ -38,4 +40,29 @@ func ensureIPv6DefaultRoute(t *testing.T) {
 			t.Logf("delete IPv6 fallback default route: %v", err)
 		}
 	})
+
+	requireUsableIPv6Nexthop(t)
+}
+
+// requireUsableIPv6Nexthop skips the test unless the resolved IPv6 default
+// nexthop can actually carry a route. Installing the default route succeeding
+// does not imply the kernel accepts it as a nexthop for a concrete prefix.
+func requireUsableIPv6Nexthop(t *testing.T) {
+	t.Helper()
+
+	nexthop, err := GetNextHop(netip.IPv6Unspecified())
+	if err != nil {
+		t.Skipf("resolve IPv6 default nexthop: %v", err)
+	}
+
+	probe := netip.MustParsePrefix("100::64/128")
+	switch err := addRoute(probe, nexthop, syscall.RT_TABLE_MAIN); {
+	case err == nil:
+		if err := removeRoute(probe, nexthop, syscall.RT_TABLE_MAIN); err != nil {
+			t.Logf("remove IPv6 probe route: %v", err)
+		}
+	case errors.Is(err, syscall.EEXIST):
+	default:
+		t.Skipf("IPv6 nexthop %s unusable for route installation: %v", nexthop, err)
+	}
 }

--- a/client/internal/routemanager/systemops/v6route_linux_test.go
+++ b/client/internal/routemanager/systemops/v6route_linux_test.go
@@ -55,11 +55,18 @@ func requireUsableIPv6Nexthop(t *testing.T) {
 		t.Skipf("resolve IPv6 default nexthop: %v", err)
 	}
 
-	probe := netip.MustParsePrefix("100::64/128")
-	switch err := addRoute(probe, nexthop, syscall.RT_TABLE_MAIN); {
+	probe := &netlink.Route{
+		Scope:  netlink.SCOPE_UNIVERSE,
+		Table:  syscall.RT_TABLE_MAIN,
+		Family: netlink.FAMILY_V6,
+		Dst:    &net.IPNet{IP: net.ParseIP("100::64"), Mask: net.CIDRMask(128, 128)},
+	}
+	require.NoError(t, addNextHop(nexthop, probe), "build IPv6 probe route")
+
+	switch err := netlink.RouteAdd(probe); {
 	case err == nil:
-		if err := removeRoute(probe, nexthop, syscall.RT_TABLE_MAIN); err != nil {
-			t.Logf("remove IPv6 probe route: %v", err)
+		if err := netlink.RouteDel(probe); err != nil && !errors.Is(err, syscall.ESRCH) {
+			t.Logf("delete IPv6 probe route: %v", err)
 		}
 	case errors.Is(err, syscall.EEXIST):
 	default:


### PR DESCRIPTION
## Describe your changes

ensureIPv6DefaultRoute treated a successful netlink RouteAdd as proof that a usable IPv6 nexthop exists. Installing ::/0 via loopback can succeed while the kernel still rejects that nexthop for a concrete prefix, which surfaced on ubuntu22/20260810.260 runners as:

    add route to table: netlink add route: invalid argument

Probe the resolved nexthop by installing and removing a discard-prefix route through the same code path the tests use, and skip when it fails. EEXIST means the nexthop already carries a route, so it counts as usable.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for IPv6 default-route nexthops installing concrete probe routes.
  * Validates behavior both when fallback routes are added and when they already exist.
  * Skips unusable nexthops and cleans up successfully installed probe routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->