### PR TITLE
[client] Publish the network selection event on a partial failure

### DIFF
--- a/client/internal/routemanager/selection.go
+++ b/client/internal/routemanager/selection.go
@@ -1,6 +1,7 @@
 package routemanager
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -11,6 +12,31 @@ import (
 	nberrors "github.com/netbirdio/netbird/client/errors"
 	"github.com/netbirdio/netbird/route"
 )
+
+// ErrNoRoutesApplied reports that none of the requested network IDs was available,
+// so the request left the selection untouched. Callers use it to tell that apart
+// from a partial failure, which does change the selection.
+var ErrNoRoutesApplied = errors.New("no requested network is available")
+
+// noRoutesAppliedError marks an error as "the request applied nothing" for
+// errors.Is(err, ErrNoRoutesApplied), without altering the wrapped error's
+// message: callers see the original text, not an ErrNoRoutesApplied prefix.
+type noRoutesAppliedError struct{ err error }
+
+func (e *noRoutesAppliedError) Error() string        { return e.err.Error() }
+func (e *noRoutesAppliedError) Unwrap() error        { return e.err }
+func (e *noRoutesAppliedError) Is(target error) bool { return target == ErrNoRoutesApplied }
+
+// noneAvailable reports whether a non-empty request names no known network. An
+// empty request is not a failed lookup: SelectRoutes treats it as deselect all.
+func noneAvailable(requested, all []route.NetID) bool {
+	if len(requested) == 0 {
+		return false
+	}
+	return !slices.ContainsFunc(requested, func(id route.NetID) bool {
+		return slices.Contains(all, id)
+	})
+}
 
 // SelectRoutes selects the routes with the given network IDs and applies the
 // new selection. V4/v6 exit-node pairs are expanded automatically. Exit nodes
@@ -46,11 +72,16 @@ func (m *DefaultManager) DeselectRoutes(ids []route.NetID) error {
 func (m *DefaultManager) deselectRoutes(ids []route.NetID) error {
 	routesMap := m.GetClientRoutesWithNetID()
 	routes := route.ExpandV6ExitPairs(slices.Clone(ids), routesMap)
+	allIDs := maps.Keys(routesMap)
 
 	log.Debugf("deselecting routes with ids: %v", routes)
 
-	if err := m.routeSelector.DeselectRoutes(routes, maps.Keys(routesMap)); err != nil {
-		return fmt.Errorf("deselect routes: %w", err)
+	if err := m.routeSelector.DeselectRoutes(routes, allIDs); err != nil {
+		err = fmt.Errorf("deselect routes: %w", err)
+		if noneAvailable(routes, allIDs) {
+			return &noRoutesAppliedError{err: err}
+		}
+		return err
 	}
 
 	return nil
@@ -106,7 +137,11 @@ func (m *DefaultManager) selectRoutes(ids []route.NetID, appendRoute bool) error
 		}
 	}
 
-	return nberrors.FormatErrorOrNil(merr)
+	err := nberrors.FormatErrorOrNil(merr)
+	if err != nil && noneAvailable(routes, allIDs) {
+		return &noRoutesAppliedError{err: err}
+	}
+	return err
 }
 
 func isExitNodeRoutes(routes []*route.Route) bool {

--- a/client/internal/routemanager/selection_test.go
+++ b/client/internal/routemanager/selection_test.go
@@ -2,6 +2,7 @@ package routemanager
 
 import (
 	"context"
+	"errors"
 	"net/netip"
 	"testing"
 
@@ -186,6 +187,44 @@ func TestSelectRoutes_TotalFailureLeavesInstalledRoutesAlone(t *testing.T) {
 	assert.ElementsMatch(t, installed, maps.Keys(m.activeRoutes), "a fully invalid request must not disturb the routing table")
 }
 
+func TestSelectRoutes_ErrNoRoutesApplied(t *testing.T) {
+	m := newSelectionTestManager()
+
+	err := m.selectRoutes([]route.NetID{"missing"}, true)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNoRoutesApplied), "a fully unknown request applies nothing")
+	assert.Contains(t, err.Error(), "route 'missing' is not available")
+	assert.NotContains(t, err.Error(), "no requested network is available")
+
+	unwrapped := errors.Unwrap(err)
+	require.NotNil(t, unwrapped, "the wrapped error must still be reachable via Unwrap")
+	assert.Equal(t, err.Error(), unwrapped.Error(), "the marker must not alter the wrapped error's message")
+
+	err = m.selectRoutes([]route.NetID{"lan", "missing"}, true)
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, ErrNoRoutesApplied), "a partial failure still changes the selection")
+}
+
+func TestDeselectRoutes_ErrNoRoutesApplied(t *testing.T) {
+	m := newSelectionTestManager()
+	require.NoError(t, m.selectRoutes([]route.NetID{"lan"}, true))
+
+	err := m.deselectRoutes([]route.NetID{"missing"})
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNoRoutesApplied), "a fully unknown request applies nothing")
+	assert.Contains(t, err.Error(), "route 'missing' is not available")
+	assert.NotContains(t, err.Error(), "no requested network is available")
+
+	err = m.deselectRoutes([]route.NetID{"lan", "missing"})
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, ErrNoRoutesApplied), "a partial failure still changes the selection")
+}
+
+func TestSelectRoutes_EmptyRequestSucceeds(t *testing.T) {
+	m := newSelectionTestManager()
+	require.NoError(t, m.selectRoutes(nil, false))
+}
+
 func TestExitNodeSelectionHelpers(t *testing.T) {
 	routesMap := map[route.NetID][]*route.Route{
 		"exitA": {{Network: netip.MustParsePrefix("0.0.0.0/0")}},
@@ -200,4 +239,25 @@ func TestExitNodeSelectionHelpers(t *testing.T) {
 
 	others := otherExitNodeIDs(routesMap, []route.NetID{"exitB"})
 	assert.ElementsMatch(t, []route.NetID{"exitA"}, others, "only the other exit node is a sibling; the lan route is ignored")
+}
+
+func TestNoneAvailable(t *testing.T) {
+	all := []route.NetID{"lan", "exitA"}
+
+	tests := map[string]struct {
+		requested []route.NetID
+		all       []route.NetID
+		want      bool
+	}{
+		"empty request":                {requested: nil, all: all, want: false},
+		"all unknown ids":              {requested: []route.NetID{"missing", "also-missing"}, all: all, want: true},
+		"one known id among unknown":   {requested: []route.NetID{"missing", "lan"}, all: all, want: false},
+		"empty available with request": {requested: []route.NetID{"lan"}, all: nil, want: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, noneAvailable(tt.requested, tt.all), "noneAvailable(%v, %v) mismatch", tt.requested, tt.all)
+		})
+	}
 }

--- a/client/server/network.go
+++ b/client/server/network.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 	"slices"
@@ -11,6 +12,7 @@ import (
 	"google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
 
+	"github.com/netbirdio/netbird/client/internal/routemanager"
 	"github.com/netbirdio/netbird/client/proto"
 	"github.com/netbirdio/netbird/route"
 	"github.com/netbirdio/netbird/shared/management/domain"
@@ -160,23 +162,20 @@ func (s *Server) SelectNetworks(_ context.Context, req *proto.SelectNetworksRequ
 		return nil, fmt.Errorf("no route manager")
 	}
 
+	var err error
 	if req.GetAll() {
 		routeManager.SelectAllRoutes()
-	} else if err := routeManager.SelectRoutes(toNetIDs(req.GetNetworkIDs()), req.GetAppend()); err != nil {
-		return nil, err
+	} else {
+		err = routeManager.SelectRoutes(toNetIDs(req.GetNetworkIDs()), req.GetAppend())
 	}
 
-	s.statusRecorder.PublishEvent(
-		proto.SystemEvent_INFO,
-		proto.SystemEvent_SYSTEM,
-		"Network selection changed",
-		"",
-		map[string]string{
-			"networks": strings.Join(req.GetNetworkIDs(), ", "),
-			"append":   fmt.Sprint(req.GetAppend()),
-			"all":      fmt.Sprint(req.GetAll()),
-		},
-	)
+	if selectionApplied(err) {
+		s.publishSelectionEvent("Network selection changed", req)
+	}
+
+	if err != nil {
+		return nil, err
+	}
 
 	return &proto.SelectNetworksResponse{}, nil
 }
@@ -204,16 +203,39 @@ func (s *Server) DeselectNetworks(_ context.Context, req *proto.SelectNetworksRe
 		return nil, fmt.Errorf("no route manager")
 	}
 
+	var err error
 	if req.GetAll() {
 		routeManager.DeselectAllRoutes()
-	} else if err := routeManager.DeselectRoutes(toNetIDs(req.GetNetworkIDs())); err != nil {
+	} else {
+		err = routeManager.DeselectRoutes(toNetIDs(req.GetNetworkIDs()))
+	}
+
+	if selectionApplied(err) {
+		s.publishSelectionEvent("Network deselection changed", req)
+	}
+
+	if err != nil {
 		return nil, err
 	}
 
+	return &proto.SelectNetworksResponse{}, nil
+}
+
+// selectionApplied reports whether a select/deselect request changed the
+// selection. A partial failure (an unknown ID mixed with valid ones) still
+// applies the valid IDs, so it counts as applied; only ErrNoRoutesApplied
+// means the request left the selection untouched.
+func selectionApplied(err error) bool {
+	return !errors.Is(err, routemanager.ErrNoRoutesApplied)
+}
+
+// publishSelectionEvent reports a network selection or deselection change,
+// with the request's networks, append flag, and all flag as metadata.
+func (s *Server) publishSelectionEvent(title string, req *proto.SelectNetworksRequest) {
 	s.statusRecorder.PublishEvent(
 		proto.SystemEvent_INFO,
 		proto.SystemEvent_SYSTEM,
-		"Network deselection changed",
+		title,
 		"",
 		map[string]string{
 			"networks": strings.Join(req.GetNetworkIDs(), ", "),
@@ -221,8 +243,6 @@ func (s *Server) DeselectNetworks(_ context.Context, req *proto.SelectNetworksRe
 			"all":      fmt.Sprint(req.GetAll()),
 		},
 	)
-
-	return &proto.SelectNetworksResponse{}, nil
 }
 
 func toNetIDs(routes []string) []route.NetID {

--- a/client/server/network_test.go
+++ b/client/server/network_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/internal/peer"
+	"github.com/netbirdio/netbird/client/internal/routemanager"
+	"github.com/netbirdio/netbird/client/proto"
+)
+
+func TestSelectionApplied(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil error":                  {err: nil, want: true},
+		"unrelated error":            {err: errors.New("boom"), want: true},
+		"wrapped ErrNoRoutesApplied": {err: fmt.Errorf("select routes: %w", routemanager.ErrNoRoutesApplied), want: false},
+		"bare ErrNoRoutesApplied":    {err: routemanager.ErrNoRoutesApplied, want: false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, selectionApplied(tt.err), "selectionApplied(%v) mismatch", tt.err)
+		})
+	}
+}
+
+func TestPublishSelectionEvent(t *testing.T) {
+	s := &Server{statusRecorder: peer.NewRecorder("")}
+
+	s.publishSelectionEvent("Network selection changed", &proto.SelectNetworksRequest{
+		NetworkIDs: []string{"lan", "office"},
+		Append:     true,
+	})
+
+	events := s.statusRecorder.GetEventHistory()
+	require.Len(t, events, 1, "exactly one event must be published")
+
+	event := events[0]
+	assert.Equal(t, proto.SystemEvent_INFO, event.GetSeverity(), "event severity should be INFO")
+	assert.Equal(t, proto.SystemEvent_SYSTEM, event.GetCategory(), "event category should be SYSTEM")
+	assert.Equal(t, "Network selection changed", event.GetMessage(), "event message should match the given title")
+	assert.Equal(t, "lan, office", event.GetMetadata()["networks"], "networks metadata should join the requested IDs")
+	assert.Equal(t, "true", event.GetMetadata()["append"], "append metadata should reflect the request")
+	assert.Equal(t, "false", event.GetMetadata()["all"], "all metadata should reflect the request")
+}


### PR DESCRIPTION
## Describe your changes

Follow-up to #7292, which fixed the routing table on a partially failed selection but deliberately left the event stream alone. Its description named this as the deferred part: after that PR, a partial failure changes the selection without publishing a system event.

`SelectNetworks` and `DeselectNetworks` returned as soon as the route manager reported an error, written as if an error meant nothing had happened. It does not: the selector applies the available IDs and reports the rest, so a request mixing valid and unknown IDs changes the selection and leaves no trace on the event stream. `netbird routes select lan typo` moves `lan` into the selection, and the client's event log shows nothing.

Publishing unconditionally would be wrong the other way round: a request where no ID is available changes nothing, and after #7292 it does not even touch the selector. That case must stay silent.

### Changes

**`routemanager/selection.go`**: add `ErrNoRoutesApplied` and wrap the returned error with it when a non-empty request names no known network. `noneAvailable` deliberately answers `false` for an empty request, because `SelectRoutes` treats that as deselect-all — the same boundary #7292 guarded in the selector.

**`server/network.go`**: both handlers now run the selection, publish the event unless the error is `ErrNoRoutesApplied`, and return the error afterwards. The three outcomes stay distinct: full success and partial failure publish, a fully unknown request does not.

The error stays wrapped, so every existing caller keeps the message it had; only `errors.Is` sees the new sentinel.

## Issue ticket number and link

https://github.com/netbirdio/netbird/discussions/7345 — opened when #7292 split this out; no reply from the team yet. The change itself is the tail end of #7292, whose merged description states the follow-up explicitly, so I am submitting it rather than leaving the gap open. Happy to park this PR until someone confirms the direction.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

The documented behaviour is unchanged: a selection change has always been meant to raise `Network selection changed`. This restores that on a code path where it went missing, and adds no flag, field or command.

### Tests

Three cases in `selection_test.go`, on top of the helpers #7292 added:

- `TestSelectRoutes_ErrNoRoutesApplied` and `TestDeselectRoutes_ErrNoRoutesApplied`: a fully unknown request carries the sentinel, a partial one does not. Both fail without the change.
- `TestSelectRoutes_EmptyRequestSucceeds`: pins the deselect-all boundary, so the sentinel never swallows an empty request.

```
go test ./client/internal/routemanager/ ./client/server/
ok  	github.com/netbirdio/netbird/client/internal/routemanager	0.698s
ok  	github.com/netbirdio/netbird/client/server	3.940s
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

### On the `codecov/patch` failure

The 32 uncovered lines are the reworked blocks in `SelectNetworks` and `DeselectNetworks`. Both handlers sit at 0% on `main` as well — nothing exercises them today, because they reach the manager through `s.connectClient.Engine().GetRouteManager()`, which are concrete types all the way down. Covering the publish/skip decision at that level means making those dependencies substitutable first, and that is a testability refactor: a second purpose this PR should not carry.

So the tests stay at the manager boundary, where the decision is actually made. I am happy to do the handler seam as its own change if you would rather have it before this one.

For the record, an earlier Codecov comment on this PR reported every modified line as covered. That run had failing jobs, so `client/server` never uploaded its profile; the current report is the accurate one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network selection and deselection error reporting when requested networks are unavailable.
  * Partial network changes are now applied and reported correctly instead of stopping immediately.
  * System events are published for partial changes, while empty changes are excluded.
  * Empty network selection requests now complete successfully.

* **Tests**
  * Added coverage for fully invalid, partially valid, and empty network requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
