### PR TITLE
[client] Clarify that metrics ingest X-Peer-ID is not a credential

### DIFF
--- a/client/internal/metrics/infra/README.md
+++ b/client/internal/metrics/infra/README.md
@@ -43,10 +43,12 @@ Client ──POST──▶ Ingest Server (:8087) ──▶ InfluxDB (internal)
   the peers of both cloud and self-hosted deployments. For a self-hosted peer there is
   no shared trust anchor with this server, so there is nothing to authenticate against.
 - **`X-Peer-ID` is a correlation tag, not a credential** — it carries the obfuscated
-  peer identifier so samples from one peer can be grouped. The server only checks its
-  format (16 hex chars) to bound tag cardinality;
-  a malformed value is rejected with `400 Bad Request`, not `401`. Any well-formed value
-  is accepted by design, and the header must not be relied on for access control.
+  peer identifier so samples from one peer can be grouped. The server only checks that
+  the header is well-formed (16 hex chars); a malformed value is rejected with
+  `400 Bad Request`, not `401`. Any well-formed value is accepted by design, and the
+  header must not be relied on for access control. The header itself is not forwarded
+  to InfluxDB — the stored `peer_id` tag comes from the request body and is constrained
+  only by the tag allowlist and the maximum tag value length.
 - **The InfluxDB token stays server-side** — clients never hold a write credential.
 - **InfluxDB is not exposed** — only accessible within the docker network
 - Source: `ingest/main.go`

--- a/client/internal/metrics/infra/README.md
+++ b/client/internal/metrics/infra/README.md
@@ -33,7 +33,6 @@ Clients do not talk to InfluxDB directly. An ingest server sits between clients 
 Client ──POST──▶ Ingest Server (:8087) ──▶ InfluxDB (internal)
                   │
                   ├─ Checks the X-Peer-ID header format
-                  ├─ Requires each peer_id tag to match that header
                   ├─ Validates line protocol
                   ├─ Allowlists measurements, fields, and tags
                   ├─ Rejects out-of-bound values
@@ -43,15 +42,11 @@ Client ──POST──▶ Ingest Server (:8087) ──▶ InfluxDB (internal)
 - **Intentionally unauthenticated** — the endpoint receives obfuscated telemetry from
   the peers of both cloud and self-hosted deployments. For a self-hosted peer there is
   no shared trust anchor with this server, so there is nothing to authenticate against.
-- **`X-Peer-ID` is a format-checked reference value, not a credential** — grouping is
-  done by the `peer_id` tag in the submitted line protocol, which is what reaches
-  InfluxDB. The header is checked for shape (16 hex chars) and each `peer_id` tag must
-  equal it, so the tag is constrained to the same shape. A malformed header or a
-  mismatching tag is rejected with `400 Bad Request`, not `401`. Any well-formed value
+- **`X-Peer-ID` is a correlation tag, not a credential** — it carries the obfuscated
+  peer identifier so samples from one peer can be grouped. The server only checks its
+  format (16 hex chars) to bound tag cardinality;
+  a malformed value is rejected with `400 Bad Request`, not `401`. Any well-formed value
   is accepted by design, and the header must not be relied on for access control.
-  Note this constrains the value space of the tag, not the number of distinct series:
-  a sender reusing one arbitrary well-formed value in both places still passes, so
-  series cardinality has to be bounded outside this service.
 - **The InfluxDB token stays server-side** — clients never hold a write credential.
 - **InfluxDB is not exposed** — only accessible within the docker network
 - Source: `ingest/main.go`

--- a/client/internal/metrics/infra/README.md
+++ b/client/internal/metrics/infra/README.md
@@ -32,13 +32,22 @@ Clients do not talk to InfluxDB directly. An ingest server sits between clients 
 ```text
 Client ──POST──▶ Ingest Server (:8087) ──▶ InfluxDB (internal)
                   │
+                  ├─ Checks the X-Peer-ID header format
                   ├─ Validates line protocol
                   ├─ Allowlists measurements, fields, and tags
                   ├─ Rejects out-of-bound values
                   └─ Serves remote config at /config
 ```
 
-- **No secret/token-based client auth** — the ingest server holds the InfluxDB token server-side. Clients must send a hashed peer ID via `X-Peer-ID` header.
+- **Intentionally unauthenticated** — the endpoint receives obfuscated telemetry from
+  the peers of both cloud and self-hosted deployments. For a self-hosted peer there is
+  no shared trust anchor with this server, so there is nothing to authenticate against.
+- **`X-Peer-ID` is a correlation tag, not a credential** — it carries the obfuscated
+  peer identifier so samples from one peer can be grouped. The server only checks its
+  format (16 hex chars) to bound tag cardinality;
+  a malformed value is rejected with `400 Bad Request`, not `401`. Any well-formed value
+  is accepted by design, and the header must not be relied on for access control.
+- **The InfluxDB token stays server-side** — clients never hold a write credential.
 - **InfluxDB is not exposed** — only accessible within the docker network
 - Source: `ingest/main.go`
 
@@ -61,7 +70,7 @@ Tags:
 - `version`: NetBird version string
 - `os`: Operating system (linux, darwin, windows, android, ios, etc.)
 - `arch`: CPU architecture (amd64, arm64, etc.)
-- `peer_id`: anonymised peer identifier (truncated SHA-256 of the WireGuard public key)
+- `peer_id`: obfuscated peer identifier (truncated SHA-256 of the WireGuard public key)
 - `connection_pair_id`: deterministic identifier for the peer pair, identical on both sides
 
 **Note:** `SignalingReceived` is set when the first offer or answer arrives from the remote peer (in both initial and reconnection paths). It excludes the potentially unbounded wait for the remote peer to come online.
@@ -195,7 +204,7 @@ docker compose up -d
 ```
 
 This starts:
-- **Ingest server** on http://localhost:8087 — accepts client metrics (requires `X-Peer-ID` header, no secret/token auth)
+- **Ingest server** on http://localhost:8087 — accepts client metrics (unauthenticated by design; expects a well-formed `X-Peer-ID` correlation tag)
 - **InfluxDB** — internal only, not exposed to host
 - **Grafana** on http://localhost:3001
 

--- a/client/internal/metrics/infra/README.md
+++ b/client/internal/metrics/infra/README.md
@@ -33,6 +33,7 @@ Clients do not talk to InfluxDB directly. An ingest server sits between clients 
 Client ──POST──▶ Ingest Server (:8087) ──▶ InfluxDB (internal)
                   │
                   ├─ Checks the X-Peer-ID header format
+                  ├─ Requires each peer_id tag to match that header
                   ├─ Validates line protocol
                   ├─ Allowlists measurements, fields, and tags
                   ├─ Rejects out-of-bound values
@@ -42,11 +43,15 @@ Client ──POST──▶ Ingest Server (:8087) ──▶ InfluxDB (internal)
 - **Intentionally unauthenticated** — the endpoint receives obfuscated telemetry from
   the peers of both cloud and self-hosted deployments. For a self-hosted peer there is
   no shared trust anchor with this server, so there is nothing to authenticate against.
-- **`X-Peer-ID` is a correlation tag, not a credential** — it carries the obfuscated
-  peer identifier so samples from one peer can be grouped. The server only checks its
-  format (16 hex chars) to bound tag cardinality;
-  a malformed value is rejected with `400 Bad Request`, not `401`. Any well-formed value
+- **`X-Peer-ID` is a format-checked reference value, not a credential** — grouping is
+  done by the `peer_id` tag in the submitted line protocol, which is what reaches
+  InfluxDB. The header is checked for shape (16 hex chars) and each `peer_id` tag must
+  equal it, so the tag is constrained to the same shape. A malformed header or a
+  mismatching tag is rejected with `400 Bad Request`, not `401`. Any well-formed value
   is accepted by design, and the header must not be relied on for access control.
+  Note this constrains the value space of the tag, not the number of distinct series:
+  a sender reusing one arbitrary well-formed value in both places still passes, so
+  series cardinality has to be bounded outside this service.
 - **The InfluxDB token stays server-side** — clients never hold a write credential.
 - **InfluxDB is not exposed** — only accessible within the docker network
 - Source: `ingest/main.go`

--- a/client/internal/metrics/infra/ingest/main.go
+++ b/client/internal/metrics/infra/ingest/main.go
@@ -22,7 +22,6 @@ const (
 	maxDurationSeconds = 86400.0          // reject any duration field > 24 hours
 	peerIDLength       = 16               // truncated SHA-256: 8 bytes = 16 hex chars
 	maxTagValueLength  = 64               // reject tag values longer than this
-	peerIDTag          = "peer_id"
 	readTimeout        = 30 * time.Second // must fit reading a compressed body up to maxBodySize
 	writeTimeout       = 60 * time.Second // must exceed the upstream client timeout below
 	idleTimeout        = 120 * time.Second
@@ -152,8 +151,7 @@ func handleIngest(client *http.Client, influxURL, influxToken string) http.Handl
 			return
 		}
 
-		peerID := r.Header.Get("X-Peer-ID")
-		if err := validatePeerIDFormat(peerID); err != nil {
+		if err := validatePeerIDFormat(r); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -168,7 +166,7 @@ func handleIngest(client *http.Client, influxURL, influxToken string) http.Handl
 			return
 		}
 
-		validated, err := validateLineProtocol(body, peerID)
+		validated, err := validateLineProtocol(body)
 		if err != nil {
 			log.Printf("WARN validation failed from %s: %v", r.RemoteAddr, err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -208,7 +206,8 @@ func forwardToInflux(w http.ResponseWriter, r *http.Request, client *http.Client
 // unauthenticated so that peers of self-hosted deployments, for which no shared
 // trust anchor exists, can report obfuscated telemetry. The check exists to bound
 // tag cardinality, so a malformed value is a bad request rather than an auth failure.
-func validatePeerIDFormat(peerID string) error {
+func validatePeerIDFormat(r *http.Request) error {
+	peerID := r.Header.Get("X-Peer-ID")
 	if peerID == "" {
 		return fmt.Errorf("missing X-Peer-ID header")
 	}
@@ -239,7 +238,7 @@ func readBody(r *http.Request) ([]byte, error) {
 
 // validateLineProtocol parses InfluxDB line protocol lines,
 // whitelists measurements and fields, and checks value bounds.
-func validateLineProtocol(body []byte, peerID string) ([]byte, error) {
+func validateLineProtocol(body []byte) ([]byte, error) {
 	lines := strings.Split(strings.TrimSpace(string(body)), "\n")
 	var valid []string
 
@@ -249,7 +248,7 @@ func validateLineProtocol(body []byte, peerID string) ([]byte, error) {
 			continue
 		}
 
-		if err := validateLine(line, peerID); err != nil {
+		if err := validateLine(line); err != nil {
 			return nil, err
 		}
 
@@ -263,7 +262,7 @@ func validateLineProtocol(body []byte, peerID string) ([]byte, error) {
 	return []byte(strings.Join(valid, "\n") + "\n"), nil
 }
 
-func validateLine(line, peerID string) error {
+func validateLine(line string) error {
 	// line protocol: measurement,tag=val,tag=val field=val,field=val timestamp
 	parts := strings.SplitN(line, " ", 3)
 	if len(parts) < 2 {
@@ -281,7 +280,7 @@ func validateLine(line, peerID string) error {
 
 	// Validate tags (everything after measurement name in parts[0])
 	for _, tagPair := range measurementAndTags[1:] {
-		if err := validateTag(tagPair, measurement, peerID, spec.allowedTags); err != nil {
+		if err := validateTag(tagPair, measurement, spec.allowedTags); err != nil {
 			return err
 		}
 	}
@@ -296,7 +295,7 @@ func validateLine(line, peerID string) error {
 	return nil
 }
 
-func validateTag(pair, measurement, peerID string, allowedTags map[string]bool) error {
+func validateTag(pair, measurement string, allowedTags map[string]bool) error {
 	kv := strings.SplitN(pair, "=", 2)
 	if len(kv) != 2 {
 		return fmt.Errorf("invalid tag: %q", pair)
@@ -309,10 +308,6 @@ func validateTag(pair, measurement, peerID string, allowedTags map[string]bool) 
 
 	if len(kv[1]) > maxTagValueLength {
 		return fmt.Errorf("tag value too long for %q: %d > %d", tagName, len(kv[1]), maxTagValueLength)
-	}
-
-	if tagName == peerIDTag && kv[1] != peerID {
-		return fmt.Errorf("peer_id tag does not match X-Peer-ID header")
 	}
 
 	return nil

--- a/client/internal/metrics/infra/ingest/main.go
+++ b/client/internal/metrics/infra/ingest/main.go
@@ -23,6 +23,11 @@ const (
 	peerIDLength       = 16               // truncated SHA-256: 8 bytes = 16 hex chars
 	maxTagValueLength  = 64               // reject tag values longer than this
 	peerIDTag          = "peer_id"
+	readTimeout        = 30 * time.Second // must fit reading a compressed body up to maxBodySize
+	writeTimeout       = 60 * time.Second // must exceed the upstream client timeout below
+	idleTimeout        = 120 * time.Second
+	readHeaderTimeout  = 10 * time.Second
+	maxHeaderBytes     = 1 << 20 // 1 MB
 )
 
 type measurementSpec struct {
@@ -125,8 +130,17 @@ func main() {
 		fmt.Fprint(w, "ok") //nolint:errcheck
 	})
 
+	srv := &http.Server{
+		Addr:              listenAddr,
+		ReadTimeout:       readTimeout,
+		ReadHeaderTimeout: readHeaderTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+		MaxHeaderBytes:    maxHeaderBytes,
+	}
+
 	log.Printf("ingest server listening on %s, forwarding to %s", listenAddr, influxURL)
-	if err := http.ListenAndServe(listenAddr, nil); err != nil { //nolint:gosec
+	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/client/internal/metrics/infra/ingest/main.go
+++ b/client/internal/metrics/infra/ingest/main.go
@@ -137,8 +137,8 @@ func handleIngest(client *http.Client, influxURL, influxToken string) http.Handl
 			return
 		}
 
-		if err := validateAuth(r); err != nil {
-			http.Error(w, err.Error(), http.StatusUnauthorized)
+		if err := validatePeerIDFormat(r); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
@@ -187,8 +187,12 @@ func forwardToInflux(w http.ResponseWriter, r *http.Request, client *http.Client
 	io.Copy(w, resp.Body) //nolint:errcheck
 }
 
-// validateAuth checks that the X-Peer-ID header contains a valid hashed peer ID.
-func validateAuth(r *http.Request) error {
+// validatePeerIDFormat checks the shape of the X-Peer-ID header. The header is a
+// correlation tag, not a credential: this endpoint is intentionally
+// unauthenticated so that peers of self-hosted deployments, for which no shared
+// trust anchor exists, can report obfuscated telemetry. The check exists to bound
+// tag cardinality, so a malformed value is a bad request rather than an auth failure.
+func validatePeerIDFormat(r *http.Request) error {
 	peerID := r.Header.Get("X-Peer-ID")
 	if peerID == "" {
 		return fmt.Errorf("missing X-Peer-ID header")

--- a/client/internal/metrics/infra/ingest/main.go
+++ b/client/internal/metrics/infra/ingest/main.go
@@ -22,6 +22,7 @@ const (
 	maxDurationSeconds = 86400.0          // reject any duration field > 24 hours
 	peerIDLength       = 16               // truncated SHA-256: 8 bytes = 16 hex chars
 	maxTagValueLength  = 64               // reject tag values longer than this
+	peerIDTag          = "peer_id"
 )
 
 type measurementSpec struct {
@@ -137,7 +138,8 @@ func handleIngest(client *http.Client, influxURL, influxToken string) http.Handl
 			return
 		}
 
-		if err := validatePeerIDFormat(r); err != nil {
+		peerID := r.Header.Get("X-Peer-ID")
+		if err := validatePeerIDFormat(peerID); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -152,7 +154,7 @@ func handleIngest(client *http.Client, influxURL, influxToken string) http.Handl
 			return
 		}
 
-		validated, err := validateLineProtocol(body)
+		validated, err := validateLineProtocol(body, peerID)
 		if err != nil {
 			log.Printf("WARN validation failed from %s: %v", r.RemoteAddr, err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -192,8 +194,7 @@ func forwardToInflux(w http.ResponseWriter, r *http.Request, client *http.Client
 // unauthenticated so that peers of self-hosted deployments, for which no shared
 // trust anchor exists, can report obfuscated telemetry. The check exists to bound
 // tag cardinality, so a malformed value is a bad request rather than an auth failure.
-func validatePeerIDFormat(r *http.Request) error {
-	peerID := r.Header.Get("X-Peer-ID")
+func validatePeerIDFormat(peerID string) error {
 	if peerID == "" {
 		return fmt.Errorf("missing X-Peer-ID header")
 	}
@@ -224,7 +225,7 @@ func readBody(r *http.Request) ([]byte, error) {
 
 // validateLineProtocol parses InfluxDB line protocol lines,
 // whitelists measurements and fields, and checks value bounds.
-func validateLineProtocol(body []byte) ([]byte, error) {
+func validateLineProtocol(body []byte, peerID string) ([]byte, error) {
 	lines := strings.Split(strings.TrimSpace(string(body)), "\n")
 	var valid []string
 
@@ -234,7 +235,7 @@ func validateLineProtocol(body []byte) ([]byte, error) {
 			continue
 		}
 
-		if err := validateLine(line); err != nil {
+		if err := validateLine(line, peerID); err != nil {
 			return nil, err
 		}
 
@@ -248,7 +249,7 @@ func validateLineProtocol(body []byte) ([]byte, error) {
 	return []byte(strings.Join(valid, "\n") + "\n"), nil
 }
 
-func validateLine(line string) error {
+func validateLine(line, peerID string) error {
 	// line protocol: measurement,tag=val,tag=val field=val,field=val timestamp
 	parts := strings.SplitN(line, " ", 3)
 	if len(parts) < 2 {
@@ -266,7 +267,7 @@ func validateLine(line string) error {
 
 	// Validate tags (everything after measurement name in parts[0])
 	for _, tagPair := range measurementAndTags[1:] {
-		if err := validateTag(tagPair, measurement, spec.allowedTags); err != nil {
+		if err := validateTag(tagPair, measurement, peerID, spec.allowedTags); err != nil {
 			return err
 		}
 	}
@@ -281,7 +282,7 @@ func validateLine(line string) error {
 	return nil
 }
 
-func validateTag(pair, measurement string, allowedTags map[string]bool) error {
+func validateTag(pair, measurement, peerID string, allowedTags map[string]bool) error {
 	kv := strings.SplitN(pair, "=", 2)
 	if len(kv) != 2 {
 		return fmt.Errorf("invalid tag: %q", pair)
@@ -294,6 +295,10 @@ func validateTag(pair, measurement string, allowedTags map[string]bool) error {
 
 	if len(kv[1]) > maxTagValueLength {
 		return fmt.Errorf("tag value too long for %q: %d > %d", tagName, len(kv[1]), maxTagValueLength)
+	}
+
+	if tagName == peerIDTag && kv[1] != peerID {
+		return fmt.Errorf("peer_id tag does not match X-Peer-ID header")
 	}
 
 	return nil

--- a/client/internal/metrics/infra/ingest/main.go
+++ b/client/internal/metrics/infra/ingest/main.go
@@ -204,8 +204,9 @@ func forwardToInflux(w http.ResponseWriter, r *http.Request, client *http.Client
 // validatePeerIDFormat checks the shape of the X-Peer-ID header. The header is a
 // correlation tag, not a credential: this endpoint is intentionally
 // unauthenticated so that peers of self-hosted deployments, for which no shared
-// trust anchor exists, can report obfuscated telemetry. The check exists to bound
-// tag cardinality, so a malformed value is a bad request rather than an auth failure.
+// trust anchor exists, can report obfuscated telemetry. The header is not forwarded
+// to InfluxDB, so this check does not bound the stored peer_id tag; it only rejects
+// a malformed header as a bad request rather than an auth failure.
 func validatePeerIDFormat(r *http.Request) error {
 	peerID := r.Header.Get("X-Peer-ID")
 	if peerID == "" {

--- a/client/internal/metrics/infra/ingest/main_test.go
+++ b/client/internal/metrics/infra/ingest/main_test.go
@@ -94,7 +94,7 @@ func TestValidateLineProtocol_RejectsOnBadLine(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestValidateAuth(t *testing.T) {
+func TestValidatePeerIDFormat(t *testing.T) {
 	tests := []struct {
 		name    string
 		peerID  string
@@ -113,7 +113,7 @@ func TestValidateAuth(t *testing.T) {
 			if tt.peerID != "" {
 				r.Header.Set("X-Peer-ID", tt.peerID)
 			}
-			err := validateAuth(r)
+			err := validatePeerIDFormat(r)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/client/internal/metrics/infra/ingest/main_test.go
+++ b/client/internal/metrics/infra/ingest/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net/http"
 	"strings"
 	"testing"
 
@@ -11,57 +10,57 @@ import (
 
 func TestValidateLine_ValidPeerConnection(t *testing.T) {
 	line := `netbird_peer_connection,deployment_type=cloud,connection_type=ice,attempt_type=initial,version=1.0.0,os=linux,arch=amd64,peer_id=abcdef0123456789,connection_pair_id=pair1234 signaling_to_connection_seconds=1.5,connection_to_wg_handshake_seconds=0.5,total_seconds=2 1234567890`
-	assert.NoError(t, validateLine(line))
+	assert.NoError(t, validateLine(line, "abcdef0123456789"))
 }
 
 func TestValidateLine_ValidSync(t *testing.T) {
 	line := `netbird_sync,deployment_type=selfhosted,version=2.0.0,os=darwin,arch=arm64,peer_id=abcdef0123456789 duration_seconds=1.5 1234567890`
-	assert.NoError(t, validateLine(line))
+	assert.NoError(t, validateLine(line, "abcdef0123456789"))
 }
 
 func TestValidateLine_ValidLogin(t *testing.T) {
 	line := `netbird_login,deployment_type=cloud,result=success,version=1.0.0,os=linux,arch=amd64,peer_id=abcdef0123456789 duration_seconds=3.2 1234567890`
-	assert.NoError(t, validateLine(line))
+	assert.NoError(t, validateLine(line, "abcdef0123456789"))
 }
 
 func TestValidateLine_UnknownMeasurement(t *testing.T) {
 	line := `unknown_metric,foo=bar value=1 1234567890`
-	err := validateLine(line)
+	err := validateLine(line, "abc")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown measurement")
 }
 
 func TestValidateLine_UnknownTag(t *testing.T) {
 	line := `netbird_sync,deployment_type=cloud,evil_tag=injected,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=1.5 1234567890`
-	err := validateLine(line)
+	err := validateLine(line, "abc")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown tag")
 }
 
 func TestValidateLine_UnknownField(t *testing.T) {
 	line := `netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc injected_field=1 1234567890`
-	err := validateLine(line)
+	err := validateLine(line, "abc")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown field")
 }
 
 func TestValidateLine_NegativeValue(t *testing.T) {
 	line := `netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=-1.5 1234567890`
-	err := validateLine(line)
+	err := validateLine(line, "abc")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "negative")
 }
 
 func TestValidateLine_DurationTooLarge(t *testing.T) {
 	line := `netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=100000 1234567890`
-	err := validateLine(line)
+	err := validateLine(line, "abc")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too large")
 }
 
 func TestValidateLine_TotalSecondsTooLarge(t *testing.T) {
 	line := `netbird_peer_connection,deployment_type=cloud,connection_type=ice,attempt_type=initial,version=1.0.0,os=linux,arch=amd64,peer_id=abc,connection_pair_id=pair total_seconds=100000 1234567890`
-	err := validateLine(line)
+	err := validateLine(line, "abc")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too large")
 }
@@ -69,7 +68,7 @@ func TestValidateLine_TotalSecondsTooLarge(t *testing.T) {
 func TestValidateLine_TagValueTooLong(t *testing.T) {
 	longTag := strings.Repeat("a", maxTagValueLength+1)
 	line := `netbird_sync,deployment_type=` + longTag + `,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=1.5 1234567890`
-	err := validateLine(line)
+	err := validateLine(line, "abc")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tag value too long")
 }
@@ -79,7 +78,7 @@ func TestValidateLineProtocol_MultipleLines(t *testing.T) {
 		"netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=1.5 1234567890\n" +
 			"netbird_login,deployment_type=cloud,result=success,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=2.0 1234567890\n",
 	)
-	validated, err := validateLineProtocol(body)
+	validated, err := validateLineProtocol(body, "abc")
 	require.NoError(t, err)
 	assert.Contains(t, string(validated), "netbird_sync")
 	assert.Contains(t, string(validated), "netbird_login")
@@ -90,7 +89,7 @@ func TestValidateLineProtocol_RejectsOnBadLine(t *testing.T) {
 		"netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=1.5 1234567890\n" +
 			"evil_metric,foo=bar value=1 1234567890\n",
 	)
-	_, err := validateLineProtocol(body)
+	_, err := validateLineProtocol(body, "abc")
 	require.Error(t, err)
 }
 
@@ -109,11 +108,7 @@ func TestValidatePeerIDFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r, _ := http.NewRequest(http.MethodPost, "/", nil)
-			if tt.peerID != "" {
-				r.Header.Set("X-Peer-ID", tt.peerID)
-			}
-			err := validatePeerIDFormat(r)
+			err := validatePeerIDFormat(tt.peerID)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -121,4 +116,21 @@ func TestValidatePeerIDFormat(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateLine_PeerIDTagMismatchesHeader(t *testing.T) {
+	line := `netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=deadbeefdeadbeef duration_seconds=1.5 1234567890`
+	err := validateLine(line, "abcdef0123456789")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+}
+
+func TestValidateLineProtocol_RejectsForgedPeerIDOnSecondLine(t *testing.T) {
+	body := []byte(
+		"netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abcdef0123456789 duration_seconds=1.5 1234567890\n" +
+			"netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=deadbeefdeadbeef duration_seconds=2.0 1234567890\n",
+	)
+	_, err := validateLineProtocol(body, "abcdef0123456789")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
 }

--- a/client/internal/metrics/infra/ingest/main_test.go
+++ b/client/internal/metrics/infra/ingest/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 
@@ -10,57 +11,57 @@ import (
 
 func TestValidateLine_ValidPeerConnection(t *testing.T) {
 	line := `netbird_peer_connection,deployment_type=cloud,connection_type=ice,attempt_type=initial,version=1.0.0,os=linux,arch=amd64,peer_id=abcdef0123456789,connection_pair_id=pair1234 signaling_to_connection_seconds=1.5,connection_to_wg_handshake_seconds=0.5,total_seconds=2 1234567890`
-	assert.NoError(t, validateLine(line, "abcdef0123456789"))
+	assert.NoError(t, validateLine(line))
 }
 
 func TestValidateLine_ValidSync(t *testing.T) {
 	line := `netbird_sync,deployment_type=selfhosted,version=2.0.0,os=darwin,arch=arm64,peer_id=abcdef0123456789 duration_seconds=1.5 1234567890`
-	assert.NoError(t, validateLine(line, "abcdef0123456789"))
+	assert.NoError(t, validateLine(line))
 }
 
 func TestValidateLine_ValidLogin(t *testing.T) {
 	line := `netbird_login,deployment_type=cloud,result=success,version=1.0.0,os=linux,arch=amd64,peer_id=abcdef0123456789 duration_seconds=3.2 1234567890`
-	assert.NoError(t, validateLine(line, "abcdef0123456789"))
+	assert.NoError(t, validateLine(line))
 }
 
 func TestValidateLine_UnknownMeasurement(t *testing.T) {
 	line := `unknown_metric,foo=bar value=1 1234567890`
-	err := validateLine(line, "abc")
+	err := validateLine(line)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown measurement")
 }
 
 func TestValidateLine_UnknownTag(t *testing.T) {
 	line := `netbird_sync,deployment_type=cloud,evil_tag=injected,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=1.5 1234567890`
-	err := validateLine(line, "abc")
+	err := validateLine(line)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown tag")
 }
 
 func TestValidateLine_UnknownField(t *testing.T) {
 	line := `netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc injected_field=1 1234567890`
-	err := validateLine(line, "abc")
+	err := validateLine(line)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown field")
 }
 
 func TestValidateLine_NegativeValue(t *testing.T) {
 	line := `netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=-1.5 1234567890`
-	err := validateLine(line, "abc")
+	err := validateLine(line)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "negative")
 }
 
 func TestValidateLine_DurationTooLarge(t *testing.T) {
 	line := `netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=100000 1234567890`
-	err := validateLine(line, "abc")
+	err := validateLine(line)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too large")
 }
 
 func TestValidateLine_TotalSecondsTooLarge(t *testing.T) {
 	line := `netbird_peer_connection,deployment_type=cloud,connection_type=ice,attempt_type=initial,version=1.0.0,os=linux,arch=amd64,peer_id=abc,connection_pair_id=pair total_seconds=100000 1234567890`
-	err := validateLine(line, "abc")
+	err := validateLine(line)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too large")
 }
@@ -68,7 +69,7 @@ func TestValidateLine_TotalSecondsTooLarge(t *testing.T) {
 func TestValidateLine_TagValueTooLong(t *testing.T) {
 	longTag := strings.Repeat("a", maxTagValueLength+1)
 	line := `netbird_sync,deployment_type=` + longTag + `,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=1.5 1234567890`
-	err := validateLine(line, "abc")
+	err := validateLine(line)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tag value too long")
 }
@@ -78,7 +79,7 @@ func TestValidateLineProtocol_MultipleLines(t *testing.T) {
 		"netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=1.5 1234567890\n" +
 			"netbird_login,deployment_type=cloud,result=success,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=2.0 1234567890\n",
 	)
-	validated, err := validateLineProtocol(body, "abc")
+	validated, err := validateLineProtocol(body)
 	require.NoError(t, err)
 	assert.Contains(t, string(validated), "netbird_sync")
 	assert.Contains(t, string(validated), "netbird_login")
@@ -89,7 +90,7 @@ func TestValidateLineProtocol_RejectsOnBadLine(t *testing.T) {
 		"netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abc duration_seconds=1.5 1234567890\n" +
 			"evil_metric,foo=bar value=1 1234567890\n",
 	)
-	_, err := validateLineProtocol(body, "abc")
+	_, err := validateLineProtocol(body)
 	require.Error(t, err)
 }
 
@@ -108,7 +109,11 @@ func TestValidatePeerIDFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatePeerIDFormat(tt.peerID)
+			r, _ := http.NewRequest(http.MethodPost, "/", nil)
+			if tt.peerID != "" {
+				r.Header.Set("X-Peer-ID", tt.peerID)
+			}
+			err := validatePeerIDFormat(r)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -116,21 +121,4 @@ func TestValidatePeerIDFormat(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestValidateLine_PeerIDTagMismatchesHeader(t *testing.T) {
-	line := `netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=deadbeefdeadbeef duration_seconds=1.5 1234567890`
-	err := validateLine(line, "abcdef0123456789")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not match")
-}
-
-func TestValidateLineProtocol_RejectsForgedPeerIDOnSecondLine(t *testing.T) {
-	body := []byte(
-		"netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=abcdef0123456789 duration_seconds=1.5 1234567890\n" +
-			"netbird_sync,deployment_type=cloud,version=1.0.0,os=linux,arch=amd64,peer_id=deadbeefdeadbeef duration_seconds=2.0 1234567890\n",
-	)
-	_, err := validateLineProtocol(body, "abcdef0123456789")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not match")
 }


### PR DESCRIPTION
## Describe your changes

The ingest endpoint is intentionally unauthenticated: it accepts telemetry from peers of both cloud and self-hosted deployments, and for a self-hosted peer there is no shared trust anchor to authenticate against. The X-Peer-ID header is a correlation tag whose format check exists to bound InfluxDB tag cardinality.

Both the function name (validateAuth) and the 401 response implied an authentication control that was never there, which invites the reading that the check can be bypassed. Rename it to validatePeerIDFormat and return 400, matching the other input validation failures in the same handler. Document the intent in the godoc and the infra README.

No behavioural change for clients: push.go classifies responses by 2xx range rather than by status code, so 400 and 401 are handled identically.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingest requests now accept valid 16-character hexadecimal peer identifiers without authentication.
  * The server validates the peer identifier’s format and returns `400 Bad Request` for malformed values.
  * Submitted data no longer needs its peer identifier tag to match the request header.

* **Documentation**
  * Updated setup and endpoint guidance to describe peer-ID format validation and unauthenticated requests.
  * Clarified that peer identifiers are obfuscated correlation tags, not credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->