### PR TITLE
[client] Declare multi-buffer support for the loopback XDP program

### DIFF
--- a/client/internal/ebpf/ebpf/manager_linux.go
+++ b/client/internal/ebpf/ebpf/manager_linux.go
@@ -2,17 +2,21 @@ package ebpf
 
 import (
 	_ "embed"
+	"fmt"
 	"net"
 	"sync"
 
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/rlimit"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 
 	"github.com/netbirdio/netbird/client/internal/ebpf/manager"
 )
 
 const (
+	xdpProgName = "nb_xdp_prog"
+
 	mapKeyFeatures uint32 = 0
 
 	featureFlagWGProxy      = 0b00000001
@@ -68,21 +72,48 @@ func (tf *GeneralManager) loadXdp() error {
 		return err
 	}
 
-	// load pre-compiled programs into the kernel.
-	err = loadBpfObjects(&tf.bpfObjs, nil)
+	// lo has no native XDP, so the program runs in generic mode. Unless it
+	// declares multi-buffer support the kernel must linearize every non-linear
+	// skb before running it. Loopback packets are up to 64 KB, so that is a
+	// contiguous GFP_ATOMIC allocation per packet, and when it fails the packet
+	// is dropped before the program runs, stalling local TCP connections.
+	// Multi-buffer XDP in generic mode requires kernel 6.3, so fall back to a
+	// plain attach when the kernel rejects it.
+	err = tf.attachXdp(iFace.Index, true)
+	if err == nil {
+		return nil
+	}
+	log.Debugf("failed to attach multi-buffer xdp program, retrying without it: %s", err)
+
+	return tf.attachXdp(iFace.Index, false)
+}
+
+func (tf *GeneralManager) attachXdp(iFaceIndex int, multiBuffer bool) error {
+	spec, err := loadBpf()
 	if err != nil {
-		return err
+		return fmt.Errorf("load bpf spec: %w", err)
+	}
+
+	if multiBuffer {
+		prog, ok := spec.Programs[xdpProgName]
+		if !ok {
+			return fmt.Errorf("program %s not found in bpf spec", xdpProgName)
+		}
+		prog.Flags |= unix.BPF_F_XDP_HAS_FRAGS
+	}
+
+	if err := spec.LoadAndAssign(&tf.bpfObjs, nil); err != nil {
+		return fmt.Errorf("load bpf objects: %w", err)
 	}
 
 	tf.link, err = link.AttachXDP(link.XDPOptions{
 		Program:   tf.bpfObjs.NbXdpProg,
-		Interface: iFace.Index,
+		Interface: iFaceIndex,
 	})
-
 	if err != nil {
 		_ = tf.bpfObjs.Close()
 		tf.link = nil
-		return err
+		return fmt.Errorf("attach xdp: %w", err)
 	}
 	return nil
 }

--- a/client/internal/ebpf/ebpf/manager_linux.go
+++ b/client/internal/ebpf/ebpf/manager_linux.go
@@ -111,7 +111,9 @@ func (tf *GeneralManager) attachXdp(iFaceIndex int, multiBuffer bool) error {
 		Interface: iFaceIndex,
 	})
 	if err != nil {
-		_ = tf.bpfObjs.Close()
+		if closeErr := tf.bpfObjs.Close(); closeErr != nil {
+			log.Debugf("failed to close bpf objects after xdp attach error: %s", closeErr)
+		}
 		tf.link = nil
 		return fmt.Errorf("attach xdp: %w", err)
 	}


### PR DESCRIPTION
## Describe your changes

The eBPF WireGuard proxy attaches its XDP program to `lo`, which supports only generic (skb) mode. There the kernel has to linearize every non-linear skb before the program runs, unless the program declares multi-buffer support. Loopback packets are up to 64 KB, so this means a large contiguous atomic allocation for every local packet, and when that allocation fails the kernel drops the packet before the program runs. The drop is silent, so local TCP connections retransmit into the same failure and stall instead of erroring out.

- Declare multi-buffer support for the loopback XDP program at load time, so the kernel no longer needs to linearize loopback packets
- Retry the attach without multi-buffer support for kernels that reject it

Kernels older than 6.3 do not support multi-buffer XDP in generic mode and keep linearizing; moving the port rewrite to a TC ingress hook would remove the linearization on those too, and can be done separately.

### Reproducing

Roughly: run a client with the eBPF proxy active (so `nb_xdp_prog` is attached to `lo`) on a host whose buddy allocator has no free blocks left at the order needed for a 64 KB skb head, then pull anything larger than ~64 KB over `127.0.0.1`. The transfer delivers part of the response and then hangs until timeout with no connection reset; detaching the XDP program makes it work again. The same failure can be produced on demand on a healthy host by making atomic allocations above 64 KB fail, with the drops showing up as `kfree_skb` from the generic XDP receive path.

## Issue ticket number and link

https://github.com/netbirdio/netbird/discussions/7227

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): internal packet path, no user-facing configuration or behavior change

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for processing multi-buffer network packets with XDP.
  * Added automatic fallback when multi-buffer attachment is unavailable.

* **Bug Fixes**
  * Improved error messages for BPF loading and attachment failures.
  * Enhanced program identification before enabling advanced packet-processing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->