### PR TITLE
[client] fix a flake in TestResolver_ConcurrentStaleHitsCollapseRefresh test

### DIFF
--- a/client/internal/dns/mgmt/mgmt_refresh_test.go
+++ b/client/internal/dns/mgmt/mgmt_refresh_test.go
@@ -224,6 +224,7 @@ func TestResolver_StaleTriggersAsyncRefresh(t *testing.T) {
 }
 
 func TestResolver_ConcurrentStaleHitsCollapseRefresh(t *testing.T) {
+	semaphore := make(chan struct{})
 	r := NewResolver()
 	chain := newFakeChain()
 	chain.setAnswer("mgmt.example.com.", dns.TypeA, "10.0.0.2")
@@ -239,7 +240,7 @@ func TestResolver_ConcurrentStaleHitsCollapseRefresh(t *testing.T) {
 				break
 			}
 		}
-		time.Sleep(50 * time.Millisecond) // hold inflight long enough to collide
+		<-semaphore // block the call to force request collision
 	}
 
 	r.SetChainResolver(chain, 50)
@@ -255,12 +256,11 @@ func TestResolver_ConcurrentStaleHitsCollapseRefresh(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			queryA(t, r, "mgmt.example.com.")
-		}()
+		})
 	}
+	close(semaphore)
 	wg.Wait()
 
 	waitFor(t, 2*time.Second, func() bool {

--- a/client/internal/dns/mgmt/mgmt_refresh_test.go
+++ b/client/internal/dns/mgmt/mgmt_refresh_test.go
@@ -260,12 +260,13 @@ func TestResolver_ConcurrentStaleHitsCollapseRefresh(t *testing.T) {
 			queryA(t, r, "mgmt.example.com.")
 		})
 	}
+
+	assert.Eventually(t, func() bool { return inflight.Load() >= 1 }, 2*time.Second, 100*time.Millisecond)
+
 	close(semaphore)
 	wg.Wait()
 
-	waitFor(t, 2*time.Second, func() bool {
-		return inflight.Load() == 0
-	})
+	assert.Eventually(t, func() bool { return inflight.Load() == 0 }, 2*time.Second, 100*time.Millisecond)
 
 	calls := chain.callCount("mgmt.example.com.", dns.TypeA)
 	assert.LessOrEqual(t, calls, 2, "singleflight must collapse concurrent refreshes (got %d)", calls)


### PR DESCRIPTION
## Describe your changes
Ran into a flake, see https://github.com/netbirdio/netbird/actions/runs/32865045493/job/97858134083?pr=7305#step:8:53. This PR forces a collision in dns requests in a deterministic way.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of concurrent refresh testing through more deterministic synchronization.
  * Enhanced validation that concurrent refresh operations complete successfully.
  * Replaced timing-sensitive completion checks with more robust eventual verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->