### PR TITLE
[client] Return the context error when the SSH handshake fails with it

### DIFF
--- a/client/ssh/handshake.go
+++ b/client/ssh/handshake.go
@@ -27,7 +27,7 @@ func Handshake(ctx context.Context, conn net.Conn, addr string, config *ssh.Clie
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {
 		closeHandshake(conn, "conn after handshake error")
-		return nil, fmt.Errorf("ssh handshake: %w", err)
+		return nil, handshakeError(ctx, err)
 	}
 
 	if err := conn.SetDeadline(time.Time{}); err != nil {
@@ -42,4 +42,14 @@ func closeHandshake(c io.Closer, label string) {
 	if err := c.Close(); err != nil {
 		log.Debugf("ssh: close %s: %v", label, err)
 	}
+}
+
+func handshakeError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("ssh handshake: %w: %w", ctxErr, err)
+	}
+	if deadline, ok := ctx.Deadline(); ok && !time.Now().Before(deadline) {
+		return fmt.Errorf("ssh handshake: %w: %w", context.DeadlineExceeded, err)
+	}
+	return fmt.Errorf("ssh handshake: %w", err)
 }

--- a/client/ssh/handshake.go
+++ b/client/ssh/handshake.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
@@ -13,26 +12,23 @@ import (
 
 // Handshake runs the SSH client handshake on an already dialed conn and
 // returns the resulting client. Dialing bounds only the TCP establishment;
-// without a deadline on the socket a peer that accepts and then goes silent
-// blocks the handshake forever, so the context deadline is applied to conn
-// for the duration of the handshake. conn is closed on any error.
+// a peer that accepts and then goes silent would block the handshake forever,
+// so conn is closed as soon as ctx is done, which unblocks the handshake and
+// surfaces the context error. conn is closed on any error.
 func Handshake(ctx context.Context, conn net.Conn, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
-	if deadline, ok := ctx.Deadline(); ok {
-		if err := conn.SetDeadline(deadline); err != nil {
-			closeHandshake(conn, "conn after deadline error")
-			return nil, fmt.Errorf("set handshake deadline: %w", err)
-		}
-	}
+	stop := context.AfterFunc(ctx, func() { closeHandshake(conn, "conn on context done") })
 
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {
-		closeHandshake(conn, "conn after handshake error")
+		if stop() {
+			closeHandshake(conn, "conn after handshake error")
+		}
 		return nil, handshakeError(ctx, err)
 	}
 
-	if err := conn.SetDeadline(time.Time{}); err != nil {
-		closeHandshake(sshConn, "ssh conn after deadline clear error")
-		return nil, fmt.Errorf("clear handshake deadline: %w", err)
+	if !stop() {
+		closeHandshake(sshConn, "ssh conn after context done")
+		return nil, fmt.Errorf("ssh handshake: %w", ctx.Err())
 	}
 
 	return ssh.NewClient(sshConn, chans, reqs), nil
@@ -47,9 +43,6 @@ func closeHandshake(c io.Closer, label string) {
 func handshakeError(ctx context.Context, err error) error {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return fmt.Errorf("ssh handshake: %w: %w", ctxErr, err)
-	}
-	if deadline, ok := ctx.Deadline(); ok && !time.Now().Before(deadline) {
-		return fmt.Errorf("ssh handshake: %w: %w", context.DeadlineExceeded, err)
 	}
 	return fmt.Errorf("ssh handshake: %w", err)
 }

--- a/client/ssh/handshake_test.go
+++ b/client/ssh/handshake_test.go
@@ -1,0 +1,76 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestHandshake_ContextDeadlineWrapped(t *testing.T) {
+	conn := dialSilentServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := Handshake(ctx, conn, conn.RemoteAddr().String(), testClientConfig())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.DeadlineExceeded), "expected context.DeadlineExceeded, got: %v", err)
+}
+
+func TestHandshake_ContextCanceledWrapped(t *testing.T) {
+	conn := dialSilentServer(t)
+	require.NoError(t, conn.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Handshake(ctx, conn, conn.RemoteAddr().String(), testClientConfig())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got: %v", err)
+}
+
+func TestHandshake_NonContextErrorNotWrapped(t *testing.T) {
+	conn := dialSilentServer(t)
+	require.NoError(t, conn.Close())
+
+	_, err := Handshake(context.Background(), conn, conn.RemoteAddr().String(), testClientConfig())
+	require.Error(t, err)
+	require.False(t, errors.Is(err, context.Canceled))
+	require.False(t, errors.Is(err, context.DeadlineExceeded))
+}
+
+func testClientConfig() *ssh.ClientConfig {
+	return &ssh.ClientConfig{
+		User:            "test",
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+}
+
+// dialSilentServer returns a client conn to a server that accepts and never
+// sends anything, so the SSH handshake blocks until the deadline hits.
+func dialSilentServer(t *testing.T) net.Conn {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		c, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		t.Cleanup(func() { _ = c.Close() })
+	}()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}

--- a/client/ssh/handshake_test.go
+++ b/client/ssh/handshake_test.go
@@ -22,16 +22,26 @@ func TestHandshake_ContextDeadlineWrapped(t *testing.T) {
 	require.True(t, errors.Is(err, context.DeadlineExceeded), "expected context.DeadlineExceeded, got: %v", err)
 }
 
-func TestHandshake_ContextCanceledWrapped(t *testing.T) {
+func TestHandshake_ContextCancelUnblocks(t *testing.T) {
 	conn := dialSilentServer(t)
-	require.NoError(t, conn.Close())
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	defer cancel()
+	time.AfterFunc(50*time.Millisecond, cancel)
 
-	_, err := Handshake(ctx, conn, conn.RemoteAddr().String(), testClientConfig())
-	require.Error(t, err)
-	require.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got: %v", err)
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := Handshake(ctx, conn, conn.RemoteAddr().String(), testClientConfig())
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		require.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("handshake did not return after context cancellation")
+	}
 }
 
 func TestHandshake_NonContextErrorNotWrapped(t *testing.T) {
@@ -52,7 +62,7 @@ func testClientConfig() *ssh.ClientConfig {
 }
 
 // dialSilentServer returns a client conn to a server that accepts and never
-// sends anything, so the SSH handshake blocks until the deadline hits.
+// sends anything, so the SSH handshake blocks until the context is done.
 func dialSilentServer(t *testing.T) net.Conn {
 	t.Helper()
 

--- a/client/ssh/handshake_test.go
+++ b/client/ssh/handshake_test.go
@@ -60,12 +60,16 @@ func dialSilentServer(t *testing.T) net.Conn {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+
 	go func() {
 		c, err := listener.Accept()
 		if err != nil {
 			return
 		}
-		t.Cleanup(func() { _ = c.Close() })
+		defer func() { _ = c.Close() }()
+		<-done
 	}()
 
 	conn, err := net.Dial("tcp", listener.Addr().String())


### PR DESCRIPTION
## Describe your changes

The handshake mapped the context deadline onto the socket but returned the raw socket error. Which error surfaces depends on a race between the x/crypto ssh readLoop and kexLoop goroutines: the kexLoop write fails with i/o timeout and closes the conn, and the readLoop then reports use of closed network connection. Callers checking errors.Is(err, context.DeadlineExceeded) never matched, and TestSSHClient_ContextCancellation flaked on the FreeBSD job.

Handshake now wraps the context error when the context is done or its deadline has passed. The deadline comparison is needed because the socket deadline and the context timer fire independently, so ctx.Err() can still be nil when the deadline-triggered socket error arrives.


## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH handshakes now stop promptly when their context is canceled or reaches its deadline.
  * Context cancellation and deadline errors are reported clearly while preserving unrelated connection errors.
  * Connections are properly closed when a handshake is interrupted or completes after cancellation.

* **Tests**
  * Added coverage for canceled contexts, expired deadlines, and non-context handshake errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->