### PR TITLE
[management] Refuse a usage limit a one-off setup key cannot honour

### DIFF
--- a/management/server/http/handlers/setup_keys/setupkeys_handler.go
+++ b/management/server/http/handlers/setup_keys/setupkeys_handler.go
@@ -64,6 +64,19 @@ func (h *handler) createSetupKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A one-off key can be used once, and GenerateSetupKey pins its usage limit
+	// at 1 whatever the request says. Silently overriding a caller that asked
+	// for a different number leaves them holding a key that does not do what
+	// they configured, and no way to find out except by using it. Only values
+	// above 1 are refused: usage_limit is a required field with no null, so 0
+	// cannot be told apart from a caller that has nothing to say about it.
+	if types.SetupKeyType(req.Type) == types.SetupKeyOneOff && req.UsageLimit > 1 {
+		util.WriteError(r.Context(), status.Errorf(status.InvalidArgument,
+			"usage_limit %d is not valid for a one-off setup key, which can be used once; use type reusable for a key that can be used more than once",
+			req.UsageLimit), w)
+		return
+	}
+
 	expiresIn := time.Duration(req.ExpiresIn) * time.Second
 
 	if expiresIn < 0 {

--- a/management/server/http/handlers/setup_keys/setupkeys_handler_test.go
+++ b/management/server/http/handlers/setup_keys/setupkeys_handler_test.go
@@ -135,6 +135,40 @@ func TestSetupKeysHandlers(t *testing.T) {
 			expectedSetupKey: expectedNewKey,
 		},
 		{
+			// A one-off key is used once. Asking for more used to be accepted
+			// and then quietly reduced to 1.
+			name:        "Create One-Off Setup Key With Conflicting Usage Limit",
+			requestType: http.MethodPost,
+			requestPath: "/api/setup-keys",
+			requestBody: bytes.NewBuffer(
+				[]byte(fmt.Sprintf("{\"name\":\"%s\",\"type\":\"one-off\",\"expires_in\":86400,\"usage_limit\":5}", newSetupKeyName))),
+			expectedStatus: http.StatusUnprocessableEntity,
+			expectedBody:   false,
+		},
+		{
+			// 0 is what a caller sends when it has nothing to say about the
+			// usage limit, since the field is required and has no null, so it
+			// has to keep working.
+			name:        "Create One-Off Setup Key Without Usage Limit",
+			requestType: http.MethodPost,
+			requestPath: "/api/setup-keys",
+			requestBody: bytes.NewBuffer(
+				[]byte(fmt.Sprintf("{\"name\":\"%s\",\"type\":\"one-off\",\"expires_in\":86400,\"usage_limit\":0}", newSetupKeyName))),
+			expectedStatus: http.StatusOK,
+			expectedBody:   false,
+		},
+		{
+			// Only one-off keys are constrained; a reusable key means what it
+			// says.
+			name:        "Create Reusable Setup Key With Usage Limit",
+			requestType: http.MethodPost,
+			requestPath: "/api/setup-keys",
+			requestBody: bytes.NewBuffer(
+				[]byte(fmt.Sprintf("{\"name\":\"%s\",\"type\":\"reusable\",\"expires_in\":86400,\"usage_limit\":5}", newSetupKeyName))),
+			expectedStatus: http.StatusOK,
+			expectedBody:   false,
+		},
+		{
 			name:        "Update Setup Key",
 			requestType: http.MethodPut,
 			requestPath: "/api/setup-keys/" + defaultSetupKey.Id,

--- a/management/server/http/testing/integration/setupkeys_handler_integration_test.go
+++ b/management/server/http/testing/integration/setupkeys_handler_integration_test.go
@@ -136,7 +136,10 @@ func Test_SetupKeys_Create(t *testing.T) {
 			},
 		},
 		{
-			name:        "Create Setup Key as on-off with more than one usage",
+			// The key used to be created anyway, with its usage limit quietly
+			// reduced to 1, so the caller was told a key they had not asked for
+			// was what they asked for.
+			name:        "Create Setup Key as one-off with more than one usage",
 			requestType: http.MethodPost,
 			requestPath: "/api/setup-keys",
 			requestBody: &api.CreateSetupKeyRequest{
@@ -146,23 +149,7 @@ func Test_SetupKeys_Create(t *testing.T) {
 				Type:       "one-off",
 				UsageLimit: 3,
 			},
-			expectedStatus: http.StatusOK,
-			expectedResponse: &api.SetupKey{
-				AutoGroups: []string{},
-				Ephemeral:  false,
-				Expires:    time.Time{},
-				Id:         "",
-				Key:        "",
-				LastUsed:   time.Time{},
-				Name:       testing_tools.NewKeyName,
-				Revoked:    false,
-				State:      "valid",
-				Type:       "one-off",
-				UpdatedAt:  time.Now(),
-				UsageLimit: 1,
-				UsedTimes:  0,
-				Valid:      true,
-			},
+			expectedStatus: http.StatusUnprocessableEntity,
 		},
 		{
 			name:        "Create Setup Key with expiration in the past",


### PR DESCRIPTION
## Describe your changes

`GenerateSetupKey` pins a one-off key at a single use and ignores whatever `usage_limit` the request asked for. A caller that asks for five gets a key that works once, is told the creation succeeded, and finds out only by using it.

Terraform found this the hard way. The provider sends the usage limit it planned, the server stores a different one, the next refresh writes the server's value into state, and from then on every plan sees a change on an attribute that forces replacement — so adding a group to a one-off setup key destroyed the key and issued a new secret in its place. The provider side of that is fixed separately in netbirdio/terraform-provider-netbird#201; this is the half that stops the server from quietly disagreeing with its callers.

`createSetupKey` now rejects `usage_limit > 1` on a one-off key with a message naming the reusable type, which is what a caller asking for more than one use actually wants.

The behaviour was deliberate enough to be asserted: `Test_SetupKeys_Create` had a case called "Create Setup Key as on-off with more than one usage" expecting a created key whose reported limit was 1 rather than the 3 requested. That case now expects the rejection and keeps its place in the table, since it is the one that says what happens when a request contradicts the key type. **If the silent override was load-bearing for something I have not found, this is the PR to say so on.**

## Who this affects

**The dashboard needs no change.** Checked rather than assumed — every place it creates a setup key sends `usage_limit: 1` for a one-off:

| Call site | type | usage_limit |
| --- | --- | --- |
| `setup-keys/SetupKeyModal.tsx:212` | `reusable ? "reusable" : "one-off"` | `reusable ? parseInt(usageLimit) : 1` |
| `setup-netbird-modal/SetupModal.tsx` | `"one-off"` | `1` |
| `networks/routing-peers/NetworkRoutingPeerModal.tsx` | `"one-off"` | `1` |
| `onboarding/p2p/OnboardingSecondDevice.tsx` | `"one-off"` | `1` |
| `onboarding/networks/OnboardingAddRoutingPeer.tsx` | `"one-off"` | `1` |

The user-facing modal is the only one where a number can be typed, and the usage-limit field is reachable only in the reusable branch. The two `PUT` call sites echo `usage_limit` back in the update body, but `updateSetupKey` reads only `auto_groups` and `revoked`, and this PR does not touch that handler.

**`usage_limit: 0` is still accepted, deliberately.** It is a required field in the request schema with no null in it, so a caller with nothing to say about the limit has no way to say that except by sending 0 — the Go client and hand-written API calls both do. Refusing it would break them.

Rejecting 0 as well is the stricter reading of the same rule, and it is now clear what that would and would not cost: not the dashboard, which already sends 1, but every caller that omits the field, including terraform-provider versions before the fix linked above. It needs `usage_limit` made optional in the OpenAPI schema first. Happy to follow up if the team wants it — a separate, coordinated change rather than something to smuggle in here.

## Issue ticket number and link

Raised by the NetBird team from a user report: adding groups to an existing one-off setup key created through Terraform recreated the key.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

The API reference already describes a one-off key as single-use and `usage_limit` as the number of times a key can be used; this makes the server behave the way that text already says it does. Nothing in the request or response schema changes.

### Docs PR URL (required if "docs added" is checked)

n/a

## Summary by CodeRabbit

* **Bug Fixes**
  * One-time setup keys now reject usage limits greater than one with a clear validation error.
  * One-time keys without a usage limit and reusable keys with positive limits continue to work as expected.