### PR TITLE
[client] Rename TURN-specific wg proxy naming to relayed connections

### DIFF
--- a/client/iface/wgproxy/bind/proxy.go
+++ b/client/iface/wgproxy/bind/proxy.go
@@ -53,15 +53,15 @@ func NewProxyBind(bind Bind, mtu uint16) *ProxyBind {
 	return p
 }
 
-// AddTurnConn adds a new connection to the bind.
+// AddRelayedConn adds a new connection to the bind.
 // endpoint is the NetBird address of the remote peer. The SetEndpoint return with the address what will be used in the
 // WireGuard configuration.
 //
 // Parameters:
 //   - ctx: Context is used for proxyToLocal to avoid unnecessary error messages
 //   - nbAddr: The NetBird UDP address of the remote peer, it required to generate fake address
-//   - remoteConn: The established TURN connection to the remote peer
-func (p *ProxyBind) AddTurnConn(ctx context.Context, nbAddr *net.UDPAddr, remoteConn net.Conn) error {
+//   - remoteConn: The established relayed connection to the remote peer
+func (p *ProxyBind) AddRelayedConn(ctx context.Context, nbAddr *net.UDPAddr, remoteConn net.Conn) error {
 	fakeNetIP, err := fakeAddress(nbAddr)
 	if err != nil {
 		return err

--- a/client/iface/wgproxy/ebpf/proxy.go
+++ b/client/iface/wgproxy/ebpf/proxy.go
@@ -30,9 +30,9 @@ type WGEBPFProxy struct {
 	proxyPort         int
 	mtu               uint16
 
-	ebpfManager   ebpfMgr.Manager
-	turnConnStore map[uint16]net.Conn
-	turnConnMutex sync.Mutex
+	ebpfManager      ebpfMgr.Manager
+	relayedConnStore map[uint16]net.Conn
+	relayedConnMutex sync.Mutex
 
 	lastUsedPort uint16
 	rawConnIPv4  net.PacketConn
@@ -50,7 +50,7 @@ func NewWGEBPFProxy(wgPort int, mtu uint16) *WGEBPFProxy {
 		localWGListenPort: wgPort,
 		mtu:               mtu,
 		ebpfManager:       ebpf.GetEbpfManagerInstance(),
-		turnConnStore:     make(map[uint16]net.Conn),
+		relayedConnStore:  make(map[uint16]net.Conn),
 	}
 	return wgProxy
 }
@@ -110,14 +110,14 @@ func (p *WGEBPFProxy) Listen() error {
 	return nil
 }
 
-// AddTurnConn add new turn connection for the proxy
-func (p *WGEBPFProxy) AddTurnConn(turnConn net.Conn) (*net.UDPAddr, error) {
-	wgEndpointPort, err := p.storeTurnConn(turnConn)
+// AddRelayedConn add new relayed connection for the proxy
+func (p *WGEBPFProxy) AddRelayedConn(relayedConn net.Conn) (*net.UDPAddr, error) {
+	wgEndpointPort, err := p.storeRelayedConn(relayedConn)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Infof("turn conn added to wg proxy store: %s, endpoint port: :%d", turnConn.RemoteAddr(), wgEndpointPort)
+	log.Infof("relayed conn added to wg proxy store: %s, endpoint port: :%d", relayedConn.RemoteAddr(), wgEndpointPort)
 
 	wgEndpoint := &net.UDPAddr{
 		IP:   net.ParseIP(loopbackAddr),
@@ -186,12 +186,12 @@ func (p *WGEBPFProxy) readAndForwardPacket(buf []byte) error {
 		return fmt.Errorf("failed to read UDP packet from WG: %w", err)
 	}
 
-	p.turnConnMutex.Lock()
-	conn, ok := p.turnConnStore[uint16(addr.Port)]
-	p.turnConnMutex.Unlock()
+	p.relayedConnMutex.Lock()
+	conn, ok := p.relayedConnStore[uint16(addr.Port)]
+	p.relayedConnMutex.Unlock()
 	if !ok {
 		if p.ctx.Err() == nil {
-			log.Debugf("turn conn not found by port because conn already has been closed: %d", addr.Port)
+			log.Debugf("relayed conn not found by port because conn already has been closed: %d", addr.Port)
 		}
 		return nil
 	}
@@ -202,32 +202,32 @@ func (p *WGEBPFProxy) readAndForwardPacket(buf []byte) error {
 	return nil
 }
 
-func (p *WGEBPFProxy) storeTurnConn(turnConn net.Conn) (uint16, error) {
-	p.turnConnMutex.Lock()
-	defer p.turnConnMutex.Unlock()
+func (p *WGEBPFProxy) storeRelayedConn(relayedConn net.Conn) (uint16, error) {
+	p.relayedConnMutex.Lock()
+	defer p.relayedConnMutex.Unlock()
 
 	np, err := p.nextFreePort()
 	if err != nil {
 		return np, err
 	}
-	p.turnConnStore[np] = turnConn
+	p.relayedConnStore[np] = relayedConn
 	return np, nil
 }
 
-func (p *WGEBPFProxy) removeTurnConn(turnConnID uint16) {
-	p.turnConnMutex.Lock()
-	defer p.turnConnMutex.Unlock()
+func (p *WGEBPFProxy) removeRelayedConn(relayedConnID uint16) {
+	p.relayedConnMutex.Lock()
+	defer p.relayedConnMutex.Unlock()
 
-	_, ok := p.turnConnStore[turnConnID]
+	_, ok := p.relayedConnStore[relayedConnID]
 	if ok {
-		log.Debugf("remove turn conn from store by port: %d", turnConnID)
+		log.Debugf("remove relayed conn from store by port: %d", relayedConnID)
 	}
-	delete(p.turnConnStore, turnConnID)
+	delete(p.relayedConnStore, relayedConnID)
 }
 
 func (p *WGEBPFProxy) nextFreePort() (uint16, error) {
-	if len(p.turnConnStore) == 65535 {
-		return 0, fmt.Errorf("reached maximum turn connection numbers")
+	if len(p.relayedConnStore) == 65535 {
+		return 0, fmt.Errorf("reached maximum relayed connection numbers")
 	}
 generatePort:
 	if p.lastUsedPort == 65535 {
@@ -236,7 +236,7 @@ generatePort:
 		p.lastUsedPort++
 	}
 
-	if _, ok := p.turnConnStore[p.lastUsedPort]; ok {
+	if _, ok := p.relayedConnStore[p.lastUsedPort]; ok {
 		goto generatePort
 	}
 	return p.lastUsedPort, nil

--- a/client/iface/wgproxy/ebpf/proxy.go
+++ b/client/iface/wgproxy/ebpf/proxy.go
@@ -197,7 +197,7 @@ func (p *WGEBPFProxy) readAndForwardPacket(buf []byte) error {
 	}
 
 	if _, err := conn.Write(buf[:n]); err != nil {
-		return fmt.Errorf("failed to forward local WG packet (%d) to remote turn conn: %w", addr.Port, err)
+		return fmt.Errorf("forward local WG packet (%d) to remote relayed conn: %w", addr.Port, err)
 	}
 	return nil
 }

--- a/client/iface/wgproxy/ebpf/proxy_test.go
+++ b/client/iface/wgproxy/ebpf/proxy_test.go
@@ -9,32 +9,32 @@ import (
 func TestWGEBPFProxy_connStore(t *testing.T) {
 	wgProxy := NewWGEBPFProxy(1, 1280)
 
-	p, _ := wgProxy.storeTurnConn(nil)
+	p, _ := wgProxy.storeRelayedConn(nil)
 	if p != 1 {
 		t.Errorf("invalid initial port: %d", wgProxy.lastUsedPort)
 	}
 
 	numOfConns := 10
 	for i := 0; i < numOfConns; i++ {
-		p, _ = wgProxy.storeTurnConn(nil)
+		p, _ = wgProxy.storeRelayedConn(nil)
 	}
 	if p != uint16(numOfConns)+1 {
 		t.Errorf("invalid last used port: %d, expected: %d", p, numOfConns+1)
 	}
-	if len(wgProxy.turnConnStore) != numOfConns+1 {
-		t.Errorf("invalid store size: %d, expected: %d", len(wgProxy.turnConnStore), numOfConns+1)
+	if len(wgProxy.relayedConnStore) != numOfConns+1 {
+		t.Errorf("invalid store size: %d, expected: %d", len(wgProxy.relayedConnStore), numOfConns+1)
 	}
 }
 
 func TestWGEBPFProxy_portCalculation_overflow(t *testing.T) {
 	wgProxy := NewWGEBPFProxy(1, 1280)
 
-	_, _ = wgProxy.storeTurnConn(nil)
+	_, _ = wgProxy.storeRelayedConn(nil)
 	wgProxy.lastUsedPort = 65535
-	p, _ := wgProxy.storeTurnConn(nil)
+	p, _ := wgProxy.storeRelayedConn(nil)
 
-	if len(wgProxy.turnConnStore) != 2 {
-		t.Errorf("invalid store size: %d, expected: %d", len(wgProxy.turnConnStore), 2)
+	if len(wgProxy.relayedConnStore) != 2 {
+		t.Errorf("invalid store size: %d, expected: %d", len(wgProxy.relayedConnStore), 2)
 	}
 
 	if p != 2 {
@@ -46,11 +46,11 @@ func TestWGEBPFProxy_portCalculation_maxConn(t *testing.T) {
 	wgProxy := NewWGEBPFProxy(1, 1280)
 
 	for i := 0; i < 65535; i++ {
-		_, _ = wgProxy.storeTurnConn(nil)
+		_, _ = wgProxy.storeRelayedConn(nil)
 	}
 
-	_, err := wgProxy.storeTurnConn(nil)
+	_, err := wgProxy.storeRelayedConn(nil)
 	if err == nil {
-		t.Errorf("invalid turn conn store calculation")
+		t.Errorf("invalid relayed conn store calculation")
 	}
 }

--- a/client/iface/wgproxy/ebpf/wrapper.go
+++ b/client/iface/wgproxy/ebpf/wrapper.go
@@ -121,10 +121,10 @@ func NewProxyWrapper(proxy *WGEBPFProxy) *ProxyWrapper {
 	}
 }
 
-func (p *ProxyWrapper) AddTurnConn(ctx context.Context, _ *net.UDPAddr, remoteConn net.Conn) error {
-	addr, err := p.wgeBPFProxy.AddTurnConn(remoteConn)
+func (p *ProxyWrapper) AddRelayedConn(ctx context.Context, _ *net.UDPAddr, remoteConn net.Conn) error {
+	addr, err := p.wgeBPFProxy.AddRelayedConn(remoteConn)
 	if err != nil {
-		return fmt.Errorf("add turn conn: %w", err)
+		return fmt.Errorf("add relayed conn: %w", err)
 	}
 
 	headers, err := NewPacketHeaders(p.wgeBPFProxy.localWGListenPort, addr)
@@ -252,7 +252,7 @@ func (p *ProxyWrapper) CloseConn() error {
 }
 
 func (p *ProxyWrapper) proxyToLocal(ctx context.Context) {
-	defer p.wgeBPFProxy.removeTurnConn(uint16(p.wgRelayedEndpointAddr.Port))
+	defer p.wgeBPFProxy.removeRelayedConn(uint16(p.wgRelayedEndpointAddr.Port))
 
 	buf := make([]byte, p.wgeBPFProxy.mtu+bufsize.WGBufferOverhead)
 	for {
@@ -273,7 +273,7 @@ func (p *ProxyWrapper) proxyToLocal(ctx context.Context) {
 			if ctx.Err() != nil {
 				return
 			}
-			log.Errorf("failed to write out turn pkg to local conn: %v", err)
+			log.Errorf("failed to write out relayed pkg to local conn: %v", err)
 		}
 	}
 }
@@ -286,7 +286,7 @@ func (p *ProxyWrapper) readFromRemote(ctx context.Context, buf []byte) (int, err
 		}
 		p.closeListener.Notify()
 		if !errors.Is(err, io.EOF) {
-			log.Errorf("failed to read from turn conn (endpoint: :%d): %s", p.wgRelayedEndpointAddr.Port, err)
+			log.Errorf("failed to read from relayed conn (endpoint: :%d): %s", p.wgRelayedEndpointAddr.Port, err)
 		}
 		return 0, err
 	}

--- a/client/iface/wgproxy/proxy.go
+++ b/client/iface/wgproxy/proxy.go
@@ -7,7 +7,7 @@ import (
 
 // Proxy is a transfer layer between the relayed connection and the WireGuard
 type Proxy interface {
-	AddTurnConn(ctx context.Context, endpoint *net.UDPAddr, remoteConn net.Conn) error
+	AddRelayedConn(ctx context.Context, endpoint *net.UDPAddr, remoteConn net.Conn) error
 	EndpointAddr() *net.UDPAddr // EndpointAddr returns the address of the WireGuard peer endpoint
 	Work()                      // Work start or resume the proxy
 	Pause()                     // Pause to forward the packages from remote connection to WireGuard. The opposite way still works.

--- a/client/iface/wgproxy/proxy_test.go
+++ b/client/iface/wgproxy/proxy_test.go
@@ -95,7 +95,7 @@ func TestProxyCloseByRemoteConn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			addr, _ := net.ResolveUDPAddr("udp", "100.108.135.221:51892")
 			relayedConn := newMockConn()
-			err := tt.proxy.AddTurnConn(ctx, addr, relayedConn)
+			err := tt.proxy.AddRelayedConn(ctx, addr, relayedConn)
 			if err != nil {
 				t.Errorf("error: %v", err)
 			}
@@ -157,7 +157,7 @@ func redirectTraffic(t *testing.T, proxy Proxy, wgPort int, endPointAddr *net.UD
 		_ = relayedServer.Close()
 	}()
 
-	if err := proxy.AddTurnConn(context.Background(), endPointAddr, relayedConn); err != nil {
+	if err := proxy.AddRelayedConn(context.Background(), endPointAddr, relayedConn); err != nil {
 		t.Errorf("error: %v", err)
 	}
 	defer func() {

--- a/client/iface/wgproxy/redirect_test.go
+++ b/client/iface/wgproxy/redirect_test.go
@@ -119,9 +119,9 @@ func testRedirectAs(t *testing.T, proxy Proxy, wgPort int, nbAddr, p2pEndpoint *
 	}
 	defer relayConn.Close()
 
-	// Add TURN connection to proxy
-	if err := proxy.AddTurnConn(ctx, nbAddr, relayConn); err != nil {
-		t.Fatalf("failed to add TURN connection: %v", err)
+	// Add relayed connection to proxy
+	if err := proxy.AddRelayedConn(ctx, nbAddr, relayConn); err != nil {
+		t.Fatalf("failed to add relayed connection: %v", err)
 	}
 	defer func() {
 		if err := proxy.CloseConn(); err != nil {
@@ -304,8 +304,8 @@ func TestRedirectAs_Multiple_Switches(t *testing.T) {
 		Port: 38746,
 	}
 
-	if err := proxy.AddTurnConn(ctx, nbAddr, relayConn); err != nil {
-		t.Fatalf("failed to add TURN connection: %v", err)
+	if err := proxy.AddRelayedConn(ctx, nbAddr, relayConn); err != nil {
+		t.Fatalf("failed to add relayed connection: %v", err)
 	}
 	defer func() {
 		if err := proxy.CloseConn(); err != nil {

--- a/client/iface/wgproxy/udp/proxy.go
+++ b/client/iface/wgproxy/udp/proxy.go
@@ -51,7 +51,7 @@ func NewWGUDPProxy(wgPort int, mtu uint16) *WGUDPProxy {
 	return p
 }
 
-// AddRelayedConn
+// AddRelayedConn dials the local WireGuard port and stores the relayed connection.
 // The provided Context must be non-nil. If the context expires before
 // the connection is complete, an error is returned. Once successfully
 // connected, any expiration of the context will not affect the

--- a/client/iface/wgproxy/udp/proxy.go
+++ b/client/iface/wgproxy/udp/proxy.go
@@ -51,12 +51,12 @@ func NewWGUDPProxy(wgPort int, mtu uint16) *WGUDPProxy {
 	return p
 }
 
-// AddTurnConn
+// AddRelayedConn
 // The provided Context must be non-nil. If the context expires before
 // the connection is complete, an error is returned. Once successfully
 // connected, any expiration of the context will not affect the
 // connection.
-func (p *WGUDPProxy) AddTurnConn(ctx context.Context, _ *net.UDPAddr, remoteConn net.Conn) error {
+func (p *WGUDPProxy) AddRelayedConn(ctx context.Context, _ *net.UDPAddr, remoteConn net.Conn) error {
 	dialer := net.Dialer{}
 	localConn, err := dialer.DialContext(ctx, "udp", fmt.Sprintf(":%d", p.localWGListenPort))
 	if err != nil {

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -879,8 +879,7 @@ func (conn *Conn) newProxy(remoteConn net.Conn) (wgproxy.Proxy, error) {
 
 	wgProxy := conn.config.WgConfig.WgInterface.GetProxy()
 	if err := wgProxy.AddRelayedConn(conn.ctx, udpAddr, remoteConn); err != nil {
-		conn.Log.Errorf("failed to add relayed net.Conn to local proxy: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("add relayed conn to proxy: %w", err)
 	}
 	return wgProxy, nil
 }

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -440,7 +440,7 @@ func (conn *Conn) onICEConnectionIsReady(priority conntype.ConnPriority, iceConn
 		conn.dumpState.NewLocalProxy()
 		wgProxy, err = conn.newProxy(iceConnInfo.RemoteConn)
 		if err != nil {
-			conn.Log.Errorf("failed to add turn net.Conn to local proxy: %v", err)
+			conn.Log.Errorf("failed to add relayed net.Conn to local proxy: %v", err)
 			return
 		}
 		ep = wgProxy.EndpointAddr()
@@ -878,8 +878,8 @@ func (conn *Conn) newProxy(remoteConn net.Conn) (wgproxy.Proxy, error) {
 	}
 
 	wgProxy := conn.config.WgConfig.WgInterface.GetProxy()
-	if err := wgProxy.AddTurnConn(conn.ctx, udpAddr, remoteConn); err != nil {
-		conn.Log.Errorf("failed to add turn net.Conn to local proxy: %v", err)
+	if err := wgProxy.AddRelayedConn(conn.ctx, udpAddr, remoteConn); err != nil {
+		conn.Log.Errorf("failed to add relayed net.Conn to local proxy: %v", err)
 		return nil, err
 	}
 	return wgProxy, nil

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -517,8 +517,8 @@ func (w *WorkerICE) onConnectionStateChange(agent *icemaker.ThreadSafeAgent, dia
 			w.logSuccessfulPaths(agent)
 			return
 		case ice.ConnectionStateFailed, ice.ConnectionStateDisconnected, ice.ConnectionStateClosed:
-			// ice.ConnectionStateClosed happens when we recreate the agent. For the P2P to TURN switch important to
-			// notify the conn.onICEStateDisconnected changes to update the current used priority
+			// ice.ConnectionStateClosed happens when we recreate the agent. The P2P to relay switch requires
+			// notifying conn.onICEStateDisconnected so it can update the currently used priority.
 
 			sessionChanged := w.closeAgent(agent, dialerCancel)
 

--- a/client/internal/peer/worker_ice.go
+++ b/client/internal/peer/worker_ice.go
@@ -255,8 +255,8 @@ func (w *WorkerICE) connect(ctx context.Context, agent *icemaker.ThreadSafeAgent
 		return
 	}
 
-	w.log.Debugf("turn agent dial")
-	remoteConn, err := w.turnAgentDial(ctx, agent, remoteOfferAnswer)
+	w.log.Debugf("agent dial")
+	remoteConn, err := w.agentDial(ctx, agent, remoteOfferAnswer)
 	if err != nil {
 		w.log.Debugf("failed to dial the remote peer: %s", err)
 		w.closeAgent(agent, w.agentDialerCancel)
@@ -532,7 +532,7 @@ func (w *WorkerICE) onConnectionStateChange(agent *icemaker.ThreadSafeAgent, dia
 	}
 }
 
-func (w *WorkerICE) turnAgentDial(ctx context.Context, agent *icemaker.ThreadSafeAgent, remoteOfferAnswer *OfferAnswer) (*ice.Conn, error) {
+func (w *WorkerICE) agentDial(ctx context.Context, agent *icemaker.ThreadSafeAgent, remoteOfferAnswer *OfferAnswer) (*ice.Conn, error) {
 	if isController(w.config) {
 		return agent.Dial(ctx, remoteOfferAnswer.IceCredentials.UFrag, remoteOfferAnswer.IceCredentials.Pwd)
 	} else {


### PR DESCRIPTION
## Describe your changes

The WireGuard proxy plumbing was named after TURN, but it carries any relayed connection: relay server connections and ICE connections that are relayed on the local side. TURN is deprecated and barely used, so the naming is misleading. This renames those identifiers, log messages, and comments to generic relay wording. No behavior change.

- Rename the proxy interface method `AddTurnConn` to `AddRelayedConn` in all implementations (bind, userspace UDP, eBPF) and at the call site
- Rename the eBPF proxy's connection store, mutex, and helpers to relayed-connection names
- Reword proxy log messages and comments that referred to "turn conn"
- Rename the ICE worker's `turnAgentDial` to `agentDial`, since it dials or accepts the ICE agent regardless of candidate type

Naming that genuinely refers to TURN is untouched: TURN server config and probing, the ICE-over-TURN connection type and metric, TURN domain extraction for DNS, and the pion mux contract.

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal identifier and log naming only)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **API Updates**
  - Renamed the connection-registration API from TURN-specific terminology to `AddRelayedConn`.
  - Updated proxy implementations and integrations to use the new naming.
  - Connection behavior, setup, and error handling remain unchanged.

- **Bug Fixes**
  - Updated connection handling, cleanup, capacity checks, and error messages to consistently refer to relayed connections.
  - Generalized connection switching terminology from P2P-to-TURN to P2P-to-relay.

- **Tests**
  - Updated proxy, redirect, and connection-store coverage for the renamed API and terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->