### PR TITLE
[client] Expose the remote jobs opt-in in mobile

### DIFF
--- a/client/android/preferences.go
+++ b/client/android/preferences.go
@@ -325,6 +325,27 @@ func (p *Preferences) SetDisableIPv6(disable bool) {
 	p.configInput.DisableIPv6 = &disable
 }
 
+// GetRemoteJobsAllowed reads the remote jobs opt-in from config file
+func (p *Preferences) GetRemoteJobsAllowed() (bool, error) {
+	if p.configInput.RemoteJobsAllowed != nil {
+		return *p.configInput.RemoteJobsAllowed, nil
+	}
+
+	cfg, err := profilemanager.ReadConfig(p.configInput.ConfigPath)
+	if err != nil {
+		return false, err
+	}
+	if cfg.RemoteJobsAllowed == nil {
+		return false, nil
+	}
+	return *cfg.RemoteJobsAllowed, err
+}
+
+// SetRemoteJobsAllowed stores the given value and waits for commit
+func (p *Preferences) SetRemoteJobsAllowed(allowed bool) {
+	p.configInput.RemoteJobsAllowed = &allowed
+}
+
 // Commit writes out the changes to the config file
 func (p *Preferences) Commit() error {
 	_, err := profilemanager.UpdateOrCreateConfig(p.configInput)

--- a/client/ios/NetBirdSDK/preferences.go
+++ b/client/ios/NetBirdSDK/preferences.go
@@ -128,6 +128,27 @@ func (p *Preferences) SetDisableIPv6(disable bool) {
 	p.configInput.DisableIPv6 = &disable
 }
 
+// GetRemoteJobsAllowed reads the remote jobs opt-in from config file
+func (p *Preferences) GetRemoteJobsAllowed() (bool, error) {
+	if p.configInput.RemoteJobsAllowed != nil {
+		return *p.configInput.RemoteJobsAllowed, nil
+	}
+
+	cfg, err := profilemanager.ReadConfig(p.configInput.ConfigPath)
+	if err != nil {
+		return false, err
+	}
+	if cfg.RemoteJobsAllowed == nil {
+		return false, nil
+	}
+	return *cfg.RemoteJobsAllowed, err
+}
+
+// SetRemoteJobsAllowed stores the given value and waits for commit
+func (p *Preferences) SetRemoteJobsAllowed(allowed bool) {
+	p.configInput.RemoteJobsAllowed = &allowed
+}
+
 // Commit write out the changes into config file
 func (p *Preferences) Commit() error {
 	// Use DirectUpdateOrCreateConfig to avoid atomic file operations (temp file + rename)


### PR DESCRIPTION
## Describe your changes

Remote jobs (debug bundle requests from management) are gated behind Config.RemoteJobsAllowed, which defaults to false and could only be enabled through the CLI flag or an MDM policy. The mobile SDKs had no way to set it, so the mobile clients always refused the job.

Add GetRemoteJobsAllowed/SetRemoteJobsAllowed to both mobile Preferences types, following the existing ServerSSHAllowed accessors, so the apps can offer a settings toggle for it.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android and iOS preference controls for opting in or out of remote jobs.
  * Added persistent retrieval and updates for the remote-jobs setting.
  * The setting defaults to disabled when no saved preference is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->