### PR TITLE
[client, ios] Fix context cancellation during restart

### DIFF
--- a/client/android/client.go
+++ b/client/android/client.go
@@ -41,6 +41,8 @@ const (
 	AnonymizeLevelStrict  = nbAnonymize.LevelStrictString
 )
 
+const stopRunWaitTimeout = 20 * time.Second
+
 // TunAdapter export internal TunAdapter for mobile
 type TunAdapter interface {
 	device.TunAdapter
@@ -89,6 +91,8 @@ type Client struct {
 	stateMu       sync.RWMutex
 	connectClient *internal.ConnectClient
 	config        *profilemanager.Config
+	runGeneration uint64
+	runDone       chan struct{}
 	cacheDir      string
 	// Identifies the running profile for the SSO login hint; see profile_state.go.
 	cfgPath string
@@ -112,13 +116,33 @@ type Client struct {
 	extendCancel context.CancelFunc
 }
 
-func (c *Client) setState(cfg *profilemanager.Config, cacheDir string, cfgPath string, cc *internal.ConnectClient) {
+func (c *Client) beginRun(cancel context.CancelFunc) (uint64, chan struct{}) {
+	done := make(chan struct{})
+
+	c.stateMu.Lock()
+	c.runGeneration++
+	generation := c.runGeneration
+	c.runDone = done
+	c.stateMu.Unlock()
+
+	c.ctxCancelLock.Lock()
+	c.ctxCancel = cancel
+	c.ctxCancelLock.Unlock()
+
+	return generation, done
+}
+
+func (c *Client) publishState(generation uint64, cfg *profilemanager.Config, cacheDir string, cfgPath string, cc *internal.ConnectClient) bool {
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
+	if c.runGeneration != generation {
+		return false
+	}
 	c.config = cfg
 	c.cacheDir = cacheDir
 	c.cfgPath = cfgPath
 	c.connectClient = cc
+	return true
 }
 
 func (c *Client) stateSnapshot() (*profilemanager.Config, string, *internal.ConnectClient) {
@@ -188,9 +212,9 @@ func (c *Client) Run(platformFiles PlatformFiles, urlOpener URLOpener, isAndroid
 
 	runCtx, runCancel := context.WithCancel(ctxWithValues)
 	defer runCancel()
-	c.ctxCancelLock.Lock()
-	c.ctxCancel = runCancel
-	c.ctxCancelLock.Unlock()
+
+	generation, done := c.beginRun(runCancel)
+	defer close(done)
 	ctx := runCtx
 
 	auth := NewAuthWithConfig(ctx, cfg, cfgFile)
@@ -203,7 +227,10 @@ func (c *Client) Run(platformFiles PlatformFiles, urlOpener URLOpener, isAndroid
 
 	connectClient := internal.NewConnectClient(ctx, cfg, c.recorder,
 		internal.WithNetEvents(c.netMgr))
-	c.setState(cfg, cacheDir, cfgFile, connectClient)
+	if !c.publishState(generation, cfg, cacheDir, cfgFile, connectClient) {
+		log.Infof("run: superseded by a newer run, aborting startup")
+		return nil
+	}
 	// This path runs the interactive SSO flow, so reaching here means the peer
 	// is authenticated again — release the latch Status() reports from. Clear
 	// only once the fresh connect client is installed: until then Status()
@@ -237,40 +264,55 @@ func (c *Client) RunWithoutLogin(platformFiles PlatformFiles, dns *DNSList, dnsR
 	ctxWithValues := context.WithValue(context.Background(), system.DeviceNameCtxKey, c.deviceName)
 	runCtx, runCancel := context.WithCancel(ctxWithValues)
 	defer runCancel()
-	c.ctxCancelLock.Lock()
-	c.ctxCancel = runCancel
-	c.ctxCancelLock.Unlock()
+
+	generation, done := c.beginRun(runCancel)
+	defer close(done)
 	ctx := runCtx
 
 	// todo do not throw error in case of cancelled context
 	ctx = internal.CtxInitState(ctx)
 	connectClient := internal.NewConnectClient(ctx, cfg, c.recorder,
 		internal.WithNetEvents(c.netMgr))
-	c.setState(cfg, cacheDir, cfgFile, connectClient)
+	if !c.publishState(generation, cfg, cacheDir, cfgFile, connectClient) {
+		log.Infof("run: superseded by a newer run, aborting startup")
+		return nil
+	}
 	return connectClient.RunOnAndroid(c.tunAdapter, c.iFaceDiscover, c.networkChangeListener, slices.Clone(dns.items), dnsReadyListener, stateFile, cacheDir)
 }
 
 // Stop the internal client and free the resources
 func (c *Client) Stop() {
 	c.stateMu.Lock()
+	c.runGeneration++
 	cc := c.connectClient
+	done := c.runDone
 	c.connectClient = nil
 	c.config = nil
+	c.runDone = nil
 	c.stateMu.Unlock()
+
+	c.ctxCancelLock.Lock()
+	cancel := c.ctxCancel
+	c.ctxCancel = nil
+	c.ctxCancelLock.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
 
 	if cc != nil {
 		if err := cc.Stop(); err != nil {
 			log.Errorf("Stop: failed stopping the connect client: %v", err)
 		}
-		return
 	}
 
-	c.ctxCancelLock.Lock()
-	defer c.ctxCancelLock.Unlock()
-	if c.ctxCancel == nil {
-		return
+	if done != nil {
+		select {
+		case <-done:
+		case <-time.After(stopRunWaitTimeout):
+			log.Warnf("Stop: timed out waiting for the run loop to exit")
+		}
 	}
-	c.ctxCancel()
 }
 
 func (c *Client) RenewTun(fd int) error {

--- a/client/android/client.go
+++ b/client/android/client.go
@@ -181,16 +181,17 @@ func (c *Client) Run(platformFiles PlatformFiles, urlOpener URLOpener, isAndroid
 	c.recorder.UpdateManagementAddress(cfg.ManagementURL.String())
 	c.recorder.UpdateRosenpass(cfg.RosenpassEnabled, cfg.RosenpassPermissive)
 
-	var ctx context.Context
 	//nolint
 	ctxWithValues := context.WithValue(context.Background(), system.DeviceNameCtxKey, c.deviceName)
 	//nolint
 	ctxWithValues = context.WithValue(ctxWithValues, system.UiVersionCtxKey, c.uiVersion)
 
+	runCtx, runCancel := context.WithCancel(ctxWithValues)
+	defer runCancel()
 	c.ctxCancelLock.Lock()
-	ctx, c.ctxCancel = context.WithCancel(ctxWithValues)
-	defer c.ctxCancel()
+	c.ctxCancel = runCancel
 	c.ctxCancelLock.Unlock()
+	ctx := runCtx
 
 	auth := NewAuthWithConfig(ctx, cfg, cfgFile)
 	err = auth.login(urlOpener, isAndroidTV)
@@ -232,13 +233,14 @@ func (c *Client) RunWithoutLogin(platformFiles PlatformFiles, dns *DNSList, dnsR
 	c.recorder.UpdateManagementAddress(cfg.ManagementURL.String())
 	c.recorder.UpdateRosenpass(cfg.RosenpassEnabled, cfg.RosenpassPermissive)
 
-	var ctx context.Context
 	//nolint
 	ctxWithValues := context.WithValue(context.Background(), system.DeviceNameCtxKey, c.deviceName)
+	runCtx, runCancel := context.WithCancel(ctxWithValues)
+	defer runCancel()
 	c.ctxCancelLock.Lock()
-	ctx, c.ctxCancel = context.WithCancel(ctxWithValues)
-	defer c.ctxCancel()
+	c.ctxCancel = runCancel
 	c.ctxCancelLock.Unlock()
+	ctx := runCtx
 
 	// todo do not throw error in case of cancelled context
 	ctx = internal.CtxInitState(ctx)
@@ -250,12 +252,24 @@ func (c *Client) RunWithoutLogin(platformFiles PlatformFiles, dns *DNSList, dnsR
 
 // Stop the internal client and free the resources
 func (c *Client) Stop() {
+	c.stateMu.Lock()
+	cc := c.connectClient
+	c.connectClient = nil
+	c.config = nil
+	c.stateMu.Unlock()
+
+	if cc != nil {
+		if err := cc.Stop(); err != nil {
+			log.Errorf("Stop: failed stopping the connect client: %v", err)
+		}
+		return
+	}
+
 	c.ctxCancelLock.Lock()
 	defer c.ctxCancelLock.Unlock()
 	if c.ctxCancel == nil {
 		return
 	}
-
 	c.ctxCancel()
 }
 

--- a/client/android/client.go
+++ b/client/android/client.go
@@ -4,7 +4,6 @@ package android
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -42,10 +41,6 @@ const (
 	AnonymizeLevelStrict  = nbAnonymize.LevelStrictString
 )
 
-const stopRunWaitTimeout = 20 * time.Second
-
-var errClientAlreadyRunning = errors.New("client is already running")
-
 // TunAdapter export internal TunAdapter for mobile
 type TunAdapter interface {
 	device.TunAdapter
@@ -81,6 +76,8 @@ type Client struct {
 	tunAdapter            device.TunAdapter
 	iFaceDiscover         IFaceDiscover
 	recorder              *peer.Status
+	ctxCancel             context.CancelFunc
+	ctxCancelLock         *sync.Mutex
 	deviceName            string
 	uiVersion             string
 	networkChangeListener listener.NetworkChangeListener
@@ -89,16 +86,9 @@ type Client struct {
 	// sweeper into each new ConnectClient.
 	netMgr *netevents.Manager
 
-	// stateMu guards the run lifecycle as one unit: the cancel installed by
-	// the current run, the channel it closes on exit, and the state it
-	// published. One run at a time: startRun refuses a second Run while the
-	// previous one has not exited, and the platform serializes Stop before
-	// Start, so no generation tracking is needed.
 	stateMu       sync.RWMutex
 	connectClient *internal.ConnectClient
 	config        *profilemanager.Config
-	runDone       chan struct{}
-	ctxCancel     context.CancelFunc
 	cacheDir      string
 	// Identifies the running profile for the SSO login hint; see profile_state.go.
 	cfgPath string
@@ -122,40 +112,13 @@ type Client struct {
 	extendCancel context.CancelFunc
 }
 
-func (c *Client) startRun(cancel context.CancelFunc) (chan struct{}, error) {
-	c.stateMu.Lock()
-	defer c.stateMu.Unlock()
-
-	if c.runDone != nil {
-		return nil, errClientAlreadyRunning
-	}
-
-	done := make(chan struct{})
-	c.runDone = done
-	c.ctxCancel = cancel
-	return done, nil
-}
-
-func (c *Client) finishRun(done chan struct{}) {
-	c.stateMu.Lock()
-	c.connectClient = nil
-	c.config = nil
-	c.cacheDir = ""
-	c.cfgPath = ""
-	c.runDone = nil
-	c.ctxCancel = nil
-	c.stateMu.Unlock()
-
-	close(done)
-}
-
 func (c *Client) setState(cfg *profilemanager.Config, cacheDir string, cfgPath string, cc *internal.ConnectClient) {
 	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
 	c.config = cfg
 	c.cacheDir = cacheDir
 	c.cfgPath = cfgPath
 	c.connectClient = cc
-	c.stateMu.Unlock()
 }
 
 func (c *Client) stateSnapshot() (*profilemanager.Config, string, *internal.ConnectClient) {
@@ -193,6 +156,7 @@ func NewClient(androidSDKVersion int, deviceName string, uiVersion string, tunAd
 		tunAdapter:            tunAdapter,
 		iFaceDiscover:         iFaceDiscover,
 		recorder:              recorder,
+		ctxCancelLock:         &sync.Mutex{},
 		networkChangeListener: networkChangeListener,
 		netMgr:                netevents.NewManager(recorder),
 	}
@@ -217,20 +181,16 @@ func (c *Client) Run(platformFiles PlatformFiles, urlOpener URLOpener, isAndroid
 	c.recorder.UpdateManagementAddress(cfg.ManagementURL.String())
 	c.recorder.UpdateRosenpass(cfg.RosenpassEnabled, cfg.RosenpassPermissive)
 
+	var ctx context.Context
 	//nolint
 	ctxWithValues := context.WithValue(context.Background(), system.DeviceNameCtxKey, c.deviceName)
 	//nolint
 	ctxWithValues = context.WithValue(ctxWithValues, system.UiVersionCtxKey, c.uiVersion)
 
-	runCtx, runCancel := context.WithCancel(ctxWithValues)
-	defer runCancel()
-
-	done, err := c.startRun(runCancel)
-	if err != nil {
-		return err
-	}
-	defer c.finishRun(done)
-	ctx := runCtx
+	c.ctxCancelLock.Lock()
+	ctx, c.ctxCancel = context.WithCancel(ctxWithValues)
+	defer c.ctxCancel()
+	c.ctxCancelLock.Unlock()
 
 	auth := NewAuthWithConfig(ctx, cfg, cfgFile)
 	err = auth.login(urlOpener, isAndroidTV)
@@ -272,17 +232,13 @@ func (c *Client) RunWithoutLogin(platformFiles PlatformFiles, dns *DNSList, dnsR
 	c.recorder.UpdateManagementAddress(cfg.ManagementURL.String())
 	c.recorder.UpdateRosenpass(cfg.RosenpassEnabled, cfg.RosenpassPermissive)
 
+	var ctx context.Context
 	//nolint
 	ctxWithValues := context.WithValue(context.Background(), system.DeviceNameCtxKey, c.deviceName)
-	runCtx, runCancel := context.WithCancel(ctxWithValues)
-	defer runCancel()
-
-	done, err := c.startRun(runCancel)
-	if err != nil {
-		return err
-	}
-	defer c.finishRun(done)
-	ctx := runCtx
+	c.ctxCancelLock.Lock()
+	ctx, c.ctxCancel = context.WithCancel(ctxWithValues)
+	defer c.ctxCancel()
+	c.ctxCancelLock.Unlock()
 
 	// todo do not throw error in case of cancelled context
 	ctx = internal.CtxInitState(ctx)
@@ -292,27 +248,15 @@ func (c *Client) RunWithoutLogin(platformFiles PlatformFiles, dns *DNSList, dnsR
 	return connectClient.RunOnAndroid(c.tunAdapter, c.iFaceDiscover, c.networkChangeListener, slices.Clone(dns.items), dnsReadyListener, stateFile, cacheDir)
 }
 
-// Stop cancels the running client and waits for the run loop to exit, so a
-// caller that restarts immediately cannot race the outgoing teardown.
+// Stop the internal client and free the resources
 func (c *Client) Stop() {
-	c.stateMu.RLock()
-	done := c.runDone
-	cancel := c.ctxCancel
-	c.stateMu.RUnlock()
-
-	if cancel != nil {
-		cancel()
-	}
-
-	if done == nil {
+	c.ctxCancelLock.Lock()
+	defer c.ctxCancelLock.Unlock()
+	if c.ctxCancel == nil {
 		return
 	}
 
-	select {
-	case <-done:
-	case <-time.After(stopRunWaitTimeout):
-		log.Warnf("Stop: timed out waiting for the run loop to exit")
-	}
+	c.ctxCancel()
 }
 
 func (c *Client) RenewTun(fd int) error {

--- a/client/android/client.go
+++ b/client/android/client.go
@@ -4,6 +4,7 @@ package android
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -42,6 +43,8 @@ const (
 )
 
 const stopRunWaitTimeout = 20 * time.Second
+
+var errClientAlreadyRunning = errors.New("client is already running")
 
 // TunAdapter export internal TunAdapter for mobile
 type TunAdapter interface {
@@ -86,14 +89,14 @@ type Client struct {
 	// sweeper into each new ConnectClient.
 	netMgr *netevents.Manager
 
-	// stateMu guards the run lifecycle as one unit: the generation that
-	// identifies the current run, the client and cancel it installed, and the
-	// channel it closes on exit. Splitting the cancel out under its own lock
-	// let a Stop cancel a run that started after its generation snapshot.
+	// stateMu guards the run lifecycle as one unit: the cancel installed by
+	// the current run, the channel it closes on exit, and the state it
+	// published. One run at a time: startRun refuses a second Run while the
+	// previous one has not exited, and the platform serializes Stop before
+	// Start, so no generation tracking is needed.
 	stateMu       sync.RWMutex
 	connectClient *internal.ConnectClient
 	config        *profilemanager.Config
-	runGeneration uint64
 	runDone       chan struct{}
 	ctxCancel     context.CancelFunc
 	cacheDir      string
@@ -119,30 +122,40 @@ type Client struct {
 	extendCancel context.CancelFunc
 }
 
-func (c *Client) beginRun(cancel context.CancelFunc) (uint64, chan struct{}) {
-	done := make(chan struct{})
-
-	c.stateMu.Lock()
-	c.runGeneration++
-	generation := c.runGeneration
-	c.runDone = done
-	c.ctxCancel = cancel
-	c.stateMu.Unlock()
-
-	return generation, done
-}
-
-func (c *Client) publishState(generation uint64, cfg *profilemanager.Config, cacheDir string, cfgPath string, cc *internal.ConnectClient) bool {
+func (c *Client) startRun(cancel context.CancelFunc) (chan struct{}, error) {
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
-	if c.runGeneration != generation {
-		return false
+
+	if c.runDone != nil {
+		return nil, errClientAlreadyRunning
 	}
+
+	done := make(chan struct{})
+	c.runDone = done
+	c.ctxCancel = cancel
+	return done, nil
+}
+
+func (c *Client) finishRun(done chan struct{}) {
+	c.stateMu.Lock()
+	c.connectClient = nil
+	c.config = nil
+	c.cacheDir = ""
+	c.cfgPath = ""
+	c.runDone = nil
+	c.ctxCancel = nil
+	c.stateMu.Unlock()
+
+	close(done)
+}
+
+func (c *Client) setState(cfg *profilemanager.Config, cacheDir string, cfgPath string, cc *internal.ConnectClient) {
+	c.stateMu.Lock()
 	c.config = cfg
 	c.cacheDir = cacheDir
 	c.cfgPath = cfgPath
 	c.connectClient = cc
-	return true
+	c.stateMu.Unlock()
 }
 
 func (c *Client) stateSnapshot() (*profilemanager.Config, string, *internal.ConnectClient) {
@@ -212,8 +225,11 @@ func (c *Client) Run(platformFiles PlatformFiles, urlOpener URLOpener, isAndroid
 	runCtx, runCancel := context.WithCancel(ctxWithValues)
 	defer runCancel()
 
-	generation, done := c.beginRun(runCancel)
-	defer close(done)
+	done, err := c.startRun(runCancel)
+	if err != nil {
+		return err
+	}
+	defer c.finishRun(done)
 	ctx := runCtx
 
 	auth := NewAuthWithConfig(ctx, cfg, cfgFile)
@@ -226,10 +242,7 @@ func (c *Client) Run(platformFiles PlatformFiles, urlOpener URLOpener, isAndroid
 
 	connectClient := internal.NewConnectClient(ctx, cfg, c.recorder,
 		internal.WithNetEvents(c.netMgr))
-	if !c.publishState(generation, cfg, cacheDir, cfgFile, connectClient) {
-		log.Infof("run: superseded by a newer run, aborting startup")
-		return nil
-	}
+	c.setState(cfg, cacheDir, cfgFile, connectClient)
 	// This path runs the interactive SSO flow, so reaching here means the peer
 	// is authenticated again — release the latch Status() reports from. Clear
 	// only once the fresh connect client is installed: until then Status()
@@ -264,50 +277,41 @@ func (c *Client) RunWithoutLogin(platformFiles PlatformFiles, dns *DNSList, dnsR
 	runCtx, runCancel := context.WithCancel(ctxWithValues)
 	defer runCancel()
 
-	generation, done := c.beginRun(runCancel)
-	defer close(done)
+	done, err := c.startRun(runCancel)
+	if err != nil {
+		return err
+	}
+	defer c.finishRun(done)
 	ctx := runCtx
 
 	// todo do not throw error in case of cancelled context
 	ctx = internal.CtxInitState(ctx)
 	connectClient := internal.NewConnectClient(ctx, cfg, c.recorder,
 		internal.WithNetEvents(c.netMgr))
-	if !c.publishState(generation, cfg, cacheDir, cfgFile, connectClient) {
-		log.Infof("run: superseded by a newer run, aborting startup")
-		return nil
-	}
+	c.setState(cfg, cacheDir, cfgFile, connectClient)
 	return connectClient.RunOnAndroid(c.tunAdapter, c.iFaceDiscover, c.networkChangeListener, slices.Clone(dns.items), dnsReadyListener, stateFile, cacheDir)
 }
 
-// Stop the internal client and free the resources
+// Stop cancels the running client and waits for the run loop to exit, so a
+// caller that restarts immediately cannot race the outgoing teardown.
 func (c *Client) Stop() {
-	c.stateMu.Lock()
-	c.runGeneration++
-	cc := c.connectClient
+	c.stateMu.RLock()
 	done := c.runDone
 	cancel := c.ctxCancel
-	c.connectClient = nil
-	c.config = nil
-	c.runDone = nil
-	c.ctxCancel = nil
-	c.stateMu.Unlock()
+	c.stateMu.RUnlock()
 
 	if cancel != nil {
 		cancel()
 	}
 
-	if cc != nil {
-		if err := cc.Stop(); err != nil {
-			log.Errorf("Stop: failed stopping the connect client: %v", err)
-		}
+	if done == nil {
+		return
 	}
 
-	if done != nil {
-		select {
-		case <-done:
-		case <-time.After(stopRunWaitTimeout):
-			log.Warnf("Stop: timed out waiting for the run loop to exit")
-		}
+	select {
+	case <-done:
+	case <-time.After(stopRunWaitTimeout):
+		log.Warnf("Stop: timed out waiting for the run loop to exit")
 	}
 }
 

--- a/client/android/client.go
+++ b/client/android/client.go
@@ -78,8 +78,6 @@ type Client struct {
 	tunAdapter            device.TunAdapter
 	iFaceDiscover         IFaceDiscover
 	recorder              *peer.Status
-	ctxCancel             context.CancelFunc
-	ctxCancelLock         *sync.Mutex
 	deviceName            string
 	uiVersion             string
 	networkChangeListener listener.NetworkChangeListener
@@ -88,11 +86,16 @@ type Client struct {
 	// sweeper into each new ConnectClient.
 	netMgr *netevents.Manager
 
+	// stateMu guards the run lifecycle as one unit: the generation that
+	// identifies the current run, the client and cancel it installed, and the
+	// channel it closes on exit. Splitting the cancel out under its own lock
+	// let a Stop cancel a run that started after its generation snapshot.
 	stateMu       sync.RWMutex
 	connectClient *internal.ConnectClient
 	config        *profilemanager.Config
 	runGeneration uint64
 	runDone       chan struct{}
+	ctxCancel     context.CancelFunc
 	cacheDir      string
 	// Identifies the running profile for the SSO login hint; see profile_state.go.
 	cfgPath string
@@ -123,11 +126,8 @@ func (c *Client) beginRun(cancel context.CancelFunc) (uint64, chan struct{}) {
 	c.runGeneration++
 	generation := c.runGeneration
 	c.runDone = done
-	c.stateMu.Unlock()
-
-	c.ctxCancelLock.Lock()
 	c.ctxCancel = cancel
-	c.ctxCancelLock.Unlock()
+	c.stateMu.Unlock()
 
 	return generation, done
 }
@@ -180,7 +180,6 @@ func NewClient(androidSDKVersion int, deviceName string, uiVersion string, tunAd
 		tunAdapter:            tunAdapter,
 		iFaceDiscover:         iFaceDiscover,
 		recorder:              recorder,
-		ctxCancelLock:         &sync.Mutex{},
 		networkChangeListener: networkChangeListener,
 		netMgr:                netevents.NewManager(recorder),
 	}
@@ -286,15 +285,12 @@ func (c *Client) Stop() {
 	c.runGeneration++
 	cc := c.connectClient
 	done := c.runDone
+	cancel := c.ctxCancel
 	c.connectClient = nil
 	c.config = nil
 	c.runDone = nil
-	c.stateMu.Unlock()
-
-	c.ctxCancelLock.Lock()
-	cancel := c.ctxCancel
 	c.ctxCancel = nil
-	c.ctxCancelLock.Unlock()
+	c.stateMu.Unlock()
 
 	if cancel != nil {
 		cancel()

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -93,6 +93,8 @@ type Client struct {
 	stateMu       sync.RWMutex
 	connectClient *internal.ConnectClient
 	config        *profilemanager.Config
+	runGeneration uint64
+	runDone       chan struct{}
 }
 
 // NewClient instantiate a new Client
@@ -164,9 +166,9 @@ func (c *Client) Run(fd int32, interfaceName string, envList *EnvList) error {
 	ctxWithValues = context.WithValue(ctxWithValues, system.OsVersionCtxKey, c.osVersion)
 	runCtx, runCancel := context.WithCancel(ctxWithValues)
 	defer runCancel()
-	c.ctxCancelLock.Lock()
-	c.ctxCancel = runCancel
-	c.ctxCancelLock.Unlock()
+
+	generation, done := c.beginRun(runCancel)
+	defer close(done)
 	ctx := runCtx
 
 	// No login pre-flight here. The engine's own loginToManagement (connect.go) performs
@@ -189,7 +191,10 @@ func (c *Client) Run(fd int32, interfaceName string, envList *EnvList) error {
 
 	connectClient := internal.NewConnectClient(ctx, cfg, c.recorder,
 		internal.WithNetEvents(c.netMgr))
-	c.setState(cfg, connectClient)
+	if !c.publishState(generation, cfg, connectClient) {
+		log.Infof("Run: superseded by a newer run, aborting startup")
+		return nil
+	}
 	// Persist the latest sync response so DebugBundle can include the network
 	// map. On iOS this is backed by disk to keep it out of the constrained
 	// process memory (see the syncstore package).
@@ -219,24 +224,36 @@ func (c *Client) NotifyNetworkChange() {
 // Stop the internal client and free the resources
 func (c *Client) Stop() {
 	c.stateMu.Lock()
+	c.runGeneration++
 	cc := c.connectClient
+	done := c.runDone
 	c.connectClient = nil
 	c.config = nil
+	c.runDone = nil
 	c.stateMu.Unlock()
+
+	c.ctxCancelLock.Lock()
+	cancel := c.ctxCancel
+	c.ctxCancel = nil
+	c.ctxCancelLock.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
 
 	if cc != nil {
 		if err := cc.Stop(); err != nil {
 			log.Errorf("Stop: failed stopping the connect client: %v", err)
 		}
-		return
 	}
 
-	c.ctxCancelLock.Lock()
-	defer c.ctxCancelLock.Unlock()
-	if c.ctxCancel == nil {
-		return
+	if done != nil {
+		select {
+		case <-done:
+		case <-time.After(stopRunWaitTimeout):
+			log.Warnf("Stop: timed out waiting for the run loop to exit")
+		}
 	}
-	c.ctxCancel()
 }
 
 // DebugBundle generates a debug bundle, uploads it and returns the upload key.
@@ -442,6 +459,8 @@ func (c *Client) IsLoginRequired() bool {
 
 // loginForMobileAuthTimeout is the timeout for requesting auth info from the server
 const loginForMobileAuthTimeout = 30 * time.Second
+
+const stopRunWaitTimeout = 20 * time.Second
 
 func (c *Client) LoginForMobile() string {
 	//nolint
@@ -735,11 +754,31 @@ func (c *Client) DeselectRoute(id string) error {
 
 // setState stores the running engine state so DebugBundle can reuse the live
 // config and ConnectClient. It is cleared on Stop.
-func (c *Client) setState(cfg *profilemanager.Config, cc *internal.ConnectClient) {
+func (c *Client) beginRun(cancel context.CancelFunc) (uint64, chan struct{}) {
+	done := make(chan struct{})
+
+	c.stateMu.Lock()
+	c.runGeneration++
+	generation := c.runGeneration
+	c.runDone = done
+	c.stateMu.Unlock()
+
+	c.ctxCancelLock.Lock()
+	c.ctxCancel = cancel
+	c.ctxCancelLock.Unlock()
+
+	return generation, done
+}
+
+func (c *Client) publishState(generation uint64, cfg *profilemanager.Config, cc *internal.ConnectClient) bool {
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
+	if c.runGeneration != generation {
+		return false
+	}
 	c.config = cfg
 	c.connectClient = cc
+	return true
 }
 
 // stateSnapshot returns the current config and ConnectClient under the lock.

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -156,17 +156,18 @@ func (c *Client) Run(fd int32, interfaceName string, envList *EnvList) error {
 	c.recorder.UpdateManagementAddress(cfg.ManagementURL.String())
 	c.recorder.UpdateRosenpass(cfg.RosenpassEnabled, cfg.RosenpassPermissive)
 
-	var ctx context.Context
 	//nolint
 	ctxWithValues := context.WithValue(context.Background(), system.DeviceNameCtxKey, c.deviceName)
 	//nolint
 	ctxWithValues = context.WithValue(ctxWithValues, system.OsNameCtxKey, c.osName)
 	//nolint
 	ctxWithValues = context.WithValue(ctxWithValues, system.OsVersionCtxKey, c.osVersion)
+	runCtx, runCancel := context.WithCancel(ctxWithValues)
+	defer runCancel()
 	c.ctxCancelLock.Lock()
-	ctx, c.ctxCancel = context.WithCancel(ctxWithValues)
-	defer c.ctxCancel()
+	c.ctxCancel = runCancel
 	c.ctxCancelLock.Unlock()
+	ctx := runCtx
 
 	// No login pre-flight here. The engine's own loginToManagement (connect.go) performs
 	// the authoritative Login immediately before the first Sync, so a LoginSync() call at
@@ -217,14 +218,25 @@ func (c *Client) NotifyNetworkChange() {
 
 // Stop the internal client and free the resources
 func (c *Client) Stop() {
+	c.stateMu.Lock()
+	cc := c.connectClient
+	c.connectClient = nil
+	c.config = nil
+	c.stateMu.Unlock()
+
+	if cc != nil {
+		if err := cc.Stop(); err != nil {
+			log.Errorf("Stop: failed stopping the connect client: %v", err)
+		}
+		return
+	}
+
 	c.ctxCancelLock.Lock()
 	defer c.ctxCancelLock.Unlock()
 	if c.ctxCancel == nil {
 		return
 	}
-
 	c.ctxCancel()
-	c.setState(nil, nil)
 }
 
 // DebugBundle generates a debug bundle, uploads it and returns the upload key.
@@ -376,16 +388,14 @@ func (c *Client) IsLoginRequiredCached() bool {
 }
 
 func (c *Client) IsLoginRequired() bool {
-	var ctx context.Context
 	//nolint
 	ctxWithValues := context.WithValue(context.Background(), system.DeviceNameCtxKey, c.deviceName)
 	//nolint
 	ctxWithValues = context.WithValue(ctxWithValues, system.OsNameCtxKey, c.osName)
 	//nolint
 	ctxWithValues = context.WithValue(ctxWithValues, system.OsVersionCtxKey, c.osVersion)
-	c.ctxCancelLock.Lock()
-	defer c.ctxCancelLock.Unlock()
-	ctx, c.ctxCancel = context.WithCancel(ctxWithValues)
+	ctx, cancel := context.WithCancel(ctxWithValues)
+	defer cancel()
 
 	var cfg *profilemanager.Config
 	var err error
@@ -434,16 +444,19 @@ func (c *Client) IsLoginRequired() bool {
 const loginForMobileAuthTimeout = 30 * time.Second
 
 func (c *Client) LoginForMobile() string {
-	var ctx context.Context
 	//nolint
 	ctxWithValues := context.WithValue(context.Background(), system.DeviceNameCtxKey, c.deviceName)
 	//nolint
 	ctxWithValues = context.WithValue(ctxWithValues, system.OsNameCtxKey, c.osName)
 	//nolint
 	ctxWithValues = context.WithValue(ctxWithValues, system.OsVersionCtxKey, c.osVersion)
-	c.ctxCancelLock.Lock()
-	defer c.ctxCancelLock.Unlock()
-	ctx, c.ctxCancel = context.WithCancel(ctxWithValues)
+	ctx, cancel := context.WithCancel(ctxWithValues)
+	loginDone := false
+	defer func() {
+		if !loginDone {
+			cancel()
+		}
+	}()
 
 	// Use DirectUpdateOrCreateConfig to avoid atomic file operations (temp file + rename)
 	// which are blocked by the tvOS sandbox in App Group containers
@@ -470,7 +483,9 @@ func (c *Client) LoginForMobile() string {
 	}
 
 	// This could cause a potential race condition with loading the extension which need to be handled on swift side
+	loginDone = true
 	go func() {
+		defer cancel()
 		tokenInfo, err := oAuthFlow.WaitToken(ctx, flowInfo)
 		if err != nil {
 			log.Errorf("LoginForMobile: WaitToken failed: %v", err)

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -74,8 +74,6 @@ type Client struct {
 	cacheDir              string
 	logFilePath           string
 	recorder              *peer.Status
-	ctxCancel             context.CancelFunc
-	ctxCancelLock         *sync.Mutex
 	deviceName            string
 	osName                string
 	osVersion             string
@@ -90,11 +88,16 @@ type Client struct {
 	// preloadedConfig holds config loaded from JSON (used on tvOS where file writes are blocked)
 	preloadedConfig *profilemanager.Config
 
+	// stateMu guards the run lifecycle as one unit: the generation that
+	// identifies the current run, the client and cancel it installed, and the
+	// channel it closes on exit. Splitting the cancel out under its own lock
+	// let a Stop cancel a run that started after its generation snapshot.
 	stateMu       sync.RWMutex
 	connectClient *internal.ConnectClient
 	config        *profilemanager.Config
 	runGeneration uint64
 	runDone       chan struct{}
+	ctxCancel     context.CancelFunc
 }
 
 // NewClient instantiate a new Client
@@ -109,7 +112,6 @@ func NewClient(cfgFile, stateFile, cacheDir, logFilePath, deviceName string, osV
 		osName:                osName,
 		osVersion:             osVersion,
 		recorder:              recorder,
-		ctxCancelLock:         &sync.Mutex{},
 		networkChangeListener: networkChangeListener,
 		dnsManager:            dnsManager,
 		netMgr:                netevents.NewManager(recorder),
@@ -250,15 +252,12 @@ func (c *Client) stopLocked(wait bool) chan struct{} {
 	c.runGeneration++
 	cc := c.connectClient
 	done := c.runDone
+	cancel := c.ctxCancel
 	c.connectClient = nil
 	c.config = nil
 	c.runDone = nil
-	c.stateMu.Unlock()
-
-	c.ctxCancelLock.Lock()
-	cancel := c.ctxCancel
 	c.ctxCancel = nil
-	c.ctxCancelLock.Unlock()
+	c.stateMu.Unlock()
 
 	if cancel != nil {
 		cancel()
@@ -785,11 +784,8 @@ func (c *Client) beginRun(cancel context.CancelFunc) (uint64, chan struct{}) {
 	c.runGeneration++
 	generation := c.runGeneration
 	c.runDone = done
-	c.stateMu.Unlock()
-
-	c.ctxCancelLock.Lock()
 	c.ctxCancel = cancel
-	c.ctxCancelLock.Unlock()
+	c.stateMu.Unlock()
 
 	return generation, done
 }

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -222,7 +222,30 @@ func (c *Client) NotifyNetworkChange() {
 }
 
 // Stop the internal client and free the resources
+// Stop tears the client down and waits for the run loop to exit, so a caller
+// that restarts immediately cannot race the outgoing teardown.
 func (c *Client) Stop() {
+	done := c.stopLocked(true)
+	if done == nil {
+		return
+	}
+
+	select {
+	case <-done:
+	case <-time.After(stopRunWaitTimeout):
+		log.Warnf("Stop: timed out waiting for the run loop to exit")
+	}
+}
+
+// StopWithoutWait tears the client down without waiting for the run loop.
+// Use it where the caller is on a deadline the wait could overrun, such as
+// NEPacketTunnelProvider.stopTunnel, which iOS gives only a few seconds
+// before it kills the extension.
+func (c *Client) StopWithoutWait() {
+	c.stopLocked(false)
+}
+
+func (c *Client) stopLocked(wait bool) chan struct{} {
 	c.stateMu.Lock()
 	c.runGeneration++
 	cc := c.connectClient
@@ -242,18 +265,19 @@ func (c *Client) Stop() {
 	}
 
 	if cc != nil {
-		if err := cc.Stop(); err != nil {
-			log.Errorf("Stop: failed stopping the connect client: %v", err)
+		stopConnectClient := func() {
+			if err := cc.Stop(); err != nil {
+				log.Errorf("Stop: failed stopping the connect client: %v", err)
+			}
+		}
+		if wait {
+			stopConnectClient()
+		} else {
+			go stopConnectClient()
 		}
 	}
 
-	if done != nil {
-		select {
-		case <-done:
-		case <-time.After(stopRunWaitTimeout):
-			log.Warnf("Stop: timed out waiting for the run loop to exit")
-		}
-	}
+	return done
 }
 
 // DebugBundle generates a debug bundle, uploads it and returns the upload key.

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -4,6 +4,7 @@ package NetBirdSDK
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 	"os"
@@ -36,6 +37,8 @@ const (
 	AnonymizeLevelDefault = nbAnonymize.LevelDefaultString
 	AnonymizeLevelStrict  = nbAnonymize.LevelStrictString
 )
+
+var errClientAlreadyRunning = errors.New("client is already running")
 
 // RouteListener export internal RouteListener for mobile
 type NetworkChangeListener interface {
@@ -88,14 +91,14 @@ type Client struct {
 	// preloadedConfig holds config loaded from JSON (used on tvOS where file writes are blocked)
 	preloadedConfig *profilemanager.Config
 
-	// stateMu guards the run lifecycle as one unit: the generation that
-	// identifies the current run, the client and cancel it installed, and the
-	// channel it closes on exit. Splitting the cancel out under its own lock
-	// let a Stop cancel a run that started after its generation snapshot.
+	// stateMu guards the run lifecycle as one unit: the cancel installed by
+	// the current run, the channel it closes on exit, and the state it
+	// published. One run at a time: startRun refuses a second Run while the
+	// previous one has not exited, and the platform serializes Stop before
+	// Start, so no generation tracking is needed.
 	stateMu       sync.RWMutex
 	connectClient *internal.ConnectClient
 	config        *profilemanager.Config
-	runGeneration uint64
 	runDone       chan struct{}
 	ctxCancel     context.CancelFunc
 }
@@ -169,8 +172,11 @@ func (c *Client) Run(fd int32, interfaceName string, envList *EnvList) error {
 	runCtx, runCancel := context.WithCancel(ctxWithValues)
 	defer runCancel()
 
-	generation, done := c.beginRun(runCancel)
-	defer close(done)
+	done, err := c.startRun(runCancel)
+	if err != nil {
+		return err
+	}
+	defer c.finishRun(done)
 	ctx := runCtx
 
 	// No login pre-flight here. The engine's own loginToManagement (connect.go) performs
@@ -193,10 +199,7 @@ func (c *Client) Run(fd int32, interfaceName string, envList *EnvList) error {
 
 	connectClient := internal.NewConnectClient(ctx, cfg, c.recorder,
 		internal.WithNetEvents(c.netMgr))
-	if !c.publishState(generation, cfg, connectClient) {
-		log.Infof("Run: superseded by a newer run, aborting startup")
-		return nil
-	}
+	c.setState(cfg, connectClient)
 	// Persist the latest sync response so DebugBundle can include the network
 	// map. On iOS this is backed by disk to keep it out of the constrained
 	// process memory (see the syncstore package).
@@ -223,11 +226,10 @@ func (c *Client) NotifyNetworkChange() {
 	c.netMgr.NotifyNetworkChange()
 }
 
-// Stop the internal client and free the resources
-// Stop tears the client down and waits for the run loop to exit, so a caller
-// that restarts immediately cannot race the outgoing teardown.
+// Stop cancels the running client and waits for the run loop to exit, so a
+// caller that restarts immediately cannot race the outgoing teardown.
 func (c *Client) Stop() {
-	done := c.stopLocked(true)
+	done := c.cancelRun()
 	if done == nil {
 		return
 	}
@@ -239,41 +241,22 @@ func (c *Client) Stop() {
 	}
 }
 
-// StopWithoutWait tears the client down without waiting for the run loop.
+// StopWithoutWait cancels the running client without waiting for the run loop.
 // Use it where the caller is on a deadline the wait could overrun, such as
 // NEPacketTunnelProvider.stopTunnel, which iOS gives only a few seconds
 // before it kills the extension.
 func (c *Client) StopWithoutWait() {
-	c.stopLocked(false)
+	c.cancelRun()
 }
 
-func (c *Client) stopLocked(wait bool) chan struct{} {
-	c.stateMu.Lock()
-	c.runGeneration++
-	cc := c.connectClient
+func (c *Client) cancelRun() chan struct{} {
+	c.stateMu.RLock()
 	done := c.runDone
 	cancel := c.ctxCancel
-	c.connectClient = nil
-	c.config = nil
-	c.runDone = nil
-	c.ctxCancel = nil
-	c.stateMu.Unlock()
+	c.stateMu.RUnlock()
 
 	if cancel != nil {
 		cancel()
-	}
-
-	if cc != nil {
-		stopConnectClient := func() {
-			if err := cc.Stop(); err != nil {
-				log.Errorf("Stop: failed stopping the connect client: %v", err)
-			}
-		}
-		if wait {
-			stopConnectClient()
-		} else {
-			go stopConnectClient()
-		}
 	}
 
 	return done
@@ -775,30 +758,36 @@ func (c *Client) DeselectRoute(id string) error {
 	return nil
 }
 
-// setState stores the running engine state so DebugBundle can reuse the live
-// config and ConnectClient. It is cleared on Stop.
-func (c *Client) beginRun(cancel context.CancelFunc) (uint64, chan struct{}) {
-	done := make(chan struct{})
-
-	c.stateMu.Lock()
-	c.runGeneration++
-	generation := c.runGeneration
-	c.runDone = done
-	c.ctxCancel = cancel
-	c.stateMu.Unlock()
-
-	return generation, done
-}
-
-func (c *Client) publishState(generation uint64, cfg *profilemanager.Config, cc *internal.ConnectClient) bool {
+func (c *Client) startRun(cancel context.CancelFunc) (chan struct{}, error) {
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
-	if c.runGeneration != generation {
-		return false
+
+	if c.runDone != nil {
+		return nil, errClientAlreadyRunning
 	}
+
+	done := make(chan struct{})
+	c.runDone = done
+	c.ctxCancel = cancel
+	return done, nil
+}
+
+func (c *Client) finishRun(done chan struct{}) {
+	c.stateMu.Lock()
+	c.connectClient = nil
+	c.config = nil
+	c.runDone = nil
+	c.ctxCancel = nil
+	c.stateMu.Unlock()
+
+	close(done)
+}
+
+func (c *Client) setState(cfg *profilemanager.Config, cc *internal.ConnectClient) {
+	c.stateMu.Lock()
 	c.config = cfg
 	c.connectClient = cc
-	return true
+	c.stateMu.Unlock()
 }
 
 // stateSnapshot returns the current config and ConnectClient under the lock.

--- a/client/ios/NetBirdSDK/client.go
+++ b/client/ios/NetBirdSDK/client.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -83,7 +84,7 @@ type Client struct {
 	networkChangeListener listener.NetworkChangeListener
 	onHostDnsFn           func([]string)
 	dnsManager            dns.IosDnsManager
-	loginComplete         bool
+	loginComplete         atomic.Bool
 	// netMgr outlives engine restarts: it mirrors the OS connectivity, not
 	// the engine lifecycle. Run injects its state and sweeper into each new
 	// ConnectClient.
@@ -527,18 +528,18 @@ func (c *Client) LoginForMobile() string {
 			log.Errorf("LoginForMobile: Login failed: %v", err)
 			return
 		}
-		c.loginComplete = true
+		c.loginComplete.Store(true)
 	}()
 
 	return flowInfo.VerificationURIComplete
 }
 
 func (c *Client) IsLoginComplete() bool {
-	return c.loginComplete
+	return c.loginComplete.Load()
 }
 
 func (c *Client) ClearLoginComplete() {
-	c.loginComplete = false
+	c.loginComplete.Store(false)
 }
 
 func (c *Client) GetRoutesSelectionDetails() (*RoutesSelectionDetails, error) {


### PR DESCRIPTION
## Describe your changes

A user switching from wifi to cellular lost all Internet traffic until they turned NetBird off. An iOS debug bundle caught it: the network-change restart calls `Stop()`, which cancelled a shared context and returned immediately instead of waiting for the run loop. The teardown then ran long (`failed to remove WireGuard interface utun6: timeout`, ~5s), so the restart's `start` landed on the dying context and failed with `failed creating connection to Management Service: context canceled` — 2ms after the old run finally exited. The tunnel stayed up with no engine behind it, black-holing traffic.

- `Stop()` now drives `ConnectClient.Stop()`, which cancels and waits for the run loop to exit.
- `Run()` owns its cancel locally, so a concurrent call can't cancel it through the shared field.
- `IsLoginRequired()` / `LoginForMobile()` stop overwriting the shared cancel — `restartClient` calls into that path. `LoginForMobile`'s cancel moves into the goroutine that outlives the call so the OAuth wait isn't cut short.
- Android gets the same change **preventively**: same structural defect, but no auto-restart on network change and no interface-removal timeout, so it isn't reachable there today.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal lifecycle fix, no user-facing surface changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run start and stop handling for more reliable cancellation.
  * Reduced the risk of inconsistent lifecycle states when starting or stopping operations.
  * Ensured cancellation actions are applied atomically during run transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->