### PR TITLE
[client] Do not log the WireGuard key on a parse failure

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -242,7 +242,7 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 	wrapErr := state.Wrap
 	myPrivateKey, err := wgtypes.ParseKey(c.config.PrivateKey)
 	if err != nil {
-		log.Errorf("failed parsing Wireguard key %s: [%s]", c.config.PrivateKey, err.Error())
+		log.Errorf("failed parsing Wireguard key: %s", err)
 		return wrapErr(err)
 	}
 


### PR DESCRIPTION
## Describe your changes

`ConnectClient.run` logged the raw WireGuard private key when `wgtypes.ParseKey` failed on it. Drop the key from the message: the error already says whether the payload was not valid base64 (it reports the offending byte offset) or the wrong size (it reports the length), so the key added nothing an operator can act on.

## Issue ticket number and link

No public issue: found while sweeping the client for secrets reaching log sinks. The line is at `client/internal/connect.go:245` on `main`.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

One log line. No CLI, config or API change.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy and security by preventing raw WireGuard private key values from appearing in error logs.
  * Error logs now include only the relevant parsing error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->