### PR TITLE
[misc] Skip the protobuf breaking check on branch-creation pushes

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -27,7 +27,22 @@ jobs:
           push: false
           archive: false
           pr_comment: false
-          build: false
           lint: false
           format: false
-          breaking: true
+          # A push that creates a branch carries no `before` commit, so the
+          # action's default baseline is the all-zero SHA and `buf breaking`
+          # dies cloning it. Skipping costs nothing: every commit on a freshly
+          # cut release branch should have already passed this check on main.
+          breaking: ${{ !github.event.created }}
+          # The alternative is to compare against the default branch instead of
+          # skipping. Not used: buf clones the baseline when the job runs, so a
+          # main that has moved on since the branch was cut reads as protos
+          # deleted on the release branch. Resolving to an empty string on every
+          # other event is what keeps the action's own default in place, which
+          # stacked pull requests need.
+          # breaking_against: >-
+          #   ${{ github.event.created
+          #     && format('{0}#format=git,branch={1}',
+          #               github.event.repository.clone_url,
+          #               github.event.repository.default_branch)
+          #     || '' }}


### PR DESCRIPTION
## Describe your changes

A push that creates a branch sends the all-zero SHA as `before`, and bufbuild/buf-action unconditionally builds its default baseline from it:(src/inputs.ts:86), so `buf breaking` failed cloning a ref that does not exist. This broke the first run on every new release-* branch, most recently release-0.78.

Gate `breaking` on github.event.created instead. Nothing is lost: every commit on a freshly cut release branch already passed the check on main, and pushes with a real `before` -- plus pull requests, which compare against their own base -- keep the action's own default baseline, so stacked PRs are unaffected.

Also drop `build: false`, which is not an input this action accepts and only produced a warning.

## Issue ticket number and link

N/A

## Stack

N/A

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change — Bug fix to a build action.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Restored the default build behavior for Buf validation.
  - Updated breaking-change checks to skip branch-creation events and run for other event types.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->