### PR TITLE
[misc] Restart the brew-installed NetBird service after upgrade if it was running

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -456,7 +456,7 @@ brews:
 
       opoo <<~EOS
         The NetBird service is still running the previous version. Restart it with:
-          sudo netbird service restart
+          sudo #{opt_bin}/netbird service restart
       EOS
     custom_block: |
       # The daemon runs as root, so the process table is the only place its
@@ -467,15 +467,23 @@ brews:
       # `which netbird` resolved to), so anchoring the pattern to it keeps
       # command lines that merely mention "netbird service run" from matching.
       def daemon_running?
-        Kernel.system("pgrep", "-f", "^#{HOMEBREW_PREFIX}/bin/netbird service run",
+        Kernel.system("pgrep", "-f", "^#{Regexp.escape(HOMEBREW_PREFIX)}/bin/netbird service run",
                       out: File::NULL, err: File::NULL)
       end
 
-      # Not `Formula#system`: that one raises on a non-zero exit, and a failed
-      # restart attempt must fall through to the printed instructions instead.
+      # Signals the service manager directly instead of running `netbird service
+      # restart`: netbird implements restart as stop-then-start, which would START
+      # the daemon if it were stopped in the instant after the check above.
+      # `launchctl kill` only signals a live service (KeepAlive then relaunches it
+      # with the new binary) and `systemctl try-restart` is a no-op for a stopped
+      # unit, so neither can ever start a deliberately stopped daemon.
       def restart_daemon
-        Kernel.system("sudo", "-n", "#{opt_bin}/netbird", "service", "restart",
-                      out: File::NULL, err: File::NULL)
+        restart = if OS.mac?
+          ["launchctl", "kill", "SIGTERM", "system/netbird"]
+        else
+          ["systemctl", "try-restart", "netbird"]
+        end
+        Kernel.system("sudo", "-n", *restart, out: File::NULL, err: File::NULL)
       end
 
 uploads:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -456,13 +456,17 @@ brews:
       # pseudoterminal, where $stdin.tty? is true even for a headless
       # `brew upgrade` and a prompt would stall it until sudo times out.
       #
-      # Success is judged by outcome, not by reconfigure's exit status: the
-      # daemon seen above must actually be gone afterwards. Reconfigure only
-      # manages the default service name, and a daemon installed under a custom
-      # name (-s) is indistinguishable by its command line -- if a stale default
-      # definition let reconfigure "succeed" against the wrong service, the old
-      # process would still be running and the instructions still print.
-      return if default_service? && restart_daemon && !daemon_pids.intersect?(running)
+      # Success is judged by outcome, not by reconfigure's exit status: a fresh
+      # daemon process must be running afterwards and the one seen above must be
+      # gone. Reconfigure only manages the default service name, and a daemon
+      # installed under a custom name (-s) is indistinguishable by its command
+      # line -- if a stale default definition let reconfigure "succeed" against
+      # the wrong service, the old process would still be running; if the new
+      # daemon died on startup, none would be. Both print the instructions.
+      if default_service? && restart_daemon
+        replacement = daemon_pids
+        return if !replacement.empty? && !replacement.intersect?(running)
+      end
 
       opoo <<~EOS
         The NetBird service is still running the previous version. Restart it with:
@@ -481,6 +485,8 @@ brews:
         pattern = "^#{Regexp.escape(HOMEBREW_PREFIX)}/(opt/netbird/|Cellar/netbird/[^/]+/)?bin/netbird service run"
         IO.popen(["pgrep", "-f", pattern], err: File::NULL, &:read).split
       rescue Errno::ENOENT
+        # No pgrep, no way to know whether a daemon is running: stay silent
+        # rather than warn every system whose daemon is simply stopped.
         []
       end
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -448,42 +448,40 @@ brews:
 
       ohai "Restarting the NetBird service"
       # `sudo -n` only: brew resets the sudo timestamp at startup, so this
-      # succeeds just for NOPASSWD setups -- and an interactive prompt cannot
-      # be offered here, because the post-install sandbox runs this code in a
+      # succeeds just for NOPASSWD setups -- and an interactive prompt cannot be
+      # offered here, because the post-install sandbox runs this code in a
       # pseudoterminal, where $stdin.tty? is true even for a headless
       # `brew upgrade` and a prompt would stall it until sudo times out.
       return if restart_daemon
 
       opoo <<~EOS
         The NetBird service is still running the previous version. Restart it with:
-          sudo #{opt_bin}/netbird service restart
+          sudo #{opt_bin}/netbird service reconfigure
       EOS
     custom_block: |
-      # The daemon runs as root, so the process table is the only place its
-      # state can be read from without asking for a password ("netbird service
-      # status" and launchctl both report a root daemon as stopped when asked
-      # by a plain user). The daemon's command line starts with the stable
-      # brew-linked binary path ("netbird service install" records the path
-      # `which netbird` resolved to), so anchoring the pattern to it keeps
-      # command lines that merely mention "netbird service run" from matching.
+      # The daemon runs as root, so the process table is the only place its state
+      # can be read from without asking for a password ("netbird service status"
+      # and launchctl both report a root daemon as stopped when asked by a plain
+      # user). "netbird service install" records the executable path the installing
+      # process resolved to: the stable brew-linked path on macOS, but the
+      # versioned Cellar path on Linux (/proc/self/exe resolves symlinks), so the
+      # anchored pattern accepts the stable, opt, and Cellar spellings. A plain
+      # group instead of "(?:" because pgrep matches POSIX ERE.
       def daemon_running?
-        Kernel.system("pgrep", "-f", "^#{Regexp.escape(HOMEBREW_PREFIX)}/bin/netbird service run",
+        Kernel.system("pgrep", "-f",
+                      "^#{Regexp.escape(HOMEBREW_PREFIX)}/(opt/netbird/|Cellar/netbird/[^/]+/)?bin/netbird service run",
                       out: File::NULL, err: File::NULL)
       end
 
-      # Signals the service manager directly instead of running `netbird service
-      # restart`: netbird implements restart as stop-then-start, which would START
-      # the daemon if it were stopped in the instant after the check above.
-      # `launchctl kill` only signals a live service (KeepAlive then relaunches it
-      # with the new binary) and `systemctl try-restart` is a no-op for a stopped
-      # unit, so neither can ever start a deliberately stopped daemon.
+      # `netbird service reconfigure` rewrites the service definition with the
+      # just-upgraded binary before starting it again -- a plain restart re-execs
+      # the path recorded at install time, which on Linux is the previous
+      # version's Cellar directory. Reconfigure also re-checks the running state
+      # itself and only starts the service again when it found it running, so a
+      # daemon stopped in the meantime stays stopped.
       def restart_daemon
-        restart = if OS.mac?
-          ["launchctl", "kill", "SIGTERM", "system/netbird"]
-        else
-          ["systemctl", "try-restart", "netbird"]
-        end
-        Kernel.system("sudo", "-n", *restart, out: File::NULL, err: File::NULL)
+        Kernel.system("sudo", "-n", "#{opt_bin}/netbird", "service", "reconfigure",
+                      out: File::NULL, err: File::NULL)
       end
 
 uploads:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -446,7 +446,8 @@ brews:
     # Runs on reinstall as well as upgrade -- intended: either way the binary
     # under the daemon was just replaced, so a running daemon is equally stale.
     post_install: |
-      return unless daemon_running?
+      running = daemon_pids
+      return if running.empty?
 
       ohai "Restarting the NetBird service"
       # `sudo -n` only: brew resets the sudo timestamp at startup, so this
@@ -454,7 +455,14 @@ brews:
       # offered here, because the post-install sandbox runs this code in a
       # pseudoterminal, where $stdin.tty? is true even for a headless
       # `brew upgrade` and a prompt would stall it until sudo times out.
-      return if default_service? && restart_daemon
+      #
+      # Success is judged by outcome, not by reconfigure's exit status: the
+      # daemon seen above must actually be gone afterwards. Reconfigure only
+      # manages the default service name, and a daemon installed under a custom
+      # name (-s) is indistinguishable by its command line -- if a stale default
+      # definition let reconfigure "succeed" against the wrong service, the old
+      # process would still be running and the instructions still print.
+      return if default_service? && restart_daemon && !daemon_pids.intersect?(running)
 
       opoo <<~EOS
         The NetBird service is still running the previous version. Restart it with:
@@ -469,16 +477,17 @@ brews:
       # versioned Cellar path on Linux (/proc/self/exe resolves symlinks), so the
       # anchored pattern accepts the stable, opt, and Cellar spellings. A plain
       # group instead of "(?:" because pgrep matches POSIX ERE.
-      def daemon_running?
-        Kernel.system("pgrep", "-f",
-                      "^#{Regexp.escape(HOMEBREW_PREFIX)}/(opt/netbird/|Cellar/netbird/[^/]+/)?bin/netbird service run",
-                      out: File::NULL, err: File::NULL)
+      def daemon_pids
+        pattern = "^#{Regexp.escape(HOMEBREW_PREFIX)}/(opt/netbird/|Cellar/netbird/[^/]+/)?bin/netbird service run"
+        IO.popen(["pgrep", "-f", pattern], err: File::NULL, &:read).split
+      rescue Errno::ENOENT
+        []
       end
 
-      # `netbird service reconfigure` only manages the default service name, and a
-      # daemon installed under a custom name (-s) cannot be told apart by its
-      # command line, so only a service whose default definition exists is
-      # reconfigured; anything else gets the printed instructions.
+      # Reconfigure needs the default service definition: it only manages the
+      # default service name, and against a missing definition it fails before
+      # touching anything. Skipping the doomed sudo attempt keeps a stale stopped
+      # default service from being rewritten as a side effect.
       def default_service?
         File.exist?(OS.mac? ? "/Library/LaunchDaemons/netbird.plist" : "/etc/systemd/system/netbird.service")
       end

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -454,7 +454,7 @@ brews:
       # offered here, because the post-install sandbox runs this code in a
       # pseudoterminal, where $stdin.tty? is true even for a headless
       # `brew upgrade` and a prompt would stall it until sudo times out.
-      return if restart_daemon
+      return if default_service? && restart_daemon
 
       opoo <<~EOS
         The NetBird service is still running the previous version. Restart it with:
@@ -475,12 +475,24 @@ brews:
                       out: File::NULL, err: File::NULL)
       end
 
+      # `netbird service reconfigure` only manages the default service name, and a
+      # daemon installed under a custom name (-s) cannot be told apart by its
+      # command line, so only a service whose default definition exists is
+      # reconfigured; anything else gets the printed instructions.
+      def default_service?
+        File.exist?(OS.mac? ? "/Library/LaunchDaemons/netbird.plist" : "/etc/systemd/system/netbird.service")
+      end
+
       # `netbird service reconfigure` rewrites the service definition with the
       # just-upgraded binary before starting it again -- a plain restart re-execs
       # the path recorded at install time, which on Linux is the previous
-      # version's Cellar directory. Reconfigure also re-checks the running state
-      # itself and only starts the service again when it found it running, so a
-      # daemon stopped in the meantime stays stopped.
+      # version's Cellar directory. Reconfigure re-checks the running state itself
+      # and only starts the service again when it found it running. That re-check
+      # is not atomic with its final start, but closing the remaining
+      # milliseconds-wide window needs the atomic service-manager verbs
+      # (systemctl try-restart, launchctl kill), which re-exec the recorded --
+      # on Linux stale -- executable path instead of the new binary; upstream
+      # semantics win here.
       def restart_daemon
         Kernel.system("sudo", "-n", "#{opt_bin}/netbird", "service", "reconfigure",
                       out: File::NULL, err: File::NULL)

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -439,6 +439,38 @@ brews:
     license: "BSD3"
     test: |
       system "#{bin}/{{ .ProjectName	}} version"
+    # Restart the daemon after `brew upgrade` -- launchd (or systemd) keeps the
+    # old process alive after the binary swap, so NetBird would silently keep
+    # serving the previous version. Restart only when the daemon is already
+    # running, so an upgrade never starts a deliberately stopped daemon.
+    post_install: |
+      return unless daemon_running?
+
+      ohai "Restarting the NetBird service"
+      # `sudo -n` first, so a still-cached credential means no prompt at all.
+      return if restart_daemon(sudo_args: ["-n"], err: File::NULL)
+      return if $stdin.tty? && restart_daemon
+
+      opoo <<~EOS
+        The NetBird service is still running the previous version. Restart it with:
+          sudo netbird service restart
+      EOS
+    custom_block: |
+      # The daemon runs as root, so the process table is the only place its
+      # state can be read from without asking for a password ("netbird service
+      # status" and launchctl both report a root daemon as stopped when asked
+      # by a plain user). The leading slash keeps shell command lines that
+      # merely mention "netbird service run" from matching.
+      def daemon_running?
+        Kernel.system("pgrep", "-f", "/netbird service run", out: File::NULL, err: File::NULL)
+      end
+
+      # Not `Formula#system`: that one sends the child's output to a log file,
+      # which would swallow the sudo password prompt, and raises on a non-zero
+      # exit.
+      def restart_daemon(sudo_args: [], **options)
+        Kernel.system("sudo", *sudo_args, "#{opt_bin}/netbird", "service", "restart", **options)
+      end
 
 uploads:
   - name: debian

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -443,6 +443,8 @@ brews:
     # old process alive after the binary swap, so NetBird would silently keep
     # serving the previous version. Restart only when the daemon is already
     # running, so an upgrade never starts a deliberately stopped daemon.
+    # Runs on reinstall as well as upgrade -- intended: either way the binary
+    # under the daemon was just replaced, so a running daemon is equally stale.
     post_install: |
       return unless daemon_running?
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -447,9 +447,12 @@ brews:
       return unless daemon_running?
 
       ohai "Restarting the NetBird service"
-      # `sudo -n` first, so a still-cached credential means no prompt at all.
-      return if restart_daemon(sudo_args: ["-n"], err: File::NULL)
-      return if $stdin.tty? && restart_daemon
+      # `sudo -n` only: brew resets the sudo timestamp at startup, so this
+      # succeeds just for NOPASSWD setups -- and an interactive prompt cannot
+      # be offered here, because the post-install sandbox runs this code in a
+      # pseudoterminal, where $stdin.tty? is true even for a headless
+      # `brew upgrade` and a prompt would stall it until sudo times out.
+      return if restart_daemon
 
       opoo <<~EOS
         The NetBird service is still running the previous version. Restart it with:
@@ -459,17 +462,20 @@ brews:
       # The daemon runs as root, so the process table is the only place its
       # state can be read from without asking for a password ("netbird service
       # status" and launchctl both report a root daemon as stopped when asked
-      # by a plain user). The leading slash keeps shell command lines that
-      # merely mention "netbird service run" from matching.
+      # by a plain user). The daemon's command line starts with the stable
+      # brew-linked binary path ("netbird service install" records the path
+      # `which netbird` resolved to), so anchoring the pattern to it keeps
+      # command lines that merely mention "netbird service run" from matching.
       def daemon_running?
-        Kernel.system("pgrep", "-f", "/netbird service run", out: File::NULL, err: File::NULL)
+        Kernel.system("pgrep", "-f", "^#{HOMEBREW_PREFIX}/bin/netbird service run",
+                      out: File::NULL, err: File::NULL)
       end
 
-      # Not `Formula#system`: that one sends the child's output to a log file,
-      # which would swallow the sudo password prompt, and raises on a non-zero
-      # exit.
-      def restart_daemon(sudo_args: [], **options)
-        Kernel.system("sudo", *sudo_args, "#{opt_bin}/netbird", "service", "restart", **options)
+      # Not `Formula#system`: that one raises on a non-zero exit, and a failed
+      # restart attempt must fall through to the printed instructions instead.
+      def restart_daemon
+        Kernel.system("sudo", "-n", "#{opt_bin}/netbird", "service", "restart",
+                      out: File::NULL, err: File::NULL)
       end
 
 uploads:


### PR DESCRIPTION
## Describe your changes

`brew upgrade netbird` swaps the binary, but launchd (macOS) / systemd (Linux) keeps the old daemon process alive, so NetBird silently keeps serving the previous version until something restarts it. (The `netbird-ui` cask's `installer.sh` reinstalls the service on *cask* upgrades, but a formula-only `brew upgrade netbird` leaves the old daemon running.)

This adds `post_install`/`custom_block` to the `brews:` entry of `.goreleaser.yaml`, so the generated `netbird.rb` restarts the daemon after an upgrade:

- **Only when it was already running** — an upgrade never starts a daemon the user deliberately stopped. The running state is read from the process table (`pgrep -f "/netbird service run"`) because `netbird service status` and `launchctl` both report a root daemon as *Stopped* when asked by a plain (non-root) user.
- Restart uses `sudo netbird service restart` — cross-platform, via NetBird's own service manager. `sudo -n` is tried first, so a still-cached sudo credential means no prompt at all; otherwise one prompt on interactive terminals.
- Without a usable sudo credential (non-interactive runs), it prints the restart one-liner instead of failing the upgrade.

The legacy `def post_install` form (GoReleaser's `post_install` field) is used instead of Homebrew's newer `post_install_steps` DSL because the DSL cannot express the "only when already running" guard — an unconditional `run netbird service restart` step would start a stopped daemon.

Same change applied directly to the generated formula for reference: markusheiden/homebrew-tap#1

Testing:
- YAML validated; the formula as GoReleaser renders it (custom_block at class level, post_install body wrapped in `def post_install`) passes `ruby -c` and `brew style` with no new offenses
- Rendered formula loaded through Homebrew 6.0: `post_install_defined? => true`
- Verified against a live macOS daemon (`/opt/homebrew/bin/netbird service run`, root, KeepAlive): detection returns true; full `post_install` exercised non-interactively — detects the daemon, `sudo -n` fails quietly, no TTY, prints the warning and exits cleanly without failing the upgrade
- Untested: the interactive sudo prompt path under a real `brew upgrade`

## Issue ticket number and link

No pre-agreed issue — packaging-only change to the generated Homebrew formula; no NetBird code paths are touched. Happy to file one if the team prefers.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why) — install-time packaging behavior; the hook explains itself in the `brew upgrade` output and falls back to printing the manual restart command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Homebrew upgrades and reinstalls now automatically reconfigure and restart the NetBird service only when it was already running.
  - Stopped services remain unchanged during upgrades.
  - Restart attempts no longer trigger interactive password prompts.
  - Service detection is more precise, reducing the risk of targeting unrelated processes.
  - Failed automatic restarts remain quiet and provide an updated warning when manual `service reconfigure` is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->