### PR TITLE
[client] Send the login hint from the desktop UI's session extend

### DIFF
--- a/client/internal/profilemanager/profilemanager.go
+++ b/client/internal/profilemanager/profilemanager.go
@@ -165,6 +165,11 @@ func (pm *ProfileManager) setActiveProfileState(id ID) error {
 }
 
 // GetLoginHint retrieves the email from the active profile to use as login_hint.
+//
+// TODO: only works when called as the logged-in user; the root-owned daemon
+// resolves the state file under /root/.config/netbird and always gets "".
+// Every caller now fills the hint itself, so dropping this and the daemon-side
+// fallbacks in client/server/server.go is the suggested fix.
 func GetLoginHint() string {
 	pm := NewProfileManager()
 	activeProf, err := pm.GetActiveProfile()

--- a/client/ui/authsession/service.go
+++ b/client/ui/authsession/service.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
 
+	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/proto"
 )
 
@@ -60,6 +61,9 @@ func (s *Session) RequestExtend(ctx context.Context, p ExtendStartParams) (Exten
 
 	// a request from the UI implies a graphical session, which the daemon cannot detect itself
 	req := &proto.RequestExtendAuthSessionRequest{HasGraphicalSession: true}
+	if p.Hint == "" {
+		p.Hint = profilemanager.GetLoginHint()
+	}
 	if p.Hint != "" {
 		h := p.Hint
 		req.Hint = &h


### PR DESCRIPTION
## Describe your changes

RequestExtend left the hint empty and relied on the daemon's GetLoginHint fallback. That fallback reads the per-profile state file from the calling process's user config dir, so the root-owned daemon looks under /root/.config/netbird and never finds the file the UI wrote under the user's own config dir. Every session extend therefore went out without a login_hint, leaving the IdP to guess the account.

Resolve it in the UI instead, which runs as the logged-in user and already reads the same file for Profiles.List. Mirrors what the CLI's extend path does.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication session extensions by automatically supplying the appropriate login hint when it is missing.
  * Increased reliability for login operations initiated by system-managed services.
* **Documentation**
  * Added internal guidance documenting a known limitation in login-hint handling for future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->