### PR TITLE
Fix ICE candidate baseline initialization race on startup

### DIFF
--- a/client/internal/peer/guard/ice_monitor.go
+++ b/client/internal/peer/guard/ice_monitor.go
@@ -28,6 +28,7 @@ type ICEMonitor struct {
 	tickerPeriod  time.Duration
 
 	currentCandidatesAddress []string
+	baselineInitialized      bool
 	candidatesMu             sync.Mutex
 }
 
@@ -49,9 +50,13 @@ func (cm *ICEMonitor) Start(ctx context.Context, onChanged func()) {
 		return
 	}
 
-	// Initial check to populate the candidates for later comparison
-	if _, err := cm.handleCandidateTick(ctx, ufrag, pwd); err != nil {
-		log.Warnf("Failed to check initial ICE candidates: %v", err)
+	// Initial check to populate the candidates for later comparison, only if STUN/TURN config is ready
+	if cm.hasStunTurnConfig() {
+		if _, err := cm.handleCandidateTick(ctx, ufrag, pwd); err != nil {
+			log.Warnf("Failed to check initial ICE candidates: %v", err)
+		}
+	} else {
+		log.Debugf("STUN/TURN config not yet available, delaying initial ICE candidate gather")
 	}
 
 	ticker := time.NewTicker(cm.tickerPeriod)
@@ -60,6 +65,11 @@ func (cm *ICEMonitor) Start(ctx context.Context, onChanged func()) {
 	for {
 		select {
 		case <-ticker.C:
+			if !cm.hasStunTurnConfig() {
+				log.Debugf("STUN/TURN config not yet available, skipping ICE candidate gather")
+				continue
+			}
+
 			changed, err := cm.handleCandidateTick(ctx, ufrag, pwd)
 			if err != nil {
 				log.Warnf("Failed to check ICE changes: %v", err)
@@ -131,6 +141,12 @@ func (cm *ICEMonitor) updateCandidates(newCandidates []ice.Candidate) bool {
 	}
 	sort.Strings(newAddresses)
 
+	if !cm.baselineInitialized {
+		cm.currentCandidatesAddress = newAddresses
+		cm.baselineInitialized = true
+		return false
+	}
+
 	if len(cm.currentCandidatesAddress) != len(newAddresses) {
 		cm.currentCandidatesAddress = newAddresses
 		return true
@@ -143,6 +159,10 @@ func (cm *ICEMonitor) updateCandidates(newCandidates []ice.Candidate) bool {
 	}
 
 	return false
+}
+
+func (cm *ICEMonitor) hasStunTurnConfig() bool {
+	return cm.iceConfig.StunTurn != nil && cm.iceConfig.StunTurn.Load() != nil
 }
 
 func candidateTypesP2P() []ice.CandidateType {

--- a/client/internal/peer/guard/ice_monitor_test.go
+++ b/client/internal/peer/guard/ice_monitor_test.go
@@ -1,0 +1,102 @@
+package guard
+
+import (
+	"testing"
+
+	icemaker "github.com/netbirdio/netbird/client/internal/peer/ice"
+	"github.com/pion/ice/v4"
+	"github.com/pion/stun/v3"
+)
+
+// mockCandidate implements ice.Candidate for testing
+type mockCandidate struct {
+	ice.Candidate // Embedded interface allows us to ignore unneeded methods
+	address       string
+}
+
+func (m mockCandidate) Address() string {
+	return m.address
+}
+
+func TestICEMonitor_updateCandidates_InitialGatherPopulatesBaseline(t *testing.T) {
+	cm := &ICEMonitor{}
+
+	hostCandidate := mockCandidate{address: "192.168.1.100"}
+	srflxCandidate := mockCandidate{address: "203.0.113.50"}
+
+	// 1. First successful gather establishes the baseline.
+	// This simulates the first tick after STUN config becomes available.
+	changed := cm.updateCandidates([]ice.Candidate{
+		hostCandidate,
+		srflxCandidate,
+	})
+
+	if changed {
+		t.Errorf("First gather should populate baseline without reporting change")
+	}
+	if !cm.baselineInitialized {
+		t.Errorf("Baseline should be marked as initialized")
+	}
+	if len(cm.currentCandidatesAddress) != 2 {
+		t.Errorf("Baseline was not populated correctly")
+	}
+
+	// 2. Second gather: identical candidates
+	// Should not report change
+	changed = cm.updateCandidates([]ice.Candidate{hostCandidate, srflxCandidate})
+	if changed {
+		t.Errorf("Subsequent gather with identical candidates should not report change")
+	}
+
+	// 3. Third gather: new candidate added (genuine network change)
+	newHostCandidate := mockCandidate{address: "10.0.0.5"}
+	changed = cm.updateCandidates([]ice.Candidate{hostCandidate, srflxCandidate, newHostCandidate})
+	if !changed {
+		t.Errorf("Subsequent gather with new candidates should report change")
+	}
+}
+
+func TestICEMonitor_hasStunTurnConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		stunTurn *icemaker.StunTurn
+		setup    func(*icemaker.StunTurn)
+		expected bool
+	}{
+		{
+			name:     "Nil StunTurn pointer",
+			stunTurn: nil,
+			setup:    func(st *icemaker.StunTurn) {},
+			expected: false,
+		},
+		{
+			name:     "StunTurn pointer not nil but Load returns nil",
+			stunTurn: &icemaker.StunTurn{},
+			setup:    func(st *icemaker.StunTurn) {}, // atomic.Value implicitly holds nil
+			expected: false,
+		},
+		{
+			name:     "StunTurn populated",
+			stunTurn: &icemaker.StunTurn{},
+			setup: func(st *icemaker.StunTurn) {
+				st.Store([]*stun.URI{{Scheme: stun.SchemeTypeSTUN, Host: "stun.netbird.io"}})
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := &ICEMonitor{
+				iceConfig: icemaker.Config{
+					StunTurn: tt.stunTurn,
+				},
+			}
+			tt.setup(tt.stunTurn)
+
+			if got := cm.hasStunTurnConfig(); got != tt.expected {
+				t.Errorf("hasStunTurnConfig() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes

Fixes the ICE monitor reporting a phantom network change one monitor period after startup when the initial candidate baseline is gathered before the STUN/TURN configuration is available.

The initial gather is now skipped when the STUN/TURN configuration has not yet been loaded. The first subsequent successful gather establishes the candidate baseline without reporting a network change.

Changes:

- Skip the initial ICE candidate gather when STUN/TURN configuration is not yet available.
- Treat the first successful candidate gather as baseline initialization rather than a network change.
- Add regression tests covering initial baseline population and STUN/TURN configuration availability.

## Issue ticket number and link

Fixes #7165

## Stack

<!-- branch-stack -->

### Checklist

- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change links an issue the NetBird team agreed on beforehand: #7165

## Documentation

- [x] Documentation is **not needed** for this change because this is an internal bug fix with no user-facing API, CLI, configuration, or behavior documentation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ICE candidate change detection by establishing an initial baseline before reporting changes.
  * Prevented unnecessary candidate gathering when STUN/TURN configuration is unavailable.
  * Added safeguards for empty or missing connection configuration.

* **Tests**
  * Added coverage for initial, repeated, and changed candidate gathers.
  * Added validation for different STUN/TURN configuration states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->