### PR TITLE
[client] Start the restarted UI with the user's environment block

### DIFF
--- a/client/internal/updater/installer/installer_run_windows.go
+++ b/client/internal/updater/installer/installer_run_windows.go
@@ -307,6 +307,16 @@ func startUIInSession(uiPath string, sessionID uint32) error {
 		}
 	}()
 
+	var env *uint16
+	if err := windows.CreateEnvironmentBlock(&env, primaryToken, false); err != nil {
+		return fmt.Errorf("create environment block: %w", err)
+	}
+	defer func() {
+		if err := windows.DestroyEnvironmentBlock(env); err != nil {
+			log.Warnf("failed to destroy environment block: %v", err)
+		}
+	}()
+
 	// Prepare startup info
 	var si windows.StartupInfo
 	si.Cb = uint32(unsafe.Sizeof(si))
@@ -329,7 +339,7 @@ func startUIInSession(uiPath string, sessionID uint32) error {
 		nil,
 		false,
 		creationFlags,
-		nil,
+		env,
 		nil,
 		&si,
 		&pi,


### PR DESCRIPTION
## Describe your changes

The updater runs as LocalSystem and started netbird-ui via CreateProcessAsUser with a nil environment, so the UI inherited the SYSTEM environment (USERPROFILE, APPDATA pointing at systemprofile) while running under the user's token. The WebView2-based UI exits immediately in that state, so the UI never came back after an update.

Build the environment from the user's token with CreateEnvironmentBlock and pass it to CreateProcessAsUser.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows update installation by ensuring launched installer processes receive the correct user-specific environment settings.
  * Increased reliability of installer startup in the active user session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->