### PR TITLE
[infrastructure] Improve domain, Docker Compose, and license validation in self-hosted scripts

### DIFF
--- a/infrastructure_files/getting-started-enterprise.sh
+++ b/infrastructure_files/getting-started-enterprise.sh
@@ -15,6 +15,9 @@ NETBIRD_EULA_URL="https://netbird.io/self-hosted-EULA"
 # server trusts X-Forwarded-* headers from this address only.
 TRAEFIK_IP="172.30.0.10"
 
+LICENSE_VERDICT="unknown"
+LICENSE_LOG_LINES=""
+
 check_docker_compose() {
   if ! command -v docker &> /dev/null && ! command -v docker-compose &> /dev/null; then
     echo "Docker is not installed or not in PATH. Please follow the steps from the official guide: https://docs.docker.com/engine/install/" > /dev/stderr
@@ -227,6 +230,90 @@ wait_postgres() {
   set -e
 }
 
+wait_for_license_verdict() {
+  local counter=0
+  local logs=""
+
+  echo -n "Waiting for the server to validate the license"
+  while [[ $counter -lt 60 ]]; do
+    logs=$($DOCKER_COMPOSE_COMMAND logs --no-color --tail=all netbird-server 2>/dev/null || true)
+
+    if grep -qi "license invalidated" <<< "$logs"; then
+      echo " rejected"
+      LICENSE_VERDICT="rejected"
+      LICENSE_LOG_LINES=$(grep -i "license" <<< "$logs" | tail -n 5 || true)
+      return 0
+    fi
+
+    if grep -qi "license validated" <<< "$logs"; then
+      echo " ok"
+      LICENSE_VERDICT="ok"
+      return 0
+    fi
+
+    echo -n " ."
+    sleep 2
+    counter=$((counter + 1))
+  done
+
+  echo " no verdict in 120s"
+  LICENSE_VERDICT="unknown"
+  LICENSE_LOG_LINES=$(grep -iE "failed to validate license|error validating license" <<< "$logs" | tail -n 3 || true)
+  return 0
+}
+
+report_license_verdict() {
+  if [[ "$LICENSE_VERDICT" == "ok" ]]; then
+    return 0
+  fi
+
+  if [[ "$LICENSE_VERDICT" == "unknown" ]]; then
+    echo ""
+    echo "  ⚠  The server logged no license verdict within 120s."
+    if [[ -n "$LICENSE_LOG_LINES" ]]; then
+      echo "     It was still reporting validation errors:"
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && echo "     $line"
+      done <<< "$LICENSE_LOG_LINES"
+    fi
+    echo ""
+    echo "     Check the verdict with:"
+    echo ""
+    echo "       $DOCKER_COMPOSE_COMMAND logs netbird-server | grep -i license"
+    return 0
+  fi
+
+  local unreachable="false"
+  if grep -qi "couldn't be validated with the license server" <<< "$LICENSE_LOG_LINES"; then
+    unreachable="true"
+  fi
+
+  echo ""
+  if [[ "$unreachable" == "true" ]]; then
+    echo "  ⚠  The server could not validate the license:"
+  else
+    echo "  ⚠  The server rejected the license key:"
+  fi
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && echo "     $line"
+  done <<< "$LICENSE_LOG_LINES"
+  echo ""
+  echo "     The stack is up, and only the license check did not pass."
+  echo ""
+  if [[ "$unreachable" == "true" ]]; then
+    echo "     The license server could not be reached, so the key itself was"
+    echo "     never checked. Confirm this host has outbound access to the"
+    echo "     license server, then restart:"
+  else
+    echo "     Check the reason the server gave above, verify that"
+    echo "     NETBIRD_LICENSE_KEY in .env matches the key you were issued,"
+    echo "     then restart:"
+  fi
+  echo ""
+  echo "       $DOCKER_COMPOSE_COMMAND up -d"
+  return 0
+}
+
 init_environment() {
   check_openssl
   DOCKER_COMPOSE_COMMAND=$(check_docker_compose)
@@ -306,6 +393,9 @@ init_environment() {
   $DOCKER_COMPOSE_COMMAND up -d
 
   echo ""
+  wait_for_license_verdict
+
+  echo ""
   echo "Done."
   echo ""
   echo "Dashboard: https://${NETBIRD_DOMAIN}"
@@ -315,6 +405,12 @@ init_environment() {
   echo ""
   echo "Tail logs:"
   echo "  cd $(pwd) && $DOCKER_COMPOSE_COMMAND logs -f netbird-server traefik"
+
+  report_license_verdict
+
+  if [[ "$LICENSE_VERDICT" == "rejected" ]]; then
+    exit 1
+  fi
 }
 
 # ------------------------------------------------------------------

--- a/infrastructure_files/getting-started-enterprise.sh
+++ b/infrastructure_files/getting-started-enterprise.sh
@@ -16,15 +16,21 @@ NETBIRD_EULA_URL="https://netbird.io/self-hosted-EULA"
 TRAEFIK_IP="172.30.0.10"
 
 check_docker_compose() {
-  if command -v docker-compose &> /dev/null; then
-    echo "docker-compose"
-    return
+  if ! command -v docker &> /dev/null && ! command -v docker-compose &> /dev/null; then
+    echo "Docker is not installed or not in PATH. Please follow the steps from the official guide: https://docs.docker.com/engine/install/" > /dev/stderr
+    exit 1
   fi
-  if docker compose --help &> /dev/null; then
+
+  if docker compose version &> /dev/null; then
     echo "docker compose"
     return
   fi
-  echo "docker-compose is not installed or not in PATH. See https://docs.docker.com/engine/install/" > /dev/stderr
+  if command -v docker-compose &> /dev/null && docker-compose version &> /dev/null; then
+    echo "docker-compose"
+    return
+  fi
+
+  echo "Docker Compose is not installed or not in PATH. Please follow the steps from the official guide: https://docs.docker.com/compose/install/" > /dev/stderr
   exit 1
 }
 

--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -98,17 +98,37 @@ get_main_ip_address() {
 }
 
 check_nb_domain() {
-  DOMAIN=$1
-  if [[ "$DOMAIN-x" == "-x" ]]; then
+  local domain="$1"
+
+  if [[ -z "$domain" ]]; then
     echo "The NETBIRD_DOMAIN variable cannot be empty." > /dev/stderr
     return 1
   fi
-
-  if [[ "$DOMAIN" == "netbird.example.com" ]]; then
+  if [[ "$domain" == "use-ip" ]]; then
+    return 0
+  fi
+  if [[ "$domain" == "netbird.example.com" ]]; then
     echo "The NETBIRD_DOMAIN cannot be netbird.example.com" > /dev/stderr
     return 1
   fi
+  if [[ "$domain" =~ ^[0-9.]+$ ]]; then
+    echo "'$domain' is an IP address. Use 'use-ip' to install on this host's IP over HTTP, or an FQDN to get a TLS certificate." > /dev/stderr
+    return 1
+  fi
+  if [[ ! "$domain" =~ ^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+$ ]]; then
+    echo "'$domain' is not a valid FQDN. It needs at least one dot (e.g. netbird.my-domain.com), with no scheme, port or trailing dot." > /dev/stderr
+    return 1
+  fi
   return 0
+}
+
+check_domain_resolves() {
+  local domain="$1"
+  if command -v getent &> /dev/null && getent hosts "$domain" &> /dev/null; then return 0; fi
+  if command -v host &> /dev/null && host "$domain" &> /dev/null; then return 0; fi
+  if command -v dig &> /dev/null && [[ -n "$(dig +short "$domain" 2>/dev/null)" ]]; then return 0; fi
+  if command -v nslookup &> /dev/null && nslookup "$domain" &> /dev/null; then return 0; fi
+  return 1
 }
 
 # Non-interactive configuration
@@ -170,7 +190,22 @@ read_nb_domain() {
   read -r READ_NETBIRD_DOMAIN < /dev/tty
   if ! check_nb_domain "$READ_NETBIRD_DOMAIN"; then
     read_nb_domain
+    return
   fi
+
+  if [[ "$READ_NETBIRD_DOMAIN" != "use-ip" ]] && ! check_domain_resolves "$READ_NETBIRD_DOMAIN"; then
+    local confirm=""
+    echo "" > /dev/stderr
+    echo "Warning: '$READ_NETBIRD_DOMAIN' does not resolve via DNS from this host." > /dev/stderr
+    echo "TLS certificate issuance and client connections will fail until it does." > /dev/stderr
+    echo -n "Continue anyway? [y/N]: " > /dev/stderr
+    read -r confirm < /dev/tty
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+      read_nb_domain
+      return
+    fi
+  fi
+
   echo "$READ_NETBIRD_DOMAIN"
   return 0
 }
@@ -439,12 +474,28 @@ configure_domain() {
   # Domain is validated (not a free-form value), so it keeps its own guard
   # rather than going through resolve(): a valid NETBIRD_DOMAIN is used as-is,
   # otherwise we prompt, or abort when there is no terminal to prompt on.
+  local prompted="false"
   if ! check_nb_domain "$NETBIRD_DOMAIN"; then
     if ! tty_available; then
-      echo "NETBIRD_DOMAIN is required for a non-interactive install." > /dev/stderr
+      # check_nb_domain has already explained what is wrong with the value; all
+      # that is left is to say which knob to turn, since there is no prompt.
+      if [[ -n "$NETBIRD_DOMAIN" ]]; then
+        echo "NETBIRD_DOMAIN='$NETBIRD_DOMAIN' cannot be used for a non-interactive install." > /dev/stderr
+      else
+        echo "NETBIRD_DOMAIN is required for a non-interactive install." > /dev/stderr
+      fi
       exit 1
     fi
     NETBIRD_DOMAIN=$(read_nb_domain)
+    prompted="true"
+  fi
+
+  # read_nb_domain already probed DNS and asked whether to continue, so only the
+  # env-var path is left to cover. It stays a warning there: an unattended
+  # install may legitimately run before the record is published.
+  if [[ "$prompted" == "false" && "$NETBIRD_DOMAIN" != "use-ip" ]] && ! check_domain_resolves "$NETBIRD_DOMAIN"; then
+    echo "Warning: '$NETBIRD_DOMAIN' does not resolve via DNS from this host." > /dev/stderr
+    echo "TLS certificate issuance and client connections will fail until it does." > /dev/stderr
   fi
 
   if [[ "$NETBIRD_DOMAIN" == "use-ip" ]]; then

--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -60,18 +60,21 @@ check_docker_sock_perms() {
 }
 
 check_docker_compose() {
-  if command -v docker-compose &> /dev/null
-  then
-      echo "docker-compose"
-      return
-  fi
-  if docker compose --help &> /dev/null
-  then
-      echo "docker compose"
-      return
+  if ! command -v docker &> /dev/null && ! command -v docker-compose &> /dev/null; then
+    echo "Docker is not installed or not in PATH. Please follow the steps from the official guide: https://docs.docker.com/engine/install/" > /dev/stderr
+    exit 1
   fi
 
-  echo "docker-compose is not installed or not in PATH. Please follow the steps from the official guide: https://docs.docker.com/engine/install/" > /dev/stderr
+  if docker compose version &> /dev/null; then
+    echo "docker compose"
+    return
+  fi
+  if command -v docker-compose &> /dev/null && docker-compose version &> /dev/null; then
+    echo "docker-compose"
+    return
+  fi
+
+  echo "Docker Compose is not installed or not in PATH. Please follow the steps from the official guide: https://docs.docker.com/compose/install/" > /dev/stderr
   exit 1
 }
 

--- a/infrastructure_files/getting-started.sh
+++ b/infrastructure_files/getting-started.sh
@@ -477,8 +477,6 @@ configure_domain() {
   local prompted="false"
   if ! check_nb_domain "$NETBIRD_DOMAIN"; then
     if ! tty_available; then
-      # check_nb_domain has already explained what is wrong with the value; all
-      # that is left is to say which knob to turn, since there is no prompt.
       if [[ -n "$NETBIRD_DOMAIN" ]]; then
         echo "NETBIRD_DOMAIN='$NETBIRD_DOMAIN' cannot be used for a non-interactive install." > /dev/stderr
       else
@@ -490,9 +488,6 @@ configure_domain() {
     prompted="true"
   fi
 
-  # read_nb_domain already probed DNS and asked whether to continue, so only the
-  # env-var path is left to cover. It stays a warning there: an unattended
-  # install may legitimately run before the record is published.
   if [[ "$prompted" == "false" && "$NETBIRD_DOMAIN" != "use-ip" ]] && ! check_domain_resolves "$NETBIRD_DOMAIN"; then
     echo "Warning: '$NETBIRD_DOMAIN' does not resolve via DNS from this host." > /dev/stderr
     echo "TLS certificate issuance and client connections will fail until it does." > /dev/stderr

--- a/infrastructure_files/migrate-to-enterprise.sh
+++ b/infrastructure_files/migrate-to-enterprise.sh
@@ -1022,11 +1022,11 @@ wait_for_license_verdict() {
     if grep -qi "license invalidated" <<< "$logs"; then
       echo " rejected"
       LICENSE_VERDICT="rejected"
-      LICENSE_LOG_LINES=$(grep -i "license" <<< "$logs" | tail -n 5)
+      LICENSE_LOG_LINES=$(grep -i "license" <<< "$logs" | tail -n 5 || true)
       return 0
     fi
 
-    if grep -qi "successful license validation" <<< "$logs"; then
+    if grep -qi "license validated" <<< "$logs"; then
       echo " ok"
       LICENSE_VERDICT="ok"
       return 0
@@ -1039,7 +1039,7 @@ wait_for_license_verdict() {
 
   echo " no verdict in 120s"
   LICENSE_VERDICT="unknown"
-  LICENSE_LOG_LINES=$(grep -iE "failed to validate license|error validating license" <<< "$logs" | tail -n 3)
+  LICENSE_LOG_LINES=$(grep -iE "failed to validate license|error validating license" <<< "$logs" | tail -n 3 || true)
   return 0
 }
 
@@ -1150,18 +1150,33 @@ apply_changes() {
   echo "Migration complete."
 
   if [[ "$LICENSE_VERDICT" == "rejected" ]]; then
+    local unreachable="false"
+    if grep -qi "couldn't be validated with the license server" <<< "$LICENSE_LOG_LINES"; then
+      unreachable="true"
+    fi
+
     echo ""
-    echo "  ⚠  The server rejected the license key:"
+    if [[ "$unreachable" == "true" ]]; then
+      echo "  ⚠  The server could not validate the license:"
+    else
+      echo "  ⚠  The server rejected the license key:"
+    fi
     while IFS= read -r line; do
       [[ -n "$line" ]] && echo "     $line"
     done <<< "$LICENSE_LOG_LINES"
     echo ""
     echo "     The migration itself completed: the images and any migrated data"
-    echo "     are in place, and only the license was refused."
+    echo "     are in place, and only the license check did not pass."
     echo ""
-    echo "     Check the reason the server gave above, verify that"
-    echo "     NB_LICENSE_KEY in .env matches the key you were issued, then"
-    echo "     restart:"
+    if [[ "$unreachable" == "true" ]]; then
+      echo "     The license server could not be reached, so the key itself was"
+      echo "     never checked. Confirm this host has outbound access to the"
+      echo "     license server, then restart:"
+    else
+      echo "     Check the reason the server gave above, verify that"
+      echo "     NB_LICENSE_KEY in .env matches the key you were issued, then"
+      echo "     restart:"
+    fi
     echo ""
     echo "       $DOCKER_COMPOSE_COMMAND up -d"
   elif [[ "$LICENSE_VERDICT" == "unknown" ]]; then

--- a/infrastructure_files/migrate-to-enterprise.sh
+++ b/infrastructure_files/migrate-to-enterprise.sh
@@ -63,15 +63,21 @@ ENTERPRISE_CONFIG="no"
 NETBIRD_EULA_URL="https://netbird.io/self-hosted-EULA"
 
 check_docker_compose() {
-  if command -v docker-compose &> /dev/null; then
-    echo "docker-compose"
-    return
+  if ! command -v docker &> /dev/null && ! command -v docker-compose &> /dev/null; then
+    echo "Docker is not installed or not in PATH. Please follow the steps from the official guide: https://docs.docker.com/engine/install/" > /dev/stderr
+    exit 1
   fi
-  if docker compose --help &> /dev/null; then
+
+  if docker compose version &> /dev/null; then
     echo "docker compose"
     return
   fi
-  echo "docker-compose is not installed or not in PATH." > /dev/stderr
+  if command -v docker-compose &> /dev/null && docker-compose version &> /dev/null; then
+    echo "docker-compose"
+    return
+  fi
+
+  echo "Docker Compose is not installed or not in PATH. Please follow the steps from the official guide: https://docs.docker.com/compose/install/" > /dev/stderr
   exit 1
 }
 

--- a/infrastructure_files/migrate-to-enterprise.sh
+++ b/infrastructure_files/migrate-to-enterprise.sh
@@ -40,6 +40,10 @@ ENTERPRISE_CONFIG_FILE="config.yaml.enterprise"
 # completed successfully.
 ROLLBACK_STATE="disarmed"
 ENV_EXISTED="unknown"
+# Verdict the server logs about the license key on startup: ok, rejected, or
+# unknown when neither line appeared before the timeout.
+LICENSE_VERDICT="unknown"
+LICENSE_LOG_LINES=""
 ENV_BACKUP=""
 PG_VOLUME_NAME=""
 BACKUP_DIR=""
@@ -1000,6 +1004,37 @@ init_migration() {
   check_stale_postgres_volume
 }
 
+wait_for_license_verdict() {
+  local counter=0
+  local logs=""
+
+  echo -n "Waiting for the server to validate the license"
+  while [[ $counter -lt 60 ]]; do
+    logs=$($DOCKER_COMPOSE_COMMAND logs --no-color --tail=200 "$COMBINED_SERVICE" 2>/dev/null || true)
+
+    if grep -qi "license invalidated\|license key invalid" <<< "$logs"; then
+      echo " rejected"
+      LICENSE_VERDICT="rejected"
+      LICENSE_LOG_LINES=$(grep -i "license" <<< "$logs" | tail -n 5)
+      return 0
+    fi
+
+    if grep -qi "successful license validation" <<< "$logs"; then
+      echo " ok"
+      LICENSE_VERDICT="ok"
+      return 0
+    fi
+
+    echo -n " ."
+    sleep 2
+    counter=$((counter + 1))
+  done
+
+  echo " no verdict in 120s"
+  LICENSE_VERDICT="unknown"
+  return 0
+}
+
 apply_changes() {
   # From here on a failure must roll the deployment back.
   ROLLBACK_STATE="armed"
@@ -1101,7 +1136,31 @@ apply_changes() {
   $DOCKER_COMPOSE_COMMAND up -d
 
   echo ""
+  wait_for_license_verdict
+
+  echo ""
   echo "Migration complete."
+
+  if [[ "$LICENSE_VERDICT" == "rejected" ]]; then
+    echo ""
+    echo "  ⚠  The server rejected the license key:"
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && echo "     $line"
+    done <<< "$LICENSE_LOG_LINES"
+    echo ""
+    echo "     The migration itself completed: the images and any migrated data"
+    echo "     are in place, and only the license was refused."
+    echo ""
+    echo "     Verify that NB_LICENSE_KEY in .env matches the key you were"
+    echo "     issued, correct it if it does not, then restart:"
+    echo ""
+    echo "       $DOCKER_COMPOSE_COMMAND up -d"
+  elif [[ "$LICENSE_VERDICT" == "unknown" ]]; then
+    echo ""
+    echo "  ⚠  The server logged no license verdict within 120s. Check it with:"
+    echo ""
+    echo "       $DOCKER_COMPOSE_COMMAND logs $COMBINED_SERVICE | grep -i license"
+  fi
 
   # Nothing left to undo.
   ROLLBACK_STATE="disarmed"
@@ -1122,6 +1181,11 @@ print_summary() {
   fi
   [[ "$ENABLE_FLOW" == "yes" ]] && echo "  Traffic flow:     enabled"
   [[ "$ENABLE_FLOW" != "yes" ]] && echo "  Traffic flow:     disabled"
+  case "$LICENSE_VERDICT" in
+    ok)       echo "  License:          validated by the server" ;;
+    rejected) echo "  License:          REJECTED - see above, the install is not usable yet" ;;
+    *)        echo "  License:          not confirmed (no verdict in the logs yet)" ;;
+  esac
   echo ""
   echo "  Generated files (next to your docker-compose.yml):"
   echo "    $OVERRIDE_FILE"
@@ -1176,3 +1240,10 @@ trap 'exit 130' INT TERM
 init_migration
 apply_changes
 print_summary
+
+# A rejected license leaves a migrated but unusable install. Say so in the exit
+# code too, or a wrapper script reads this run as a clean success.
+if [[ "$LICENSE_VERDICT" == "rejected" ]]; then
+  exit 1
+fi
+exit 0

--- a/infrastructure_files/migrate-to-enterprise.sh
+++ b/infrastructure_files/migrate-to-enterprise.sh
@@ -1016,9 +1016,10 @@ wait_for_license_verdict() {
 
   echo -n "Waiting for the server to validate the license"
   while [[ $counter -lt 60 ]]; do
-    logs=$($DOCKER_COMPOSE_COMMAND logs --no-color --tail=200 "$COMBINED_SERVICE" 2>/dev/null || true)
 
-    if grep -qi "license invalidated\|license key invalid" <<< "$logs"; then
+    logs=$($DOCKER_COMPOSE_COMMAND logs --no-color --tail=all "$COMBINED_SERVICE" 2>/dev/null || true)
+
+    if grep -qi "license invalidated" <<< "$logs"; then
       echo " rejected"
       LICENSE_VERDICT="rejected"
       LICENSE_LOG_LINES=$(grep -i "license" <<< "$logs" | tail -n 5)
@@ -1038,6 +1039,7 @@ wait_for_license_verdict() {
 
   echo " no verdict in 120s"
   LICENSE_VERDICT="unknown"
+  LICENSE_LOG_LINES=$(grep -iE "failed to validate license|error validating license" <<< "$logs" | tail -n 3)
   return 0
 }
 
@@ -1157,13 +1159,22 @@ apply_changes() {
     echo "     The migration itself completed: the images and any migrated data"
     echo "     are in place, and only the license was refused."
     echo ""
-    echo "     Verify that NB_LICENSE_KEY in .env matches the key you were"
-    echo "     issued, correct it if it does not, then restart:"
+    echo "     Check the reason the server gave above, verify that"
+    echo "     NB_LICENSE_KEY in .env matches the key you were issued, then"
+    echo "     restart:"
     echo ""
     echo "       $DOCKER_COMPOSE_COMMAND up -d"
   elif [[ "$LICENSE_VERDICT" == "unknown" ]]; then
     echo ""
-    echo "  ⚠  The server logged no license verdict within 120s. Check it with:"
+    echo "  ⚠  The server logged no license verdict within 120s."
+    if [[ -n "$LICENSE_LOG_LINES" ]]; then
+      echo "     It was still reporting validation errors:"
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && echo "     $line"
+      done <<< "$LICENSE_LOG_LINES"
+    fi
+    echo ""
+    echo "     Check the verdict with:"
     echo ""
     echo "       $DOCKER_COMPOSE_COMMAND logs $COMBINED_SERVICE | grep -i license"
   fi


### PR DESCRIPTION
## Describe your changes

This PR improves validation in the self-hosted scripts so invalid input fails early with clearer errors.

`getting-started.sh` now validates that the domain is a proper FQDN before generating configuration files. It rejects IP addresses, URLs, ports, and single-label hostnames. DNS resolution is also checked: interactive installs ask whether to continue, while unattended installs only display a warning.

Docker Compose detection now uses docker compose version instead of `--help`, which could incorrectly succeed when the plugin was missing. The scripts prefer the Compose plugin, fall back to docker-compose, and report missing Docker Engine and Docker Compose separately.

`migrate-to-enterprise.sh` now checks the server logs to confirm whether the license was accepted. An explicit rejection prints the relevant logs and exits with a non-zero status. If no result appears within 120 seconds, the script reports that verification timed out without failing the migration.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for modern and legacy Docker Compose commands during setup and migration.
  * Added domain validation for IP addresses, hostnames, and the `use-ip` option.
  * Added DNS resolution checks with warnings and confirmation prompts for unresolved domains.
  * Added license validation during enterprise setup and migration, including success, rejection, and timeout reporting.

* **Bug Fixes**
  * Improved error messages when Docker or Docker Compose is unavailable.
  * Migration now fails when licensing is rejected and provides clearer guidance for license server connectivity issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->