### PR TITLE
[management] Add Agent Network managed proxy to the API spec

### DIFF
--- a/client/proto/generate.sh
+++ b/client/proto/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if ! which realpath >/dev/null 2>&1; then

--- a/encryption/testprotos/generate.sh
+++ b/encryption/testprotos/generate.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 protoc -I testprotos/ testprotos/testproto.proto --go_out=.

--- a/flow/proto/generate.sh
+++ b/flow/proto/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if ! which realpath > /dev/null 2>&1

--- a/shared/management/http/api/generate.sh
+++ b/shared/management/http/api/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if ! which realpath > /dev/null 2>&1

--- a/shared/management/http/api/openapi.yml
+++ b/shared/management/http/api/openapi.yml
@@ -6443,6 +6443,44 @@ components:
         - enable_prompt_collection
         - redact_pii
         - access_log_retention_days
+    AgentNetworkManagedProxy:
+      type: object
+      description: A NetBird-managed Agent Network gateway deployment.
+      properties:
+        id:
+          type: string
+          description: Managed proxy deployment ID.
+          example: "d1m3kebd9pcs0c1pnu7g"
+        state:
+          type: string
+          description: Derived deployment state. `provisioning` until the gateway is rolled out and connected, `ready` while the gateway actively serves the endpoint, `failed` when the rollout reported a failure.
+          enum: [ "provisioning", "ready", "failed" ]
+          example: "ready"
+        endpoint:
+          type: string
+          description: The account's gateway hostname.
+          example: "brave-otter.gateway.netbird.io"
+        region:
+          type: string
+          description: Region of the cluster hosting the deployment.
+          example: "us-east"
+        message:
+          type: string
+          description: Failure detail reported by the rollout. Only set when state is `failed`.
+      required:
+        - id
+        - state
+        - endpoint
+    AgentNetworkManagedProxyConflict:
+      type: object
+      description: Conflict body returned when the account already has an Agent Network endpoint that managed provisioning does not own, naming that endpoint.
+      properties:
+        endpoint:
+          type: string
+          description: The Agent Network endpoint already assigned to the account.
+          example: "llm.example.com"
+      required:
+        - endpoint
     AgentNetworkBudgetRule:
       type: object
       description: Account-level budget rule. A limit-only rule bound to groups and/or users that applies across all policies as a min-wins ceiling. Empty targets means it applies to every caller.
@@ -13523,6 +13561,67 @@ paths:
                 example: { }
         '400':
           "$ref": "#/components/responses/bad_request"
+        '401':
+          "$ref": "#/components/responses/requires_authentication"
+        '403':
+          "$ref": "#/components/responses/forbidden"
+        '404':
+          "$ref": "#/components/responses/not_found"
+        '500':
+          "$ref": "#/components/responses/internal_error"
+  /api/integrations/agent-network/managed-proxy:
+    post:
+      summary: Provision a managed Agent Network gateway
+      description: Starts provisioning of a NetBird-managed Agent Network gateway for the account, allocating its endpoint under the managed zone on the first call. Idempotent — answers 202 when this call started (or, after a failure, restarted) provisioning and 200 when a deployment already exists, reporting current state either way. Returns 409 when the account already has an Agent Network endpoint that managed provisioning does not own, and 503 when endpoint allocation is temporarily exhausted.
+      tags: [ Agent Network ]
+      security:
+        - BearerAuth: [ ]
+        - TokenAuth: [ ]
+      responses:
+        '200':
+          description: A managed gateway deployment already exists; reports its current state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentNetworkManagedProxy'
+        '202':
+          description: Provisioning started, or restarted after a reported failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentNetworkManagedProxy'
+        '401':
+          "$ref": "#/components/responses/requires_authentication"
+        '403':
+          "$ref": "#/components/responses/forbidden"
+        '409':
+          description: The account already has an Agent Network endpoint not owned by managed provisioning
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentNetworkManagedProxyConflict'
+        '500':
+          "$ref": "#/components/responses/internal_error"
+        '503':
+          description: Endpoint allocation is temporarily exhausted; retry later
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    get:
+      summary: Retrieve managed Agent Network gateway status
+      description: Reports the account's managed gateway deployment and its derived state. Returns 404 when the account has no managed deployment.
+      tags: [ Agent Network ]
+      security:
+        - BearerAuth: [ ]
+        - TokenAuth: [ ]
+      responses:
+        '200':
+          description: The account's managed gateway deployment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentNetworkManagedProxy'
         '401':
           "$ref": "#/components/responses/requires_authentication"
         '403':

--- a/shared/management/http/api/types.gen.go
+++ b/shared/management/http/api/types.gen.go
@@ -77,6 +77,27 @@ func (e AgentNetworkConsumptionDimensionKind) Valid() bool {
 	}
 }
 
+// Defines values for AgentNetworkManagedProxyState.
+const (
+	AgentNetworkManagedProxyStateFailed       AgentNetworkManagedProxyState = "failed"
+	AgentNetworkManagedProxyStateProvisioning AgentNetworkManagedProxyState = "provisioning"
+	AgentNetworkManagedProxyStateReady        AgentNetworkManagedProxyState = "ready"
+)
+
+// Valid indicates whether the value is a known member of the AgentNetworkManagedProxyState enum.
+func (e AgentNetworkManagedProxyState) Valid() bool {
+	switch e {
+	case AgentNetworkManagedProxyStateFailed:
+		return true
+	case AgentNetworkManagedProxyStateProvisioning:
+		return true
+	case AgentNetworkManagedProxyStateReady:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CreateAzureIntegrationRequestHost.
 const (
 	CreateAzureIntegrationRequestHostMicrosoftCom CreateAzureIntegrationRequestHost = "microsoft.com"
@@ -2222,6 +2243,33 @@ type AgentNetworkGuardrailRequest struct {
 
 	// Name Display name for the guardrail.
 	Name string `json:"name"`
+}
+
+// AgentNetworkManagedProxy A NetBird-managed Agent Network gateway deployment.
+type AgentNetworkManagedProxy struct {
+	// Endpoint The account's gateway hostname.
+	Endpoint string `json:"endpoint"`
+
+	// Id Managed proxy deployment ID.
+	Id string `json:"id"`
+
+	// Message Failure detail reported by the rollout. Only set when state is `failed`.
+	Message *string `json:"message,omitempty"`
+
+	// Region Region of the cluster hosting the deployment.
+	Region *string `json:"region,omitempty"`
+
+	// State Derived deployment state. `provisioning` until the gateway is rolled out and connected, `ready` while the gateway actively serves the endpoint, `failed` when the rollout reported a failure.
+	State AgentNetworkManagedProxyState `json:"state"`
+}
+
+// AgentNetworkManagedProxyState Derived deployment state. `provisioning` until the gateway is rolled out and connected, `ready` while the gateway actively serves the endpoint, `failed` when the rollout reported a failure.
+type AgentNetworkManagedProxyState string
+
+// AgentNetworkManagedProxyConflict Conflict body returned when the account already has an Agent Network endpoint that managed provisioning does not own, naming that endpoint.
+type AgentNetworkManagedProxyConflict struct {
+	// Endpoint The Agent Network endpoint already assigned to the account.
+	Endpoint string `json:"endpoint"`
 }
 
 // AgentNetworkModelDiscoveryRequest defines model for AgentNetworkModelDiscoveryRequest.

--- a/shared/management/proto/generate.sh
+++ b/shared/management/proto/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if ! which realpath > /dev/null 2>&1

--- a/shared/signal/proto/generate.sh
+++ b/shared/signal/proto/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if ! which realpath > /dev/null 2>&1


### PR DESCRIPTION
## Describe your changes

Adding OpenAPI spec for in-progress proxy work.

## Issue ticket number and link

N/A

## Stack

N/A

### Checklist
- [ ] Is it a bug fix
- [x] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change — Just adding spec.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API support to provision and retrieve managed Agent Network proxy deployments.
  * Deployment details include status, endpoint, region, and applicable failure information.
  * Existing deployments are returned without creating duplicates.
  * Added responses for endpoint conflicts, unavailable capacity, and missing deployments.

* **Compatibility**
  * Updated supporting generation scripts to locate Bash through the environment, improving portability across systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->