### PR TITLE
[client] Pick the probe port from the system in Test_freePort

### DIFF
--- a/client/internal/connect_test.go
+++ b/client/internal/connect_test.go
@@ -6,6 +6,27 @@ import (
 )
 
 func Test_freePort(t *testing.T) {
+	// Ports are obtained from the OS instead of hardcoded: a fixed number can
+	// fall inside the ephemeral range and be occupied by an unrelated process
+	// on the test runner, making the test flaky.
+	busy, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
+	if err != nil {
+		t.Fatalf("failed to bind busy port: %v", err)
+	}
+	defer func() {
+		_ = busy.Close()
+	}()
+	busyPort := busy.LocalAddr().(*net.UDPAddr).Port
+
+	free, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
+	if err != nil {
+		t.Fatalf("failed to bind free port: %v", err)
+	}
+	freePortNum := free.LocalAddr().(*net.UDPAddr).Port
+	if err := free.Close(); err != nil {
+		t.Fatalf("failed to close free port: %v", err)
+	}
+
 	tests := []struct {
 		name        string
 		port        int
@@ -20,32 +41,17 @@ func Test_freePort(t *testing.T) {
 		},
 		{
 			name:        "provided and available",
-			port:        51821,
-			want:        51821,
+			port:        freePortNum,
+			want:        freePortNum,
 			shouldMatch: true,
 		},
 		{
 			name:        "provided and not available",
-			port:        51830,
-			want:        51830,
+			port:        busyPort,
+			want:        busyPort,
 			shouldMatch: false,
 		},
 	}
-	c1, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
-	if err != nil {
-		t.Errorf("freePort error = %v", err)
-	}
-	defer func(c1 *net.UDPConn) {
-		_ = c1.Close()
-	}(c1)
-
-	if tests[1].port == c1.LocalAddr().(*net.UDPAddr).Port {
-		tests[1].port++
-		tests[1].want++
-	}
-
-	tests[2].port = c1.LocalAddr().(*net.UDPAddr).Port
-	tests[2].want = c1.LocalAddr().(*net.UDPAddr).Port
 
 	for _, tt := range tests {
 

--- a/client/internal/connect_test.go
+++ b/client/internal/connect_test.go
@@ -5,71 +5,78 @@ import (
 	"testing"
 )
 
+// probeFreePort asks the OS for a free UDP port and immediately releases it.
+// The returned number is only a hint: nothing stops another process from
+// grabbing the same port before the caller gets a chance to bind it.
+//
+// A hardcoded port number is not an option here: any fixed number can fall
+// inside the ephemeral range and be held by an unrelated process on the test
+// runner.
+func probeFreePort(t *testing.T) int {
+	t.Helper()
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
+	if err != nil {
+		t.Fatalf("failed to bind probe port: %v", err)
+	}
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	if err := conn.Close(); err != nil {
+		t.Fatalf("failed to close probe port: %v", err)
+	}
+	return port
+}
+
 func Test_freePort(t *testing.T) {
-	// Ports are obtained from the OS instead of hardcoded: a fixed number can
-	// fall inside the ephemeral range and be occupied by an unrelated process
-	// on the test runner, making the test flaky.
-	busy, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
-	if err != nil {
-		t.Fatalf("failed to bind busy port: %v", err)
-	}
-	defer func() {
-		_ = busy.Close()
-	}()
-	busyPort := busy.LocalAddr().(*net.UDPAddr).Port
+	t.Run("when port is 0 use random port", func(t *testing.T) {
+		got, err := freePort(0)
+		if err != nil {
+			t.Fatalf("got an error while getting free port: %v", err)
+		}
+		if got == 0 {
+			t.Errorf("got port 0, want a non-zero random port")
+		}
+	})
 
-	free, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
-	if err != nil {
-		t.Fatalf("failed to bind free port: %v", err)
-	}
-	freePortNum := free.LocalAddr().(*net.UDPAddr).Port
-	if err := free.Close(); err != nil {
-		t.Fatalf("failed to close free port: %v", err)
-	}
+	t.Run("provided and available", func(t *testing.T) {
+		const maxAttempts = 5
 
-	tests := []struct {
-		name        string
-		port        int
-		want        int
-		shouldMatch bool
-	}{
-		{
-			name:        "when port is 0 use random port",
-			port:        0,
-			want:        0,
-			shouldMatch: false,
-		},
-		{
-			name:        "provided and available",
-			port:        freePortNum,
-			want:        freePortNum,
-			shouldMatch: true,
-		},
-		{
-			name:        "provided and not available",
-			port:        busyPort,
-			want:        busyPort,
-			shouldMatch: false,
-		},
-	}
+		// The probed port is released before freePort binds it, so an
+		// unrelated process on the test runner can grab it in between,
+		// making freePort fall back to a different port. Retry with a
+		// freshly probed port instead of failing on a lost race.
+		for attempt := 1; attempt <= maxAttempts; attempt++ {
+			candidate := probeFreePort(t)
 
-	for _, tt := range tests {
-
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := freePort(tt.port)
-
+			got, err := freePort(candidate)
 			if err != nil {
-				t.Errorf("got an error while getting free port: %v", err)
+				t.Fatalf("got an error while getting free port: %v", err)
 			}
 
-			if tt.shouldMatch && got != tt.want {
-				t.Errorf("got a different port %v, want %v", got, tt.want)
+			if got == candidate {
+				return
 			}
+			t.Logf("attempt %d: freePort returned %d instead of the requested %d, retrying", attempt, got, candidate)
+		}
 
-			if !tt.shouldMatch && got == tt.want {
-				t.Errorf("got the same port %v, want a different port", tt.want)
-			}
+		t.Fatalf("freePort did not return the requested free port after %d attempts", maxAttempts)
+	})
+
+	t.Run("provided and not available", func(t *testing.T) {
+		busy, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
+		if err != nil {
+			t.Fatalf("failed to bind busy port: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = busy.Close()
 		})
+		busyPort := busy.LocalAddr().(*net.UDPAddr).Port
 
-	}
+		got, err := freePort(busyPort)
+		if err != nil {
+			t.Fatalf("got an error while getting free port: %v", err)
+		}
+		if got == busyPort {
+			t.Errorf("got the same port %v, want a different port", busyPort)
+		}
+	})
 }


### PR DESCRIPTION
## Describe your changes

`Test_freePort` hardcoded UDP port 51821 for its "provided and available" case. That number sits inside the Linux ephemeral port range (`net.ipv4.ip_local_port_range`, 32768–60999 by default), so any unrelated process on the runner can be holding it when the test runs. `freePort` then does exactly what it is supposed to do — falls back to a system-assigned port — and the test fails:

```
--- FAIL: Test_freePort (0.00s)
    --- FAIL: Test_freePort/provided_and_available (0.00s)
        connect_test.go:60: got a different port 61169, want 51821
```

Nothing in this repository binds 51821 under the unit job, so this is not a collision with a sibling test — the port simply is not ours to assume.

The test now asks the kernel for both ports it needs. The busy one is bound and held open for the duration of the test, the available one is bound, its number recorded, and the socket closed right away. As a side effect the table no longer has to be patched by index after it is declared.

`freePort` itself is unchanged; this is test-only.

**Verified locally.** Holding 51821 with the same `net.ListenUDP` call that `freePort` makes, and then running the test:

```
# before this change
--- FAIL: Test_freePort/provided_and_available (0.00s)
    connect_test.go:60: got a different port 57942, want 51821

# after
ok  github.com/netbirdio/netbird/client/internal  0.484s   (10 runs)
```

Without the port held, `go test ./client/internal/ -run Test_freePort -count=50` passes.

## Issue ticket number and link

None. Test-only fix with no behavior change, so per CONTRIBUTING.md this falls under a trivial fix rather than needing an agreed ticket.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand.

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (test-only, no user-visible behavior changes)

### Docs PR URL (required if "docs added" is checked)

n/a


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved port availability test reliability by dynamically selecting operating-system-assigned busy and available UDP ports.
  * Added coverage for random port selection, available requested ports, and unavailable requested ports.
  * Reduced test flakiness by retrying when a previously probed port is claimed before use.
  * Removed dependence on hardcoded port numbers and manual collision avoidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->