### PR TITLE
[client] Close the session-expiration dialog only on renewal

### DIFF
--- a/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
+++ b/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
@@ -18,7 +18,7 @@ import { formatRemaining } from "@/lib/formatters";
 const DEFAULT_SECONDS = 360;
 const WINDOW_WIDTH = 360;
 const SOON_THRESHOLD_SECONDS = 60 * 60;
-const RENEWAL_MARGIN_MS = 60 * 1000;
+const DEADLINE_TOLERANCE_MS = 5 * 1000;
 
 export default function SessionExpirationDialog() {
     const { t } = useTranslation();
@@ -30,12 +30,19 @@ export default function SessionExpirationDialog() {
         const n = Number.parseInt(raw, 10);
         return Number.isFinite(n) && n > 0 ? n : DEFAULT_SECONDS;
     }, [params]);
+    const initialDeadline = useMemo(() => {
+        const raw = params.get("deadline");
+        if (!raw) return null;
+        const n = Number.parseInt(raw, 10);
+        return Number.isFinite(n) && n > 0 ? n : null;
+    }, [params]);
 
     const [remaining, setRemaining] = useState(initialSeconds);
     const [busy, setBusy] = useState(false);
     const busyRef = useRef(busy);
     busyRef.current = busy;
-    const openedDeadlineRef = useRef(Date.now() + initialSeconds * 1000);
+    const openedDeadlineRef = useRef(initialDeadline ?? Date.now() + initialSeconds * 1000);
+    const exactDeadlineRef = useRef(initialDeadline !== null);
     const expired = remaining <= 0;
     const expiredRef = useRef(expired);
     expiredRef.current = expired;
@@ -47,8 +54,9 @@ export default function SessionExpirationDialog() {
 
     useEffect(() => {
         setRemaining(initialSeconds);
-        openedDeadlineRef.current = Date.now() + initialSeconds * 1000;
-    }, [initialSeconds]);
+        openedDeadlineRef.current = initialDeadline ?? Date.now() + initialSeconds * 1000;
+        exactDeadlineRef.current = initialDeadline !== null;
+    }, [initialSeconds, initialDeadline]);
 
     useEffect(() => {
         const id = globalThis.setInterval(() => {
@@ -59,19 +67,22 @@ export default function SessionExpirationDialog() {
 
     // Auto-close only when the session was actually renewed elsewhere (tray action, CLI,
     // main window): the daemon keeps emitting Connected snapshots regardless of session
-    // state, so the signal is the deadline jumping past the one this dialog counts toward.
+    // state, so the signal is the deadline jumping past the one this dialog was opened for.
+    // With the exact deadline from the URL any forward jump counts; the seconds-derived
+    // fallback needs a tolerance for the Go-side truncation and mount latency.
     // Don't auto-close while busy (aborts our WaitExtend) or expired (hides the state).
     useEffect(() => {
         const off = Events.On(
             "netbird:status",
-            (ev: { data: { status?: string; sessionExpiresAt?: string } }) => {
+            (ev: { data: { status?: string; sessionExpiresAt?: string | null } }) => {
                 if (busyRef.current || expiredRef.current) return;
                 if (ev?.data?.status !== "Connected") return;
                 const raw = ev?.data?.sessionExpiresAt;
                 if (!raw) return;
                 const renewed = Date.parse(raw);
                 if (!Number.isFinite(renewed)) return;
-                if (renewed - openedDeadlineRef.current > RENEWAL_MARGIN_MS) {
+                const tolerance = exactDeadlineRef.current ? 0 : DEADLINE_TOLERANCE_MS;
+                if (renewed - openedDeadlineRef.current > tolerance) {
                     WindowManager.CloseSessionExpiration().catch(console.error);
                 }
             },

--- a/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
+++ b/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
@@ -18,6 +18,7 @@ import { formatRemaining } from "@/lib/formatters";
 const DEFAULT_SECONDS = 360;
 const WINDOW_WIDTH = 360;
 const SOON_THRESHOLD_SECONDS = 60 * 60;
+const RENEWAL_MARGIN_MS = 60 * 1000;
 
 export default function SessionExpirationDialog() {
     const { t } = useTranslation();
@@ -34,6 +35,7 @@ export default function SessionExpirationDialog() {
     const [busy, setBusy] = useState(false);
     const busyRef = useRef(busy);
     busyRef.current = busy;
+    const openedDeadlineRef = useRef(Date.now() + initialSeconds * 1000);
     const expired = remaining <= 0;
     const expiredRef = useRef(expired);
     expiredRef.current = expired;
@@ -45,6 +47,7 @@ export default function SessionExpirationDialog() {
 
     useEffect(() => {
         setRemaining(initialSeconds);
+        openedDeadlineRef.current = Date.now() + initialSeconds * 1000;
     }, [initialSeconds]);
 
     useEffect(() => {
@@ -54,14 +57,25 @@ export default function SessionExpirationDialog() {
         return () => globalThis.clearInterval(id);
     }, [initialSeconds]);
 
+    // Auto-close only when the session was actually renewed elsewhere (tray action, CLI,
+    // main window): the daemon keeps emitting Connected snapshots regardless of session
+    // state, so the signal is the deadline jumping past the one this dialog counts toward.
     // Don't auto-close while busy (aborts our WaitExtend) or expired (hides the state).
     useEffect(() => {
-        const off = Events.On("netbird:status", (ev: { data: { status?: string } }) => {
-            if (busyRef.current || expiredRef.current) return;
-            if (ev?.data?.status === "Connected") {
-                WindowManager.CloseSessionExpiration().catch(console.error);
-            }
-        });
+        const off = Events.On(
+            "netbird:status",
+            (ev: { data: { status?: string; sessionExpiresAt?: string } }) => {
+                if (busyRef.current || expiredRef.current) return;
+                if (ev?.data?.status !== "Connected") return;
+                const raw = ev?.data?.sessionExpiresAt;
+                if (!raw) return;
+                const renewed = Date.parse(raw);
+                if (!Number.isFinite(renewed)) return;
+                if (renewed - openedDeadlineRef.current > RENEWAL_MARGIN_MS) {
+                    WindowManager.CloseSessionExpiration().catch(console.error);
+                }
+            },
+        );
         return () => {
             off();
         };

--- a/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
+++ b/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
@@ -58,9 +58,12 @@ export default function SessionExpirationDialog() {
         exactDeadlineRef.current = initialDeadline !== null;
     }, [initialSeconds, initialDeadline]);
 
+    // Recompute from the absolute deadline instead of decrementing per tick: webview
+    // timers get suspended for tens of seconds (App Nap / hidden-window throttling),
+    // so a tick counter drifts behind the wall clock by the suspended time.
     useEffect(() => {
         const id = globalThis.setInterval(() => {
-            setRemaining((s) => (s <= 1 ? 0 : s - 1));
+            setRemaining(Math.max(0, Math.ceil((openedDeadlineRef.current - Date.now()) / 1000)));
         }, 1000);
         return () => globalThis.clearInterval(id);
     }, [initialSeconds]);

--- a/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
+++ b/client/ui/frontend/src/modules/session/SessionExpirationDialog.tsx
@@ -19,6 +19,10 @@ const DEFAULT_SECONDS = 360;
 const WINDOW_WIDTH = 360;
 const SOON_THRESHOLD_SECONDS = 60 * 60;
 const DEADLINE_TOLERANCE_MS = 5 * 1000;
+// The final-warning deadline reaches the Go side as RFC3339 truncated to whole
+// seconds, while the status snapshot carries millisecond precision, so an
+// unchanged deadline can look up to 999 ms newer than the exact URL value.
+const EXACT_DEADLINE_TOLERANCE_MS = 999;
 
 export default function SessionExpirationDialog() {
     const { t } = useTranslation();
@@ -71,8 +75,9 @@ export default function SessionExpirationDialog() {
     // Auto-close only when the session was actually renewed elsewhere (tray action, CLI,
     // main window): the daemon keeps emitting Connected snapshots regardless of session
     // state, so the signal is the deadline jumping past the one this dialog was opened for.
-    // With the exact deadline from the URL any forward jump counts; the seconds-derived
-    // fallback needs a tolerance for the Go-side truncation and mount latency.
+    // With the exact deadline from the URL any jump past its sub-second precision loss
+    // counts; the seconds-derived fallback needs a wider tolerance for the Go-side
+    // truncation and mount latency.
     // Don't auto-close while busy (aborts our WaitExtend) or expired (hides the state).
     useEffect(() => {
         const off = Events.On(
@@ -84,7 +89,9 @@ export default function SessionExpirationDialog() {
                 if (!raw) return;
                 const renewed = Date.parse(raw);
                 if (!Number.isFinite(renewed)) return;
-                const tolerance = exactDeadlineRef.current ? 0 : DEADLINE_TOLERANCE_MS;
+                const tolerance = exactDeadlineRef.current
+                    ? EXACT_DEADLINE_TOLERANCE_MS
+                    : DEADLINE_TOLERANCE_MS;
                 if (renewed - openedDeadlineRef.current > tolerance) {
                     WindowManager.CloseSessionExpiration().catch(console.error);
                 }

--- a/client/ui/services/windowmanager.go
+++ b/client/ui/services/windowmanager.go
@@ -292,11 +292,15 @@ func (s *WindowManager) CloseBrowserLogin() {
 }
 
 // OpenSessionExpiration shows the countdown warning on the cursor's display; seconds seeds
-// the countdown. Singleton, destroyed on close.
-func (s *WindowManager) OpenSessionExpiration(seconds int) {
+// the countdown and deadlineUnixMilli (0 when unknown) is the absolute deadline the dialog
+// compares renewal snapshots against. Singleton, destroyed on close.
+func (s *WindowManager) OpenSessionExpiration(seconds int, deadlineUnixMilli int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	startURL := "/#/dialog/session-expiration?seconds=" + strconv.Itoa(seconds)
+	if deadlineUnixMilli > 0 {
+		startURL += "&deadline=" + strconv.FormatInt(deadlineUnixMilli, 10)
+	}
 	if s.sessionExpiration == nil {
 		opts := DialogWindowOptions("session-expiration", s.title("window.title.sessionExpiration"), startURL, s.linuxIcon)
 		opts.Screen = s.getScreenBasedOnCursorPosition()

--- a/client/ui/tray_events.go
+++ b/client/ui/tray_events.go
@@ -76,7 +76,8 @@ func (t *Tray) onSystemEvent(ev *application.CustomEvent) {
 
 	if se.Metadata != nil && se.Metadata[authsession.MetaWarning] == "true" {
 		if se.Metadata[authsession.MetaFinal] == "true" {
-			t.openSessionExpiration()
+			deadline, _ := authsession.ParseExpiresAt(se.Metadata[authsession.MetaExpiresAt])
+			t.openSessionExpiration(deadline)
 			return
 		}
 		t.notifySessionWarning(

--- a/client/ui/tray_session.go
+++ b/client/ui/tray_session.go
@@ -284,12 +284,23 @@ func (t *Tray) dismissSessionWarning() {
 }
 
 // openSessionExpiration fires the fallback dialog when the earlier warning notification wasn't dismissed.
-// Idempotent on the WindowManager side.
-func (t *Tray) openSessionExpiration() {
+// deadline is the absolute expiry from the warning event's metadata; when zero (older daemon,
+// malformed metadata) the cached status-snapshot deadline fills in. Idempotent on the
+// WindowManager side.
+func (t *Tray) openSessionExpiration(deadline time.Time) {
 	if t.svc.WindowManager == nil {
 		return
 	}
-	t.svc.WindowManager.OpenSessionExpiration(finalWarningCountdownSeconds)
+	if deadline.IsZero() {
+		t.sessionMu.Lock()
+		deadline = t.sessionExpiresAt
+		t.sessionMu.Unlock()
+	}
+	var deadlineMs int64
+	if !deadline.IsZero() {
+		deadlineMs = deadline.UnixMilli()
+	}
+	t.svc.WindowManager.OpenSessionExpiration(finalWarningCountdownSeconds, deadlineMs)
 }
 
 // openSessionExtendFlow opens the SessionExpiration window seeded with the cached deadline's remaining time,
@@ -310,5 +321,5 @@ func (t *Tray) openSessionExtendFlow() {
 	if t.svc.WindowManager == nil {
 		return
 	}
-	t.svc.WindowManager.OpenSessionExpiration(seconds)
+	t.svc.WindowManager.OpenSessionExpiration(seconds, deadline.UnixMilli())
 }


### PR DESCRIPTION
## Describe your changes

The session-expiration dialog auto-closed on any Connected status snapshot. The daemon emits those periodically regardless of session state, so the renew popup vanished on the next snapshot (~30s) with no chance to re-authenticate.

- Close the dialog only when the snapshot's session deadline jumps past the one the dialog was opened for, i.e. the session was actually renewed elsewhere (tray action, CLI, main window).
- Pass the absolute deadline (unix ms) to the dialog from both call sites so the comparison is exact; keep a small tolerance for the seconds-derived fallback and for the warning metadata's whole-second precision.
- Derive the countdown from the deadline instead of decrementing per tick, so webview timer suspensions (App Nap) no longer leave the displayed time behind the wall clock.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-expiration dialogs by using the precise expiration deadline.
  * Ensured expiration details remain accurate when opened from tray notifications or extension flows.
  * Added fallback handling when the expiration deadline is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
