### PR TITLE
[client] Fix staticcheck findings from the updated golangci-lint

### DIFF
--- a/client/cmd/service_controller.go
+++ b/client/cmd/service_controller.go
@@ -45,8 +45,8 @@ func daemonServerOptions(network string) []grpc.ServerOption {
 		return nil
 	}
 
-	creds := ipcauth.NewTransportCredentials()
-	if creds == nil {
+	creds := ipcauth.NewTransportCredentials() //nolint:staticcheck
+	if creds == nil {                          //nolint:staticcheck // nil only on platforms without a peer-identity primitive
 		log.Warnf("daemon IPC has no peer-identity primitive on %s: privileged operations will be denied", runtime.GOOS)
 		return nil
 	}

--- a/client/cmd/service_socket.go
+++ b/client/cmd/service_socket.go
@@ -27,8 +27,8 @@ func listenOnAddress(addr string) (*socketListener, error) {
 	}
 
 	if network == "npipe" {
-		listener, path, err := listenNamedPipe(address)
-		if err != nil {
+		listener, path, err := listenNamedPipe(address) //nolint:staticcheck
+		if err != nil {                                 //nolint:staticcheck // always errors on non-Windows builds
 			return nil, err
 		}
 		return &socketListener{Listener: listener, network: network, address: path}, nil

--- a/client/internal/acl/manager.go
+++ b/client/internal/acl/manager.go
@@ -116,11 +116,11 @@ func (d *DefaultManager) ApplyFiltering(networkMap *mgmProto.NetworkMap, dnsRout
 // firewall state, so an identical hash means an identical resulting ruleset.
 func (d *DefaultManager) firewallConfigHash(networkMap *mgmProto.NetworkMap, dnsRouteFeatureFlag bool) (uint64, error) {
 	return hashstructure.Hash(struct {
-		PeerRules            []*mgmProto.FirewallRule
-		PeerRulesIsEmpty     bool
-		RouteRules           []*mgmProto.RouteFirewallRule
-		RouteRulesIsEmpty    bool
-		DNSRouteFeatureFlag  bool
+		PeerRules           []*mgmProto.FirewallRule
+		PeerRulesIsEmpty    bool
+		RouteRules          []*mgmProto.RouteFirewallRule
+		RouteRulesIsEmpty   bool
+		DNSRouteFeatureFlag bool
 	}{
 		PeerRules:           networkMap.GetFirewallRules(),
 		PeerRulesIsEmpty:    networkMap.GetFirewallRulesIsEmpty(),
@@ -144,13 +144,13 @@ func (d *DefaultManager) applyPeerACLs(networkMap *mgmProto.NetworkMap) {
 		log.Warn("this peer is connected to a NetBird Management service with an older version. Allowing all traffic from connected peers")
 		rules = append(rules,
 			&mgmProto.FirewallRule{
-				PeerIP:    "0.0.0.0",
+				PeerIP:    "0.0.0.0", //nolint:staticcheck
 				Direction: mgmProto.RuleDirection_IN,
 				Action:    mgmProto.RuleAction_ACCEPT,
 				Protocol:  mgmProto.RuleProtocol_ALL,
 			},
 			&mgmProto.FirewallRule{
-				PeerIP:    "0.0.0.0",
+				PeerIP:    "0.0.0.0", //nolint:staticcheck
 				Direction: mgmProto.RuleDirection_OUT,
 				Action:    mgmProto.RuleAction_ACCEPT,
 				Protocol:  mgmProto.RuleProtocol_ALL,
@@ -406,7 +406,6 @@ func (d *DefaultManager) getPeerRuleID(
 func (d *DefaultManager) getRuleGroupingSelector(rule *mgmProto.FirewallRule) string {
 	return fmt.Sprintf("%v:%v:%v:%s:%v", strconv.Itoa(int(rule.Direction)), rule.Action, rule.Protocol, rule.Port, rule.PortInfo)
 }
-
 
 // extractRuleIP extracts the peer IP from a firewall rule.
 // If sourcePrefixes is populated (new management), decode the first entry and use its address.

--- a/client/internal/acl/manager_test.go
+++ b/client/internal/acl/manager_test.go
@@ -5,9 +5,9 @@ import (
 	"net/netip"
 	"testing"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/netbirdio/netbird/client/firewall"
 	"github.com/netbirdio/netbird/client/iface"
@@ -87,7 +87,7 @@ func TestDefaultManager(t *testing.T) {
 		networkMap.FirewallRules = append(
 			networkMap.FirewallRules,
 			&mgmProto.FirewallRule{
-				PeerIP:    "10.93.0.3",
+				PeerIP:    "10.93.0.3", //nolint:staticcheck
 				Direction: mgmProto.RuleDirection_IN,
 				Action:    mgmProto.RuleAction_DROP,
 				Protocol:  mgmProto.RuleProtocol_ICMP,
@@ -556,12 +556,12 @@ func TestApplyFilteringSkipsUnchangedConfig(t *testing.T) {
 
 func buildNetworkMap(peerRules, routeRules int) *mgmProto.NetworkMap {
 	nm := &mgmProto.NetworkMap{
-		FirewallRulesIsEmpty:      peerRules == 0,
+		FirewallRulesIsEmpty:       peerRules == 0,
 		RoutesFirewallRulesIsEmpty: routeRules == 0,
 	}
 	for i := range peerRules {
 		nm.FirewallRules = append(nm.FirewallRules, &mgmProto.FirewallRule{
-			PeerIP:    fmt.Sprintf("10.%d.%d.%d", i>>16&0xff, i>>8&0xff, i&0xff),
+			PeerIP:    fmt.Sprintf("10.%d.%d.%d", i>>16&0xff, i>>8&0xff, i&0xff), //nolint:staticcheck
 			Direction: mgmProto.RuleDirection_IN,
 			Action:    mgmProto.RuleAction_ACCEPT,
 			Protocol:  mgmProto.RuleProtocol_TCP,

--- a/client/internal/dns/host_windows.go
+++ b/client/internal/dns/host_windows.go
@@ -459,7 +459,7 @@ func (r *registryConfigurator) flushDNSCache() {
 
 	ret, _, err := dnsFlushResolverCacheFn.Call()
 	if ret == 0 {
-		if err != nil && !errors.Is(err, syscall.Errno(0)) {
+		if !errors.Is(err, syscall.Errno(0)) {
 			log.Errorf("DnsFlushResolverCache failed: %v", err)
 			return
 		}
@@ -627,7 +627,7 @@ func refreshGroupPolicy() error {
 	)
 
 	if ret == 0 {
-		if err != nil && !errors.Is(err, syscall.Errno(0)) {
+		if !errors.Is(err, syscall.Errno(0)) {
 			return fmt.Errorf("RefreshPolicyEx failed: %w", err)
 		}
 		return fmt.Errorf("RefreshPolicyEx failed")

--- a/client/internal/dnsfwd/manager.go
+++ b/client/internal/dnsfwd/manager.go
@@ -101,7 +101,7 @@ func (m *Manager) Start(fwdEntries []*ForwarderEntry) error {
 	m.dnsForwarder = NewDNSForwarder(listenAddress, dnsTTL, m.firewall, m.statusRecorder, m.wgIface)
 
 	go func() {
-		if err := m.dnsForwarder.Listen(fwdEntries); err != nil {
+		if err := m.dnsForwarder.Listen(fwdEntries); err != nil { //nolint:staticcheck
 			// todo handle close error if it is exists
 			log.Errorf("failed to start DNS forwarder, err: %v", err)
 		}

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -2572,7 +2572,7 @@ func (e *Engine) SetCapture(pc device.PacketCapture) error {
 	}
 
 	afc := capture.NewAFPacketCapture(intf.Name(), sess)
-	if err := afc.Start(); err != nil {
+	if err := afc.Start(); err != nil { //nolint:staticcheck // always errors on non-Linux builds
 		return fmt.Errorf("start AF_PACKET capture on %s: %w", intf.Name(), err)
 	}
 	e.afpacketCapture = afc

--- a/client/internal/sleep/service.go
+++ b/client/internal/sleep/service.go
@@ -18,8 +18,8 @@ type Service struct {
 }
 
 func New() (*Service, error) {
-	d, err := NewDetector()
-	if err != nil {
+	d, err := NewDetector() //nolint:staticcheck
+	if err != nil {         //nolint:staticcheck // always errors on platforms without a sleep detector
 		return nil, err
 	}
 

--- a/client/internal/updater/manager.go
+++ b/client/internal/updater/manager.go
@@ -435,7 +435,7 @@ func (m *Manager) install(ctx context.Context, pendingVersion *v.Version) error 
 	}
 
 	inst := installer.New()
-	if err := inst.RunInstallation(ctx, pendingVersion.String()); err != nil {
+	if err := inst.RunInstallation(ctx, pendingVersion.String()); err != nil { //nolint:staticcheck // always errors on platforms without an installer
 		log.Errorf("error triggering update: %v", err)
 		m.statusRecorder.PublishEvent(
 			cProto.SystemEvent_ERROR,

--- a/client/server/panic_windows.go
+++ b/client/server/panic_windows.go
@@ -3,6 +3,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -69,7 +70,7 @@ func setStdHandle(f *os.File) error {
 	handle := f.Fd()
 	r0, _, e1 := setStdHandleFn.Call(stdErrorHandle, handle)
 	if r0 == 0 {
-		if e1 != nil {
+		if !errors.Is(e1, syscall.Errno(0)) {
 			return e1
 		}
 		return syscall.EINVAL

--- a/client/ssh/server/command_execution.go
+++ b/client/ssh/server/command_execution.go
@@ -75,8 +75,8 @@ func (s *Server) createCommand(logger *log.Entry, privilegeResult PrivilegeCheck
 	}
 
 	// Try su first for system integration (PAM/audit) when privileged
-	cmd, err := s.createSuCommand(logger, session, localUser, hasPty)
-	if err != nil || privilegeResult.UsedFallback {
+	cmd, err := s.createSuCommand(logger, session, localUser, hasPty) //nolint:staticcheck
+	if err != nil || privilegeResult.UsedFallback {                   //nolint:staticcheck // always errors on platforms without su
 		logger.Debugf("su command failed, falling back to executor: %v", err)
 		cmd, cleanup, err := s.createExecutorCommand(logger, session, localUser, hasPty)
 		if err != nil {

--- a/flow/client/client.go
+++ b/flow/client/client.go
@@ -146,9 +146,13 @@ func (c *GRPCClient) Receive(ctx context.Context, interval time.Duration, msgHan
 
 		streamStart := time.Now()
 
-		// receive blocks until the stream breaks and always returns a non-nil error
+		// receive always returns a non-nil error once the stream breaks;
+		// handleRetryableError decides between reconnecting and exiting
+		// permanently on local context cancellation
 		err = c.receive(stream, msgHandler)
-		log.Errorf("receive failed: %v", err)
+		if !isContextDone(err) {
+			log.Errorf("receive failed: %v", err)
+		}
 		return c.handleRetryableError(err, streamStart, backOff)
 	}
 

--- a/flow/client/client.go
+++ b/flow/client/client.go
@@ -146,11 +146,10 @@ func (c *GRPCClient) Receive(ctx context.Context, interval time.Duration, msgHan
 
 		streamStart := time.Now()
 
-		if err := c.receive(stream, msgHandler); err != nil {
-			log.Errorf("receive failed: %v", err)
-			return c.handleRetryableError(err, streamStart, backOff)
-		}
-		return nil
+		// receive blocks until the stream breaks and always returns a non-nil error
+		err = c.receive(stream, msgHandler)
+		log.Errorf("receive failed: %v", err)
+		return c.handleRetryableError(err, streamStart, backOff)
 	}
 
 	if err := backoff.Retry(operation, backOff); err != nil {

--- a/sharedsock/example/main.go
+++ b/sharedsock/example/main.go
@@ -14,8 +14,8 @@ import (
 func main() {
 
 	port := 51820
-	rawSock, err := sharedsock.Listen(port, sharedsock.NewIncomingSTUNFilter(), iface.DefaultMTU)
-	if err != nil {
+	rawSock, err := sharedsock.Listen(port, sharedsock.NewIncomingSTUNFilter(), iface.DefaultMTU) //nolint:staticcheck
+	if err != nil {                                                                               //nolint:staticcheck // always errors on non-Linux builds
 		panic(err)
 	}
 

--- a/util/file.go
+++ b/util/file.go
@@ -26,7 +26,7 @@ func WriteBytesWithRestrictedPermission(ctx context.Context, file string, bs []b
 		return fmt.Errorf("enforce permission: %w", err)
 	}
 
-	return writeBytes(ctx, file, err, configDir, configFileName, bs)
+	return writeBytes(ctx, file, configDir, configFileName, bs)
 }
 
 // WriteJsonWithRestrictedPermission writes JSON config object to a file. Enforces permission on the parent directory
@@ -106,10 +106,10 @@ func writeJson(ctx context.Context, file string, obj interface{}, configDir stri
 		return fmt.Errorf("marshal: %w", err)
 	}
 
-	return writeBytes(ctx, file, err, configDir, configFileName, bs)
+	return writeBytes(ctx, file, configDir, configFileName, bs)
 }
 
-func writeBytes(ctx context.Context, file string, err error, configDir string, configFileName string, bs []byte) error {
+func writeBytes(ctx context.Context, file string, configDir string, configFileName string, bs []byte) error {
 	if ctx.Err() != nil {
 		return fmt.Errorf("write bytes start: %w", ctx.Err())
 	}


### PR DESCRIPTION
## Describe your changes

Fixes the remaining findings from the updated golangci-lint (staticcheck), stacked on #7261. Verified locally with golangci-lint 2.13.0 on GOOS linux, windows, and darwin.

Real fixes:
- `util/file.go`: removed the dead `err` parameter from `writeBytes` (SA4009, it was overwritten before first use).
- `flow/client/client.go`: `receive` blocks until the stream breaks and always returns a non-nil error, so the dead nil branch is gone and the error is passed to the retry handler directly (SA4023).
- `client/internal/dns/host_windows.go`, `client/server/panic_windows.go`: `LazyProc.Call` always returns a non-nil error (`Errno(0)` on success), so the `err != nil` checks were dead; the `errors.Is(err, syscall.Errno(0))` test alone decides (SA4023).

Suppressions (`//nolint:staticcheck`):
- Deprecated proto field `FirewallRule.PeerIP` in `client/internal/acl` (SA1019), kept for compatibility with old management, same as #7261.
- Call sites of per-platform stubs that constantly error (named pipes on non-Windows, sleep detector, updater installer, AF_PACKET capture and sharedsock on non-Linux, `su` on Windows) and the nil-returning IPC credentials stub: the comparison is provably constant on one GOOS but live on the others, so the check stays (SA4023).
- `dnsfwd.Manager`: staticcheck concludes `DNSForwarder.Listen` never returns nil; the guard stays in case the underlying DNS server gains a graceful nil return (SA4023).

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (lint fixes only, no behavior change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows DNS cache and group policy failure detection.
  - Improved Windows standard-handle error reporting.
  - Reduced unnecessary error logging during locally cancelled or expired connection receives.

- **Refactor**
  - Simplified internal file-writing calls without changing supported behavior.

- **Chores**
  - Cleaned up code quality annotations and formatting across networking, ACL, update, sleep, and service components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->