### PR TITLE
[management, client] add protobuf breaking changes check

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,8 +1,8 @@
 name: protobuf checks
 on:
   push:
-    paths:
-      - '**.proto'
+#    paths:
+#      - '**.proto'
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -16,7 +16,4 @@ jobs:
           persist-credentials: false
       - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3 # v1.5.0
         with:
-          format: false
-          lint: false
-          push: false
-          archive: false
+          breaking: true

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,8 +1,12 @@
 name: protobuf checks
 on:
   push:
+    branches:
+      - main
+      - "release-*"
+  pull_request:
     paths:
-      - '**.proto'
+      - "**.proto"
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -6,7 +6,7 @@ on:
       - "release-*"
   pull_request:
     paths:
-      - ".github/workflows/buf.yaml"
+      - ".github/workflows/buf.yml"
       - "**/buf.yaml"
       - "**/buf.lock"
       - "**/buf.gen.yaml"

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -25,4 +25,9 @@ jobs:
       - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3 # v1.5.0
         with:
           push: false
+          archive: false
+          pr_comment: false
+          build: false
+          lint: false
+          format: false
           breaking: true

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,8 +1,8 @@
 name: protobuf checks
 on:
   push:
-#    paths:
-#      - '**.proto'
+    paths:
+      - '**.proto'
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,0 +1,22 @@
+name: protobuf checks
+on:
+  push:
+    paths:
+      - '**.proto'
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3 # v1.5.0
+        with:
+          format: false
+          lint: false
+          push: false
+          archive: false

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -16,4 +16,5 @@ jobs:
           persist-credentials: false
       - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3 # v1.5.0
         with:
+          push: false
           breaking: true

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -6,6 +6,10 @@ on:
       - "release-*"
   pull_request:
     paths:
+      - ".github/workflows/buf.yaml"
+      - "**/buf.yaml"
+      - "**/buf.lock"
+      - "**/buf.gen.yaml"
       - "**.proto"
 permissions:
   contents: read

--- a/shared/management/proto/management.proto
+++ b/shared/management/proto/management.proto
@@ -92,7 +92,6 @@ message JobRequest {
 enum JobStatus {
   unknown_status = 0; //placeholder
   succeeded = 1;
-  failed = 2;
 }
 
 message JobResponse{

--- a/shared/management/proto/management.proto
+++ b/shared/management/proto/management.proto
@@ -92,6 +92,7 @@ message JobRequest {
 enum JobStatus {
   unknown_status = 0; //placeholder
   succeeded = 1;
+  failed = 2;
 }
 
 message JobResponse{


### PR DESCRIPTION
## Describe your changes
This PR adds a github workflow to catch protobuf breaking changes. See https://github.com/netbirdio/netbird/actions/runs/32748152216/job/97498490569 for an example of a failing check.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* API schema validation now runs on pushes to the main and release branches.
* Pull requests that modify protobuf definitions automatically trigger validation.
* Validation uses read-only permissions and pinned tooling for improved security and consistency.
* Automated checks detect potentially breaking schema changes.
* Validation workflows no longer push schema updates automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->