### PR TITLE
[client] Renew the Android TUN only when the routes it carries change

### DIFF
--- a/client/internal/routemanager/notifier/notifier_android.go
+++ b/client/internal/routemanager/notifier/notifier_android.go
@@ -4,8 +4,6 @@ package notifier
 
 import (
 	"net/netip"
-	"slices"
-	"sort"
 	"sync"
 
 	"github.com/netbirdio/netbird/client/internal/listener"
@@ -74,20 +72,4 @@ func (n *Notifier) notifyLocked() {
 
 func (n *Notifier) Close() {
 	// unused
-}
-
-func routesToStrings(routes []*route.Route) []string {
-	nets := make([]string, 0, len(routes))
-	for _, r := range routes {
-		nets = append(nets, r.NetString())
-	}
-	return nets
-}
-
-func hasRouteDiff(a []*route.Route, b []*route.Route) bool {
-	as := routesToStrings(a)
-	bs := routesToStrings(b)
-	sort.Strings(as)
-	sort.Strings(bs)
-	return !slices.Equal(as, bs)
 }

--- a/client/internal/routemanager/notifier/route_diff.go
+++ b/client/internal/routemanager/notifier/route_diff.go
@@ -1,0 +1,27 @@
+package notifier
+
+import (
+	"slices"
+	"sort"
+
+	"github.com/netbirdio/netbird/route"
+)
+
+// routePrefixes returns the distinct prefixes a route set covers, sorted.
+// Duplicates are dropped deliberately: an HA group hands us one route per
+// peer serving the same prefix, and the platform is given the prefix, not the
+// candidates. Counting them would report a change every time a peer joins or
+// leaves a group, and on Android each report renews the TUN.
+func routePrefixes(routes []*route.Route) []string {
+	nets := make([]string, 0, len(routes))
+	for _, r := range routes {
+		nets = append(nets, r.NetString())
+	}
+	sort.Strings(nets)
+	return slices.Compact(nets)
+}
+
+// hasRouteDiff reports whether the prefixes the two route sets cover differ.
+func hasRouteDiff(a []*route.Route, b []*route.Route) bool {
+	return !slices.Equal(routePrefixes(a), routePrefixes(b))
+}

--- a/client/internal/routemanager/notifier/route_diff_test.go
+++ b/client/internal/routemanager/notifier/route_diff_test.go
@@ -1,0 +1,88 @@
+package notifier
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netbirdio/netbird/route"
+)
+
+func routeFor(id route.ID, prefix string) *route.Route {
+	return &route.Route{
+		ID:      id,
+		NetID:   "net",
+		Network: netip.MustParsePrefix(prefix),
+	}
+}
+
+// TestHasRouteDiff_IgnoresHACandidateCount is the reason the comparison
+// deduplicates. Every notification renews the TUN, and a renewed TUN
+// invalidates the sockets the embedded servers are listening on, so a peer
+// joining or leaving an HA group must not count as a route change when the
+// prefixes the TUN carries are identical.
+func TestHasRouteDiff_IgnoresHACandidateCount(t *testing.T) {
+	onePeer := []*route.Route{routeFor("a", "10.0.0.0/24")}
+	twoPeers := []*route.Route{
+		routeFor("a", "10.0.0.0/24"),
+		routeFor("b", "10.0.0.0/24"),
+	}
+
+	assert.False(t, hasRouteDiff(onePeer, twoPeers),
+		"a second peer serving the same prefix is not a route change")
+	assert.False(t, hasRouteDiff(twoPeers, onePeer),
+		"losing one of two peers serving the same prefix is not a route change")
+}
+
+func TestHasRouteDiff_ReportsRealChanges(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []*route.Route
+		b    []*route.Route
+		want bool
+	}{
+		{
+			name: "added prefix",
+			a:    []*route.Route{routeFor("a", "10.0.0.0/24")},
+			b:    []*route.Route{routeFor("a", "10.0.0.0/24"), routeFor("b", "10.0.1.0/24")},
+			want: true,
+		},
+		{
+			name: "removed prefix",
+			a:    []*route.Route{routeFor("a", "10.0.0.0/24"), routeFor("b", "10.0.1.0/24")},
+			b:    []*route.Route{routeFor("a", "10.0.0.0/24")},
+			want: true,
+		},
+		{
+			name: "replaced prefix",
+			a:    []*route.Route{routeFor("a", "10.0.0.0/24")},
+			b:    []*route.Route{routeFor("a", "10.0.1.0/24")},
+			want: true,
+		},
+		{
+			name: "same prefix, different order",
+			a:    []*route.Route{routeFor("a", "10.0.1.0/24"), routeFor("b", "10.0.0.0/24")},
+			b:    []*route.Route{routeFor("b", "10.0.0.0/24"), routeFor("a", "10.0.1.0/24")},
+			want: false,
+		},
+		{
+			name: "all routes gone",
+			a:    []*route.Route{routeFor("a", "10.0.0.0/24")},
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "both empty",
+			a:    nil,
+			b:    nil,
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasRouteDiff(tc.a, tc.b),
+				"route diff for %s", tc.name)
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes

The Android route notifier compared one entry per route, and an HA group hands it one route per peer serving the same prefix. A peer joining or leaving a group therefore read as a route change and triggered a TUN renewal, even though the set of prefixes the TUN carries was identical. In an environment with peers coming and going this fires continuously, and each renewal replaces the interface.

- Compare the deduplicated set of prefixes instead of the per-peer route list, so only a real change to what the TUN carries triggers a renewal
- Move the comparison into an untagged file so its tests run on every platform, since a test behind the `android` build tag never executes in CI

## Issue ticket number and link

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal behavior of the Android route notifier, with no user-visible surface.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route change detection to ignore changes in the number of peers serving the same network prefix.
  * Notifications are now limited to meaningful route changes, such as added, removed, or replaced network prefixes.
  * Route comparisons consistently handle reordered and empty route sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->