### PR TITLE
[client] Report network addresses on Android for posture checks

### DIFF
--- a/client/android/client.go
+++ b/client/android/client.go
@@ -152,6 +152,7 @@ func NewClient(androidSDKVersion int, deviceName string, uiVersion string, tunAd
 	execWorkaround(androidSDKVersion)
 
 	net.SetAndroidProtectSocketFn(tunAdapter.ProtectSocket)
+	system.SetIFaceDiscover(iFaceDiscover)
 	return &Client{
 		deviceName:            deviceName,
 		uiVersion:             uiVersion,

--- a/client/system/info_android.go
+++ b/client/system/info_android.go
@@ -30,6 +30,11 @@ func GetInfo(ctx context.Context) *Info {
 		kernelVersion = osInfo[2]
 	}
 
+	addrs, err := networkAddresses()
+	if err != nil {
+		log.Warnf("failed to discover network addresses: %s", err)
+	}
+
 	gio := &Info{
 		GoOS:               runtime.GOOS,
 		Kernel:             kernel,
@@ -41,6 +46,7 @@ func GetInfo(ctx context.Context) *Info {
 		NetbirdVersion:     version.NetbirdVersion(),
 		UIVersion:          extractUIVersion(ctx),
 		KernelVersion:      kernelVersion,
+		NetworkAddresses:   addrs,
 		SystemSerialNumber: serial(),
 		SystemProductName:  productModel(),
 		SystemManufacturer: productManufacturer(),

--- a/client/system/info_android.go
+++ b/client/system/info_android.go
@@ -32,7 +32,7 @@ func GetInfo(ctx context.Context) *Info {
 
 	addrs, err := networkAddresses()
 	if err != nil {
-		log.Warnf("failed to discover network addresses: %s", err)
+		log.Warnf("discover network addresses: %s", err)
 	}
 
 	gio := &Info{

--- a/client/system/network_addr.go
+++ b/client/system/network_addr.go
@@ -1,4 +1,4 @@
-//go:build !ios
+//go:build !ios && !android
 
 package system
 

--- a/client/system/network_addr_android.go
+++ b/client/system/network_addr_android.go
@@ -11,6 +11,7 @@ type IFaceDiscover interface {
 	IFaces() (string, error)
 }
 
+// SetIFaceDiscover configures the Android interface discovery provider.
 func SetIFaceDiscover(discover IFaceDiscover) {
 	iFaceDiscover = discover
 }

--- a/client/system/network_addr_android.go
+++ b/client/system/network_addr_android.go
@@ -66,6 +66,12 @@ func toNetworkAddress(address string) (NetworkAddress, bool) {
 	if err != nil {
 		return NetworkAddress{}, false
 	}
+	if prefix.Addr().Is4In6() {
+		if prefix.Bits() < 96 {
+			return NetworkAddress{}, false
+		}
+		prefix = netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Bits()-96)
+	}
 	ip := prefix.Addr()
 	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsMulticast() {
 		return NetworkAddress{}, false

--- a/client/system/network_addr_android.go
+++ b/client/system/network_addr_android.go
@@ -1,0 +1,82 @@
+package system
+
+import (
+	"net/netip"
+	"strings"
+)
+
+var iFaceDiscover IFaceDiscover
+
+type IFaceDiscover interface {
+	IFaces() (string, error)
+}
+
+func SetIFaceDiscover(discover IFaceDiscover) {
+	iFaceDiscover = discover
+}
+
+func networkAddresses() ([]NetworkAddress, error) {
+	if iFaceDiscover == nil {
+		return nil, nil
+	}
+	ifaces, err := iFaceDiscover.IFaces()
+	if err != nil {
+		return nil, err
+	}
+
+	var netAddresses []NetworkAddress
+	for _, line := range strings.Split(ifaces, "\n") {
+		addresses, ok := interfaceAddresses(line)
+		if !ok {
+			continue
+		}
+		for _, address := range addresses {
+			netAddr, ok := toNetworkAddress(address)
+			if !ok {
+				continue
+			}
+			if isDuplicated(netAddresses, netAddr) {
+				continue
+			}
+			netAddresses = append(netAddresses, netAddr)
+		}
+	}
+	return netAddresses, nil
+}
+
+func interfaceAddresses(line string) ([]string, bool) {
+	parts := strings.Split(line, "|")
+	if len(parts) != 2 {
+		return nil, false
+	}
+	flags := strings.Fields(parts[0])
+	if len(flags) != 8 {
+		return nil, false
+	}
+	up, loopback := flags[3], flags[5]
+	if up != "true" || loopback == "true" {
+		return nil, false
+	}
+	return strings.Fields(parts[1]), true
+}
+
+func toNetworkAddress(address string) (NetworkAddress, bool) {
+	prefix, err := netip.ParsePrefix(address)
+	if err != nil {
+		return NetworkAddress{}, false
+	}
+	ip := prefix.Addr()
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsMulticast() {
+		return NetworkAddress{}, false
+	}
+	return NetworkAddress{NetIP: prefix}, true
+}
+
+func isDuplicated(addresses []NetworkAddress, addr NetworkAddress) bool {
+	for _, duplicated := range addresses {
+		if duplicated.NetIP == addr.NetIP {
+			return true
+		}
+	}
+	return false
+}

--- a/client/system/network_addr_test.go
+++ b/client/system/network_addr_test.go
@@ -1,4 +1,4 @@
-//go:build !ios
+//go:build !ios && !android
 
 package system
 


### PR DESCRIPTION
## Describe your changes

Android never reported its local network interfaces, so `PeerNetworkRange` posture checks could not be evaluated: `NetworkAddresses` always arrived empty.

`net.Interfaces()` is unusable on Android 11+ (SELinux blocks netlink), so the addresses are parsed from the interface description the host app already provides via `stdnet.ExternalIFaceDiscover`. The MAC filter is skipped, mirroring #5906
for iOS, since Android does not expose MACs either and nothing reads `Mac` server side.


## Issue ticket number and link

https://github.com/netbirdio/netbird/discussions/7174

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Android network address discovery.
  - Reports active, non-loopback network addresses while filtering invalid, duplicate, link-local, and multicast addresses.
  - Supports normalized IPv4-mapped addresses for more consistent network information.

- **Bug Fixes**
  - Android client information now includes discovered network addresses.
  - Discovery failures are handled gracefully with warnings, preserving client initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->