### PR TITLE
[client] Add a lazy-connection override and device name reporting to the WASM client

### DIFF
--- a/client/embed/embed.go
+++ b/client/embed/embed.go
@@ -91,6 +91,13 @@ type Options struct {
 	// when the embedded client must never act as a stepping stone into
 	// the host's local network (e.g. the proxy's overlay peer).
 	BlockLANAccess bool
+	// LazyConnectionEnabled is a tri-state local override for lazy connections,
+	// mirroring the NB_LAZY_CONN env var. Nil defers to the management feature
+	// flag; a set value overrides it in both directions. A short-lived,
+	// purpose-built client (such as the browser portal) reaches only the few
+	// peers its grant covers and sets this to false, so its peers connect eagerly
+	// and the first request does not pay for the connection being established.
+	LazyConnectionEnabled *bool
 	// WireguardPort is the port for the tunnel interface. Use 0 for a random port.
 	WireguardPort *int
 	// MTU is the MTU for the tunnel interface.
@@ -218,6 +225,15 @@ func New(opts Options) (*Client, error) {
 
 	if opts.PrivateKey != "" {
 		config.PrivateKey = opts.PrivateKey
+	}
+
+	if opts.LazyConnectionEnabled != nil {
+		// Runtime-only override, read back through lazyconn.ParseState; a set value
+		// wins over the management feature flag in both directions.
+		config.LazyConnection = "off"
+		if *opts.LazyConnectionEnabled {
+			config.LazyConnection = "on"
+		}
 	}
 
 	if opts.Performance.PreallocatedBuffersPerPool != nil {

--- a/client/embed/embed.go
+++ b/client/embed/embed.go
@@ -93,10 +93,10 @@ type Options struct {
 	BlockLANAccess bool
 	// LazyConnectionEnabled is a tri-state local override for lazy connections,
 	// mirroring the NB_LAZY_CONN env var. Nil defers to the management feature
-	// flag; a set value overrides it in both directions. A short-lived,
-	// purpose-built client (such as the browser portal) reaches only the few
-	// peers its grant covers and sets this to false, so its peers connect eagerly
-	// and the first request does not pay for the connection being established.
+	// flag; a set value overrides it in both directions. A short-lived client
+	// that reaches only a few known peers can set this to false, so its peers
+	// connect eagerly and the first request does not wait for the connection to
+	// be established.
 	LazyConnectionEnabled *bool
 	// WireguardPort is the port for the tunnel interface. Use 0 for a random port.
 	WireguardPort *int

--- a/client/system/info_js.go
+++ b/client/system/info_js.go
@@ -15,7 +15,7 @@ func UpdateStaticInfoAsync() {
 }
 
 // GetInfo retrieves system information for WASM environment
-func GetInfo(_ context.Context) *Info {
+func GetInfo(ctx context.Context) *Info {
 	info := &Info{
 		GoOS:           runtime.GOOS,
 		Kernel:         runtime.GOARCH,
@@ -30,6 +30,13 @@ func GetInfo(_ context.Context) *Info {
 	collectBrowserInfo(info)
 	collectLocationInfo(info)
 	collectSystemInfo(info)
+
+	// A caller-provided device name wins, as on the other platforms. A peer
+	// registered over an API keeps reporting the name it was registered with,
+	// so its meta does not change on the first sync.
+	if name := extractDeviceName(ctx, info.Hostname); name != "" {
+		info.Hostname = name
+	}
 	return info
 }
 

--- a/client/system/info_js_test.go
+++ b/client/system/info_js_test.go
@@ -1,0 +1,27 @@
+//go:build js
+
+package system
+
+import (
+	"context"
+	"testing"
+)
+
+// TestGetInfoHonorsDeviceName covers a caller-provided device name reaching the
+// reported hostname, so a peer registered over an API keeps reporting the name
+// it was registered with instead of renaming itself on its first sync.
+func TestGetInfoHonorsDeviceName(t *testing.T) {
+	ctx := context.WithValue(context.Background(), DeviceNameCtxKey, "session-name")
+	if got := GetInfo(ctx).Hostname; got != "session-name" {
+		t.Errorf("hostname should carry the caller's device name, got %q", got)
+	}
+}
+
+// TestGetInfoWithoutDeviceNameKeepsFallback covers the embed layer's habit of
+// always setting the context value: an empty name must not blank the hostname.
+func TestGetInfoWithoutDeviceNameKeepsFallback(t *testing.T) {
+	ctx := context.WithValue(context.Background(), DeviceNameCtxKey, "")
+	if got := GetInfo(ctx).Hostname; got == "" {
+		t.Error("an empty device name must not blank the hostname")
+	}
+}

--- a/client/system/process_test.go
+++ b/client/system/process_test.go
@@ -1,3 +1,5 @@
+//go:build windows || (linux && !android) || (darwin && !ios) || freebsd
+
 package system
 
 import (

--- a/client/wasm/cmd/main.go
+++ b/client/wasm/cmd/main.go
@@ -56,7 +56,7 @@ func startClient(ctx context.Context, nbClient *netbird.Client) error {
 // parseClientOptions extracts NetBird options from JavaScript object
 func parseClientOptions(jsOptions js.Value) (netbird.Options, error) {
 	options := netbird.Options{
-		DeviceName: "dashboard-client",
+		DeviceName: "wasm-client",
 		LogLevel:   defaultLogLevel,
 	}
 
@@ -89,6 +89,15 @@ func parseClientOptions(jsOptions js.Value) (netbird.Options, error) {
 
 	if disableIPv6 := jsOptions.Get("disableIPv6"); !disableIPv6.IsNull() && !disableIPv6.IsUndefined() {
 		options.DisableIPv6 = disableIPv6.Bool()
+	}
+
+	// The caller decides whether this client uses lazy connections; left unset it
+	// defers to the management feature flag. A short-lived, interactive caller
+	// turns it off so its sessions reach the few peers their grant covers eagerly,
+	// instead of the first request waiting for the connection to be established.
+	if v := jsOptions.Get("lazyConnectionEnabled"); !v.IsNull() && !v.IsUndefined() {
+		lazyConnectionEnabled := v.Bool()
+		options.LazyConnectionEnabled = &lazyConnectionEnabled
 	}
 
 	return options, nil

--- a/client/wasm/cmd/main.go
+++ b/client/wasm/cmd/main.go
@@ -86,20 +86,39 @@ func parseClientOptions(jsOptions js.Value) (netbird.Options, error) {
 		options.DeviceName = deviceName.String()
 	}
 
-	if disableIPv6 := jsOptions.Get("disableIPv6"); !disableIPv6.IsNull() && !disableIPv6.IsUndefined() {
-		options.DisableIPv6 = disableIPv6.Bool()
+	disableIPv6, err := boolOption(jsOptions, "disableIPv6")
+	if err != nil {
+		return options, err
+	}
+	if disableIPv6 != nil {
+		options.DisableIPv6 = *disableIPv6
 	}
 
 	// The caller decides whether this client uses lazy connections; left unset it
 	// defers to the management feature flag. A short-lived, interactive caller
 	// turns it off so its sessions reach the few peers their grant covers eagerly,
 	// instead of the first request waiting for the connection to be established.
-	if v := jsOptions.Get("lazyConnectionEnabled"); !v.IsNull() && !v.IsUndefined() {
-		lazyConnectionEnabled := v.Bool()
-		options.LazyConnectionEnabled = &lazyConnectionEnabled
+	lazyConnectionEnabled, err := boolOption(jsOptions, "lazyConnectionEnabled")
+	if err != nil {
+		return options, err
 	}
+	options.LazyConnectionEnabled = lazyConnectionEnabled
 
 	return options, nil
+}
+
+// boolOption reads a boolean option, returning nil when the caller left it out.
+// js.Value.Bool panics on any other type, so a wrong type is reported instead.
+func boolOption(jsOptions js.Value, name string) (*bool, error) {
+	v := jsOptions.Get(name)
+	if v.IsNull() || v.IsUndefined() {
+		return nil, nil
+	}
+	if v.Type() != js.TypeBoolean {
+		return nil, fmt.Errorf("option %s must be a boolean, got %s", name, v.Type())
+	}
+	b := v.Bool()
+	return &b, nil
 }
 
 // createStartMethod creates the start method for the client

--- a/client/wasm/cmd/main.go
+++ b/client/wasm/cmd/main.go
@@ -56,8 +56,7 @@ func startClient(ctx context.Context, nbClient *netbird.Client) error {
 // parseClientOptions extracts NetBird options from JavaScript object
 func parseClientOptions(jsOptions js.Value) (netbird.Options, error) {
 	options := netbird.Options{
-		DeviceName: "wasm-client",
-		LogLevel:   defaultLogLevel,
+		LogLevel: defaultLogLevel,
 	}
 
 	if jwtToken := jsOptions.Get("jwtToken"); !jwtToken.IsNull() && !jwtToken.IsUndefined() {

--- a/client/wasm/cmd/main_test.go
+++ b/client/wasm/cmd/main_test.go
@@ -1,0 +1,64 @@
+//go:build js
+
+package main
+
+import (
+	"syscall/js"
+	"testing"
+)
+
+// TestParseClientOptionsBooleans covers the boolean options against the value
+// kinds a JS caller can pass: js.Value.Bool panics on anything but a boolean,
+// so a wrong type has to be rejected before it reaches the client.
+func TestParseClientOptionsBooleans(t *testing.T) {
+	t.Run("unset leaves the lazy override empty", func(t *testing.T) {
+		options, err := parseClientOptions(js.Global().Get("Object").New())
+		if err != nil {
+			t.Fatalf("parse options: %v", err)
+		}
+		if options.LazyConnectionEnabled != nil {
+			t.Errorf("lazy override should stay unset, got %v", *options.LazyConnectionEnabled)
+		}
+		if options.DisableIPv6 {
+			t.Error("disableIPv6 should default to false")
+		}
+	})
+
+	t.Run("null defers to the management flag", func(t *testing.T) {
+		jsOptions := js.Global().Get("Object").New()
+		jsOptions.Set("lazyConnectionEnabled", js.Null())
+		options, err := parseClientOptions(jsOptions)
+		if err != nil {
+			t.Fatalf("parse options: %v", err)
+		}
+		if options.LazyConnectionEnabled != nil {
+			t.Errorf("lazy override should stay unset, got %v", *options.LazyConnectionEnabled)
+		}
+	})
+
+	t.Run("booleans are carried through", func(t *testing.T) {
+		jsOptions := js.Global().Get("Object").New()
+		jsOptions.Set("lazyConnectionEnabled", false)
+		jsOptions.Set("disableIPv6", true)
+		options, err := parseClientOptions(jsOptions)
+		if err != nil {
+			t.Fatalf("parse options: %v", err)
+		}
+		if options.LazyConnectionEnabled == nil || *options.LazyConnectionEnabled {
+			t.Errorf("lazy override should be false, got %v", options.LazyConnectionEnabled)
+		}
+		if !options.DisableIPv6 {
+			t.Error("disableIPv6 should be true")
+		}
+	})
+
+	t.Run("a non-boolean is rejected", func(t *testing.T) {
+		for _, value := range []any{"true", 1, js.Global().Get("Object").New()} {
+			jsOptions := js.Global().Get("Object").New()
+			jsOptions.Set("lazyConnectionEnabled", value)
+			if _, err := parseClientOptions(jsOptions); err == nil {
+				t.Errorf("value %v should be rejected", value)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Describe your changes

Two additions to the embedded and WASM client API for callers that manage their peers programmatically:

- A tri-state lazy-connection override (`LazyConnectionEnabled *bool` in the embed options, `lazyConnectionEnabled` in the WASM options): unset defers to the management feature flag as before, and a caller can force it on or off for clients whose traffic pattern is known, such as a browser session whose first action needs the tunnel up
- The caller-provided device name now reaches the hostname the WASM client reports in its meta. A peer registered over an API keeps reporting the name it was registered with instead of renaming itself on its first sync, which also pushed a needless network map to every peer in the account
- The process check test file now carries the same build constraint as the code it tests, so the system package builds as a js test target

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (embed/WASM client options consumed by the dashboard, no end-user surface)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to enable or disable lazy connections during client configuration.
  * WebAssembly clients can provide a custom device name and lazy-connection preference.
  * Omitted settings now preserve existing configuration.

* **Bug Fixes**
  * Preserved caller-provided device names during initial synchronization.
  * Retained hostname fallback behavior when no device name is supplied.
  * Invalid non-boolean option values are now rejected.

* **Tests**
  * Added coverage for option parsing, device names, and supported platform behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->