### PR TITLE
proxy: preserve Cookie header verbatim when stripping session cookie

### DIFF
--- a/proxy/internal/proxy/reverseproxy.go
+++ b/proxy/internal/proxy/reverseproxy.go
@@ -710,15 +710,168 @@ func (p *ReverseProxy) setUntrustedForwardingHeaders(r *httputil.ProxyRequest, c
 }
 
 // stripSessionCookie removes the proxy's session cookie from the outgoing
-// request while preserving all other cookies.
+// request while preserving all other cookies. It operates on the raw Cookie
+// header text rather than round-tripping through the cookie parser, which
+// drops any cookie whose value contains a byte outside the RFC 6265
+// cookie-octet range (e.g. a `;` escaped as \073 in a quoted value). Only the
+// matching cookie pair and its adjacent delimiter are removed, so every other
+// byte is forwarded verbatim.
 func stripSessionCookie(r *httputil.ProxyRequest) {
-	cookies := r.In.Cookies()
-	r.Out.Header.Del("Cookie")
-	for _, c := range cookies {
-		if c.Name != auth.SessionCookieName {
-			r.Out.AddCookie(c)
+	in := r.In.Header.Values("Cookie")
+	if len(in) == 0 {
+		return
+	}
+
+	out := make([]string, 0, len(in))
+	changed := false
+	for _, line := range in {
+		stripped, removed := stripCookiePair(line, auth.SessionCookieName)
+		if removed {
+			changed = true
+		}
+		if stripped != "" {
+			out = append(out, stripped)
 		}
 	}
+
+	switch {
+	case len(out) == 0:
+		r.Out.Header.Del("Cookie")
+	case changed:
+		r.Out.Header.Set("Cookie", strings.Join(out, "; "))
+	default:
+		// No session cookie present: forward the header(s) exactly as received.
+		r.Out.Header["Cookie"] = in
+	}
+}
+
+// stripCookiePair removes every cookie pair named name from a single raw Cookie
+// header field value. Names are matched exactly — cookie names are
+// case-sensitive per RFC 6265 §4.1.1. Only each matching pair and one adjacent
+// separator are removed; every other byte is preserved verbatim, including
+// semicolons inside quoted values and whitespace adjacent to surviving cookies.
+//
+// The line is processed as a sequence of "segments": a segment is the text
+// between two top-level ';' separators (top-level = outside any quoted value),
+// including its leading whitespace. Each segment is matched by its name, which
+// is the trimmed token before its first '='. A matched segment is dropped
+// together with the ';' that follows it (or, for the final segment, the ';'
+// that precedes it), so surviving pairs re-join with exactly one separator.
+func stripCookiePair(line, name string) (string, bool) {
+	out := make([]byte, 0, len(line))
+	removed := false
+	lastSemi := -1 // index in out of the last written ';', or -1
+
+	segStart := 0
+	for segStart < len(line) {
+		sep := nextCookieSeparator(line, segStart)
+		if cookiePairMatches(line[segStart:sep], name) {
+			removed = true
+			if sep < len(line) {
+				// Middle or first pair: drop the segment and its trailing
+				// ';' plus the whitespace after it.
+				segStart = skipCookieSeparator(line, sep)
+				continue
+			}
+			// Final pair: drop the segment and the '; ' that precedes it,
+			// which was written when the previous segment was kept.
+			if lastSemi >= 0 {
+				out = out[:lastSemi]
+			}
+			break
+		}
+		// Keep the segment and, when a separator follows, its trailing ';'
+		// plus the whitespace after it.
+		end := sep
+		if sep < len(line) {
+			end = skipCookieSeparator(line, sep)
+		}
+		start := len(out)
+		out = append(out, line[segStart:end]...)
+		if sep < len(line) {
+			lastSemi = start + (sep - segStart)
+		}
+		segStart = end
+	}
+	return string(out), removed
+}
+
+// nextCookieSeparator returns the index of the next top-level ';' in line at or
+// after start, or len(line) if the segment runs to the end of the line. A ';'
+// inside a quoted value does not end a segment; a ';' after an unterminated
+// quote does (an unterminated '"' is an ordinary cookie-octet, per RFC 6265).
+// Only a quote that opens a value is treated as a quote opener — an embedded
+// quote in a name, value, or another pair is an ordinary byte. Quote state
+// resets at every top-level ';', so it is never tracked across segments.
+func nextCookieSeparator(line string, start int) int {
+	valueStart := -1 // index of the first byte of the value, or -1 before any '='
+	for i := start; i < len(line); i++ {
+		switch line[i] {
+		case '"':
+			// Only a quote that opens the value starts a quoted value. An
+			// embedded quote in the name or a later pair is an ordinary byte
+			// (an embedded quote paired with a later value's quote would
+			// swallow the pair between them).
+			if i == valueStart {
+				if end, ok := skipQuotedValue(line, i); ok {
+					i = end - 1
+				}
+			}
+		case '=':
+			if valueStart < 0 {
+				// Remember the first byte of the value (after optional
+				// whitespace) so the opener check above has a target.
+				valueStart = i + 1
+				for valueStart < len(line) && (line[valueStart] == ' ' || line[valueStart] == '\t') {
+					valueStart++
+				}
+			}
+		case ';':
+			return i
+		}
+	}
+	return len(line)
+}
+
+// skipQuotedValue reports whether a quoted value opens at line[i] (line[i] ==
+// '"') and, if so, returns the index just past its closing quote. A
+// backslash-escaped character — including an escaped quote — is literal and
+// does not close the value. If the quote is unterminated, ok is false and the
+// '"' must be treated as an ordinary byte.
+func skipQuotedValue(line string, i int) (int, bool) {
+	for j := i + 1; j < len(line); j++ {
+		if line[j] == '\\' {
+			j++
+			continue
+		}
+		if line[j] == '"' {
+			return j + 1, true
+		}
+	}
+	return 0, false
+}
+
+// skipCookieSeparator returns the index just past a separator at sep: the ';'
+// plus any immediately following whitespace. Removing a pair takes its whole
+// trailing separator with it, so surviving pairs re-join with exactly one
+// separator and no stray leading whitespace.
+func skipCookieSeparator(line string, sep int) int {
+	sep++
+	for sep < len(line) && (line[sep] == ' ' || line[sep] == '\t') {
+		sep++
+	}
+	return sep
+}
+
+// cookiePairMatches reports whether the raw bytes of a cookie segment are the
+// pair named name. The segment may include leading/trailing whitespace and a
+// value; the name is the trimmed token before the first '='. Comparison is
+// exact (case-sensitive, per RFC 6265 §4.1.1).
+func cookiePairMatches(segment, name string) bool {
+	if eq := strings.IndexByte(segment, '='); eq >= 0 {
+		segment = segment[:eq]
+	}
+	return strings.Trim(segment, " \t") == name
 }
 
 // stripSessionTokenQuery removes the OIDC session_token query parameter from

--- a/proxy/internal/proxy/reverseproxy_test.go
+++ b/proxy/internal/proxy/reverseproxy_test.go
@@ -216,7 +216,207 @@ func TestRewriteFunc_SessionCookieStripping(t *testing.T) {
 
 		rewrite(pr)
 
-		assert.Empty(t, pr.Out.Header.Get("Cookie"))
+		assert.NotContains(t, pr.Out.Header, "Cookie",
+			"no Cookie header should be created when the request has none")
+	})
+
+	t.Run("preserves cookie values containing escaped semicolons and removes nb_session", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		// A quoted cookie value with a semicolon escaped as \073 (as Starlette
+		// emits) round-trips fine in a browser but is dropped by Go's cookie
+		// parser, so stripSessionCookie must not parse-and-re-emit.
+		pr.In.Header.Set("Cookie",
+			`__Host-app_session="provider=self-hosted\073state=xyz\073verifier=abc"; `+auth.SessionCookieName+"=jwt-token")
+
+		rewrite(pr)
+
+		raw := pr.Out.Header.Get("Cookie")
+		assert.Equal(t,
+			`__Host-app_session="provider=self-hosted\073state=xyz\073verifier=abc"`,
+			raw,
+			"only nb_session should be removed from the raw Cookie header")
+	})
+
+	t.Run("removes nb_session from the middle and keeps exact formatting", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		pr.In.Header.Set("Cookie",
+			"app=one; "+auth.SessionCookieName+"=jwt; tracking=two")
+
+		rewrite(pr)
+
+		assert.Equal(t, "app=one; tracking=two", pr.Out.Header.Get("Cookie"),
+			"nb_session in the middle is removed with its surrounding delimiters")
+	})
+
+	t.Run("removes nb_session from the end", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		pr.In.Header.Set("Cookie", "app=one; "+auth.SessionCookieName+"=jwt")
+
+		rewrite(pr)
+
+		assert.Equal(t, "app=one", pr.Out.Header.Get("Cookie"),
+			"trailing nb_session is removed without a dangling ';'")
+	})
+
+	t.Run("removes nb_session even with an empty value", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		pr.In.Header.Set("Cookie", "app=one; "+auth.SessionCookieName+"; tracking=two")
+
+		rewrite(pr)
+
+		assert.Equal(t, "app=one; tracking=two", pr.Out.Header.Get("Cookie"),
+			"nb_session with an empty value is still stripped")
+	})
+
+	t.Run("treats cookie names as case-sensitive", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		const raw = "app=one; NB_SESSION=jwt; tracking=two"
+		pr.In.Header.Set("Cookie", raw)
+
+		rewrite(pr)
+
+		assert.Equal(t, raw, pr.Out.Header.Get("Cookie"),
+			"a differently-cased cookie name is a distinct cookie and must not be stripped")
+	})
+
+	t.Run("does not match a cookie whose name merely contains nb_session", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		pr.In.Header.Set("Cookie", "mynb_session=x; "+auth.SessionCookieName+"=jwt")
+
+		rewrite(pr)
+
+		assert.Equal(t, "mynb_session=x", pr.Out.Header.Get("Cookie"),
+			"only an exact nb_session pair is removed, not tokens containing it")
+	})
+
+	t.Run("strips nb_session across multiple Cookie headers", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		pr.In.Header.Add("Cookie", "app=one")
+		pr.In.Header.Add("Cookie", auth.SessionCookieName+"=jwt")
+		pr.In.Header.Add("Cookie", "tracking=two")
+
+		rewrite(pr)
+
+		assert.Equal(t, "app=one; tracking=two", pr.Out.Header.Get("Cookie"),
+			"nb_session is removed across multiple Cookie header fields")
+	})
+
+	t.Run("preserves a semicolon inside a quoted value", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		pr.In.Header.Set("Cookie",
+			`app="a;b"; `+auth.SessionCookieName+"=jwt; c=3")
+
+		rewrite(pr)
+
+		assert.Equal(t, `app="a;b"; c=3`, pr.Out.Header.Get("Cookie"),
+			"a literal semicolon inside a quoted value is not treated as a pair separator")
+	})
+
+	t.Run("forwards header verbatim when no session cookie is present", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		const raw = `__Host-app_session="provider=self-hosted\073state=xyz\073verifier=abc"`
+		pr.In.Header.Set("Cookie", raw)
+
+		rewrite(pr)
+
+		assert.Equal(t, raw, pr.Out.Header.Get("Cookie"),
+			"a Cookie header without nb_session must be forwarded byte-for-byte")
+	})
+
+	t.Run("deletes the header when only nb_session is present", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		pr.In.Header.Set("Cookie", auth.SessionCookieName+"=jwt")
+
+		rewrite(pr)
+
+		assert.NotContains(t, pr.Out.Header, "Cookie",
+			"when only nb_session is present the Cookie header key is removed")
+	})
+
+	t.Run("preserves trailing whitespace of a surviving cookie after a middle removal", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		pr.In.Header.Set("Cookie", "app=one; "+auth.SessionCookieName+"=jwt; tracking=two ")
+
+		rewrite(pr)
+
+		assert.Equal(t, "app=one; tracking=two ", pr.Out.Header.Get("Cookie"),
+			"removing a middle pair must not strip whitespace from surviving cookies")
+	})
+
+	t.Run("ignores a lookalike nb_session inside a quoted value", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		const raw = `app="a; ` + auth.SessionCookieName + `=fake"; tracking=two`
+		pr.In.Header.Set("Cookie", raw)
+
+		rewrite(pr)
+
+		assert.Equal(t, raw, pr.Out.Header.Get("Cookie"),
+			"a semicolon inside a quoted value is not a pair separator, so a lookalike pair inside it must not be touched")
+	})
+
+	t.Run("strips nb_session after a quoted value and keeps the quoted value intact", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		const raw = `app="a; ` + auth.SessionCookieName + `=fake"; ` + auth.SessionCookieName + "=jwt; tracking=two"
+		pr.In.Header.Set("Cookie", raw)
+
+		rewrite(pr)
+
+		assert.Equal(t, `app="a; `+auth.SessionCookieName+`=fake"; tracking=two`, pr.Out.Header.Get("Cookie"),
+			"the quoted value must survive and the real nb_session pair must be removed")
+	})
+
+	t.Run("treats an unterminated quote as an ordinary byte", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		const raw = `app="unclosed; ` + auth.SessionCookieName + `=x; c=3`
+		pr.In.Header.Set("Cookie", raw)
+
+		rewrite(pr)
+
+		assert.Equal(t, `app="unclosed; c=3`, pr.Out.Header.Get("Cookie"),
+			"an unterminated quote is an ordinary cookie-octet per RFC 6265, so nb_session is still a real pair")
+	})
+
+	t.Run("does not treat a single quote as a quote", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		const raw = `app='a; ` + auth.SessionCookieName + `=REAL; c=3`
+		pr.In.Header.Set("Cookie", raw)
+
+		rewrite(pr)
+
+		assert.Equal(t, `app='a; c=3`, pr.Out.Header.Get("Cookie"),
+			"a single quote is not a cookie quote, so nb_session is still a real pair")
+	})
+
+	t.Run("does not treat a value that starts with the name as a cookie", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		const raw = "tracking=" + auth.SessionCookieName + "=bar; c=3"
+		pr.In.Header.Set("Cookie", raw)
+
+		rewrite(pr)
+
+		assert.Equal(t, raw, pr.Out.Header.Get("Cookie"),
+			"only a real cookie-name token is matched, never a value that merely starts with the name")
+	})
+
+	t.Run("does not let an embedded quote in a session value delete survivors", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		pr.In.Header.Set("Cookie", auth.SessionCookieName+`=abc"def; x=1`)
+
+		rewrite(pr)
+
+		assert.Equal(t, "x=1", pr.Out.Header.Get("Cookie"),
+			"an embedded quote in the session value must not swallow the following cookies")
+	})
+
+	t.Run("does not let an embedded quote in a session value pair with a later quoted value", func(t *testing.T) {
+		pr := newProxyRequest(t, "http://example.com/", "1.2.3.4:5000")
+		const raw = auth.SessionCookieName + `=abc"def; app="ok"; tracking=two`
+		pr.In.Header.Set("Cookie", raw)
+
+		rewrite(pr)
+
+		assert.Equal(t, `app="ok"; tracking=two`, pr.Out.Header.Get("Cookie"),
+			"an embedded quote must not pair with a later value's quote and delete the pair between them")
 	})
 }
 


### PR DESCRIPTION
Fixes #7298

### What

`stripSessionCookie` parses the incoming `Cookie` header with `r.In.Cookies()` and re-emits each survivor with `r.Out.AddCookie()`. Go's stdlib cookie parser **drops any cookie whose value contains a byte outside `0x20–0x7e` (excluding `"` `;` `\`)** — so a cookie with a `;` in its value (e.g. Starlette's `\073`-escaped `;` in a quoted value) is silently removed before the request is forwarded.

### Repro

* App sets `Set-Cookie: __Host-app_session="provider=oidc\073state=…\073verifier=…"` (legal RFC 6265, round-trips fine browser↔origin)
* Browser sends it back on the callback request
* NetBird proxy forwards the callback with **no `Cookie` header at all**
* Upstream returns `{"detail":"Missing PKCE state cookie"}`

### Fix

Strip `nb_session` on the raw header text instead of round-tripping through the parser:

```go
func stripSessionCookie(r *httputil.ProxyRequest) {
	raw := r.In.Header.Get("Cookie")
	if raw == "" {
		return
	}

	parts := strings.Split(raw, ";")
	kept := parts[:0]
	for _, part := range parts {
		name, _, _ := strings.Cut(strings.TrimSpace(part), "=")
		if name == auth.SessionCookieName {
			continue
		}
		kept = append(kept, part)
	}

	if len(kept) == 0 {
		r.Out.Header.Del("Cookie")
		return
	}
	r.Out.Header.Set("Cookie", strings.Join(kept, ";"))
}
```

### Test

Add a subtest to `TestRewriteFunc_SessionCookieStripping` asserting a raw cookie with a `\073`-escaped `;` in its value survives byte-for-byte while `nb_session` is removed. (Existing subtests — strips `nb_session`, preserves others, no-cookie case — pass unchanged.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-cookie removal while preserving unrelated cookie values, including quoted, escaped, unterminated, and whitespace-sensitive values.
  * Cookie matching is now case-sensitive and limited to exact cookie names.
  * Correctly handles multiple cookie headers and removes the header when no cookies remain.
  * Prevents embedded or later quotes from incorrectly consuming subsequent cookie pairs.
  * Applies discovery-related response filtering consistently when rewriting upstream responses.

* **Tests**
  * Added comprehensive regression coverage for cookie parsing, preservation, and removal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
