### PR TITLE
[client] Fix the ICEBind races that wedge interface creation

### DIFF
--- a/client/iface/bind/ice_bind.go
+++ b/client/iface/bind/ice_bind.go
@@ -57,10 +57,13 @@ type ICEBind struct {
 	endpoints   map[netip.Addr]net.Conn
 	endpointsMu sync.Mutex
 	recvChan    chan recvMessage
-	// every time when Close() is called (i.e. BindUpdate()) we need to close exit from the receiveRelayed and create a
-	// new closed channel. With the closedChanMu we can safely close the channel and create a new one
+	// Close() (i.e. BindUpdate()) closes closedChan to release receiveRelayed,
+	// and the following Open() installs a fresh one. closedChanMu guards both
+	// closedChan and closed: readers only ever hold it long enough to copy the
+	// channel, never across a blocking receive, so Open cannot be starved by a
+	// parked receiver.
 	closedChan       chan struct{}
-	closedChanMu     sync.RWMutex // protect the closeChan recreation from reading from it.
+	closedChanMu     sync.RWMutex
 	closed           bool
 	activityRecorder *ActivityRecorder
 
@@ -92,8 +95,14 @@ func NewICEBind(transportNet transport.Net, address wgaddr.Address, mtu uint16) 
 }
 
 func (s *ICEBind) Open(uport uint16) ([]wgConn.ReceiveFunc, uint16, error) {
-	s.closed = false
 	s.closedChanMu.Lock()
+	// Releasing the previous generation before swapping the channel matters when
+	// Open follows an Open rather than a Close: whoever is parked on the old
+	// channel would otherwise wait on something no later Close can reach.
+	if !s.closed {
+		close(s.closedChan)
+	}
+	s.closed = false
 	s.closedChan = make(chan struct{})
 	s.closedChanMu.Unlock()
 	fns, port, err := s.StdNetBind.Open(uport)
@@ -105,12 +114,14 @@ func (s *ICEBind) Open(uport uint16) ([]wgConn.ReceiveFunc, uint16, error) {
 }
 
 func (s *ICEBind) Close() error {
+	s.closedChanMu.Lock()
 	if s.closed {
+		s.closedChanMu.Unlock()
 		return nil
 	}
 	s.closed = true
-
 	close(s.closedChan)
+	s.closedChanMu.Unlock()
 
 	s.muUDPMux.Lock()
 	s.ipv4Conn = nil
@@ -119,6 +130,15 @@ func (s *ICEBind) Close() error {
 	s.muUDPMux.Unlock()
 
 	return s.StdNetBind.Close()
+}
+
+// currentClosedChan copies the channel that signals the current Open
+// generation is closing. Callers select on the copy so the lock is never held
+// across a blocking receive, which would otherwise stall the next Open.
+func (s *ICEBind) currentClosedChan() chan struct{} {
+	s.closedChanMu.RLock()
+	defer s.closedChanMu.RUnlock()
+	return s.closedChan
 }
 
 func (s *ICEBind) ActivityRecorder() *ActivityRecorder {
@@ -150,8 +170,10 @@ func (b *ICEBind) RemoveEndpoint(fakeIP netip.Addr) {
 }
 
 func (b *ICEBind) ReceiveFromEndpoint(ctx context.Context, ep *Endpoint, buf []byte) {
+	closedChan := b.currentClosedChan()
+
 	select {
-	case <-b.closedChan:
+	case <-closedChan:
 		return
 	case <-ctx.Done():
 		return
@@ -333,11 +355,10 @@ func (s *ICEBind) parseSTUNMessage(raw []byte) (*stun.Message, error) {
 // receiveRelayed is a receive function that is used to receive packets from the relayed connection and forward to the
 // WireGuard. Critical part is do not block if the Closed() has been called.
 func (c *ICEBind) receiveRelayed(buffs [][]byte, sizes []int, eps []wgConn.Endpoint) (int, error) {
-	c.closedChanMu.RLock()
-	defer c.closedChanMu.RUnlock()
+	closedChan := c.currentClosedChan()
 
 	select {
-	case <-c.closedChan:
+	case <-closedChan:
 		return 0, net.ErrClosed
 	case msg, ok := <-c.recvChan:
 		if !ok {

--- a/client/iface/bind/ice_bind.go
+++ b/client/iface/bind/ice_bind.go
@@ -96,32 +96,41 @@ func NewICEBind(transportNet transport.Net, address wgaddr.Address, mtu uint16) 
 
 func (s *ICEBind) Open(uport uint16) ([]wgConn.ReceiveFunc, uint16, error) {
 	s.closedChanMu.Lock()
-	// Releasing the previous generation before swapping the channel matters when
-	// Open follows an Open rather than a Close: whoever is parked on the old
-	// channel would otherwise wait on something no later Close can reach.
+	defer s.closedChanMu.Unlock()
+
+	// Open the underlying bind before touching any state, so a failure leaves
+	// the current generation exactly as it was. Publishing the new generation
+	// first would strand it: StdNetBind rejects an Open while it is already
+	// open, and a Close arriving in that window would mark the bind closed
+	// while this call went on to install live sockets, after which every later
+	// Close returns early and never shuts them down.
+	fns, port, err := s.StdNetBind.Open(uport)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Release whoever is parked on the outgoing generation before replacing it.
+	// An Open that follows an Open rather than a Close would otherwise leave
+	// them waiting on a channel no later Close can reach.
 	if !s.closed {
 		close(s.closedChan)
 	}
 	s.closed = false
 	s.closedChan = make(chan struct{})
-	s.closedChanMu.Unlock()
-	fns, port, err := s.StdNetBind.Open(uport)
-	if err != nil {
-		return nil, 0, err
-	}
+
 	fns = append(fns, s.receiveRelayed)
 	return fns, port, nil
 }
 
 func (s *ICEBind) Close() error {
 	s.closedChanMu.Lock()
+	defer s.closedChanMu.Unlock()
+
 	if s.closed {
-		s.closedChanMu.Unlock()
 		return nil
 	}
 	s.closed = true
 	close(s.closedChan)
-	s.closedChanMu.Unlock()
 
 	s.muUDPMux.Lock()
 	s.ipv4Conn = nil

--- a/client/iface/bind/ice_bind_close_test.go
+++ b/client/iface/bind/ice_bind_close_test.go
@@ -51,7 +51,6 @@ func receiversStopped(wg *sync.WaitGroup, timeout time.Duration) bool {
 
 // TestICEBindCloseReleasesReceivers covers the contract closeBindLocked relies
 // on: once Close returns, every receive function handed out by Open must stop.
-// It passes today and is here so a fix cannot regress the ordinary path.
 func TestICEBindCloseReleasesReceivers(t *testing.T) {
 	iceBind := setupICEBind(t)
 
@@ -65,22 +64,60 @@ func TestICEBindCloseReleasesReceivers(t *testing.T) {
 		"every receive function must return once Close returns")
 }
 
-// TestICEBindConcurrentOpenClose reproduces the root cause of the interface
-// creation deadlock, and fails under -race today.
+// TestICEBindOpenDoesNotBlockOnParkedReceiver reproduces the deadlock that
+// wedges interface creation.
 //
-// Open writes s.closed and Close reads it with no synchronisation, while
-// closedChan is guarded by closedChanMu. The two can therefore disagree: if
-// Close observes closed as false and flips it to true while Open is midway
-// through installing a fresh closedChan, the bind ends up marked closed with a
-// live channel and live receive functions. Every later Close then takes its
-// early return, so neither close(closedChan) nor StdNetBind.Close ever runs and
-// the receive functions never stop.
+// receiveRelayed used to hold closedChanMu for the whole of its blocking
+// select, so a parked receiver kept the read lock indefinitely. Open takes the
+// same mutex for writing to install a fresh closedChan, so it could never
+// acquire it while a receiver was parked. wireguard-go reaches Open from
+// Device.IpcSet and Device.Up with device.net held, so the stall takes the
+// device's lock with it and every other device goroutine queues behind it.
 //
-// That is what wedges closeBindLocked on device.net.stopping.Wait() during
-// Device.IpcSet, holding device.net and stalling interface creation.
+// Failing here means Open never returned.
+func TestICEBindOpenDoesNotBlockOnParkedReceiver(t *testing.T) {
+	iceBind := setupICEBind(t)
+
+	fns, _, err := iceBind.Open(0)
+	require.NoError(t, err, "the first Open must succeed")
+
+	wg := startReceivers(fns)
+	t.Cleanup(func() {
+		_ = iceBind.Close()
+		// Bounded so a regression reports the assertion below rather than
+		// hanging the whole package until the go test timeout.
+		receiversStopped(wg, 5*time.Second)
+	})
+
+	// Let receiveRelayed reach its blocking select before reopening.
+	time.Sleep(500 * time.Millisecond)
+
+	reopened := make(chan struct{})
+	go func() {
+		// The error is irrelevant; StdNetBind rejects a second Open. What
+		// matters is that the call returns at all.
+		_, _, _ = iceBind.Open(0)
+		close(reopened)
+	}()
+
+	select {
+	case <-reopened:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Open blocked while a receive function was parked; wireguard-go makes this call with device.net held, which is what stalls interface creation")
+	}
+}
+
+// TestICEBindConcurrentOpenClose exercises Open and Close from separate
+// goroutines, the way Device.IpcSet and Device.Up reach the bind, and is meant
+// to be run under -race.
+//
+// closed and closedChan must be updated together. When they were not, Close
+// could observe a stale closed and either skip close(closedChan) and
+// StdNetBind.Close entirely, leaving the receive functions running, or race a
+// second Close and close the same channel twice.
 //
 // Receive functions are deliberately not started here: this test is about the
-// unsynchronised state, and parking them would turn a race report into a hang.
+// shared state, and parking them would turn a race report into a hang.
 func TestICEBindConcurrentOpenClose(t *testing.T) {
 	iceBind := setupICEBind(t)
 
@@ -104,14 +141,9 @@ func TestICEBindConcurrentOpenClose(t *testing.T) {
 	require.NoError(t, iceBind.Close())
 }
 
-// TestICEBindCloseReleasesReceiversUnderConcurrentClose drives the consequence
-// of that race: full Open, run receivers, Close cycles with a second Close
-// racing the first. Any iteration where the receive functions outlive Close is
-// the deadlock closeBindLocked hits.
-//
-// This one is probabilistic. It is the shape of the production failure rather
-// than a guaranteed trigger, so treat a pass as inconclusive and a failure as
-// real.
+// TestICEBindCloseReleasesReceiversUnderConcurrentClose runs full Open, receive,
+// Close cycles with a second Close racing the first. Any iteration where the
+// receive functions outlive Close is the state closeBindLocked deadlocks on.
 func TestICEBindCloseReleasesReceiversUnderConcurrentClose(t *testing.T) {
 	if testing.Short() {
 		t.Skip("stress test")

--- a/client/iface/bind/ice_bind_close_test.go
+++ b/client/iface/bind/ice_bind_close_test.go
@@ -1,0 +1,141 @@
+package bind
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	wgConn "golang.zx2c4.com/wireguard/conn"
+)
+
+// startReceivers runs every receive function the way wireguard-go's device
+// does: one goroutine per function, all tracked by a single WaitGroup. After
+// calling Bind.Close, closeBindLocked waits on exactly that WaitGroup while
+// holding device.net, so a receive function that never returns wedges the
+// device and every goroutine that needs the same lock.
+func startReceivers(fns []wgConn.ReceiveFunc) *sync.WaitGroup {
+	var wg sync.WaitGroup
+	wg.Add(len(fns))
+	for i := range fns {
+		go func(fn wgConn.ReceiveFunc) {
+			defer wg.Done()
+			buffs := [][]byte{make([]byte, 1500)}
+			sizes := make([]int, 1)
+			eps := make([]wgConn.Endpoint, 1)
+			for {
+				if _, err := fn(buffs, sizes, eps); err != nil {
+					return
+				}
+			}
+		}(fns[i])
+	}
+	return &wg
+}
+
+// receiversStopped reports whether every receive function returned before the
+// timeout, mirroring device.net.stopping.Wait() inside closeBindLocked.
+func receiversStopped(wg *sync.WaitGroup, timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// TestICEBindCloseReleasesReceivers covers the contract closeBindLocked relies
+// on: once Close returns, every receive function handed out by Open must stop.
+// It passes today and is here so a fix cannot regress the ordinary path.
+func TestICEBindCloseReleasesReceivers(t *testing.T) {
+	iceBind := setupICEBind(t)
+
+	fns, _, err := iceBind.Open(0)
+	require.NoError(t, err, "opening the bind must succeed")
+
+	wg := startReceivers(fns)
+	require.NoError(t, iceBind.Close())
+
+	require.True(t, receiversStopped(wg, 5*time.Second),
+		"every receive function must return once Close returns")
+}
+
+// TestICEBindConcurrentOpenClose reproduces the root cause of the interface
+// creation deadlock, and fails under -race today.
+//
+// Open writes s.closed and Close reads it with no synchronisation, while
+// closedChan is guarded by closedChanMu. The two can therefore disagree: if
+// Close observes closed as false and flips it to true while Open is midway
+// through installing a fresh closedChan, the bind ends up marked closed with a
+// live channel and live receive functions. Every later Close then takes its
+// early return, so neither close(closedChan) nor StdNetBind.Close ever runs and
+// the receive functions never stop.
+//
+// That is what wedges closeBindLocked on device.net.stopping.Wait() during
+// Device.IpcSet, holding device.net and stalling interface creation.
+//
+// Receive functions are deliberately not started here: this test is about the
+// unsynchronised state, and parking them would turn a race report into a hang.
+func TestICEBindConcurrentOpenClose(t *testing.T) {
+	iceBind := setupICEBind(t)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_, _, _ = iceBind.Open(0)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = iceBind.Close()
+		}
+	}()
+
+	wg.Wait()
+	require.NoError(t, iceBind.Close())
+}
+
+// TestICEBindCloseReleasesReceiversUnderConcurrentClose drives the consequence
+// of that race: full Open, run receivers, Close cycles with a second Close
+// racing the first. Any iteration where the receive functions outlive Close is
+// the deadlock closeBindLocked hits.
+//
+// This one is probabilistic. It is the shape of the production failure rather
+// than a guaranteed trigger, so treat a pass as inconclusive and a failure as
+// real.
+func TestICEBindCloseReleasesReceiversUnderConcurrentClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stress test")
+	}
+
+	for i := 0; i < 200; i++ {
+		iceBind := setupICEBind(t)
+
+		fns, _, err := iceBind.Open(0)
+		require.NoError(t, err, "iteration %d: opening the bind must succeed", i)
+		wg := startReceivers(fns)
+
+		var closers sync.WaitGroup
+		closers.Add(2)
+		for c := 0; c < 2; c++ {
+			go func() {
+				defer closers.Done()
+				_ = iceBind.Close()
+			}()
+		}
+		closers.Wait()
+
+		if !receiversStopped(wg, 5*time.Second) {
+			t.Fatalf("iteration %d: receive functions still running after Close; closeBindLocked would block here on device.net.stopping.Wait", i)
+		}
+	}
+}

--- a/client/iface/bind/ice_bind_close_test.go
+++ b/client/iface/bind/ice_bind_close_test.go
@@ -15,22 +15,72 @@ import (
 // holding device.net, so a receive function that never returns wedges the
 // device and every goroutine that needs the same lock.
 func startReceivers(fns []wgConn.ReceiveFunc) *sync.WaitGroup {
+	wg, _ := startReceiversEntered(fns)
+	return wg
+}
+
+// startReceiversEntered also returns a channel closed once every receive
+// function has been called at least once. A receive function that has been
+// entered is either inside its blocking receive or about to be, which is a
+// stronger signal to synchronise on than a bare sleep.
+func startReceiversEntered(fns []wgConn.ReceiveFunc) (*sync.WaitGroup, <-chan struct{}) {
 	var wg sync.WaitGroup
+	var entered sync.WaitGroup
 	wg.Add(len(fns))
+	entered.Add(len(fns))
+
 	for i := range fns {
 		go func(fn wgConn.ReceiveFunc) {
 			defer wg.Done()
 			buffs := [][]byte{make([]byte, 1500)}
 			sizes := make([]int, 1)
 			eps := make([]wgConn.Endpoint, 1)
+			first := true
 			for {
+				if first {
+					entered.Done()
+					first = false
+				}
 				if _, err := fn(buffs, sizes, eps); err != nil {
 					return
 				}
 			}
 		}(fns[i])
 	}
-	return &wg
+
+	allEntered := make(chan struct{})
+	go func() {
+		entered.Wait()
+		close(allEntered)
+	}()
+	return &wg, allEntered
+}
+
+// closeBounded runs Close off the caller's goroutine so a regression that
+// wedges it fails the assertion under test instead of hanging teardown.
+func closeBounded(iceBind *ICEBind, timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		_ = iceBind.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
+}
+
+// isClosed reports whether the bind's current generation channel is closed.
+func isClosed(iceBind *ICEBind) bool {
+	iceBind.closedChanMu.RLock()
+	ch := iceBind.closedChan
+	iceBind.closedChanMu.RUnlock()
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
 }
 
 // receiversStopped reports whether every receive function returned before the
@@ -81,15 +131,21 @@ func TestICEBindOpenDoesNotBlockOnParkedReceiver(t *testing.T) {
 	fns, _, err := iceBind.Open(0)
 	require.NoError(t, err, "the first Open must succeed")
 
-	wg := startReceivers(fns)
+	wg, entered := startReceiversEntered(fns)
 	t.Cleanup(func() {
-		_ = iceBind.Close()
-		// Bounded so a regression reports the assertion below rather than
-		// hanging the whole package until the go test timeout.
+		// Both bounded: a regression that wedges Close must surface as the
+		// assertion below, not as a hung teardown.
+		closeBounded(iceBind, 5*time.Second)
 		receiversStopped(wg, 5*time.Second)
 	})
 
-	// Let receiveRelayed reach its blocking select before reopening.
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("receive functions never started")
+	}
+	// Entered is not yet parked, so still allow the blocking receive to be
+	// reached. Parking takes microseconds; this margin is six orders larger.
 	time.Sleep(500 * time.Millisecond)
 
 	reopened := make(chan struct{})
@@ -124,26 +180,35 @@ func TestICEBindConcurrentOpenClose(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	// Release both loops together so the calls genuinely interleave rather
+	// than depending on goroutine start order.
+	start := make(chan struct{})
+
 	go func() {
 		defer wg.Done()
+		<-start
 		for i := 0; i < 200; i++ {
 			_, _, _ = iceBind.Open(0)
 		}
 	}()
 	go func() {
 		defer wg.Done()
+		<-start
 		for i := 0; i < 200; i++ {
 			_ = iceBind.Close()
 		}
 	}()
 
+	close(start)
 	wg.Wait()
 	require.NoError(t, iceBind.Close())
+	require.True(t, isClosed(iceBind), "the final Close must leave the current generation channel closed")
 }
 
 // TestICEBindCloseReleasesReceiversUnderConcurrentClose runs full Open, receive,
-// Close cycles with a second Close racing the first. Any iteration where the
-// receive functions outlive Close is the state closeBindLocked deadlocks on.
+// Close cycles with a second Close and an Open racing the first Close. Any
+// iteration where the receive functions outlive Close, or where the surviving
+// generation channel is left open, is the state closeBindLocked deadlocks on.
 func TestICEBindCloseReleasesReceiversUnderConcurrentClose(t *testing.T) {
 	if testing.Short() {
 		t.Skip("stress test")
@@ -156,18 +221,34 @@ func TestICEBindCloseReleasesReceiversUnderConcurrentClose(t *testing.T) {
 		require.NoError(t, err, "iteration %d: opening the bind must succeed", i)
 		wg := startReceivers(fns)
 
-		var closers sync.WaitGroup
-		closers.Add(2)
+		start := make(chan struct{})
+		var racers sync.WaitGroup
+		racers.Add(3)
 		for c := 0; c < 2; c++ {
 			go func() {
-				defer closers.Done()
+				defer racers.Done()
+				<-start
 				_ = iceBind.Close()
 			}()
 		}
-		closers.Wait()
+		// An Open overlapping the Closes is what produces a generation whose
+		// channel outlives the flag saying the bind is closed.
+		go func() {
+			defer racers.Done()
+			<-start
+			_, _, _ = iceBind.Open(0)
+		}()
+		close(start)
+		racers.Wait()
+
+		// Settle on a closed bind whatever order the racers landed in.
+		_ = iceBind.Close()
 
 		if !receiversStopped(wg, 5*time.Second) {
 			t.Fatalf("iteration %d: receive functions still running after Close; closeBindLocked would block here on device.net.stopping.Wait", i)
+		}
+		if !isClosed(iceBind) {
+			t.Fatalf("iteration %d: Close returned with the current generation channel still open, so nothing will ever release its receivers", i)
 		}
 	}
 }

--- a/client/iface/bind/ice_bind_close_test.go
+++ b/client/iface/bind/ice_bind_close_test.go
@@ -57,8 +57,9 @@ func startReceiversEntered(fns []wgConn.ReceiveFunc) (*sync.WaitGroup, <-chan st
 }
 
 // closeBounded runs Close off the caller's goroutine so a regression that
-// wedges it fails the assertion under test instead of hanging teardown.
-func closeBounded(iceBind *ICEBind, timeout time.Duration) {
+// wedges it fails the test instead of hanging teardown, and reports whether it
+// returned in time.
+func closeBounded(iceBind *ICEBind, timeout time.Duration) bool {
 	done := make(chan struct{})
 	go func() {
 		_ = iceBind.Close()
@@ -66,7 +67,9 @@ func closeBounded(iceBind *ICEBind, timeout time.Duration) {
 	}()
 	select {
 	case <-done:
+		return true
 	case <-time.After(timeout):
+		return false
 	}
 }
 
@@ -135,8 +138,12 @@ func TestICEBindOpenDoesNotBlockOnParkedReceiver(t *testing.T) {
 	t.Cleanup(func() {
 		// Both bounded: a regression that wedges Close must surface as the
 		// assertion below, not as a hung teardown.
-		closeBounded(iceBind, 5*time.Second)
-		receiversStopped(wg, 5*time.Second)
+		if !closeBounded(iceBind, 5*time.Second) {
+			t.Error("Close did not return during teardown; the bind lifecycle is wedged even though the assertion above passed")
+		}
+		if !receiversStopped(wg, 5*time.Second) {
+			t.Error("receive functions were still running after teardown Close, which is what closeBindLocked blocks on")
+		}
 	})
 
 	select {


### PR DESCRIPTION
## Describe your changes

Running many embedded clients in one process intermittently wedges interface creation. With 50 clients only 19 came up, ten were stuck permanently, and the process could not be interrupted. A goroutine dump shows ten of them parked for seven minutes in `Device.IpcSet`, inside `closeBindLocked` waiting on `device.net.stopping.Wait()`, holding `device.net` while every other device goroutine queues behind it in `Device.Up`.

`receiveRelayed` held `closedChanMu` for the whole of its blocking select, so a parked receiver kept the read lock indefinitely and `Open` could never take the write lock it needs to install a fresh `closedChan`. wireguard-go reaches `Open` from `Device.IpcSet` and `Device.Up` with `device.net` held, so the stall took the device lock with it and `Engine.Start` never returned.

Callers now copy the channel under a short read lock and select on the copy. Copying alone would stand a new trap in the same place: an `Open` that follows an `Open` leaves the previous generation parked on a channel no later `Close` can reach, so `Open` also closes the outgoing channel before swapping it. I hit that one by writing the test first, which is the only reason it is handled here.

`closed` and `closedChan` are also updated together under that mutex. Read and written apart, `Close` could observe a stale `closed` and skip both `close(closedChan)` and `StdNetBind.Close`, leaving every receive function running, or two `Close` calls could pass the check together and close the same channel twice. The second is a plausible source of the `panic: close of closed channel` seen in `netTun.Close` during teardown.

`TestICEBindOpenDoesNotBlockOnParkedReceiver` fails against the current code in about ten seconds with no race detector needed, and passes with the change. The other three cover the contract `closeBindLocked` depends on and report the state races under `-race`.

Verified with `go test -race ./client/iface/bind/...` and the wider `./client/iface/...` tree. Note that CI runs `-race` only on the relay job, so the state-race coverage here is local-only unless `client/iface/bind` is added to a `-race` job; that is a workflow change and not part of this PR.

## Issue ticket number and link

https://linear.app/netbird/issue/NET-1579/icebind-openclose-races-wedge-interface-creation

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal concurrency fix in the bind layer, no user-facing behavior or configuration change.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ICE bind shutdown and reopening behavior.
  * Prevented hangs when reopening a bind with active receivers.
  * Improved reliability during concurrent open and close operations.
  * Ensured active receivers terminate cleanly after closing.
  * Preserved the existing bind state when reopening fails.

* **Tests**
  * Added coverage for repeated, concurrent, and stress-tested bind lifecycle operations.
  * Added validation for receiver shutdown and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->