### PR TITLE
[client] Revert declaring multi-buffer support for the loopback XDP program

### DIFF
--- a/client/internal/ebpf/ebpf/manager_linux.go
+++ b/client/internal/ebpf/ebpf/manager_linux.go
@@ -2,21 +2,17 @@ package ebpf
 
 import (
 	_ "embed"
-	"fmt"
 	"net"
 	"sync"
 
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/rlimit"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 
 	"github.com/netbirdio/netbird/client/internal/ebpf/manager"
 )
 
 const (
-	xdpProgName = "nb_xdp_prog"
-
 	mapKeyFeatures uint32 = 0
 
 	featureFlagWGProxy      = 0b00000001
@@ -72,50 +68,21 @@ func (tf *GeneralManager) loadXdp() error {
 		return err
 	}
 
-	// lo has no native XDP, so the program runs in generic mode. Unless it
-	// declares multi-buffer support the kernel must linearize every non-linear
-	// skb before running it. Loopback packets are up to 64 KB, so that is a
-	// contiguous GFP_ATOMIC allocation per packet, and when it fails the packet
-	// is dropped before the program runs, stalling local TCP connections.
-	// Multi-buffer XDP in generic mode requires kernel 6.3, so fall back to a
-	// plain attach when the kernel rejects it.
-	err = tf.attachXdp(iFace.Index, true)
-	if err == nil {
-		return nil
-	}
-	log.Debugf("failed to attach multi-buffer xdp program, retrying without it: %s", err)
-
-	return tf.attachXdp(iFace.Index, false)
-}
-
-func (tf *GeneralManager) attachXdp(iFaceIndex int, multiBuffer bool) error {
-	spec, err := loadBpf()
+	// load pre-compiled programs into the kernel.
+	err = loadBpfObjects(&tf.bpfObjs, nil)
 	if err != nil {
-		return fmt.Errorf("load bpf spec: %w", err)
-	}
-
-	if multiBuffer {
-		prog, ok := spec.Programs[xdpProgName]
-		if !ok {
-			return fmt.Errorf("program %s not found in bpf spec", xdpProgName)
-		}
-		prog.Flags |= unix.BPF_F_XDP_HAS_FRAGS
-	}
-
-	if err := spec.LoadAndAssign(&tf.bpfObjs, nil); err != nil {
-		return fmt.Errorf("load bpf objects: %w", err)
+		return err
 	}
 
 	tf.link, err = link.AttachXDP(link.XDPOptions{
 		Program:   tf.bpfObjs.NbXdpProg,
-		Interface: iFaceIndex,
+		Interface: iFace.Index,
 	})
+
 	if err != nil {
-		if closeErr := tf.bpfObjs.Close(); closeErr != nil {
-			log.Debugf("failed to close bpf objects after xdp attach error: %s", closeErr)
-		}
+		_ = tf.bpfObjs.Close()
 		tf.link = nil
-		return fmt.Errorf("attach xdp: %w", err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Describe your changes

Reverts #7230. Declaring multi-buffer support for the loopback XDP program triggers kernel
panics on kernels 6.3 and newer, which is a far worse failure than the loopback throughput
problem the flag was meant to solve.

- Stop setting the multi-buffer flag on the loopback XDP program, restoring the previous attach path
- The flag makes generic XDP rebuild every non-linear or cloned loopback packet on the kernel's per-CPU page pool as a recycle-marked buffer, instead of just linearizing it. Those buffers then crash the kernel when something clones them further up the stack, which raw socket delivery does
- Loopback TCP stalls from the XDP program are back as a result, and need a fix that does not depend on generic XDP: a TC ingress hook, or not attaching to loopback unless the eBPF proxy is in use

## Issue ticket number and link

Fixes #7295
Reopens #7227

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal eBPF attach behavior, no user-facing surface)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network monitoring startup reliability on Linux systems.
  * Streamlined attachment of network processing components, reducing failures caused by unsupported configurations.
  * Errors are now surfaced more consistently when network setup cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->