### PR TITLE
[management] Harden OIDC issuer validation and discovery

### DIFF
--- a/management/server/identity_provider.go
+++ b/management/server/identity_provider.go
@@ -59,8 +59,13 @@ func validateOIDCIssuer(ctx context.Context, issuer string) error {
 		return fmt.Errorf("%w: %s", types.ErrIdentityProviderIssuerUnreachable, resp.Status)
 	}
 
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDiscoveryDocumentSize+1))
+	if err != nil || len(body) > maxDiscoveryDocumentSize {
+		return fmt.Errorf("%w: failed to decode provider discovery object", types.ErrIdentityProviderIssuerUnreachable)
+	}
+
 	var p oidcProviderJSON
-	if err := json.NewDecoder(io.LimitReader(resp.Body, maxDiscoveryDocumentSize)).Decode(&p); err != nil {
+	if err := json.Unmarshal(body, &p); err != nil {
 		return fmt.Errorf("%w: failed to decode provider discovery object", types.ErrIdentityProviderIssuerUnreachable)
 	}
 

--- a/management/server/identity_provider.go
+++ b/management/server/identity_provider.go
@@ -23,6 +23,9 @@ import (
 	"github.com/netbirdio/netbird/shared/management/status"
 )
 
+// maxDiscoveryDocumentSize caps the discovery document read at 1 MiB. Providers serve a few kilobytes.
+const maxDiscoveryDocumentSize = 1 << 20
+
 // oidcProviderJSON represents the OpenID Connect discovery document
 type oidcProviderJSON struct {
 	Issuer string `json:"issuer"`
@@ -35,6 +38,10 @@ func validateOIDCIssuer(ctx context.Context, issuer string) error {
 
 	httpClient := &http.Client{
 		Timeout: 10 * time.Second,
+		// An issuer that redirects its own discovery document is misconfigured.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wellKnown, nil)
@@ -48,22 +55,17 @@ func validateOIDCIssuer(ctx context.Context, issuer string) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("%w: unable to read response body: %v", types.ErrIdentityProviderIssuerUnreachable, err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%w: %s: %s", types.ErrIdentityProviderIssuerUnreachable, resp.Status, body)
+		return fmt.Errorf("%w: %s", types.ErrIdentityProviderIssuerUnreachable, resp.Status)
 	}
 
 	var p oidcProviderJSON
-	if err := json.Unmarshal(body, &p); err != nil {
-		return fmt.Errorf("%w: failed to decode provider discovery object: %v", types.ErrIdentityProviderIssuerUnreachable, err)
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxDiscoveryDocumentSize)).Decode(&p); err != nil {
+		return fmt.Errorf("%w: failed to decode provider discovery object", types.ErrIdentityProviderIssuerUnreachable)
 	}
 
 	if p.Issuer != issuer {
-		return fmt.Errorf("%w: expected %q got %q", types.ErrIdentityProviderIssuerMismatch, issuer, p.Issuer)
+		return fmt.Errorf("%w: %q", types.ErrIdentityProviderIssuerMismatch, issuer)
 	}
 
 	return nil
@@ -151,13 +153,13 @@ func (am *DefaultAccountManager) CreateIdentityProvider(ctx context.Context, acc
 		return nil, status.NewPermissionDeniedError()
 	}
 
-	if err := validateIdentityProviderConfig(ctx, idpConfig); err != nil {
-		return nil, err
-	}
-
 	embeddedManager, ok := am.idpManager.(*idp.EmbeddedIdPManager)
 	if !ok {
 		return nil, status.Errorf(status.Internal, "identity provider management requires embedded IdP")
+	}
+
+	if err := validateIdentityProviderConfig(ctx, idpConfig); err != nil {
+		return nil, err
 	}
 
 	// Generate ID if not provided
@@ -188,13 +190,13 @@ func (am *DefaultAccountManager) UpdateIdentityProvider(ctx context.Context, acc
 		return nil, status.NewPermissionDeniedError()
 	}
 
-	if err := validateIdentityProviderConfig(ctx, idpConfig); err != nil {
-		return nil, err
-	}
-
 	embeddedManager, ok := am.idpManager.(*idp.EmbeddedIdPManager)
 	if !ok {
 		return nil, status.Errorf(status.Internal, "identity provider management requires embedded IdP")
+	}
+
+	if err := validateIdentityProviderConfig(ctx, idpConfig); err != nil {
+		return nil, err
 	}
 
 	idpConfig.ID = idpID

--- a/management/server/identity_provider_test.go
+++ b/management/server/identity_provider_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -377,11 +378,23 @@ func TestValidateOIDCIssuer_DoesNotFollowRedirects(t *testing.T) {
 func TestValidateOIDCIssuer_BoundsResponseSize(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(make([]byte, maxDiscoveryDocumentSize+(1<<20)))
+		_, _ = w.Write([]byte(`{"issuer":"` + strings.Repeat("a", maxDiscoveryDocumentSize) + `"}`))
 	}))
 	t.Cleanup(srv.Close)
 
 	err := validateOIDCIssuer(context.Background(), srv.URL)
-	require.Error(t, err)
-	assert.Less(t, len(err.Error()), 4096, "The error stays a fixed size")
+	require.ErrorIs(t, err, types.ErrIdentityProviderIssuerUnreachable)
+	assert.NotErrorIs(t, err, types.ErrIdentityProviderIssuerMismatch)
+}
+
+func TestValidateOIDCIssuer_RejectsTrailingContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"http://` + r.Host + `"} {"issuer":"second"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	err := validateOIDCIssuer(context.Background(), srv.URL)
+	require.ErrorIs(t, err, types.ErrIdentityProviderIssuerUnreachable,
+		"Content after the first object is not a valid discovery document")
 }

--- a/management/server/identity_provider_test.go
+++ b/management/server/identity_provider_test.go
@@ -121,7 +121,7 @@ func createManagerWithEmbeddedIdPModeAndSetup(
 }
 
 func TestDefaultAccountManager_CreateIdentityProvider_Validation(t *testing.T) {
-	manager, _, err := createManager(t)
+	manager, _, err := createManagerWithEmbeddedIdP(t)
 	require.NoError(t, err)
 
 	userID := "testingUser"
@@ -233,7 +233,7 @@ func TestUpdateUserAuthWithSingleModeKeepsConfiguredDomain(t *testing.T) {
 }
 
 func TestDefaultAccountManager_UpdateIdentityProvider_Validation(t *testing.T) {
-	manager, _, err := createManager(t)
+	manager, _, err := createManagerWithEmbeddedIdP(t)
 	require.NoError(t, err)
 
 	userID := "testingUser"
@@ -354,4 +354,34 @@ func TestValidateOIDCIssuer_TrailingSlash(t *testing.T) {
 	// This should fail because the issuer returned doesn't have trailing slash
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, types.ErrIdentityProviderIssuerMismatch))
+}
+
+func TestValidateOIDCIssuer_DoesNotFollowRedirects(t *testing.T) {
+	var reached bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(target.Close)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/redirect-target", http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := validateOIDCIssuer(context.Background(), srv.URL)
+	require.Error(t, err)
+	assert.False(t, reached, "Redirects are not followed")
+}
+
+func TestValidateOIDCIssuer_BoundsResponseSize(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(make([]byte, maxDiscoveryDocumentSize+(1<<20)))
+	}))
+	t.Cleanup(srv.Close)
+
+	err := validateOIDCIssuer(context.Background(), srv.URL)
+	require.Error(t, err)
+	assert.Less(t, len(err.Error()), 4096, "The error stays a fixed size")
 }

--- a/management/server/types/identity_provider.go
+++ b/management/server/types/identity_provider.go
@@ -99,7 +99,13 @@ func (idp *IdentityProvider) Validate() error {
 	}
 	if idp.Issuer != "" {
 		parsedURL, err := url.Parse(idp.Issuer)
-		if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		if err != nil || parsedURL.Host == "" {
+			return ErrIdentityProviderIssuerInvalid
+		}
+		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+			return ErrIdentityProviderIssuerInvalid
+		}
+		if parsedURL.User != nil || parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
 			return ErrIdentityProviderIssuerInvalid
 		}
 	}

--- a/management/server/types/identity_provider.go
+++ b/management/server/types/identity_provider.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"net/url"
+	"strings"
 )
 
 // Identity provider validation errors
@@ -105,7 +106,7 @@ func (idp *IdentityProvider) Validate() error {
 		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
 			return ErrIdentityProviderIssuerInvalid
 		}
-		if parsedURL.User != nil || parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+		if parsedURL.User != nil || strings.ContainsAny(idp.Issuer, "?#") {
 			return ErrIdentityProviderIssuerInvalid
 		}
 	}

--- a/management/server/types/identity_provider.go
+++ b/management/server/types/identity_provider.go
@@ -103,10 +103,13 @@ func (idp *IdentityProvider) Validate() error {
 		if err != nil || parsedURL.Host == "" {
 			return ErrIdentityProviderIssuerInvalid
 		}
-		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		if parsedURL.Scheme != "https" {
 			return ErrIdentityProviderIssuerInvalid
 		}
-		if parsedURL.User != nil || strings.ContainsAny(idp.Issuer, "?#") {
+		if parsedURL.User != nil {
+			return ErrIdentityProviderIssuerInvalid
+		}
+		if strings.ContainsAny(idp.Issuer, "?#") {
 			return ErrIdentityProviderIssuerInvalid
 		}
 	}

--- a/management/server/types/identity_provider_test.go
+++ b/management/server/types/identity_provider_test.go
@@ -171,3 +171,17 @@ func TestIdentityProvider_ValidateAcceptsOriginAndPath(t *testing.T) {
 		})
 	}
 }
+
+func TestIdentityProviderValidateRejectsBareDelimiters(t *testing.T) {
+	for _, issuer := range []string{"https://idp.example.com/realms/nb?", "https://idp.example.com/realms/nb#"} {
+		t.Run(issuer, func(t *testing.T) {
+			idp := &IdentityProvider{
+				Name:     "test",
+				Type:     IdentityProviderTypeOIDC,
+				Issuer:   issuer,
+				ClientID: "client-id",
+			}
+			assert.ErrorIs(t, idp.Validate(), ErrIdentityProviderIssuerInvalid)
+		})
+	}
+}

--- a/management/server/types/identity_provider_test.go
+++ b/management/server/types/identity_provider_test.go
@@ -135,3 +135,39 @@ func TestIdentityProvider_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestIdentityProvider_ValidateRejectsNonOriginIssuers(t *testing.T) {
+	issuers := []string{
+		"http://idp.example.com/realms/nb?foo=bar",
+		"http://idp.example.com/realms/nb#section",
+		"http://user:pass@idp.example.com",
+		"ftp://idp.example.com",
+		"ldap://idp.example.com",
+	}
+
+	for _, issuer := range issuers {
+		t.Run(issuer, func(t *testing.T) {
+			idp := &IdentityProvider{
+				Name:     "test",
+				Type:     IdentityProviderTypeOIDC,
+				Issuer:   issuer,
+				ClientID: "client-id",
+			}
+			assert.ErrorIs(t, idp.Validate(), ErrIdentityProviderIssuerInvalid)
+		})
+	}
+}
+
+func TestIdentityProvider_ValidateAcceptsOriginAndPath(t *testing.T) {
+	for _, issuer := range []string{"https://idp.example.com", "https://idp.example.com/realms/nb", "http://127.0.0.1:5556/dex"} {
+		t.Run(issuer, func(t *testing.T) {
+			idp := &IdentityProvider{
+				Name:     "test",
+				Type:     IdentityProviderTypeOIDC,
+				Issuer:   issuer,
+				ClientID: "client-id",
+			}
+			assert.NoError(t, idp.Validate())
+		})
+	}
+}

--- a/management/server/types/identity_provider_test.go
+++ b/management/server/types/identity_provider_test.go
@@ -138,11 +138,12 @@ func TestIdentityProvider_Validate(t *testing.T) {
 
 func TestIdentityProvider_ValidateRejectsNonOriginIssuers(t *testing.T) {
 	issuers := []string{
-		"http://idp.example.com/realms/nb?foo=bar",
-		"http://idp.example.com/realms/nb#section",
-		"http://user:pass@idp.example.com",
+		"https://idp.example.com/realms/nb?foo=bar",
+		"https://idp.example.com/realms/nb#section",
+		"https://user:pass@idp.example.com",
 		"ftp://idp.example.com",
 		"ldap://idp.example.com",
+		"http://idp.example.com",
 	}
 
 	for _, issuer := range issuers {
@@ -159,7 +160,7 @@ func TestIdentityProvider_ValidateRejectsNonOriginIssuers(t *testing.T) {
 }
 
 func TestIdentityProvider_ValidateAcceptsOriginAndPath(t *testing.T) {
-	for _, issuer := range []string{"https://idp.example.com", "https://idp.example.com/realms/nb", "http://127.0.0.1:5556/dex"} {
+	for _, issuer := range []string{"https://idp.example.com", "https://idp.example.com/realms/nb", "https://127.0.0.1:5556/dex"} {
 		t.Run(issuer, func(t *testing.T) {
 			idp := &IdentityProvider{
 				Name:     "test",


### PR DESCRIPTION
## Describe your changes

This PR hardens OIDC issuer validation and discovery handling. Issuers are now limited to `http`/`https` URLs without user info, query strings, or fragments.

Discovery requests no longer follow redirects, and cap responses at 1 MiB. 

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->


## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Identity provider issuer validation now requires HTTPS URLs and rejects unsafe formats, including query strings, fragments, embedded user information, and unsupported schemes.
- OpenID Connect discovery validation now rejects redirects, oversized responses, malformed documents, and valid documents followed by trailing content, providing more consistent error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->