### PR TITLE
[client] Make dynamic route cleanup ordered and retryable

### DIFF
--- a/client/internal/routemanager/client/client.go
+++ b/client/internal/routemanager/client/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/netip"
 	"reflect"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -81,6 +82,9 @@ type Watcher struct {
 	currentChosenStatus *routerPeerStatus
 	handler             RouteHandler
 	updateSerial        uint64
+	runOnce             sync.Once
+	stopOnce            sync.Once
+	done                chan struct{}
 }
 
 func NewWatcher(config WatcherConfig) *Watcher {
@@ -97,6 +101,7 @@ func NewWatcher(config WatcherConfig) *Watcher {
 		peerStateUpdate:     make(chan map[string]peer.RouterState),
 		handler:             config.Handler,
 		currentChosenStatus: nil,
+		done:                make(chan struct{}),
 	}
 	return client
 }
@@ -503,24 +508,27 @@ func (w *Watcher) classifyUpdate(update RoutesUpdate) bool {
 // Start is the main point of reacting on client network routing events.
 // All the processing related to the client network should be done here. Thread-safe.
 func (w *Watcher) Start() {
-	for {
-		select {
-		case <-w.ctx.Done():
-			return
-		case routersStates := <-w.peerStateUpdate:
-			routerPeerStatuses := w.convertRouterPeerStatuses(routersStates)
-			if err := w.recalculateRoutes(reasonPeerUpdate, routerPeerStatuses); err != nil {
-				log.Errorf("Failed to recalculate routes for network [%v]: %v", w.handler, err)
-			}
-		case update := <-w.routeUpdate:
-			if update.UpdateSerial < w.updateSerial {
-				log.Warnf("Received a routes update with smaller serial number (%d -> %d), ignoring it", w.updateSerial, update.UpdateSerial)
-				continue
-			}
+	w.runOnce.Do(func() {
+		defer close(w.done)
+		for {
+			select {
+			case <-w.ctx.Done():
+				return
+			case routersStates := <-w.peerStateUpdate:
+				routerPeerStatuses := w.convertRouterPeerStatuses(routersStates)
+				if err := w.recalculateRoutes(reasonPeerUpdate, routerPeerStatuses); err != nil {
+					log.Errorf("Failed to recalculate routes for network [%v]: %v", w.handler, err)
+				}
+			case update := <-w.routeUpdate:
+				if update.UpdateSerial < w.updateSerial {
+					log.Warnf("Received a routes update with smaller serial number (%d -> %d), ignoring it", w.updateSerial, update.UpdateSerial)
+					continue
+				}
 
-			w.handleRouteUpdate(update)
+				w.handleRouteUpdate(update)
+			}
 		}
-	}
+	})
 }
 
 func (w *Watcher) handleRouteUpdate(update RoutesUpdate) {
@@ -546,17 +554,21 @@ func (w *Watcher) handleRouteUpdate(update RoutesUpdate) {
 
 // Stop stops the watcher and cleans up resources.
 func (w *Watcher) Stop() {
-	log.Debugf("Stopping watcher for network [%v]", w.handler)
+	w.stopOnce.Do(func() {
+		log.Debugf("Stopping watcher for network [%v]", w.handler)
 
-	w.cancel()
+		w.cancel()
+		w.runOnce.Do(func() { close(w.done) })
+		<-w.done
 
-	if w.currentChosen == nil {
-		return
-	}
-	if err := w.removeAllowedIPs(w.currentChosen, reasonShutdown); err != nil {
-		log.Errorf("Failed to remove routes for [%v]: %v", w.handler, err)
-	}
-	w.currentChosenStatus = nil
+		if w.currentChosen != nil {
+			if err := w.removeAllowedIPs(w.currentChosen, reasonShutdown); err != nil {
+				log.Errorf("Failed to remove routes for [%v]: %v", w.handler, err)
+			}
+		}
+		w.currentChosen = nil
+		w.currentChosenStatus = nil
+	})
 }
 
 func HandlerFromRoute(params common.HandlerParams) RouteHandler {

--- a/client/internal/routemanager/client/client_test.go
+++ b/client/internal/routemanager/client/client_test.go
@@ -1,16 +1,104 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/netip"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/routemanager/common"
 	"github.com/netbirdio/netbird/client/internal/routemanager/static"
 	"github.com/netbirdio/netbird/route"
 )
+
+type blockingRemoveHandler struct {
+	removeStarted chan struct{}
+	releaseRemove chan struct{}
+	mu            sync.Mutex
+	removeCalls   int
+}
+
+func (h *blockingRemoveHandler) String() string                 { return "test route" }
+func (h *blockingRemoveHandler) AddRoute(context.Context) error { return nil }
+func (h *blockingRemoveHandler) RemoveRoute() error             { return nil }
+func (h *blockingRemoveHandler) AddAllowedIPs(string) error     { return nil }
+func (h *blockingRemoveHandler) RemoveAllowedIPs() error {
+	h.mu.Lock()
+	h.removeCalls++
+	h.mu.Unlock()
+	close(h.removeStarted)
+	<-h.releaseRemove
+	return nil
+}
+
+func (h *blockingRemoveHandler) removals() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.removeCalls
+}
+
+func TestWatcherStopWaitsForRunningRemoval(t *testing.T) {
+	handler := &blockingRemoveHandler{
+		removeStarted: make(chan struct{}),
+		releaseRemove: make(chan struct{}),
+	}
+	w := NewWatcher(WatcherConfig{
+		Context:        context.Background(),
+		StatusRecorder: peer.NewRecorder("https://mgm"),
+		Handler:        handler,
+	})
+	w.currentChosen = &route.Route{ID: "route", Peer: "peer"}
+
+	go w.Start()
+	w.peerStateUpdate <- map[string]peer.RouterState{}
+	select {
+	case <-handler.removeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not begin removing allowed IPs")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		w.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned before the running removal completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(handler.releaseRemove)
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after the running removal completed")
+	}
+	assert.Equal(t, 1, handler.removals(), "Stop must not remove allowed IPs twice")
+	w.Stop()
+	assert.Equal(t, 1, handler.removals(), "a repeated Stop must not remove allowed IPs again")
+}
+
+func TestWatcherStopBeforeStartDoesNotBlock(t *testing.T) {
+	w := NewWatcher(WatcherConfig{Context: context.Background()})
+	w.Stop()
+
+	started := make(chan struct{})
+	go func() {
+		w.Start()
+		close(started)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("Start blocked after Stop ran first")
+	}
+}
 
 func TestGetBestrouteFromStatuses(t *testing.T) {
 	testCases := []struct {

--- a/client/internal/routemanager/client_networks_test.go
+++ b/client/internal/routemanager/client_networks_test.go
@@ -1,0 +1,38 @@
+package routemanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netbirdio/netbird/client/internal/routemanager/client"
+	"github.com/netbirdio/netbird/route"
+)
+
+// TestUpdateClientNetworksDoesNotStopObsoleteClients pins down that updateClientNetworks no
+// longer stops obsolete watchers itself - that responsibility moved to the caller (UpdateRoutes),
+// which must now call stopObsoleteClients before updateSystemRoutes so a dynamic route's allowed
+// IPs are released before its handler's state is wiped. This test only checks that
+// updateClientNetworks leaves obsolete entries alone; it does NOT cover the ordering against
+// updateSystemRoutes in UpdateRoutes itself.
+func TestUpdateClientNetworksDoesNotStopObsoleteClients(t *testing.T) {
+	id := route.HAUniqueID("net1||10.0.0.0/24")
+	watcher := client.NewWatcher(client.WatcherConfig{Context: context.Background()})
+
+	m := &DefaultManager{
+		clientNetworks: map[route.HAUniqueID]*client.Watcher{
+			id: watcher,
+		},
+		activeRoutes: map[route.HAUniqueID]client.RouteHandler{},
+	}
+
+	// networks no longer contains id, but updateClientNetworks must not touch it.
+	m.updateClientNetworks(1, route.HAMap{})
+
+	assert.Contains(t, m.clientNetworks, id, "updateClientNetworks must leave obsolete watchers for the caller to stop")
+
+	m.stopObsoleteClients(route.HAMap{})
+
+	assert.NotContains(t, m.clientNetworks, id, "stopObsoleteClients must remove the obsolete watcher")
+}

--- a/client/internal/routemanager/client_networks_test.go
+++ b/client/internal/routemanager/client_networks_test.go
@@ -10,12 +10,9 @@ import (
 	"github.com/netbirdio/netbird/route"
 )
 
-// TestUpdateClientNetworksDoesNotStopObsoleteClients pins down that updateClientNetworks no
-// longer stops obsolete watchers itself - that responsibility moved to the caller (UpdateRoutes),
-// which must now call stopObsoleteClients before updateSystemRoutes so a dynamic route's allowed
-// IPs are released before its handler's state is wiped. This test only checks that
-// updateClientNetworks leaves obsolete entries alone; it does NOT cover the ordering against
-// updateSystemRoutes in UpdateRoutes itself.
+// updateClientNetworks no longer stops obsolete watchers itself. That moved to the
+// caller, which must stop them before updateSystemRoutes so a dynamic route releases
+// its allowed IPs before its state is wiped. Only the move is pinned here.
 func TestUpdateClientNetworksDoesNotStopObsoleteClients(t *testing.T) {
 	id := route.HAUniqueID("net1||10.0.0.0/24")
 	watcher := client.NewWatcher(client.WatcherConfig{Context: context.Background()})

--- a/client/internal/routemanager/dnsinterceptor/handler.go
+++ b/client/internal/routemanager/dnsinterceptor/handler.go
@@ -93,7 +93,10 @@ func (d *DnsInterceptor) RemoveRoute() error {
 				merr = multierror.Append(merr, fmt.Errorf("remove dynamic route for IP %s: %v", routePrefix, err))
 			}
 
-			// AllowedIPs should use real IPs
+			// AllowedIPs should use real IPs.
+			// RemoveAllowedIPs clears the peer key, and the manager now calls it
+			// before RemoveRoute, so this guard is what keeps the prefixes from
+			// being decremented a second time. Do not drop it as dead defence.
 			if d.currentPeerKey != "" {
 				if _, err := d.allowedIPsRefcounter.Decrement(prefix, d.currentPeerKey); err != nil {
 					merr = multierror.Append(merr, fmt.Errorf("remove allowed IP %s: %v", prefix, err))

--- a/client/internal/routemanager/dynamic/route.go
+++ b/client/internal/routemanager/dynamic/route.go
@@ -86,7 +86,10 @@ func (r *Route) AddRoute(ctx context.Context) error {
 }
 
 // RemoveRoute will stop the dynamic resolver and remove all dynamic routes.
-// It doesn't touch allowed IPs, these should be removed separately and before calling this method.
+// Allowed IPs should preferably be removed separately, via an explicit call to
+// RemoveAllowedIPs(), before calling this method. RemoveRoute now releases any
+// allowed IPs still held as a safety net, since it clears dynamicDomains - the
+// state RemoveAllowedIPs() relies on to know what to decrement.
 func (r *Route) RemoveRoute() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -96,6 +99,16 @@ func (r *Route) RemoveRoute() error {
 	}
 
 	var merr *multierror.Error
+
+	// Only logged, never returned: this is a safety net that fires solely when a call site
+	// skipped RemoveAllowedIPs(), and updateSystemRoutes() discards the whole pending DNS
+	// batch on any error returned from here - including config for routes just added.
+	// Allowed IP release failures never reached that error path before (client.Watcher logs
+	// them too), so don't open the channel now.
+	if err := r.releaseAllowedIPsLocked(); err != nil {
+		log.Errorf("Failed to release allowed IPs for route [%v]: %v", r, err)
+	}
+
 	for domain, prefixes := range r.dynamicDomains {
 		for _, prefix := range prefixes {
 			if _, err := r.routeRefCounter.Decrement(prefix); err != nil {
@@ -131,6 +144,19 @@ func (r *Route) AddAllowedIPs(peerKey string) error {
 func (r *Route) RemoveAllowedIPs() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	return r.releaseAllowedIPsLocked()
+}
+
+// releaseAllowedIPsLocked decrements the allowed IPs refcounter for every prefix currently
+// tracked in dynamicDomains and clears currentPeerKey. Callers must already hold r.mu - it is
+// used both from RemoveAllowedIPs (which locks itself) and from RemoveRoute (which already
+// holds the lock from its start), so this method must never lock r.mu itself.
+// If currentPeerKey is empty, allowed IPs were already released (or never taken), so it's a no-op.
+func (r *Route) releaseAllowedIPsLocked() error {
+	if r.currentPeerKey == "" {
+		return nil
+	}
 
 	var merr *multierror.Error
 	for _, domainPrefixes := range r.dynamicDomains {

--- a/client/internal/routemanager/dynamic/route.go
+++ b/client/internal/routemanager/dynamic/route.go
@@ -86,10 +86,9 @@ func (r *Route) AddRoute(ctx context.Context) error {
 }
 
 // RemoveRoute will stop the dynamic resolver and remove all dynamic routes.
-// Allowed IPs should preferably be removed separately, via an explicit call to
-// RemoveAllowedIPs(), before calling this method. RemoveRoute now releases any
-// allowed IPs still held as a safety net, since it clears dynamicDomains - the
-// state RemoveAllowedIPs() relies on to know what to decrement.
+// Allowed IPs should preferably be removed separately, via RemoveAllowedIPs(),
+// before this method. RemoveRoute releases any still held as a safety net, since
+// it clears dynamicDomains, the state RemoveAllowedIPs() needs to know what to drop.
 func (r *Route) RemoveRoute() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -100,11 +99,9 @@ func (r *Route) RemoveRoute() error {
 
 	var merr *multierror.Error
 
-	// Only logged, never returned: this is a safety net that fires solely when a call site
-	// skipped RemoveAllowedIPs(), and updateSystemRoutes() discards the whole pending DNS
-	// batch on any error returned from here - including config for routes just added.
-	// Allowed IP release failures never reached that error path before (client.Watcher logs
-	// them too), so don't open the channel now.
+	// Only logged, never returned: updateSystemRoutes() drops the whole pending DNS batch
+	// on any error from here, and allowed IP release failures never reached that path
+	// before, so don't open it now.
 	if err := r.releaseAllowedIPsLocked(); err != nil {
 		log.Errorf("Failed to release allowed IPs for route [%v]: %v", r, err)
 	}
@@ -148,11 +145,9 @@ func (r *Route) RemoveAllowedIPs() error {
 	return r.releaseAllowedIPsLocked()
 }
 
-// releaseAllowedIPsLocked decrements the allowed IPs refcounter for every prefix currently
-// tracked in dynamicDomains and clears currentPeerKey. Callers must already hold r.mu - it is
-// used both from RemoveAllowedIPs (which locks itself) and from RemoveRoute (which already
-// holds the lock from its start), so this method must never lock r.mu itself.
-// If currentPeerKey is empty, allowed IPs were already released (or never taken), so it's a no-op.
+// releaseAllowedIPsLocked decrements the allowed IPs refcounter for every prefix in
+// dynamicDomains and clears currentPeerKey. The caller must hold r.mu. An empty
+// currentPeerKey means they are already released, so it is a no-op.
 func (r *Route) releaseAllowedIPsLocked() error {
 	if r.currentPeerKey == "" {
 		return nil

--- a/client/internal/routemanager/dynamic/route.go
+++ b/client/internal/routemanager/dynamic/route.go
@@ -33,6 +33,11 @@ const (
 
 type domainMap map[domain.Domain][]netip.Prefix
 
+type allowedIPRef struct {
+	prefix  netip.Prefix
+	peerKey string
+}
+
 type resolveResult struct {
 	domain domain.Domain
 	prefix netip.Prefix
@@ -45,6 +50,8 @@ type Route struct {
 	allowedIPsRefcounter *refcounter.AllowedIPsRefCounter
 	interval             time.Duration
 	dynamicDomains       domainMap
+	allowedIPRefs        map[allowedIPRef]int
+	pendingAllowedIPRefs map[allowedIPRef]struct{}
 	mu                   sync.Mutex
 	currentPeerKey       string
 	cancel               context.CancelFunc
@@ -63,6 +70,8 @@ func NewRoute(params common.HandlerParams, resolverAddr netip.AddrPort) *Route {
 		wgInterface:          params.WgInterface,
 		resolverAddr:         resolverAddr,
 		dynamicDomains:       domainMap{},
+		allowedIPRefs:        map[allowedIPRef]int{},
+		pendingAllowedIPRefs: map[allowedIPRef]struct{}{},
 	}
 }
 
@@ -146,19 +155,17 @@ func (r *Route) RemoveAllowedIPs() error {
 	return r.releaseAllowedIPsLocked()
 }
 
-// releaseAllowedIPsLocked decrements the allowed IPs refcounter for every prefix in
-// dynamicDomains. The caller must hold r.mu. An empty currentPeerKey means they are
-// already released, so it is a no-op.
+// releaseAllowedIPsLocked releases every allowed IP reference owned by this route.
+// The caller must hold r.mu.
 func (r *Route) releaseAllowedIPsLocked() error {
-	if r.currentPeerKey == "" {
-		return nil
-	}
-
 	var merr *multierror.Error
-	for _, domainPrefixes := range r.dynamicDomains {
-		for _, prefix := range domainPrefixes {
-			if _, err := r.allowedIPsRefcounter.Decrement(prefix, r.currentPeerKey); err != nil {
-				merr = multierror.Append(merr, fmt.Errorf("remove allowed IP %s: %w", prefix, err))
+	if err := r.retryPendingAllowedIPsLocked(); err != nil {
+		merr = multierror.Append(merr, err)
+	}
+	for ref, count := range r.allowedIPRefs {
+		for range count {
+			if err := r.releaseAllowedIPLocked(ref); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("remove allowed IP %s: %w", ref.prefix, err))
 			}
 		}
 	}
@@ -168,6 +175,35 @@ func (r *Route) releaseAllowedIPsLocked() error {
 	}
 
 	r.currentPeerKey = ""
+	return nil
+}
+
+func (r *Route) retryPendingAllowedIPsLocked() error {
+	var merr *multierror.Error
+	for ref := range r.pendingAllowedIPRefs {
+		if _, err := r.allowedIPsRefcounter.Decrement(ref.prefix, ref.peerKey); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("remove allowed IP %s: %w", ref.prefix, err))
+			continue
+		}
+		delete(r.pendingAllowedIPRefs, ref)
+	}
+	return nberrors.FormatErrorOrNil(merr)
+}
+
+func (r *Route) releaseAllowedIPLocked(ref allowedIPRef) error {
+	if r.allowedIPRefs[ref] == 0 {
+		return nil
+	}
+
+	r.allowedIPRefs[ref]--
+	if r.allowedIPRefs[ref] == 0 {
+		delete(r.allowedIPRefs, ref)
+	}
+
+	if _, err := r.allowedIPsRefcounter.Decrement(ref.prefix, ref.peerKey); err != nil {
+		r.pendingAllowedIPRefs[ref] = struct{}{}
+		return err
+	}
 	return nil
 }
 
@@ -285,6 +321,9 @@ func (r *Route) updateDynamicRoutes(ctx context.Context, newDomains domainMap) e
 	}
 
 	var merr *multierror.Error
+	if err := r.retryPendingAllowedIPsLocked(); err != nil {
+		merr = multierror.Append(merr, err)
+	}
 
 	for domain, newPrefixes := range newDomains {
 		oldPrefixes := r.dynamicDomains[domain]
@@ -346,7 +385,8 @@ func (r *Route) removeRoutes(prefixes []netip.Prefix) ([]netip.Prefix, error) {
 			merr = multierror.Append(merr, fmt.Errorf("remove dynamic route for IP %s: %w", prefix, err))
 		}
 		if r.currentPeerKey != "" {
-			if _, err := r.allowedIPsRefcounter.Decrement(prefix, r.currentPeerKey); err != nil {
+			ref := allowedIPRef{prefix: prefix, peerKey: r.currentPeerKey}
+			if err := r.releaseAllowedIPLocked(ref); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("remove allowed IP %s: %w", prefix, err))
 			}
 		}
@@ -367,6 +407,9 @@ func (r *Route) incrementAllowedIP(domain domain.Domain, prefix netip.Prefix, pe
 		)
 
 	}
+	allowedRef := allowedIPRef{prefix: prefix, peerKey: peerKey}
+	r.allowedIPRefs[allowedRef]++
+	delete(r.pendingAllowedIPRefs, allowedRef)
 	return nil
 }
 

--- a/client/internal/routemanager/dynamic/route.go
+++ b/client/internal/routemanager/dynamic/route.go
@@ -100,18 +100,25 @@ func (r *Route) RemoveRoute() error {
 		return fmt.Errorf("release allowed IPs: %w", err)
 	}
 
+	remainingDomains := domainMap{}
 	for domain, prefixes := range r.dynamicDomains {
+		var remainingPrefixes []netip.Prefix
 		for _, prefix := range prefixes {
 			if _, err := r.routeRefCounter.Decrement(prefix); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("remove dynamic route for IP %s: %w", prefix, err))
+				remainingPrefixes = append(remainingPrefixes, prefix)
 			}
+		}
+		if len(remainingPrefixes) > 0 {
+			remainingDomains[domain] = remainingPrefixes
+			continue
 		}
 		log.Debugf("Removed dynamic route(s) for [%s]: %s", domain.SafeString(), strings.ReplaceAll(fmt.Sprintf("%s", prefixes), " ", ", "))
 
 		r.statusRecorder.DeleteResolvedDomainsStates(domain)
 	}
 
-	r.dynamicDomains = domainMap{}
+	r.dynamicDomains = remainingDomains
 
 	return nberrors.FormatErrorOrNil(merr)
 }

--- a/client/internal/routemanager/dynamic/route.go
+++ b/client/internal/routemanager/dynamic/route.go
@@ -86,9 +86,6 @@ func (r *Route) AddRoute(ctx context.Context) error {
 }
 
 // RemoveRoute will stop the dynamic resolver and remove all dynamic routes.
-// Allowed IPs should preferably be removed separately, via RemoveAllowedIPs(),
-// before this method. RemoveRoute releases any still held as a safety net, since
-// it clears dynamicDomains, the state RemoveAllowedIPs() needs to know what to drop.
 func (r *Route) RemoveRoute() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -99,11 +96,8 @@ func (r *Route) RemoveRoute() error {
 
 	var merr *multierror.Error
 
-	// Only logged, never returned: updateSystemRoutes() drops the whole pending DNS batch
-	// on any error from here, and allowed IP release failures never reached that path
-	// before, so don't open it now.
 	if err := r.releaseAllowedIPsLocked(); err != nil {
-		log.Errorf("Failed to release allowed IPs for route [%v]: %v", r, err)
+		return fmt.Errorf("release allowed IPs: %w", err)
 	}
 
 	for domain, prefixes := range r.dynamicDomains {
@@ -146,8 +140,8 @@ func (r *Route) RemoveAllowedIPs() error {
 }
 
 // releaseAllowedIPsLocked decrements the allowed IPs refcounter for every prefix in
-// dynamicDomains and clears currentPeerKey. The caller must hold r.mu. An empty
-// currentPeerKey means they are already released, so it is a no-op.
+// dynamicDomains. The caller must hold r.mu. An empty currentPeerKey means they are
+// already released, so it is a no-op.
 func (r *Route) releaseAllowedIPsLocked() error {
 	if r.currentPeerKey == "" {
 		return nil
@@ -162,8 +156,12 @@ func (r *Route) releaseAllowedIPsLocked() error {
 		}
 	}
 
+	if err := nberrors.FormatErrorOrNil(merr); err != nil {
+		return err
+	}
+
 	r.currentPeerKey = ""
-	return nberrors.FormatErrorOrNil(merr)
+	return nil
 }
 
 func (r *Route) startResolver(ctx context.Context) {

--- a/client/internal/routemanager/dynamic/route_test.go
+++ b/client/internal/routemanager/dynamic/route_test.go
@@ -1,0 +1,117 @@
+package dynamic
+
+import (
+	"net/netip"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/internal/peer"
+	"github.com/netbirdio/netbird/client/internal/routemanager/common"
+	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
+	"github.com/netbirdio/netbird/route"
+	"github.com/netbirdio/netbird/shared/management/domain"
+)
+
+// wgAllowedIPMock records AddAllowedIP/RemoveAllowedIP calls made through the refcounter's
+// add/remove closures. It doesn't implement iface.WGIface - Route only reads r.wgInterface from
+// route_ios.go, a path this test doesn't exercise, so the mock is wired in via the refcounter
+// closures below instead of common.HandlerParams.WgInterface.
+type wgAllowedIPMock struct {
+	mu      sync.Mutex
+	added   map[string][]netip.Prefix
+	removed map[string][]netip.Prefix
+}
+
+func (m *wgAllowedIPMock) AddAllowedIP(peerKey string, allowedIP netip.Prefix) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.added == nil {
+		m.added = map[string][]netip.Prefix{}
+	}
+	m.added[peerKey] = append(m.added[peerKey], allowedIP)
+	return nil
+}
+
+func (m *wgAllowedIPMock) RemoveAllowedIP(peerKey string, allowedIP netip.Prefix) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.removed == nil {
+		m.removed = map[string][]netip.Prefix{}
+	}
+	m.removed[peerKey] = append(m.removed[peerKey], allowedIP)
+	return nil
+}
+
+func (m *wgAllowedIPMock) addedFor(peerKey string) []netip.Prefix {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.added[peerKey]
+}
+
+func (m *wgAllowedIPMock) removedFor(peerKey string) []netip.Prefix {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.removed[peerKey]
+}
+
+// TestRemoveRouteReleasesAllowedIPs exercises RemoveRoute and RemoveAllowedIPs in the reversed
+// order - RemoveRoute first, RemoveAllowedIPs second - that the manager used before its fix and
+// that some future call site could reintroduce by mistake. It's a regression guard for
+// RemoveRoute's safety net: even in that order, the old peer's allowed IP must still be released,
+// and the allowed IPs refcounter must be left usable for a subsequent peer. The manager itself now
+// calls RemoveAllowedIPs (via stopObsoleteClients) before RemoveRoute (via updateSystemRoutes);
+// that correct order isn't what's under test here.
+func TestRemoveRouteReleasesAllowedIPs(t *testing.T) {
+	wg := &wgAllowedIPMock{}
+
+	routeRefCounter := refcounter.New(
+		func(netip.Prefix, struct{}) (struct{}, error) { return struct{}{}, nil },
+		func(netip.Prefix, struct{}) error { return nil },
+	)
+
+	allowedIPsRefCounter := refcounter.NewAllowedIPs(
+		func(prefix netip.Prefix, peerKey string) (string, error) {
+			return peerKey, wg.AddAllowedIP(peerKey, prefix)
+		},
+		func(prefix netip.Prefix, peerKey string) error {
+			return wg.RemoveAllowedIP(peerKey, prefix)
+		},
+	)
+
+	r := NewRoute(common.HandlerParams{
+		Route: &route.Route{
+			ID:      "testroute:1",
+			Domains: domain.List{domain.Domain("example.com")},
+		},
+		RouteRefCounter:      routeRefCounter,
+		AllowedIPsRefCounter: allowedIPsRefCounter,
+		StatusRecorder:       peer.NewRecorder("https://mgm"),
+	}, netip.AddrPort{})
+
+	prefix := netip.MustParsePrefix("203.0.113.7/32")
+	r.dynamicDomains = domainMap{
+		domain.Domain("example.com"): {prefix},
+	}
+
+	require.NoError(t, r.AddAllowedIPs("peerA"))
+	assert.Equal(t, []netip.Prefix{prefix}, wg.addedFor("peerA"))
+
+	// Reversed order: RemoveRoute runs before RemoveAllowedIPs. RemoveRoute must release the
+	// allowed IPs itself since it's about to wipe dynamicDomains, the state RemoveAllowedIPs
+	// would otherwise need. The later RemoveAllowedIPs call must then be a safe no-op.
+	require.NoError(t, r.RemoveRoute())
+	require.NoError(t, r.RemoveAllowedIPs())
+
+	assert.Equal(t, []netip.Prefix{prefix}, wg.removedFor("peerA"),
+		"peerA's allowed IP must have been released despite the reversed call order")
+
+	t.Run("refcounter is usable for a subsequent peer", func(t *testing.T) {
+		_, err := r.allowedIPsRefcounter.Increment(prefix, "peerB")
+		require.NoError(t, err)
+		assert.Equal(t, []netip.Prefix{prefix}, wg.addedFor("peerB"),
+			"refcounter must have been fully released, allowing a new peer to take the prefix")
+	})
+}

--- a/client/internal/routemanager/dynamic/route_test.go
+++ b/client/internal/routemanager/dynamic/route_test.go
@@ -15,10 +15,9 @@ import (
 	"github.com/netbirdio/netbird/shared/management/domain"
 )
 
-// wgAllowedIPMock records AddAllowedIP/RemoveAllowedIP calls made through the refcounter's
-// add/remove closures. It doesn't implement iface.WGIface - Route only reads r.wgInterface from
-// route_ios.go, a path this test doesn't exercise, so the mock is wired in via the refcounter
-// closures below instead of common.HandlerParams.WgInterface.
+// wgAllowedIPMock records the AddAllowedIP/RemoveAllowedIP calls made through the
+// refcounter closures. It is not an iface.WGIface: Route reads r.wgInterface only on
+// the iOS path, which this test does not exercise.
 type wgAllowedIPMock struct {
 	mu      sync.Mutex
 	added   map[string][]netip.Prefix
@@ -57,13 +56,9 @@ func (m *wgAllowedIPMock) removedFor(peerKey string) []netip.Prefix {
 	return m.removed[peerKey]
 }
 
-// TestRemoveRouteReleasesAllowedIPs exercises RemoveRoute and RemoveAllowedIPs in the reversed
-// order - RemoveRoute first, RemoveAllowedIPs second - that the manager used before its fix and
-// that some future call site could reintroduce by mistake. It's a regression guard for
-// RemoveRoute's safety net: even in that order, the old peer's allowed IP must still be released,
-// and the allowed IPs refcounter must be left usable for a subsequent peer. The manager itself now
-// calls RemoveAllowedIPs (via stopObsoleteClients) before RemoveRoute (via updateSystemRoutes);
-// that correct order isn't what's under test here.
+// RemoveRoute must release the allowed IPs itself even when it runs before
+// RemoveAllowedIPs, the reversed order the manager used before this fix and that a
+// future call site could reintroduce. The refcounter must stay usable for the next peer.
 func TestRemoveRouteReleasesAllowedIPs(t *testing.T) {
 	wg := &wgAllowedIPMock{}
 
@@ -99,9 +94,8 @@ func TestRemoveRouteReleasesAllowedIPs(t *testing.T) {
 	require.NoError(t, r.AddAllowedIPs("peerA"))
 	assert.Equal(t, []netip.Prefix{prefix}, wg.addedFor("peerA"))
 
-	// Reversed order: RemoveRoute runs before RemoveAllowedIPs. RemoveRoute must release the
-	// allowed IPs itself since it's about to wipe dynamicDomains, the state RemoveAllowedIPs
-	// would otherwise need. The later RemoveAllowedIPs call must then be a safe no-op.
+	// Reversed order: RemoveRoute first. It must release the allowed IPs itself, since it
+	// wipes dynamicDomains, and the later RemoveAllowedIPs must then be a safe no-op.
 	require.NoError(t, r.RemoveRoute())
 	require.NoError(t, r.RemoveAllowedIPs())
 

--- a/client/internal/routemanager/dynamic/route_test.go
+++ b/client/internal/routemanager/dynamic/route_test.go
@@ -27,6 +27,31 @@ type wgAllowedIPMock struct {
 	removeAttempts int
 }
 
+type routeCleanupMock struct {
+	mu             sync.Mutex
+	removeFailures int
+	removeAttempts int
+}
+
+func (m *routeCleanupMock) RemoveRoute(netip.Prefix) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removeAttempts++
+	if m.removeFailures != 0 {
+		if m.removeFailures > 0 {
+			m.removeFailures--
+		}
+		return errors.New("remove route")
+	}
+	return nil
+}
+
+func (m *routeCleanupMock) attempts() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.removeAttempts
+}
+
 func (m *wgAllowedIPMock) AddAllowedIP(peerKey string, allowedIP netip.Prefix) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -124,12 +149,36 @@ func TestRemoveRoutePreservesAllowedIPCleanupAfterPersistentFailure(t *testing.T
 	assert.Equal(t, 2, wg.attempts(), "every reconciliation must retry the removal")
 }
 
+func TestRemoveRouteRetriesFailedSystemRouteCleanup(t *testing.T) {
+	wg := &wgAllowedIPMock{}
+	systemRoutes := &routeCleanupMock{removeFailures: 1}
+	r, prefix := newRouteWithCleanupMocks(t, wg, systemRoutes)
+
+	require.Error(t, r.RemoveRoute(), "the first system route removal fails")
+	assertRoutePrefixesPending(t, r, prefix)
+	assert.Equal(t, []netip.Prefix{prefix}, wg.removedFor("peerA"),
+		"allowed IP cleanup must not be repeated after it succeeds")
+
+	require.NoError(t, r.RemoveRoute(), "a later route reconciliation retries the system route cleanup")
+	assertRouteCleanupComplete(t, r)
+	assert.Equal(t, 2, systemRoutes.attempts(), "the system route removal must be attempted again")
+}
+
 func newRouteWithAllowedIP(t *testing.T, wg *wgAllowedIPMock) (*Route, netip.Prefix) {
+	return newRouteWithCleanupMocks(t, wg, nil)
+}
+
+func newRouteWithCleanupMocks(t *testing.T, wg *wgAllowedIPMock, systemRoutes *routeCleanupMock) (*Route, netip.Prefix) {
 	t.Helper()
 
 	routeRefCounter := refcounter.New(
 		func(netip.Prefix, struct{}) (struct{}, error) { return struct{}{}, nil },
-		func(netip.Prefix, struct{}) error { return nil },
+		func(prefix netip.Prefix, _ struct{}) error {
+			if systemRoutes == nil {
+				return nil
+			}
+			return systemRoutes.RemoveRoute(prefix)
+		},
 	)
 	allowedIPsRefCounter := refcounter.NewAllowedIPs(
 		func(prefix netip.Prefix, peerKey string) (string, error) {
@@ -154,6 +203,8 @@ func newRouteWithAllowedIP(t *testing.T, wg *wgAllowedIPMock) (*Route, netip.Pre
 		domain.Domain("example.com"): {prefix},
 	}
 
+	_, err := r.routeRefCounter.Increment(prefix, struct{}{})
+	require.NoError(t, err)
 	require.NoError(t, r.AddAllowedIPs("peerA"))
 	return r, prefix
 }
@@ -175,4 +226,14 @@ func assertRouteCleanupComplete(t *testing.T, r *Route) {
 	defer r.mu.Unlock()
 	assert.Empty(t, r.currentPeerKey, "the peer key must clear after successful cleanup")
 	assert.Empty(t, r.dynamicDomains, "the dynamic domains must clear after successful cleanup")
+}
+
+func assertRoutePrefixesPending(t *testing.T, r *Route, prefix netip.Prefix) {
+	t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	assert.Empty(t, r.currentPeerKey, "allowed IP cleanup already succeeded")
+	assert.Equal(t, []netip.Prefix{prefix}, r.dynamicDomains[domain.Domain("example.com")],
+		"the failed system route prefix is needed for the next cleanup attempt")
 }

--- a/client/internal/routemanager/dynamic/route_test.go
+++ b/client/internal/routemanager/dynamic/route_test.go
@@ -24,6 +24,7 @@ type wgAllowedIPMock struct {
 	added          map[string][]netip.Prefix
 	removed        map[string][]netip.Prefix
 	removeFailures int
+	removeByPrefix map[netip.Prefix]int
 	removeAttempts int
 }
 
@@ -66,6 +67,12 @@ func (m *wgAllowedIPMock) RemoveAllowedIP(peerKey string, allowedIP netip.Prefix
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.removeAttempts++
+	if m.removeByPrefix[allowedIP] != 0 {
+		if m.removeByPrefix[allowedIP] > 0 {
+			m.removeByPrefix[allowedIP]--
+		}
+		return errors.New("remove allowed IP")
+	}
 	if m.removeFailures != 0 {
 		if m.removeFailures > 0 {
 			m.removeFailures--
@@ -147,6 +154,42 @@ func TestRemoveRoutePreservesAllowedIPCleanupAfterPersistentFailure(t *testing.T
 
 	assert.Empty(t, wg.removedFor("peerA"), "a persistently failing removal must not be marked complete")
 	assert.Equal(t, 2, wg.attempts(), "every reconciliation must retry the removal")
+}
+
+func TestRemoveAllowedIPsRetriesOnlyFailedPrefix(t *testing.T) {
+	prefixA := netip.MustParsePrefix("203.0.113.7/32")
+	prefixB := netip.MustParsePrefix("203.0.113.8/32")
+	wg := &wgAllowedIPMock{removeByPrefix: map[netip.Prefix]int{prefixB: 1}}
+	r, _ := newRouteWithAllowedIP(t, wg)
+	addDynamicPrefix(t, r, domain.Domain("example.com"), prefixB, "peerA")
+
+	// A second handler owns this reference. The retry must leave it intact.
+	_, err := r.allowedIPsRefcounter.Increment(prefixA, "peerA")
+	require.NoError(t, err)
+
+	require.Error(t, r.RemoveAllowedIPs(), "the first removal of prefix B fails")
+	require.NoError(t, r.RemoveAllowedIPs(), "the retry removes only the pending prefix B")
+	assert.Equal(t, []netip.Prefix{prefixB}, wg.removedFor("peerA"),
+		"prefix A's other owner must keep it installed")
+
+	_, err = r.allowedIPsRefcounter.Decrement(prefixA, "peerA")
+	require.NoError(t, err)
+	assert.Equal(t, []netip.Prefix{prefixB, prefixA}, wg.removedFor("peerA"),
+		"removing prefix A must be deferred to its other owner")
+	assert.Equal(t, 3, wg.attempts(), "prefix A must not be decremented during the retry")
+}
+
+func TestRemoveAllowedIPsReleasesDuplicatePrefixesAcrossDomains(t *testing.T) {
+	prefix := netip.MustParsePrefix("203.0.113.7/32")
+	wg := &wgAllowedIPMock{removeFailures: 1}
+	r, _ := newRouteWithAllowedIP(t, wg)
+	addDynamicPrefix(t, r, domain.Domain("other.example.com"), prefix, "peerA")
+
+	require.Error(t, r.RemoveAllowedIPs(), "the final same-prefix removal fails once")
+	require.NoError(t, r.RemoveAllowedIPs(), "the pending removal is retried once")
+	assert.Equal(t, []netip.Prefix{prefix}, wg.removedFor("peerA"),
+		"the final of two same-prefix references must remove the allowed IP once")
+	assert.Equal(t, 2, wg.attempts(), "only the failed final removal is retried")
 }
 
 func TestRemoveRouteRetriesFailedSystemRouteCleanup(t *testing.T) {
@@ -236,4 +279,16 @@ func assertRoutePrefixesPending(t *testing.T, r *Route, prefix netip.Prefix) {
 	assert.Empty(t, r.currentPeerKey, "allowed IP cleanup already succeeded")
 	assert.Equal(t, []netip.Prefix{prefix}, r.dynamicDomains[domain.Domain("example.com")],
 		"the failed system route prefix is needed for the next cleanup attempt")
+}
+
+func addDynamicPrefix(t *testing.T, r *Route, d domain.Domain, prefix netip.Prefix, peerKey string) {
+	t.Helper()
+
+	_, err := r.routeRefCounter.Increment(prefix, struct{}{})
+	require.NoError(t, err)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.dynamicDomains[d] = append(r.dynamicDomains[d], prefix)
+	require.NoError(t, r.incrementAllowedIP(d, prefix, peerKey))
 }

--- a/client/internal/routemanager/dynamic/route_test.go
+++ b/client/internal/routemanager/dynamic/route_test.go
@@ -1,6 +1,7 @@
 package dynamic
 
 import (
+	"errors"
 	"net/netip"
 	"sync"
 	"testing"
@@ -19,9 +20,11 @@ import (
 // refcounter closures. It is not an iface.WGIface: Route reads r.wgInterface only on
 // the iOS path, which this test does not exercise.
 type wgAllowedIPMock struct {
-	mu      sync.Mutex
-	added   map[string][]netip.Prefix
-	removed map[string][]netip.Prefix
+	mu             sync.Mutex
+	added          map[string][]netip.Prefix
+	removed        map[string][]netip.Prefix
+	removeFailures int
+	removeAttempts int
 }
 
 func (m *wgAllowedIPMock) AddAllowedIP(peerKey string, allowedIP netip.Prefix) error {
@@ -37,11 +40,24 @@ func (m *wgAllowedIPMock) AddAllowedIP(peerKey string, allowedIP netip.Prefix) e
 func (m *wgAllowedIPMock) RemoveAllowedIP(peerKey string, allowedIP netip.Prefix) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.removeAttempts++
+	if m.removeFailures != 0 {
+		if m.removeFailures > 0 {
+			m.removeFailures--
+		}
+		return errors.New("remove allowed IP")
+	}
 	if m.removed == nil {
 		m.removed = map[string][]netip.Prefix{}
 	}
 	m.removed[peerKey] = append(m.removed[peerKey], allowedIP)
 	return nil
+}
+
+func (m *wgAllowedIPMock) attempts() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.removeAttempts
 }
 
 func (m *wgAllowedIPMock) addedFor(peerKey string) []netip.Prefix {
@@ -61,12 +77,60 @@ func (m *wgAllowedIPMock) removedFor(peerKey string) []netip.Prefix {
 // future call site could reintroduce. The refcounter must stay usable for the next peer.
 func TestRemoveRouteReleasesAllowedIPs(t *testing.T) {
 	wg := &wgAllowedIPMock{}
+	r, prefix := newRouteWithAllowedIP(t, wg)
+	assert.Equal(t, []netip.Prefix{prefix}, wg.addedFor("peerA"))
+
+	// Reversed order: RemoveRoute first. It must release the allowed IPs itself, since it
+	// wipes dynamicDomains, and the later RemoveAllowedIPs must then be a safe no-op.
+	require.NoError(t, r.RemoveRoute())
+	require.NoError(t, r.RemoveAllowedIPs())
+
+	assert.Equal(t, []netip.Prefix{prefix}, wg.removedFor("peerA"),
+		"peerA's allowed IP must have been released despite the reversed call order")
+
+	t.Run("refcounter is usable for a subsequent peer", func(t *testing.T) {
+		_, err := r.allowedIPsRefcounter.Increment(prefix, "peerB")
+		require.NoError(t, err)
+		assert.Equal(t, []netip.Prefix{prefix}, wg.addedFor("peerB"),
+			"refcounter must have been fully released, allowing a new peer to take the prefix")
+	})
+}
+
+func TestRemoveRouteRetriesAllowedIPCleanup(t *testing.T) {
+	wg := &wgAllowedIPMock{removeFailures: 1}
+	r, prefix := newRouteWithAllowedIP(t, wg)
+
+	require.Error(t, r.RemoveRoute(), "the first allowed IP removal fails")
+	assertRouteCleanupPending(t, r, "peerA", prefix)
+	assert.Empty(t, wg.removedFor("peerA"), "the failed removal must not be recorded as complete")
+
+	require.NoError(t, r.RemoveRoute(), "a later route reconciliation retries the cleanup")
+	assertRouteCleanupComplete(t, r)
+	assert.Equal(t, []netip.Prefix{prefix}, wg.removedFor("peerA"),
+		"the retry must remove the old peer's allowed IP")
+	assert.Equal(t, 2, wg.attempts(), "the removal must be attempted again")
+}
+
+func TestRemoveRoutePreservesAllowedIPCleanupAfterPersistentFailure(t *testing.T) {
+	wg := &wgAllowedIPMock{removeFailures: -1}
+	r, prefix := newRouteWithAllowedIP(t, wg)
+
+	for range 2 {
+		require.Error(t, r.RemoveRoute(), "a failed cleanup must keep the route retryable")
+		assertRouteCleanupPending(t, r, "peerA", prefix)
+	}
+
+	assert.Empty(t, wg.removedFor("peerA"), "a persistently failing removal must not be marked complete")
+	assert.Equal(t, 2, wg.attempts(), "every reconciliation must retry the removal")
+}
+
+func newRouteWithAllowedIP(t *testing.T, wg *wgAllowedIPMock) (*Route, netip.Prefix) {
+	t.Helper()
 
 	routeRefCounter := refcounter.New(
 		func(netip.Prefix, struct{}) (struct{}, error) { return struct{}{}, nil },
 		func(netip.Prefix, struct{}) error { return nil },
 	)
-
 	allowedIPsRefCounter := refcounter.NewAllowedIPs(
 		func(prefix netip.Prefix, peerKey string) (string, error) {
 			return peerKey, wg.AddAllowedIP(peerKey, prefix)
@@ -85,27 +149,30 @@ func TestRemoveRouteReleasesAllowedIPs(t *testing.T) {
 		AllowedIPsRefCounter: allowedIPsRefCounter,
 		StatusRecorder:       peer.NewRecorder("https://mgm"),
 	}, netip.AddrPort{})
-
 	prefix := netip.MustParsePrefix("203.0.113.7/32")
 	r.dynamicDomains = domainMap{
 		domain.Domain("example.com"): {prefix},
 	}
 
 	require.NoError(t, r.AddAllowedIPs("peerA"))
-	assert.Equal(t, []netip.Prefix{prefix}, wg.addedFor("peerA"))
+	return r, prefix
+}
 
-	// Reversed order: RemoveRoute first. It must release the allowed IPs itself, since it
-	// wipes dynamicDomains, and the later RemoveAllowedIPs must then be a safe no-op.
-	require.NoError(t, r.RemoveRoute())
-	require.NoError(t, r.RemoveAllowedIPs())
+func assertRouteCleanupPending(t *testing.T, r *Route, peerKey string, prefix netip.Prefix) {
+	t.Helper()
 
-	assert.Equal(t, []netip.Prefix{prefix}, wg.removedFor("peerA"),
-		"peerA's allowed IP must have been released despite the reversed call order")
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	assert.Equal(t, peerKey, r.currentPeerKey, "the peer key is needed for the next cleanup attempt")
+	assert.Equal(t, []netip.Prefix{prefix}, r.dynamicDomains[domain.Domain("example.com")],
+		"the prefixes are needed for the next cleanup attempt")
+}
 
-	t.Run("refcounter is usable for a subsequent peer", func(t *testing.T) {
-		_, err := r.allowedIPsRefcounter.Increment(prefix, "peerB")
-		require.NoError(t, err)
-		assert.Equal(t, []netip.Prefix{prefix}, wg.addedFor("peerB"),
-			"refcounter must have been fully released, allowing a new peer to take the prefix")
-	})
+func assertRouteCleanupComplete(t *testing.T, r *Route) {
+	t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	assert.Empty(t, r.currentPeerKey, "the peer key must clear after successful cleanup")
+	assert.Empty(t, r.dynamicDomains, "the dynamic domains must clear after successful cleanup")
 }

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -437,6 +437,11 @@ func (m *DefaultManager) UpdateRoutes(
 
 		filteredClientRoutes := m.routeSelector.FilterSelectedExitNodes(clientRoutes)
 
+		// Stop obsolete watchers before applying system routes: dynamic.Route.RemoveRoute()
+		// clears the domain state that RemoveAllowedIPs() decrements from, so allowed IPs
+		// must be released first, or the outgoing peer's allowed IPs get stuck forever.
+		m.stopObsoleteClients(filteredClientRoutes)
+
 		if err := m.updateSystemRoutes(filteredClientRoutes); err != nil {
 			merr = multierror.Append(merr, fmt.Errorf("update system routes: %w", err))
 		}
@@ -572,11 +577,14 @@ func (m *DefaultManager) TriggerSelection(networks route.HAMap) {
 
 	m.notifier.OnNewRoutes(networks)
 
+	// Stop obsolete watchers before applying system routes: dynamic.Route.RemoveRoute()
+	// clears the domain state that RemoveAllowedIPs() decrements from, so allowed IPs
+	// must be released first, or the outgoing peer's allowed IPs get stuck forever.
+	m.stopObsoleteClients(networks)
+
 	if err := m.updateSystemRoutes(networks); err != nil {
 		log.Errorf("failed to update system routes during selection: %v", err)
 	}
-
-	m.stopObsoleteClients(networks)
 
 	for id, routes := range networks {
 		if _, found := m.clientNetworks[id]; found {
@@ -627,10 +635,9 @@ func (m *DefaultManager) stopObsoleteClients(networks route.HAMap) {
 	}
 }
 
+// updateClientNetworks starts or updates the client network watchers for the given routes.
+// Callers are responsible for stopping obsolete watchers (via stopObsoleteClients) beforehand.
 func (m *DefaultManager) updateClientNetworks(updateSerial uint64, networks route.HAMap) {
-	// removing routes that do not exist as per the update from the Management service.
-	m.stopObsoleteClients(networks)
-
 	for id, routes := range networks {
 		clientNetworkWatcher, found := m.clientNetworks[id]
 		if !found {

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -437,9 +437,9 @@ func (m *DefaultManager) UpdateRoutes(
 
 		filteredClientRoutes := m.routeSelector.FilterSelectedExitNodes(clientRoutes)
 
-		// Stop obsolete watchers before applying system routes: dynamic.Route.RemoveRoute()
-		// clears the domain state that RemoveAllowedIPs() decrements from, so allowed IPs
-		// must be released first, or the outgoing peer's allowed IPs get stuck forever.
+		// Stop obsolete watchers first: RemoveRoute() clears the domain state that
+		// RemoveAllowedIPs() decrements from, so the outgoing peer's allowed IPs would
+		// otherwise stay installed forever.
 		m.stopObsoleteClients(filteredClientRoutes)
 
 		if err := m.updateSystemRoutes(filteredClientRoutes); err != nil {
@@ -577,9 +577,9 @@ func (m *DefaultManager) TriggerSelection(networks route.HAMap) {
 
 	m.notifier.OnNewRoutes(networks)
 
-	// Stop obsolete watchers before applying system routes: dynamic.Route.RemoveRoute()
-	// clears the domain state that RemoveAllowedIPs() decrements from, so allowed IPs
-	// must be released first, or the outgoing peer's allowed IPs get stuck forever.
+	// Stop obsolete watchers first: RemoveRoute() clears the domain state that
+	// RemoveAllowedIPs() decrements from, so the outgoing peer's allowed IPs would
+	// otherwise stay installed forever.
 	m.stopObsoleteClients(networks)
 
 	if err := m.updateSystemRoutes(networks); err != nil {
@@ -635,8 +635,8 @@ func (m *DefaultManager) stopObsoleteClients(networks route.HAMap) {
 	}
 }
 
-// updateClientNetworks starts or updates the client network watchers for the given routes.
-// Callers are responsible for stopping obsolete watchers (via stopObsoleteClients) beforehand.
+// updateClientNetworks starts or updates the client network watchers for the given
+// routes. Callers must stop obsolete watchers first, via stopObsoleteClients.
 func (m *DefaultManager) updateClientNetworks(updateSerial uint64, networks route.HAMap) {
 	for id, routes := range networks {
 		clientNetworkWatcher, found := m.clientNetworks[id]

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -378,6 +378,7 @@ func (m *DefaultManager) updateSystemRoutes(newRoutes route.HAMap) error {
 	for id, handler := range toRemove {
 		if err := handler.RemoveRoute(); err != nil {
 			merr = multierror.Append(merr, fmt.Errorf("remove route %s: %w", handler.String(), err))
+			continue
 		}
 		delete(m.activeRoutes, id)
 	}

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -110,6 +110,7 @@ type DefaultManager struct {
 	disableClientRoutes bool
 	disableServerRoutes bool
 	activeRoutes        map[route.HAUniqueID]client.RouteHandler
+	pendingRemovals     map[route.HAUniqueID]client.RouteHandler
 	fakeIPManager       *fakeip.Manager
 	dnsForwarderPort    atomic.Uint32
 }
@@ -140,6 +141,7 @@ func NewManager(config ManagerConfig) *DefaultManager {
 		disableClientRoutes: config.DisableClientRoutes,
 		disableServerRoutes: config.DisableServerRoutes,
 		activeRoutes:        make(map[route.HAUniqueID]client.RouteHandler),
+		pendingRemovals:     make(map[route.HAUniqueID]client.RouteHandler),
 	}
 	dm.dnsForwarderPort.Store(uint32(nbdns.ForwarderClientPort))
 
@@ -342,6 +344,7 @@ func (m *DefaultManager) Stop(stateManager *statemanager.Manager) {
 func (m *DefaultManager) updateSystemRoutes(newRoutes route.HAMap) error {
 	toAdd := make(map[route.HAUniqueID]*route.Route)
 	toRemove := make(map[route.HAUniqueID]client.RouteHandler)
+	blockedAdds := make(map[route.HAUniqueID]struct{})
 
 	for id, routes := range newRoutes {
 		if len(routes) > 0 {
@@ -358,6 +361,9 @@ func (m *DefaultManager) updateSystemRoutes(newRoutes route.HAMap) error {
 	}
 
 	var merr *multierror.Error
+	if m.pendingRemovals == nil {
+		m.pendingRemovals = make(map[route.HAUniqueID]client.RouteHandler)
+	}
 
 	// Begin batch mode to avoid calling applyHostConfig() after each DNS handler operation
 	batchStarted := false
@@ -375,15 +381,29 @@ func (m *DefaultManager) updateSystemRoutes(newRoutes route.HAMap) error {
 		}()
 	}
 
+	for id, handler := range m.pendingRemovals {
+		if err := handler.RemoveRoute(); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("remove route %s: %w", handler.String(), err))
+			blockedAdds[id] = struct{}{}
+			continue
+		}
+		delete(m.pendingRemovals, id)
+	}
+
 	for id, handler := range toRemove {
 		if err := handler.RemoveRoute(); err != nil {
 			merr = multierror.Append(merr, fmt.Errorf("remove route %s: %w", handler.String(), err))
+			m.pendingRemovals[id] = handler
+			delete(m.activeRoutes, id)
 			continue
 		}
 		delete(m.activeRoutes, id)
 	}
 
 	for id, route := range toAdd {
+		if _, blocked := blockedAdds[id]; blocked {
+			continue
+		}
 		params := common.HandlerParams{
 			Route:                route,
 			RouteRefCounter:      m.routeRefCounter,

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -365,20 +365,10 @@ func (m *DefaultManager) updateSystemRoutes(newRoutes route.HAMap) error {
 		m.pendingRemovals = make(map[route.HAUniqueID]client.RouteHandler)
 	}
 
-	// Begin batch mode to avoid calling applyHostConfig() after each DNS handler operation
-	batchStarted := false
+	// Begin batch mode to avoid calling applyHostConfig() after each DNS handler operation.
 	if m.dnsServer != nil {
 		m.dnsServer.BeginBatch()
-		batchStarted = true
-		defer func() {
-			if merr != nil {
-				// On error, cancel batch to discard partial DNS state
-				m.dnsServer.CancelBatch()
-			} else {
-				// On success, apply accumulated DNS changes
-				m.dnsServer.EndBatch()
-			}
-		}()
+		defer m.dnsServer.EndBatch()
 	}
 
 	for id, handler := range m.pendingRemovals {
@@ -426,7 +416,6 @@ func (m *DefaultManager) updateSystemRoutes(newRoutes route.HAMap) error {
 		m.activeRoutes[id] = handler
 	}
 
-	_ = batchStarted // Mark as used
 	return nberrors.FormatErrorOrNil(merr)
 }
 

--- a/client/internal/routemanager/update_system_routes_test.go
+++ b/client/internal/routemanager/update_system_routes_test.go
@@ -6,18 +6,32 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	nbdns "github.com/netbirdio/netbird/client/internal/dns"
 	"github.com/netbirdio/netbird/client/internal/routemanager/client"
 	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
 	"github.com/netbirdio/netbird/route"
+	"github.com/netbirdio/netbird/shared/management/domain"
 )
 
 type removeRouteHandler struct {
 	removeFailures int
 	removeAttempts int
 }
+
+type trackingDNSServer struct {
+	*nbdns.MockServer
+	beginCalls  int
+	endCalls    int
+	cancelCalls int
+}
+
+func (s *trackingDNSServer) BeginBatch()  { s.beginCalls++ }
+func (s *trackingDNSServer) EndBatch()    { s.endCalls++ }
+func (s *trackingDNSServer) CancelBatch() { s.cancelCalls++ }
 
 func (h *removeRouteHandler) String() string                 { return "test route" }
 func (h *removeRouteHandler) AddRoute(context.Context) error { return nil }
@@ -74,6 +88,38 @@ func TestUpdateSystemRoutesDoesNotDuplicateRouteAfterPersistentRemovalFailure(t 
 	assert.Empty(t, m.activeRoutes, "a replacement must not be created while cleanup is pending")
 	assert.Same(t, handler, m.pendingRemovals[id], "only the original handler is pending")
 	assert.Equal(t, 2, handler.removeAttempts, "every update retries the pending cleanup")
+}
+
+func TestUpdateSystemRoutesCommitsDNSBatchWhenPendingRemovalFails(t *testing.T) {
+	pendingID := route.HAUniqueID("old||10.0.0.0/24")
+	desiredID := route.HAUniqueID("new||dns.example.com")
+	registered := 0
+	dnsServer := &trackingDNSServer{MockServer: &nbdns.MockServer{
+		RegisterHandlerFunc: func(domain.List, dns.Handler, int) { registered++ },
+	}}
+	m := &DefaultManager{
+		ctx:             context.Background(),
+		activeRoutes:    map[route.HAUniqueID]client.RouteHandler{},
+		pendingRemovals: map[route.HAUniqueID]client.RouteHandler{pendingID: &removeRouteHandler{removeFailures: -1}},
+		dnsServer:       dnsServer,
+		useNewDNSRoute:  true,
+		routeRefCounter: refcounter.New(
+			func(netip.Prefix, struct{}) (struct{}, error) { return struct{}{}, nil },
+			func(netip.Prefix, struct{}) error { return nil },
+		),
+	}
+	desired := &route.Route{
+		NetworkType: route.DomainNetwork,
+		Domains:     domain.List{domain.Domain("dns.example.com")},
+	}
+
+	require.Error(t, m.updateSystemRoutes(route.HAMap{desiredID: {desired}}),
+		"the unrelated pending removal still fails")
+	assert.Contains(t, m.activeRoutes, desiredID, "the unrelated DNS route must be active")
+	assert.Equal(t, 1, registered, "the DNS handler must be registered")
+	assert.Equal(t, 1, dnsServer.beginCalls, "the DNS batch must start once")
+	assert.Equal(t, 1, dnsServer.endCalls, "the DNS batch must commit successful work")
+	assert.Zero(t, dnsServer.cancelCalls, "the DNS batch must not discard successful work")
 }
 
 func newManagerWithActiveHandler(id route.HAUniqueID, handler client.RouteHandler) *DefaultManager {

--- a/client/internal/routemanager/update_system_routes_test.go
+++ b/client/internal/routemanager/update_system_routes_test.go
@@ -241,6 +241,7 @@ func startedWatcher(t *testing.T, handler *allowedIPCleanupHandler) *client.Watc
 		StatusRecorder: statusRecorder,
 		Handler:        handler,
 	})
+	t.Cleanup(w.Stop)
 	go w.Start()
 	w.SendUpdate(client.RoutesUpdate{Routes: []*route.Route{{ID: "route", Peer: "peer"}}})
 	select {

--- a/client/internal/routemanager/update_system_routes_test.go
+++ b/client/internal/routemanager/update_system_routes_test.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	nbdns "github.com/netbirdio/netbird/client/internal/dns"
+	"github.com/netbirdio/netbird/client/internal/peer"
 	"github.com/netbirdio/netbird/client/internal/routemanager/client"
 	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
 	"github.com/netbirdio/netbird/route"
@@ -20,6 +22,44 @@ import (
 type removeRouteHandler struct {
 	removeFailures int
 	removeAttempts int
+}
+
+type allowedIPCleanupHandler struct {
+	added            chan struct{}
+	owned            bool
+	pending          bool
+	removeFailures   int
+	removeAttempts   int
+	removeRouteCalls int
+}
+
+func (h *allowedIPCleanupHandler) String() string                 { return "test route" }
+func (h *allowedIPCleanupHandler) AddRoute(context.Context) error { return nil }
+func (h *allowedIPCleanupHandler) AddAllowedIPs(string) error {
+	h.owned = true
+	close(h.added)
+	return nil
+}
+func (h *allowedIPCleanupHandler) RemoveAllowedIPs() error {
+	if !h.owned && !h.pending {
+		return nil
+	}
+	h.removeAttempts++
+	if h.removeFailures != 0 {
+		if h.removeFailures > 0 {
+			h.removeFailures--
+		}
+		h.owned = false
+		h.pending = true
+		return errors.New("remove allowed IP")
+	}
+	h.owned = false
+	h.pending = false
+	return nil
+}
+func (h *allowedIPCleanupHandler) RemoveRoute() error {
+	h.removeRouteCalls++
+	return h.RemoveAllowedIPs()
 }
 
 type trackingDNSServer struct {
@@ -122,6 +162,60 @@ func TestUpdateSystemRoutesCommitsDNSBatchWhenPendingRemovalFails(t *testing.T) 
 	assert.Zero(t, dnsServer.cancelCalls, "the DNS batch must not discard successful work")
 }
 
+func TestObsoleteWatcherCleanupHandoff(t *testing.T) {
+	testCases := []struct {
+		name                string
+		removeFailures      int
+		firstUpdateFails    bool
+		expectedRemoveCalls int
+	}{
+		{
+			name:                "transient failure retries in the same update",
+			removeFailures:      1,
+			expectedRemoveCalls: 2,
+		},
+		{
+			name:                "persistent failure moves to pending removal",
+			removeFailures:      2,
+			firstUpdateFails:    true,
+			expectedRemoveCalls: 3,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			id := route.HAUniqueID("net1||10.0.0.0/24")
+			handler := &allowedIPCleanupHandler{
+				added:          make(chan struct{}),
+				removeFailures: testCase.removeFailures,
+			}
+			m := newManagerWithActiveHandler(id, handler)
+			m.clientNetworks = map[route.HAUniqueID]*client.Watcher{id: startedWatcher(t, handler)}
+
+			m.stopObsoleteClients(route.HAMap{})
+			require.Equal(t, 1, handler.removeAttempts, "Watcher.Stop makes the first cleanup attempt")
+			assert.True(t, handler.pending, "the failed watcher cleanup must remain pending")
+			assert.Empty(t, m.clientNetworks, "the obsolete watcher must be removed")
+
+			err := m.updateSystemRoutes(route.HAMap{})
+			if testCase.firstUpdateFails {
+				require.Error(t, err, "the second cleanup attempt fails")
+				assert.Empty(t, m.activeRoutes, "a failed teardown must not remain active")
+				assert.Same(t, handler, m.pendingRemovals[id], "the handler must remain pending")
+				require.NoError(t, m.updateSystemRoutes(route.HAMap{}), "the third cleanup attempt succeeds")
+			} else {
+				require.NoError(t, err, "RemoveRoute retries the cleanup in the same route update")
+			}
+
+			assert.Empty(t, m.activeRoutes, "the removed handler must not remain active")
+			assert.Empty(t, m.pendingRemovals, "successful cleanup must clear pending state")
+			assert.False(t, handler.pending, "the handler must not retain a pending cleanup")
+			assert.Equal(t, testCase.expectedRemoveCalls, handler.removeAttempts,
+				"Stop and manager updates must make the expected cleanup attempts")
+		})
+	}
+}
+
 func newManagerWithActiveHandler(id route.HAUniqueID, handler client.RouteHandler) *DefaultManager {
 	return &DefaultManager{
 		ctx:          context.Background(),
@@ -135,4 +229,24 @@ func newManagerWithActiveHandler(id route.HAUniqueID, handler client.RouteHandle
 
 func testRoute() *route.Route {
 	return &route.Route{Network: netip.MustParsePrefix("10.0.0.0/24")}
+}
+
+func startedWatcher(t *testing.T, handler *allowedIPCleanupHandler) *client.Watcher {
+	t.Helper()
+
+	statusRecorder := peer.NewRecorder("https://mgm")
+	require.NoError(t, statusRecorder.AddPeer("peer", "peer", "100.64.0.1", ""))
+	w := client.NewWatcher(client.WatcherConfig{
+		Context:        context.Background(),
+		StatusRecorder: statusRecorder,
+		Handler:        handler,
+	})
+	go w.Start()
+	w.SendUpdate(client.RoutesUpdate{Routes: []*route.Route{{ID: "route", Peer: "peer"}}})
+	select {
+	case <-handler.added:
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not add allowed IPs")
+	}
+	return w
 }

--- a/client/internal/routemanager/update_system_routes_test.go
+++ b/client/internal/routemanager/update_system_routes_test.go
@@ -1,0 +1,59 @@
+package routemanager
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/internal/routemanager/client"
+	"github.com/netbirdio/netbird/route"
+)
+
+type removeRouteHandler struct {
+	removeFailures int
+	removeAttempts int
+}
+
+func (h *removeRouteHandler) String() string                 { return "test route" }
+func (h *removeRouteHandler) AddRoute(context.Context) error { return nil }
+func (h *removeRouteHandler) AddAllowedIPs(string) error     { return nil }
+func (h *removeRouteHandler) RemoveAllowedIPs() error        { return nil }
+func (h *removeRouteHandler) RemoveRoute() error {
+	h.removeAttempts++
+	if h.removeFailures != 0 {
+		if h.removeFailures > 0 {
+			h.removeFailures--
+		}
+		return errors.New("remove route")
+	}
+	return nil
+}
+
+func TestUpdateSystemRoutesRetainsHandlerUntilRemoveSucceeds(t *testing.T) {
+	id := route.HAUniqueID("net1||10.0.0.0/24")
+	handler := &removeRouteHandler{removeFailures: 1}
+	m := &DefaultManager{activeRoutes: map[route.HAUniqueID]client.RouteHandler{id: handler}}
+
+	require.Error(t, m.updateSystemRoutes(route.HAMap{}), "the first remove fails")
+	assert.Contains(t, m.activeRoutes, id, "a failed remove must stay available for reconciliation")
+
+	require.NoError(t, m.updateSystemRoutes(route.HAMap{}), "the next update retries the remove")
+	assert.NotContains(t, m.activeRoutes, id, "the handler is removed after cleanup succeeds")
+	assert.Equal(t, 2, handler.removeAttempts, "the handler must be called again")
+}
+
+func TestUpdateSystemRoutesRetainsHandlerAfterPersistentRemoveFailure(t *testing.T) {
+	id := route.HAUniqueID("net1||10.0.0.0/24")
+	handler := &removeRouteHandler{removeFailures: -1}
+	m := &DefaultManager{activeRoutes: map[route.HAUniqueID]client.RouteHandler{id: handler}}
+
+	for range 2 {
+		require.Error(t, m.updateSystemRoutes(route.HAMap{}), "a failed remove must keep the handler")
+		assert.Contains(t, m.activeRoutes, id, "the handler must stay available for later reconciliation")
+	}
+
+	assert.Equal(t, 2, handler.removeAttempts, "every update must retry the handler cleanup")
+}

--- a/client/internal/routemanager/update_system_routes_test.go
+++ b/client/internal/routemanager/update_system_routes_test.go
@@ -3,12 +3,14 @@ package routemanager
 import (
 	"context"
 	"errors"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/netbirdio/netbird/client/internal/routemanager/client"
+	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
 	"github.com/netbirdio/netbird/route"
 )
 
@@ -32,28 +34,59 @@ func (h *removeRouteHandler) RemoveRoute() error {
 	return nil
 }
 
-func TestUpdateSystemRoutesRetainsHandlerUntilRemoveSucceeds(t *testing.T) {
+func TestUpdateSystemRoutesRetriesFailedRemovalWhileAbsent(t *testing.T) {
 	id := route.HAUniqueID("net1||10.0.0.0/24")
 	handler := &removeRouteHandler{removeFailures: 1}
-	m := &DefaultManager{activeRoutes: map[route.HAUniqueID]client.RouteHandler{id: handler}}
+	m := newManagerWithActiveHandler(id, handler)
 
 	require.Error(t, m.updateSystemRoutes(route.HAMap{}), "the first remove fails")
-	assert.Contains(t, m.activeRoutes, id, "a failed remove must stay available for reconciliation")
+	assert.NotContains(t, m.activeRoutes, id, "a torn-down handler must not remain active")
+	assert.Same(t, handler, m.pendingRemovals[id], "the failed removal must remain retryable")
 
 	require.NoError(t, m.updateSystemRoutes(route.HAMap{}), "the next update retries the remove")
-	assert.NotContains(t, m.activeRoutes, id, "the handler is removed after cleanup succeeds")
+	assert.NotContains(t, m.pendingRemovals, id, "the pending removal must clear after cleanup succeeds")
 	assert.Equal(t, 2, handler.removeAttempts, "the handler must be called again")
 }
 
-func TestUpdateSystemRoutesRetainsHandlerAfterPersistentRemoveFailure(t *testing.T) {
+func TestUpdateSystemRoutesRecreatesDesiredRouteAfterPendingRemoval(t *testing.T) {
+	id := route.HAUniqueID("net1||10.0.0.0/24")
+	handler := &removeRouteHandler{removeFailures: 1}
+	m := newManagerWithActiveHandler(id, handler)
+	desired := testRoute()
+
+	require.Error(t, m.updateSystemRoutes(route.HAMap{}), "the first remove fails")
+	require.NoError(t, m.updateSystemRoutes(route.HAMap{id: {desired}}),
+		"a desired route is recreated after its pending removal succeeds")
+	assert.NotContains(t, m.pendingRemovals, id, "cleanup completed before recreation")
+	assert.Contains(t, m.activeRoutes, id, "the desired route must become active again")
+	assert.NotSame(t, handler, m.activeRoutes[id], "the torn-down handler must not be reused")
+}
+
+func TestUpdateSystemRoutesDoesNotDuplicateRouteAfterPersistentRemovalFailure(t *testing.T) {
 	id := route.HAUniqueID("net1||10.0.0.0/24")
 	handler := &removeRouteHandler{removeFailures: -1}
-	m := &DefaultManager{activeRoutes: map[route.HAUniqueID]client.RouteHandler{id: handler}}
+	m := newManagerWithActiveHandler(id, handler)
+	desired := testRoute()
 
-	for range 2 {
-		require.Error(t, m.updateSystemRoutes(route.HAMap{}), "a failed remove must keep the handler")
-		assert.Contains(t, m.activeRoutes, id, "the handler must stay available for later reconciliation")
+	require.Error(t, m.updateSystemRoutes(route.HAMap{}), "the first removal fails")
+	require.Error(t, m.updateSystemRoutes(route.HAMap{id: {desired}}),
+		"a desired route waits for its pending removal")
+	assert.Empty(t, m.activeRoutes, "a replacement must not be created while cleanup is pending")
+	assert.Same(t, handler, m.pendingRemovals[id], "only the original handler is pending")
+	assert.Equal(t, 2, handler.removeAttempts, "every update retries the pending cleanup")
+}
+
+func newManagerWithActiveHandler(id route.HAUniqueID, handler client.RouteHandler) *DefaultManager {
+	return &DefaultManager{
+		ctx:          context.Background(),
+		activeRoutes: map[route.HAUniqueID]client.RouteHandler{id: handler},
+		routeRefCounter: refcounter.New(
+			func(netip.Prefix, struct{}) (struct{}, error) { return struct{}{}, nil },
+			func(netip.Prefix, struct{}) error { return nil },
+		),
 	}
+}
 
-	assert.Equal(t, 2, handler.removeAttempts, "every update must retry the handler cleanup")
+func testRoute() *route.Route {
+	return &route.Route{Network: netip.MustParsePrefix("10.0.0.0/24")}
 }


### PR DESCRIPTION
## Describe your changes

Switching or removing a dynamic domain route could leave AllowedIPs installed on the old WireGuard peer. The route handler cleared the resolved-domain state before the watcher released those references, and failures during cleanup discarded the state needed for a later retry.

This change makes teardown ordered, synchronized, and retryable:

- Obsolete client watchers stop before system-route removal. `Watcher.Stop()` now cancels and joins the watcher loop before releasing AllowedIPs, is safe before `Start()`, and is idempotent.
- Dynamic handlers own the AllowedIP references they acquire. Failed physical removals are retained per prefix and peer, so retries process only failed operations and cannot decrement successful shared references twice.
- Failed system-route prefixes remain in the handler until removal succeeds.
- Failed handler removals move from `activeRoutes` into `pendingRemovals`. A route with the same ID is recreated only after the old handler finishes cleanup, so a partially torn-down handler cannot suppress its replacement.
- DNS batches always finish with `EndBatch()`. `CancelBatch()` did not roll back the DNS handler chain or extra-domain state, so cancelling after an unrelated error could leave a successfully added route in `activeRoutes` without applying its host DNS configuration.

The regression coverage includes reversed cleanup order, transient and persistent failures, shared same-peer references, duplicate prefixes across domains, failed system-route cleanup, same-ID reappearance, a partially successful DNS batch, a running watcher stopped during cleanup, repeated `Stop()`, and `Stop()` before `Start()`.

Local validation:

- `go test -race ./client/internal/routemanager ./client/internal/routemanager/client ./client/internal/routemanager/dynamic -count=1`
- `go test -race ./client/internal/routemanager/client -run 'TestWatcherStop' -count=20`
- `go test ./client/internal/routemanager/... -count=1`
- `bin/golangci-lint run ./client/internal/routemanager/... --timeout=2m`

## Issue ticket number and link

Issue Triage discussion: https://github.com/netbirdio/netbird/discussions/7284

No matching pre-existing ticket was found. I opened the PR before reading the discussion-first policy and filed the discussion afterwards. The implementation can wait for the team to validate the direction there.

## Stack

<!-- branch-stack -->

No dependent pull requests.

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal route teardown and retry behavior; no public API, protocol, or configuration changes)

### Docs PR URL (required if "docs added" is checked)

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when updating network routes by retrying cleanup operations that temporarily fail.
  - Prevented stale client network watchers from interfering with subsequent route updates.
  - Ensured dynamic routes and allowed IPs are cleaned up safely, even when removed in an unexpected order.
  - Prevented duplicate watcher shutdown operations and ensured shutdown waits for ongoing cleanup to finish.
  - DNS route updates are now committed even when unrelated route cleanup encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->