### PR TITLE
[client] Assign the Android TUN address as a host prefix

### DIFF
--- a/client/iface/device/device_android.go
+++ b/client/iface/device/device_android.go
@@ -63,7 +63,12 @@ func (t *WGTunDevice) Create(routes []string, dns string, searchDomains []string
 		searchDomainsToString = ""
 	}
 
-	fd, err := t.tunAdapter.ConfigureInterface(t.address.String(), t.address.IPv6String(), int(t.mtu), dns, searchDomainsToString, routesString)
+	ipv6Host := ""
+	if t.address.HasIPv6() {
+		ipv6Host = t.address.IPv6HostPrefix().String()
+	}
+
+	fd, err := t.tunAdapter.ConfigureInterface(t.address.HostPrefix().String(), ipv6Host, int(t.mtu), dns, searchDomainsToString, routesString)
 	if err != nil {
 		log.Errorf("failed to create Android interface: %s", err)
 		return nil, err

--- a/client/iface/wgaddr/address.go
+++ b/client/iface/wgaddr/address.go
@@ -59,10 +59,12 @@ func (addr Address) IPv6Prefix() netip.Prefix {
 	return netip.PrefixFrom(addr.IPv6, addr.IPv6Net.Bits())
 }
 
+// HostPrefix returns the v4 address as a single-host prefix.
 func (addr Address) HostPrefix() netip.Prefix {
 	return netip.PrefixFrom(addr.IP, addr.IP.BitLen())
 }
 
+// IPv6HostPrefix returns the v6 address as a single-host prefix, or an invalid prefix when no v6 overlay address is assigned.
 func (addr Address) IPv6HostPrefix() netip.Prefix {
 	if !addr.HasIPv6() {
 		return netip.Prefix{}

--- a/client/iface/wgaddr/address.go
+++ b/client/iface/wgaddr/address.go
@@ -59,6 +59,17 @@ func (addr Address) IPv6Prefix() netip.Prefix {
 	return netip.PrefixFrom(addr.IPv6, addr.IPv6Net.Bits())
 }
 
+func (addr Address) HostPrefix() netip.Prefix {
+	return netip.PrefixFrom(addr.IP, addr.IP.BitLen())
+}
+
+func (addr Address) IPv6HostPrefix() netip.Prefix {
+	if !addr.HasIPv6() {
+		return netip.Prefix{}
+	}
+	return netip.PrefixFrom(addr.IPv6, addr.IPv6.BitLen())
+}
+
 // SetIPv6FromCompact decodes a compact prefix (5 or 17 bytes) and sets the IPv6 fields.
 // Returns an error if the bytes are invalid. A nil or empty input is a no-op.
 //

--- a/client/iface/wgaddr/address_test.go
+++ b/client/iface/wgaddr/address_test.go
@@ -1,0 +1,24 @@
+package wgaddr
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddress_HostPrefix(t *testing.T) {
+	addr := MustParseWGAddress("100.91.96.107/16")
+
+	assert.Equal(t, netip.MustParsePrefix("100.91.96.107/32"), addr.HostPrefix(), "v4 host prefix must be a single host")
+	assert.Equal(t, netip.MustParsePrefix("100.91.0.0/16"), addr.Network, "network must keep the overlay prefix length")
+	assert.False(t, addr.IPv6HostPrefix().IsValid(), "no v6 overlay means no v6 host prefix")
+}
+
+func TestAddress_IPv6HostPrefix(t *testing.T) {
+	addr := MustParseWGAddress("100.91.96.107/16")
+	addr.IPv6 = netip.MustParseAddr("fd00:1234::1")
+	addr.IPv6Net = netip.MustParsePrefix("fd00:1234::/64")
+
+	assert.Equal(t, netip.MustParsePrefix("fd00:1234::1/128"), addr.IPv6HostPrefix(), "v6 host prefix must be a single host")
+}

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -848,12 +848,11 @@ func (m *DefaultManager) overlayNetworks() []string {
 	}
 
 	addr := m.wgInterface.Address()
-	if !addr.Network.IsValid() {
-		return nil
+	var nets []string
+	if addr.Network.IsValid() {
+		nets = append(nets, addr.Network.String())
 	}
-
-	nets := []string{addr.Network.String()}
-	if addr.HasIPv6() {
+	if addr.IPv6Net.IsValid() {
 		nets = append(nets, addr.IPv6Net.String())
 	}
 	return nets

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -472,23 +472,9 @@ func (m *DefaultManager) CurrentRouteRange() []string {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	if m.disableClientRoutes {
-		return nil
-	}
-
-	filtered := m.routeSelector.FilterSelectedExitNodes(m.clientRoutes)
-	var nets []string
-	for _, routes := range filtered {
-		for _, r := range routes {
-			if r.IsDynamic() {
-				continue
-			}
-			nets = append(nets, r.NetString())
-		}
-	}
-
-	if m.fakeIPManager != nil {
-		nets = append(nets, m.fakeIPManager.GetFakeIPBlock().String(), m.fakeIPManager.GetFakeIPv6Block().String())
+	nets := m.overlayNetworks()
+	if !m.disableClientRoutes {
+		nets = append(nets, m.clientRouteRange()...)
 	}
 
 	sort.Strings(nets)
@@ -854,6 +840,41 @@ func (m *DefaultManager) enforceSingleExitNode(preferred route.NetID, allIDs []r
 func (m *DefaultManager) logExitNodeUpdate(info exitNodeInfo, preferred route.NetID) {
 	log.Debugf("Exit node selection: %d available, preferred=%q (%d user-selected, %d user-deselected, %d management-selected)",
 		len(info.allIDs), preferred, len(info.userSelected), len(info.userDeselected), len(info.selectedByManagement))
+}
+
+func (m *DefaultManager) overlayNetworks() []string {
+	if m.wgInterface == nil {
+		return nil
+	}
+
+	addr := m.wgInterface.Address()
+	if !addr.Network.IsValid() {
+		return nil
+	}
+
+	nets := []string{addr.Network.String()}
+	if addr.HasIPv6() {
+		nets = append(nets, addr.IPv6Net.String())
+	}
+	return nets
+}
+
+func (m *DefaultManager) clientRouteRange() []string {
+	filtered := m.routeSelector.FilterSelectedExitNodes(m.clientRoutes)
+	var nets []string
+	for _, routes := range filtered {
+		for _, r := range routes {
+			if r.IsDynamic() {
+				continue
+			}
+			nets = append(nets, r.NetString())
+		}
+	}
+
+	if m.fakeIPManager != nil {
+		nets = append(nets, m.fakeIPManager.GetFakeIPBlock().String(), m.fakeIPManager.GetFakeIPv6Block().String())
+	}
+	return nets
 }
 
 // minNetID returns the lexicographically smallest NetID, for a deterministic

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -842,6 +842,7 @@ func (m *DefaultManager) logExitNodeUpdate(info exitNodeInfo, preferred route.Ne
 		len(info.allIDs), preferred, len(info.userSelected), len(info.userDeselected), len(info.selectedByManagement))
 }
 
+// overlayNetworks returns the v4 and v6 overlay networks of the WireGuard interface, each only when it is set.
 func (m *DefaultManager) overlayNetworks() []string {
 	if m.wgInterface == nil {
 		return nil
@@ -858,6 +859,7 @@ func (m *DefaultManager) overlayNetworks() []string {
 	return nets
 }
 
+// clientRouteRange returns the static client route networks of the selected exit nodes together with the fake IP blocks.
 func (m *DefaultManager) clientRouteRange() []string {
 	filtered := m.routeSelector.FilterSelectedExitNodes(m.clientRoutes)
 	var nets []string

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"net/url"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -478,7 +479,7 @@ func (m *DefaultManager) CurrentRouteRange() []string {
 	}
 
 	sort.Strings(nets)
-	return nets
+	return slices.Compact(nets)
 }
 
 // GetRouteSelector returns the route selector

--- a/client/internal/routemanager/reconcile_test.go
+++ b/client/internal/routemanager/reconcile_test.go
@@ -17,11 +17,12 @@ import (
 	"github.com/netbirdio/netbird/client/internal/routemanager/refcounter"
 )
 
-// reconcileWGMock is a minimal iface.WGIface that only records AddAllowedIP calls; every other
-// method is an inert stub because ReconcilePeerAllowedIPs exercises none of them.
+// reconcileWGMock is a minimal iface.WGIface that records AddAllowedIP calls and reports the
+// configured address; every other method is an inert stub because the tests exercise none of them.
 type reconcileWGMock struct {
 	mu   sync.Mutex
 	adds map[string][]netip.Prefix
+	addr wgaddr.Address
 }
 
 func (m *reconcileWGMock) AddAllowedIP(peerKey string, allowedIP netip.Prefix) error {
@@ -42,7 +43,7 @@ func (m *reconcileWGMock) added(peerKey string) []netip.Prefix {
 
 func (m *reconcileWGMock) RemoveAllowedIP(string, netip.Prefix) error { return nil }
 func (m *reconcileWGMock) Name() string                               { return "utun-test" }
-func (m *reconcileWGMock) Address() wgaddr.Address                    { return wgaddr.Address{} }
+func (m *reconcileWGMock) Address() wgaddr.Address                    { return m.addr }
 func (m *reconcileWGMock) ToInterface() *net.Interface                { return nil }
 func (m *reconcileWGMock) IsUserspaceBind() bool                      { return false }
 func (m *reconcileWGMock) GetFilter() device.PacketFilter             { return nil }

--- a/client/internal/routemanager/route_range_test.go
+++ b/client/internal/routemanager/route_range_test.go
@@ -1,0 +1,69 @@
+//go:build !windows
+
+package routemanager
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+
+	"github.com/netbirdio/netbird/client/iface/device"
+	"github.com/netbirdio/netbird/client/iface/wgaddr"
+	"github.com/netbirdio/netbird/client/internal/routeselector"
+	"github.com/netbirdio/netbird/route"
+)
+
+type routeRangeWGMock struct {
+	addr wgaddr.Address
+}
+
+func (m *routeRangeWGMock) AddAllowedIP(string, netip.Prefix) error    { return nil }
+func (m *routeRangeWGMock) RemoveAllowedIP(string, netip.Prefix) error { return nil }
+func (m *routeRangeWGMock) Name() string                               { return "utun-test" }
+func (m *routeRangeWGMock) Address() wgaddr.Address                    { return m.addr }
+func (m *routeRangeWGMock) ToInterface() *net.Interface                { return nil }
+func (m *routeRangeWGMock) IsUserspaceBind() bool                      { return false }
+func (m *routeRangeWGMock) GetFilter() device.PacketFilter             { return nil }
+func (m *routeRangeWGMock) GetDevice() *device.FilteredDevice          { return nil }
+func (m *routeRangeWGMock) GetNet() *netstack.Net                      { return nil }
+
+func TestCurrentRouteRange_OverlayNetworkWithClientRoutesDisabled(t *testing.T) {
+	m := &DefaultManager{
+		wgInterface:         &routeRangeWGMock{addr: wgaddr.MustParseWGAddress("100.91.96.107/16")},
+		disableClientRoutes: true,
+	}
+
+	assert.Equal(t, []string{"100.91.0.0/16"}, m.CurrentRouteRange(), "overlay network must be routed even when client routes are disabled")
+}
+
+func TestCurrentRouteRange_OverlayNetworksAndClientRoutes(t *testing.T) {
+	addr := wgaddr.MustParseWGAddress("100.91.96.107/16")
+	addr.IPv6 = netip.MustParseAddr("fd00:1234::1")
+	addr.IPv6Net = netip.MustParsePrefix("fd00:1234::/64")
+
+	static := &route.Route{ID: "static", NetID: "lan", Network: netip.MustParsePrefix("192.168.50.0/24"), NetworkType: route.IPv4Network}
+	dynamic := &route.Route{ID: "dynamic", NetID: "dyn", NetworkType: route.DomainNetwork}
+
+	m := &DefaultManager{
+		wgInterface:   &routeRangeWGMock{addr: addr},
+		routeSelector: routeselector.NewRouteSelector(),
+		clientRoutes: route.HAMap{
+			static.GetHAUniqueID():  {static},
+			dynamic.GetHAUniqueID(): {dynamic},
+		},
+	}
+
+	assert.Equal(t, []string{"100.91.0.0/16", "192.168.50.0/24", "fd00:1234::/64"}, m.CurrentRouteRange(), "overlay networks and static client routes must be listed, dynamic routes skipped")
+}
+
+func TestCurrentRouteRange_NoInterfaceAddress(t *testing.T) {
+	m := &DefaultManager{
+		wgInterface:         &routeRangeWGMock{},
+		disableClientRoutes: true,
+	}
+
+	assert.Empty(t, m.CurrentRouteRange(), "an unset interface address must not produce a route entry")
+}

--- a/client/internal/routemanager/route_range_test.go
+++ b/client/internal/routemanager/route_range_test.go
@@ -78,15 +78,15 @@ func TestCurrentRouteRange_IPv6AddressWithoutNetwork(t *testing.T) {
 
 func TestCurrentRouteRange_DeduplicatesPrefixes(t *testing.T) {
 	// Two HA peers serve the same prefix, and a client route announces the overlay network itself.
-	haA := &route.Route{ID: "ha-a", NetID: "lan", Peer: "peer-a", Network: netip.MustParsePrefix("192.168.50.0/24"), NetworkType: route.IPv4Network}
-	haB := &route.Route{ID: "ha-b", NetID: "lan", Peer: "peer-b", Network: netip.MustParsePrefix("192.168.50.0/24"), NetworkType: route.IPv4Network}
+	haPeerA := &route.Route{ID: "ha-a", NetID: "lan", Peer: "peer-a", Network: netip.MustParsePrefix("192.168.50.0/24"), NetworkType: route.IPv4Network}
+	haPeerB := &route.Route{ID: "ha-b", NetID: "lan", Peer: "peer-b", Network: netip.MustParsePrefix("192.168.50.0/24"), NetworkType: route.IPv4Network}
 	overlay := &route.Route{ID: "overlay", NetID: "overlay", Network: netip.MustParsePrefix("100.91.0.0/16"), NetworkType: route.IPv4Network}
 
 	m := &DefaultManager{
 		wgInterface:   &reconcileWGMock{addr: wgaddr.MustParseWGAddress("100.91.96.107/16")},
 		routeSelector: routeselector.NewRouteSelector(),
 		clientRoutes: route.HAMap{
-			haA.GetHAUniqueID():     {haA, haB},
+			haPeerA.GetHAUniqueID(): {haPeerA, haPeerB},
 			overlay.GetHAUniqueID(): {overlay},
 		},
 	}

--- a/client/internal/routemanager/route_range_test.go
+++ b/client/internal/routemanager/route_range_test.go
@@ -67,3 +67,28 @@ func TestCurrentRouteRange_NoInterfaceAddress(t *testing.T) {
 
 	assert.Empty(t, m.CurrentRouteRange(), "an unset interface address must not produce a route entry")
 }
+
+func TestCurrentRouteRange_IPv6WithoutIPv4Network(t *testing.T) {
+	addr := wgaddr.Address{
+		IPv6:    netip.MustParseAddr("fd00:1234::1"),
+		IPv6Net: netip.MustParsePrefix("fd00:1234::/64"),
+	}
+	m := &DefaultManager{
+		wgInterface:         &routeRangeWGMock{addr: addr},
+		disableClientRoutes: true,
+	}
+
+	assert.Equal(t, []string{"fd00:1234::/64"}, m.CurrentRouteRange(), "a v6 overlay network must not depend on a v4 network being set")
+}
+
+func TestCurrentRouteRange_IPv6AddressWithoutNetwork(t *testing.T) {
+	addr := wgaddr.MustParseWGAddress("100.91.96.107/16")
+	addr.IPv6 = netip.MustParseAddr("fd00:1234::1")
+
+	m := &DefaultManager{
+		wgInterface:         &routeRangeWGMock{addr: addr},
+		disableClientRoutes: true,
+	}
+
+	assert.Equal(t, []string{"100.91.0.0/16"}, m.CurrentRouteRange(), "a v6 address without a network must not produce a route entry")
+}

--- a/client/internal/routemanager/route_range_test.go
+++ b/client/internal/routemanager/route_range_test.go
@@ -3,36 +3,19 @@
 package routemanager
 
 import (
-	"net"
 	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.zx2c4.com/wireguard/tun/netstack"
 
-	"github.com/netbirdio/netbird/client/iface/device"
 	"github.com/netbirdio/netbird/client/iface/wgaddr"
 	"github.com/netbirdio/netbird/client/internal/routeselector"
 	"github.com/netbirdio/netbird/route"
 )
 
-type routeRangeWGMock struct {
-	addr wgaddr.Address
-}
-
-func (m *routeRangeWGMock) AddAllowedIP(string, netip.Prefix) error    { return nil }
-func (m *routeRangeWGMock) RemoveAllowedIP(string, netip.Prefix) error { return nil }
-func (m *routeRangeWGMock) Name() string                               { return "utun-test" }
-func (m *routeRangeWGMock) Address() wgaddr.Address                    { return m.addr }
-func (m *routeRangeWGMock) ToInterface() *net.Interface                { return nil }
-func (m *routeRangeWGMock) IsUserspaceBind() bool                      { return false }
-func (m *routeRangeWGMock) GetFilter() device.PacketFilter             { return nil }
-func (m *routeRangeWGMock) GetDevice() *device.FilteredDevice          { return nil }
-func (m *routeRangeWGMock) GetNet() *netstack.Net                      { return nil }
-
 func TestCurrentRouteRange_OverlayNetworkWithClientRoutesDisabled(t *testing.T) {
 	m := &DefaultManager{
-		wgInterface:         &routeRangeWGMock{addr: wgaddr.MustParseWGAddress("100.91.96.107/16")},
+		wgInterface:         &reconcileWGMock{addr: wgaddr.MustParseWGAddress("100.91.96.107/16")},
 		disableClientRoutes: true,
 	}
 
@@ -48,7 +31,7 @@ func TestCurrentRouteRange_OverlayNetworksAndClientRoutes(t *testing.T) {
 	dynamic := &route.Route{ID: "dynamic", NetID: "dyn", NetworkType: route.DomainNetwork}
 
 	m := &DefaultManager{
-		wgInterface:   &routeRangeWGMock{addr: addr},
+		wgInterface:   &reconcileWGMock{addr: addr},
 		routeSelector: routeselector.NewRouteSelector(),
 		clientRoutes: route.HAMap{
 			static.GetHAUniqueID():  {static},
@@ -61,7 +44,7 @@ func TestCurrentRouteRange_OverlayNetworksAndClientRoutes(t *testing.T) {
 
 func TestCurrentRouteRange_NoInterfaceAddress(t *testing.T) {
 	m := &DefaultManager{
-		wgInterface:         &routeRangeWGMock{},
+		wgInterface:         &reconcileWGMock{},
 		disableClientRoutes: true,
 	}
 
@@ -74,7 +57,7 @@ func TestCurrentRouteRange_IPv6WithoutIPv4Network(t *testing.T) {
 		IPv6Net: netip.MustParsePrefix("fd00:1234::/64"),
 	}
 	m := &DefaultManager{
-		wgInterface:         &routeRangeWGMock{addr: addr},
+		wgInterface:         &reconcileWGMock{addr: addr},
 		disableClientRoutes: true,
 	}
 
@@ -86,7 +69,7 @@ func TestCurrentRouteRange_IPv6AddressWithoutNetwork(t *testing.T) {
 	addr.IPv6 = netip.MustParseAddr("fd00:1234::1")
 
 	m := &DefaultManager{
-		wgInterface:         &routeRangeWGMock{addr: addr},
+		wgInterface:         &reconcileWGMock{addr: addr},
 		disableClientRoutes: true,
 	}
 

--- a/client/internal/routemanager/route_range_test.go
+++ b/client/internal/routemanager/route_range_test.go
@@ -75,3 +75,21 @@ func TestCurrentRouteRange_IPv6AddressWithoutNetwork(t *testing.T) {
 
 	assert.Equal(t, []string{"100.91.0.0/16"}, m.CurrentRouteRange(), "a v6 address without a network must not produce a route entry")
 }
+
+func TestCurrentRouteRange_DeduplicatesPrefixes(t *testing.T) {
+	// Two HA peers serve the same prefix, and a client route announces the overlay network itself.
+	haA := &route.Route{ID: "ha-a", NetID: "lan", Peer: "peer-a", Network: netip.MustParsePrefix("192.168.50.0/24"), NetworkType: route.IPv4Network}
+	haB := &route.Route{ID: "ha-b", NetID: "lan", Peer: "peer-b", Network: netip.MustParsePrefix("192.168.50.0/24"), NetworkType: route.IPv4Network}
+	overlay := &route.Route{ID: "overlay", NetID: "overlay", Network: netip.MustParsePrefix("100.91.0.0/16"), NetworkType: route.IPv4Network}
+
+	m := &DefaultManager{
+		wgInterface:   &reconcileWGMock{addr: wgaddr.MustParseWGAddress("100.91.96.107/16")},
+		routeSelector: routeselector.NewRouteSelector(),
+		clientRoutes: route.HAMap{
+			haA.GetHAUniqueID():     {haA, haB},
+			overlay.GetHAUniqueID(): {overlay},
+		},
+	}
+
+	assert.Equal(t, []string{"100.91.0.0/16", "192.168.50.0/24"}, m.CurrentRouteRange(), "every prefix must be listed once regardless of how many routes carry it")
+}


### PR DESCRIPTION
## Describe your changes

Android 16+ local network protection derives the blocked prefixes from the interface address prefix. A /16 address turns the whole overlay into a local network, so apps without ACCESS_LOCAL_NETWORK cannot reach any peer. Pass the address as /32 and /128 and add the overlay networks to the route list that the Android side turns into VPN routes, on both the initial create and the renew path.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android tunnel address configuration for more accurate IPv4 and IPv6 host handling.
  - Routing now consistently includes valid WireGuard overlay networks.
  - Added IPv6 overlay support to route range calculations, including IPv6-only configurations.
  - Preserved configured client routes while excluding unsupported dynamic or domain-based routes.
  - Improved behavior when interface addresses are unavailable.
  - Corrected handling of invalid or incomplete network configurations.
  - Removed duplicate route entries for more consistent routing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->