### PR TITLE
[management] Fix geolocation panics

### DIFF
--- a/management/server/geolocation/database.go
+++ b/management/server/geolocation/database.go
@@ -3,6 +3,7 @@ package geolocation
 import (
 	"context"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -21,6 +22,8 @@ const (
 	geoLiteCitySha256ZipURL = "https://pkgs.netbird.io/geolocation-dbs/GeoLite2-City-CSV/download?suffix=zip.sha256"
 	geoLiteCityMMDB         = "GeoLite2-City.mmdb"
 	geoLiteCityCSV          = "GeoLite2-City-Locations-en.csv"
+
+	geonamesCsvFields = 14
 )
 
 // loadGeolocationDatabases loads the MaxMind databases.
@@ -160,6 +163,10 @@ func loadGeonamesCsv(filepath string) ([]GeoNames, error) {
 		if index == 0 {
 			continue
 		}
+		if len(record) < geonamesCsvFields {
+			return nil, fmt.Errorf("geonames csv record %d has %d fields, want at least %d", index, len(record), geonamesCsvFields)
+		}
+
 		geoNameID, err := strconv.Atoi(record[0])
 		if err != nil {
 			return nil, err

--- a/management/server/geolocation/geolocation.go
+++ b/management/server/geolocation/geolocation.go
@@ -243,7 +243,7 @@ func getDatabaseFilename(ctx context.Context, databaseURL string, filenamePatter
 	basename := strings.SplitN(filename, ".", 2)[0]
 	// get date version from basename
 	parts := strings.SplitN(basename, "_", 2)
-	if len(parts) < 2 {
+	if len(parts) < 2 || parts[1] == "" {
 		return "", fmt.Errorf("unexpected database filename %q: missing date suffix", filename)
 	}
 	date := parts[1]

--- a/management/server/geolocation/geolocation.go
+++ b/management/server/geolocation/geolocation.go
@@ -242,7 +242,11 @@ func getDatabaseFilename(ctx context.Context, databaseURL string, filenamePatter
 	// strip suffixes that may be nested, such as .tar.gz
 	basename := strings.SplitN(filename, ".", 2)[0]
 	// get date version from basename
-	date := strings.SplitN(basename, "_", 2)[1]
+	parts := strings.SplitN(basename, "_", 2)
+	if len(parts) < 2 {
+		return "", fmt.Errorf("unexpected database filename %q: missing date suffix", filename)
+	}
+	date := parts[1]
 	// format db as "GeoLite2-Cities-{maxmind|geonames}_{DATE}.{mmdb|db}"
 	databaseFilename := filepath.Base(strings.Replace(filenamePattern, "*", date, 1))
 

--- a/management/server/geolocation/utils.go
+++ b/management/server/geolocation/utils.go
@@ -184,7 +184,12 @@ func getFilenameFromURL(url string) (string, error) {
 
 	defer resp.Body.Close()
 
-	_, params, err := mime.ParseMediaType(resp.Header["Content-Disposition"][0])
+	contentDisposition := resp.Header.Get("Content-Disposition")
+	if contentDisposition == "" {
+		return "", fmt.Errorf("no Content-Disposition header in response from %s", url)
+	}
+
+	_, params, err := mime.ParseMediaType(contentDisposition)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Describe your changes

Replaces three index-out-of-range panics in management/server/geolocation with error returns:

- `getDatabaseFilename`: filename without `_` date suffix
- `getFilenameFromURL`: response missing the Content-Disposition header
- `loadGeonamesCsv`: CSV rows with fewer than 14 fields

These run during the optional GeoLite2 database download/load; malformed input now fails the operation instead of crashing the server. No behavior change on valid input.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for geolocation database files and downloaded data.
  * Added clearer errors for incomplete CSV records, invalid filenames, and missing download metadata.
  * Prevented processing of malformed or unexpected geolocation data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->