### PR TITLE
[client] Gather fresh system info on every management sync stream connect

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1243,8 +1243,6 @@ func (e *Engine) updateChecksIfNew(checks []*mgmProto.Checks) error {
 	if isChecksEqual(e.checks, checks) {
 		return nil
 	}
-	e.checks = checks
-
 	info, ok := e.infoSource.Refresh(e.ctx, systemInfoTimeout, checks, e.overlayAddresses()...)
 	if !ok {
 		// Gathering timed out; skip the meta sync this cycle rather than blocking the
@@ -1256,6 +1254,7 @@ func (e *Engine) updateChecksIfNew(checks []*mgmProto.Checks) error {
 	if err := e.mgmClient.SyncMeta(info); err != nil {
 		return fmt.Errorf("could not sync meta: error %s", err)
 	}
+	e.checks = checks
 	return nil
 }
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1480,7 +1480,9 @@ func (e *Engine) receiveManagementEvents() {
 	e.shutdownWg.Add(1)
 	go func() {
 		defer e.shutdownWg.Done()
-		e.infoSource.Refresh(e.ctx, systemInfoTimeout, e.checks, e.overlayAddresses()...)
+		if _, ok := e.infoSource.Refresh(e.ctx, systemInfoTimeout, e.checks, e.overlayAddresses()...); !ok {
+			log.Warnf("posture checks not refreshed before the sync connect, sending the previous results")
+		}
 		err := e.mgmClient.Sync(e.ctx, e.currentSystemInfo, e.handleSync)
 		if err != nil {
 			// happens if management is unavailable for a long time.

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -265,6 +265,8 @@ type Engine struct {
 	// checks are the client-applied posture checks that need to be evaluated on the client
 	checks []*mgmProto.Checks
 
+	infoSource system.InfoSource
+
 	relayManager       *relayClient.Manager
 	stateManager       *statemanager.Manager
 	portForwardManager *portforward.Manager
@@ -1243,7 +1245,7 @@ func (e *Engine) updateChecksIfNew(checks []*mgmProto.Checks) error {
 	}
 	e.checks = checks
 
-	info, ok := system.GetInfoWithChecksTimeout(e.ctx, systemInfoTimeout, checks, e.overlayAddresses()...)
+	info, ok := e.infoSource.Refresh(e.ctx, systemInfoTimeout, checks, e.overlayAddresses()...)
 	if !ok {
 		// Gathering timed out; skip the meta sync this cycle rather than blocking the
 		// sync loop (and syncMsgMux) on a stuck system call. A later sync will retry.
@@ -1278,6 +1280,12 @@ func (e *Engine) applyInfoFlags(info *system.Info) {
 		e.config.DisableSSHAuth,
 		&e.config.RemoteJobsAllowed,
 	)
+}
+
+func (e *Engine) currentSystemInfo(ctx context.Context) *system.Info {
+	info := e.infoSource.Current(ctx, e.overlayAddresses()...)
+	e.applyInfoFlags(info)
+	return info
 }
 
 // overlayAddresses returns our own WireGuard overlay address (v4 and v6) so it
@@ -1473,15 +1481,7 @@ func (e *Engine) receiveManagementEvents() {
 	e.shutdownWg.Add(1)
 	go func() {
 		defer e.shutdownWg.Done()
-		info, ok := system.GetInfoWithChecksTimeout(e.ctx, systemInfoTimeout, e.checks, e.overlayAddresses()...)
-		if !ok {
-			// Gathering timed out; connect the stream with base info so management
-			// connectivity still comes up rather than blocking here.
-			info = system.GetInfo(e.ctx)
-		}
-		e.applyInfoFlags(info)
-
-		err := e.mgmClient.Sync(e.ctx, info, e.handleSync)
+		err := e.mgmClient.Sync(e.ctx, e.currentSystemInfo, e.handleSync)
 		if err != nil {
 			// happens if management is unavailable for a long time.
 			// We want to cancel the operation of the whole client

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1481,6 +1481,7 @@ func (e *Engine) receiveManagementEvents() {
 	e.shutdownWg.Add(1)
 	go func() {
 		defer e.shutdownWg.Done()
+		e.infoSource.Refresh(e.ctx, systemInfoTimeout, e.checks, e.overlayAddresses()...)
 		err := e.mgmClient.Sync(e.ctx, e.currentSystemInfo, e.handleSync)
 		if err != nil {
 			// happens if management is unavailable for a long time.

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1287,6 +1287,22 @@ func (e *Engine) currentSystemInfo(ctx context.Context) *system.Info {
 	return info
 }
 
+// syncInfoFunc returns the info callback for the management sync stream. The
+// first connect sends the info refreshed right before it instead of gathering
+// again; every reconnect gathers a fresh one. The stream retry loop calls the
+// callback sequentially, so the handoff needs no synchronization.
+func (e *Engine) syncInfoFunc(refreshed *system.Info) func(ctx context.Context) *system.Info {
+	return func(ctx context.Context) *system.Info {
+		if refreshed == nil {
+			return e.currentSystemInfo(ctx)
+		}
+		info := refreshed
+		refreshed = nil
+		e.applyInfoFlags(info)
+		return info
+	}
+}
+
 // overlayAddresses returns our own WireGuard overlay address (v4 and v6) so it
 // can be excluded from the reported network addresses; the interface coming and
 // going otherwise churns the peer meta on the management server.
@@ -1480,10 +1496,11 @@ func (e *Engine) receiveManagementEvents() {
 	e.shutdownWg.Add(1)
 	go func() {
 		defer e.shutdownWg.Done()
-		if _, ok := e.infoSource.Refresh(e.ctx, systemInfoTimeout, e.checks, e.overlayAddresses()...); !ok {
+		info, ok := e.infoSource.Refresh(e.ctx, systemInfoTimeout, e.checks, e.overlayAddresses()...)
+		if !ok {
 			log.Warnf("posture checks not refreshed before the sync connect, sending the previous results")
 		}
-		err := e.mgmClient.Sync(e.ctx, e.currentSystemInfo, e.handleSync)
+		err := e.mgmClient.Sync(e.ctx, e.syncInfoFunc(info), e.handleSync)
 		if err != nil {
 			// happens if management is unavailable for a long time.
 			// We want to cancel the operation of the whole client

--- a/client/internal/engine_privileged_test.go
+++ b/client/internal/engine_privileged_test.go
@@ -193,7 +193,7 @@ func TestEngine_Sync(t *testing.T) {
 	// feed updates to Engine via mocked Management client
 	updates := make(chan *mgmtProto.SyncResponse)
 	defer close(updates)
-	syncFunc := func(ctx context.Context, info *system.Info, msgHandler func(msg *mgmtProto.SyncResponse) error) error {
+	syncFunc := func(ctx context.Context, _ func(context.Context) *system.Info, msgHandler func(msg *mgmtProto.SyncResponse) error) error {
 		for msg := range updates {
 			err := msgHandler(msg)
 			if err != nil {

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -298,6 +299,50 @@ func TestEngine_FirstSyncInfoCarriesLoginChecks(t *testing.T) {
 		t.Fatal("timeout waiting for the first sync info")
 	}
 	engine.shutdownWg.Wait()
+}
+
+func TestEngine_UpdateChecksIfNewRetriesAfterFailedSyncMeta(t *testing.T) {
+	key, err := wgtypes.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(CtxInitState(context.Background()))
+	defer cancel()
+
+	syncMetaCalls := 0
+	mgmClient := &mgmt.MockClient{
+		SyncMetaFunc: func(*system.Info) error {
+			syncMetaCalls++
+			if syncMetaCalls == 1 {
+				return errors.New("management unavailable")
+			}
+			return nil
+		},
+	}
+
+	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU)
+	engine := NewEngine(ctx, cancel, &EngineConfig{
+		WgIfaceName:  "utun105",
+		WgAddr:       wgaddr.MustParseWGAddress("100.64.0.1/24"),
+		WgPrivateKey: key,
+		WgPort:       33100,
+		MTU:          iface.DefaultMTU,
+	}, EngineServices{
+		SignalClient:   &signal.MockClient{},
+		MgmClient:      mgmClient,
+		RelayManager:   relayMgr,
+		StatusRecorder: peer.NewRecorder("https://mgm"),
+	}, MobileDependency{})
+
+	checks := []*mgmtProto.Checks{{Files: []string{exe}}}
+
+	require.Error(t, engine.updateChecksIfNew(checks))
+	require.NoError(t, engine.updateChecksIfNew(checks))
+	require.NoError(t, engine.updateChecksIfNew(checks))
+
+	assert.Equal(t, 2, syncMetaCalls)
 }
 
 func TestEngine_UpdateNetworkMap(t *testing.T) {

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -31,6 +31,7 @@ import (
 	icemaker "github.com/netbirdio/netbird/client/internal/peer/ice"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/internal/routemanager"
+	"github.com/netbirdio/netbird/client/system"
 	nbdns "github.com/netbirdio/netbird/dns"
 	"github.com/netbirdio/netbird/monotime"
 	"github.com/netbirdio/netbird/route"
@@ -251,6 +252,52 @@ func TestEngine_SSHServerConsistency(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, engine.sshServer)
 	})
+}
+
+func TestEngine_FirstSyncInfoCarriesLoginChecks(t *testing.T) {
+	key, err := wgtypes.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(CtxInitState(context.Background()))
+	defer cancel()
+
+	infos := make(chan *system.Info, 1)
+	mgmClient := &mgmt.MockClient{
+		SyncFunc: func(ctx context.Context, getInfo func(context.Context) *system.Info, _ func(*mgmtProto.SyncResponse) error) error {
+			infos <- getInfo(ctx)
+			return nil
+		},
+	}
+
+	relayMgr := relayClient.NewManager(ctx, nil, key.PublicKey().String(), iface.DefaultMTU)
+	engine := NewEngine(ctx, cancel, &EngineConfig{
+		WgIfaceName:  "utun104",
+		WgAddr:       wgaddr.MustParseWGAddress("100.64.0.1/24"),
+		WgPrivateKey: key,
+		WgPort:       33100,
+		MTU:          iface.DefaultMTU,
+	}, EngineServices{
+		SignalClient:   &signal.MockClient{},
+		MgmClient:      mgmClient,
+		RelayManager:   relayMgr,
+		StatusRecorder: peer.NewRecorder("https://mgm"),
+		Checks:         []*mgmtProto.Checks{{Files: []string{exe}}},
+	}, MobileDependency{})
+
+	engine.receiveManagementEvents()
+
+	select {
+	case info := <-infos:
+		require.Len(t, info.Files, 1)
+		assert.Equal(t, exe, info.Files[0].Path)
+		assert.True(t, info.Files[0].Exist)
+	case <-time.After(20 * time.Second):
+		t.Fatal("timeout waiting for the first sync info")
+	}
+	engine.shutdownWg.Wait()
 }
 
 func TestEngine_UpdateNetworkMap(t *testing.T) {

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -301,6 +301,28 @@ func TestEngine_FirstSyncInfoCarriesLoginChecks(t *testing.T) {
 	engine.shutdownWg.Wait()
 }
 
+func TestEngine_SyncInfoFuncReusesRefreshedInfoOnce(t *testing.T) {
+	engine := &Engine{config: &EngineConfig{}}
+
+	refreshed := &system.Info{Hostname: "from-refresh"}
+	getInfo := engine.syncInfoFunc(refreshed)
+
+	first := getInfo(context.Background())
+	assert.Same(t, refreshed, first, "the first connect should send the refreshed info instead of gathering again")
+
+	second := getInfo(context.Background())
+	assert.NotSame(t, refreshed, second, "the reconnect should gather a fresh info")
+	assert.NotEqual(t, "from-refresh", second.Hostname, "the fresh info should not carry the refreshed hostname")
+}
+
+func TestEngine_SyncInfoFuncGathersWhenRefreshFailed(t *testing.T) {
+	engine := &Engine{config: &EngineConfig{}}
+
+	info := engine.syncInfoFunc(nil)(context.Background())
+	require.NotNil(t, info, "a failed refresh should fall back to gathering the info")
+	assert.NotEmpty(t, info.Hostname, "the gathered info should carry the hostname")
+}
+
 func TestEngine_UpdateChecksIfNewRetriesAfterFailedSyncMeta(t *testing.T) {
 	key, err := wgtypes.GeneratePrivateKey()
 	require.NoError(t, err)

--- a/client/system/info_source.go
+++ b/client/system/info_source.go
@@ -1,0 +1,37 @@
+package system
+
+import (
+	"context"
+	"net/netip"
+	"sync/atomic"
+	"time"
+
+	"github.com/netbirdio/netbird/shared/management/proto"
+)
+
+// InfoSource gathers the system info sent to management, keeping the posture
+// check results from the last Refresh for the cheap Current snapshots.
+type InfoSource struct {
+	files atomic.Pointer[[]File]
+}
+
+// Refresh gathers the info with the posture checks evaluated, bounded by timeout.
+func (s *InfoSource) Refresh(ctx context.Context, timeout time.Duration, checks []*proto.Checks, excludeIPs ...netip.Addr) (*Info, bool) {
+	info, ok := GetInfoWithChecksTimeout(ctx, timeout, checks, excludeIPs...)
+	if !ok {
+		return nil, false
+	}
+	files := info.Files
+	s.files.Store(&files)
+	return info, true
+}
+
+// Current gathers the info without evaluating the checks, reusing the last Refresh results.
+func (s *InfoSource) Current(ctx context.Context, excludeIPs ...netip.Addr) *Info {
+	info := GetInfo(ctx)
+	info.removeAddresses(excludeIPs...)
+	if files := s.files.Load(); files != nil {
+		info.Files = *files
+	}
+	return info
+}

--- a/client/system/info_source.go
+++ b/client/system/info_source.go
@@ -3,6 +3,7 @@ package system
 import (
 	"context"
 	"net/netip"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -21,7 +22,7 @@ func (s *InfoSource) Refresh(ctx context.Context, timeout time.Duration, checks 
 	if !ok {
 		return nil, false
 	}
-	files := info.Files
+	files := slices.Clone(info.Files)
 	s.files.Store(&files)
 	return info, true
 }

--- a/client/system/info_source_test.go
+++ b/client/system/info_source_test.go
@@ -1,0 +1,52 @@
+package system
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/shared/management/proto"
+)
+
+func TestInfoSource_CurrentBeforeRefresh(t *testing.T) {
+	var src InfoSource
+
+	info := src.Current(context.Background())
+
+	assert.Empty(t, info.Files)
+}
+
+func TestInfoSource_CurrentReusesRefreshedFiles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "agent")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+	checks := []*proto.Checks{{Files: []string{path}}}
+
+	var src InfoSource
+	refreshed, ok := src.Refresh(context.Background(), 15*time.Second, checks)
+	require.True(t, ok)
+	require.Equal(t, []File{{Path: path, Exist: true}}, refreshed.Files)
+
+	info := src.Current(context.Background())
+
+	assert.Equal(t, refreshed.Files, info.Files)
+}
+
+func TestInfoSource_CurrentExcludesAddresses(t *testing.T) {
+	addrs := GetInfo(context.Background()).NetworkAddresses
+	if len(addrs) == 0 {
+		t.Skip("no network addresses on this host")
+	}
+	excluded := addrs[0].NetIP.Addr()
+
+	var src InfoSource
+	info := src.Current(context.Background(), excluded)
+
+	for _, addr := range info.NetworkAddresses {
+		assert.NotEqual(t, excluded, addr.NetIP.Addr())
+	}
+}

--- a/client/system/info_source_test.go
+++ b/client/system/info_source_test.go
@@ -42,10 +42,17 @@ func TestInfoSource_CurrentExcludesAddresses(t *testing.T) {
 		t.Skip("no network addresses on this host")
 	}
 	excluded := addrs[0].NetIP.Addr()
+	matching := 0
+	for _, addr := range addrs {
+		if addr.NetIP.Addr() == excluded {
+			matching++
+		}
+	}
 
 	var src InfoSource
 	info := src.Current(context.Background(), excluded)
 
+	assert.Len(t, info.NetworkAddresses, len(addrs)-matching)
 	for _, addr := range info.NetworkAddresses {
 		assert.NotEqual(t, excluded, addr.NetIP.Addr())
 	}

--- a/management/server/mock_server/management_server_mock.go
+++ b/management/server/mock_server/management_server_mock.go
@@ -30,7 +30,8 @@ func (m ManagementServiceServerMock) Login(ctx context.Context, req *proto.Encry
 
 func (m ManagementServiceServerMock) Sync(msg *proto.EncryptedMessage, sync proto.ManagementService_SyncServer) error {
 	if m.SyncFunc != nil {
-		return m.Sync(msg, sync)
+		m.SyncFunc(msg, sync)
+		return nil
 	}
 	return status.Errorf(codes.Unimplemented, "method Sync not implemented")
 }

--- a/management/server/mock_server/management_server_mock.go
+++ b/management/server/mock_server/management_server_mock.go
@@ -13,7 +13,7 @@ type ManagementServiceServerMock struct {
 	proto.UnimplementedManagementServiceServer
 
 	LoginFunc                      func(context.Context, *proto.EncryptedMessage) (*proto.EncryptedMessage, error)
-	SyncFunc                       func(*proto.EncryptedMessage, proto.ManagementService_SyncServer)
+	SyncFunc                       func(*proto.EncryptedMessage, proto.ManagementService_SyncServer) error
 	GetServerKeyFunc               func(context.Context, *proto.Empty) (*proto.ServerKeyResponse, error)
 	IsHealthyFunc                  func(context.Context, *proto.Empty) (*proto.Empty, error)
 	GetDeviceAuthorizationFlowFunc func(ctx context.Context, req *proto.EncryptedMessage) (*proto.EncryptedMessage, error)
@@ -30,8 +30,7 @@ func (m ManagementServiceServerMock) Login(ctx context.Context, req *proto.Encry
 
 func (m ManagementServiceServerMock) Sync(msg *proto.EncryptedMessage, sync proto.ManagementService_SyncServer) error {
 	if m.SyncFunc != nil {
-		m.SyncFunc(msg, sync)
-		return nil
+		return m.SyncFunc(msg, sync)
 	}
 	return status.Errorf(codes.Unimplemented, "method Sync not implemented")
 }

--- a/shared/management/client/client.go
+++ b/shared/management/client/client.go
@@ -12,7 +12,7 @@ import (
 // Client is the interface for the management service client.
 type Client interface {
 	io.Closer
-	Sync(ctx context.Context, sysInfo *system.Info, msgHandler func(msg *proto.SyncResponse) error) error
+	Sync(ctx context.Context, getInfo func(ctx context.Context) *system.Info, msgHandler func(msg *proto.SyncResponse) error) error
 	Job(ctx context.Context, msgHandler func(msg *proto.JobRequest) *proto.JobResponse) error
 	Register(setupKey string, jwtToken string, sysInfo *system.Info, sshKey []byte, dnsLabels domain.List) (*proto.LoginResponse, error)
 	Login(sysInfo *system.Info, sshKey []byte, dnsLabels domain.List) (*proto.LoginResponse, error)

--- a/shared/management/client/client_test.go
+++ b/shared/management/client/client_test.go
@@ -407,21 +407,23 @@ func TestClient_SyncGathersInfoOnEveryConnect(t *testing.T) {
 	require.NoError(t, err)
 
 	hostnames := make(chan string, 2)
-	mgmtMockServer.SyncFunc = func(msg *mgmtProto.EncryptedMessage, _ mgmtProto.ManagementService_SyncServer) {
+	mgmtMockServer.SyncFunc = func(msg *mgmtProto.EncryptedMessage, _ mgmtProto.ManagementService_SyncServer) error {
 		peerKey, err := wgtypes.ParseKey(msg.GetWgPubKey())
 		if err != nil {
 			t.Errorf("invalid peer key: %v", err)
-			return
+			return status.Error(codes.InvalidArgument, err.Error())
 		}
 		syncReq := &mgmtProto.SyncRequest{}
 		if err := encryption.DecryptMessage(peerKey, serverKey, msg.Body, syncReq); err != nil {
 			t.Errorf("decrypt sync request: %v", err)
-			return
+			return status.Error(codes.InvalidArgument, err.Error())
 		}
 		select {
 		case hostnames <- syncReq.GetMeta().GetHostname():
 		default:
 		}
+		// Returning closes the stream, so the client reconnects and gathers again.
+		return nil
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -431,7 +433,9 @@ func TestClient_SyncGathersInfoOnEveryConnect(t *testing.T) {
 	require.NoError(t, err)
 
 	var gathers atomic.Int32
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		_ = client.Sync(ctx, func(ctx context.Context) *system.Info {
 			info := system.GetInfo(ctx)
 			info.Hostname = fmt.Sprintf("host-%d", gathers.Add(1))
@@ -439,13 +443,28 @@ func TestClient_SyncGathersInfoOnEveryConnect(t *testing.T) {
 		}, func(*mgmtProto.SyncResponse) error { return nil })
 	}()
 
-	for _, want := range []string{"host-1", "host-2"} {
+	// A connect attempt can fail before it reaches the server, so the sequence
+	// numbers seen here may skip. What matters is that the reconnect carries a
+	// newly gathered info instead of the one sent on the previous stream.
+	var seen []int
+	for len(seen) < 2 {
 		select {
 		case got := <-hostnames:
-			assert.Equal(t, want, got)
+			var n int
+			_, err := fmt.Sscanf(got, "host-%d", &n)
+			require.NoError(t, err, "hostname should carry the gather sequence number")
+			seen = append(seen, n)
 		case <-time.After(10 * time.Second):
-			t.Fatalf("timeout waiting for the sync request carrying %s", want)
+			t.Fatalf("timeout waiting for the second sync request, got %v", seen)
 		}
+	}
+	assert.Greater(t, seen[1], seen[0], "the reconnect should carry a newly gathered info")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for Sync to return after cancel")
 	}
 }
 

--- a/shared/management/client/client_test.go
+++ b/shared/management/client/client_test.go
@@ -2,9 +2,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -305,7 +307,7 @@ func TestClient_Sync(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		err = client.Sync(ctx, info, func(msg *mgmtProto.SyncResponse) error {
+		err = client.Sync(ctx, func(context.Context) *system.Info { return info }, func(msg *mgmtProto.SyncResponse) error {
 			ch <- msg
 			return nil
 		})
@@ -395,6 +397,56 @@ func wgKeyFromBytes(raw []byte) string {
 	}
 	copy(k[:], raw)
 	return k.String()
+}
+
+func TestClient_SyncGathersInfoOnEveryConnect(t *testing.T) {
+	s, lis, mgmtMockServer, serverKey := startMockManagement(t)
+	defer s.GracefulStop()
+
+	testKey, err := wgtypes.GenerateKey()
+	require.NoError(t, err)
+
+	hostnames := make(chan string, 2)
+	mgmtMockServer.SyncFunc = func(msg *mgmtProto.EncryptedMessage, _ mgmtProto.ManagementService_SyncServer) {
+		peerKey, err := wgtypes.ParseKey(msg.GetWgPubKey())
+		if err != nil {
+			t.Errorf("invalid peer key: %v", err)
+			return
+		}
+		syncReq := &mgmtProto.SyncRequest{}
+		if err := encryption.DecryptMessage(peerKey, serverKey, msg.Body, syncReq); err != nil {
+			t.Errorf("decrypt sync request: %v", err)
+			return
+		}
+		select {
+		case hostnames <- syncReq.GetMeta().GetHostname():
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := NewClient(ctx, lis.Addr().String(), testKey, false)
+	require.NoError(t, err)
+
+	var gathers atomic.Int32
+	go func() {
+		_ = client.Sync(ctx, func(ctx context.Context) *system.Info {
+			info := system.GetInfo(ctx)
+			info.Hostname = fmt.Sprintf("host-%d", gathers.Add(1))
+			return info
+		}, func(*mgmtProto.SyncResponse) error { return nil })
+	}()
+
+	for _, want := range []string{"host-1", "host-2"} {
+		select {
+		case got := <-hostnames:
+			assert.Equal(t, want, got)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timeout waiting for the sync request carrying %s", want)
+		}
+	}
 }
 
 func Test_SystemMetaDataFromClient(t *testing.T) {

--- a/shared/management/client/grpc.go
+++ b/shared/management/client/grpc.go
@@ -428,11 +428,7 @@ func (c *GrpcClient) handleSyncStream(ctx context.Context, serverPubKey wgtypes.
 	ctx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 
-	var sysInfo *system.Info
-	if getInfo != nil {
-		sysInfo = getInfo(ctx)
-	}
-	stream, err := c.connectToSyncStream(ctx, serverPubKey, sysInfo)
+	stream, err := c.connectToSyncStream(ctx, serverPubKey, getInfo(ctx))
 	if err != nil {
 		log.Debugf("failed to open Management Service stream: %s", err)
 		c.notifyDisconnected(err)

--- a/shared/management/client/grpc.go
+++ b/shared/management/client/grpc.go
@@ -205,9 +205,9 @@ func (c *GrpcClient) ready() bool {
 
 // Sync wraps the real client's Sync endpoint call and takes care of retries and encryption/decryption of messages
 // Blocking request. The result will be sent via msgHandler callback function
-func (c *GrpcClient) Sync(ctx context.Context, sysInfo *system.Info, msgHandler func(msg *proto.SyncResponse) error) error {
+func (c *GrpcClient) Sync(ctx context.Context, getInfo func(ctx context.Context) *system.Info, msgHandler func(msg *proto.SyncResponse) error) error {
 	return c.withMgmtStream(ctx, func(ctx context.Context, serverPubKey wgtypes.Key, backOff backoff.BackOff) error {
-		return c.handleSyncStream(ctx, serverPubKey, sysInfo, msgHandler, backOff)
+		return c.handleSyncStream(ctx, serverPubKey, getInfo, msgHandler, backOff)
 	})
 }
 
@@ -424,11 +424,11 @@ func (c *GrpcClient) sendJobResponse(
 	return nil
 }
 
-func (c *GrpcClient) handleSyncStream(ctx context.Context, serverPubKey wgtypes.Key, sysInfo *system.Info, msgHandler func(msg *proto.SyncResponse) error, backOff backoff.BackOff) error {
+func (c *GrpcClient) handleSyncStream(ctx context.Context, serverPubKey wgtypes.Key, getInfo func(ctx context.Context) *system.Info, msgHandler func(msg *proto.SyncResponse) error, backOff backoff.BackOff) error {
 	ctx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 
-	stream, err := c.connectToSyncStream(ctx, serverPubKey, sysInfo)
+	stream, err := c.connectToSyncStream(ctx, serverPubKey, getInfo(ctx))
 	if err != nil {
 		log.Debugf("failed to open Management Service stream: %s", err)
 		c.notifyDisconnected(err)

--- a/shared/management/client/grpc.go
+++ b/shared/management/client/grpc.go
@@ -428,7 +428,11 @@ func (c *GrpcClient) handleSyncStream(ctx context.Context, serverPubKey wgtypes.
 	ctx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 
-	stream, err := c.connectToSyncStream(ctx, serverPubKey, getInfo(ctx))
+	var sysInfo *system.Info
+	if getInfo != nil {
+		sysInfo = getInfo(ctx)
+	}
+	stream, err := c.connectToSyncStream(ctx, serverPubKey, sysInfo)
 	if err != nil {
 		log.Debugf("failed to open Management Service stream: %s", err)
 		c.notifyDisconnected(err)

--- a/shared/management/client/mock.go
+++ b/shared/management/client/mock.go
@@ -11,7 +11,7 @@ import (
 // MockClient is a mock implementation of the Client interface for testing.
 type MockClient struct {
 	CloseFunc                      func() error
-	SyncFunc                       func(ctx context.Context, sysInfo *system.Info, msgHandler func(msg *proto.SyncResponse) error) error
+	SyncFunc                       func(ctx context.Context, getInfo func(ctx context.Context) *system.Info, msgHandler func(msg *proto.SyncResponse) error) error
 	RegisterFunc                   func(setupKey string, jwtToken string, info *system.Info, sshKey []byte, dnsLabels domain.List) (*proto.LoginResponse, error)
 	LoginFunc                      func(info *system.Info, sshKey []byte, dnsLabels domain.List) (*proto.LoginResponse, error)
 	ExtendAuthSessionFunc          func(info *system.Info, jwtToken string) (*proto.ExtendAuthSessionResponse, error)
@@ -38,11 +38,11 @@ func (m *MockClient) Close() error {
 	return m.CloseFunc()
 }
 
-func (m *MockClient) Sync(ctx context.Context, sysInfo *system.Info, msgHandler func(msg *proto.SyncResponse) error) error {
+func (m *MockClient) Sync(ctx context.Context, getInfo func(ctx context.Context) *system.Info, msgHandler func(msg *proto.SyncResponse) error) error {
 	if m.SyncFunc == nil {
 		return nil
 	}
-	return m.SyncFunc(ctx, sysInfo, msgHandler)
+	return m.SyncFunc(ctx, getInfo, msgHandler)
 }
 
 func (m *MockClient) Job(ctx context.Context, msgHandler func(msg *proto.JobRequest) *proto.JobResponse) error {


### PR DESCRIPTION
## Describe your changes

The engine collected the peer meta once at start and reused the same Info for every Sync stream reconnect, so a mobile network switch that redials management kept reporting the old local network addresses. The peer network range posture check was then evaluated against stale data until the client restarted.

Sync now takes a gatherer that runs at each stream connect. The gatherer is cheap: GetInfo plus the cached posture check file results, kept in the new system.InfoSource, which the engine refreshes whenever the checks list changes. No process enumeration runs on the reconnect path.

Also fix the management mock server calling itself instead of SyncFunc.

## Issue ticket number and link
https://github.com/netbirdio/android-client/issues/251

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System information refreshes with posture checks before management synchronization.
  * Management connections gather current system details each time they connect.
  * Current system snapshots reuse refreshed file data and exclude selected network addresses.
  * Initial synchronization includes configured file login-check information.

* **Bug Fixes**
  * Improved synchronization reliability with up-to-date system information.
  * Failed synchronization metadata updates now retain the previous state and retry later.
  * Refresh timeouts are now logged instead of proceeding silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->