### PR TITLE
[management] Support EC keys in JWKS x5c certificates

### DIFF
--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -325,7 +325,7 @@ func publicKeyFromX5c(jwk JSONWebKey) (interface{}, error) {
 		}
 		return key, nil
 	default:
-		return nil, errKeyNotFound
+		return nil, fmt.Errorf("unsupported JWK key type %q for x5c certificate", jwk.Kty)
 	}
 }
 

--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -317,6 +317,12 @@ func publicKeyFromX5c(jwk JSONWebKey) (interface{}, error) {
 		if !ok {
 			return nil, errors.New("x5c certificate does not contain an ECDSA public key")
 		}
+		if _, err := curveFromName(jwk.Crv); err != nil {
+			return nil, err
+		}
+		if key.Curve.Params().Name != jwk.Crv {
+			return nil, fmt.Errorf("x5c certificate curve %q does not match JWK curve %q", key.Curve.Params().Name, jwk.Crv)
+		}
 		return key, nil
 	default:
 		return nil, errKeyNotFound

--- a/shared/auth/jwt/validator.go
+++ b/shared/auth/jwt/validator.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -274,8 +275,7 @@ func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
 		}
 
 		if len(jwks.Keys[k].X5c) != 0 {
-			cert := "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
-			return jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
+			return publicKeyFromX5c(jwks.Keys[k])
 		}
 
 		if jwks.Keys[k].Kty == "RSA" {
@@ -287,6 +287,40 @@ func getPublicKey(token *jwt.Token, jwks *Jwks) (interface{}, error) {
 	}
 
 	return nil, errKeyNotFound
+}
+
+// publicKeyFromX5c returns the public key of the first certificate in a JWKS x5c
+// chain, constrained to the key type declared by the JWK. It supports the same
+// key types as the non-x5c path (RSA and EC) and no others: the certificate must
+// actually hold a key of the declared type, and an unsupported kty stays
+// unsupported. This keeps x5c from widening the accepted algorithms.
+func publicKeyFromX5c(jwk JSONWebKey) (interface{}, error) {
+	der, err := base64.StdEncoding.DecodeString(jwk.X5c[0])
+	if err != nil {
+		return nil, fmt.Errorf("decode x5c certificate: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse x5c certificate: %w", err)
+	}
+
+	switch jwk.Kty {
+	case "RSA":
+		key, ok := cert.PublicKey.(*rsa.PublicKey)
+		if !ok {
+			return nil, errors.New("x5c certificate does not contain an RSA public key")
+		}
+		return key, nil
+	case "EC":
+		key, ok := cert.PublicKey.(*ecdsa.PublicKey)
+		if !ok {
+			return nil, errors.New("x5c certificate does not contain an ECDSA public key")
+		}
+		return key, nil
+	default:
+		return nil, errKeyNotFound
+	}
 }
 
 func curveFromName(crv string) (elliptic.Curve, error) {

--- a/shared/auth/jwt/validator_x5c_test.go
+++ b/shared/auth/jwt/validator_x5c_test.go
@@ -98,10 +98,14 @@ func TestGetPublicKey_X5c(t *testing.T) {
 	ecPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
+	ec384Priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+
 	rsaPriv, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
 	ecCert := x5cCertificate(t, &ecPriv.PublicKey, ecPriv)
+	ec384Cert := x5cCertificate(t, &ec384Priv.PublicKey, ec384Priv)
 	rsaCert := x5cCertificate(t, &rsaPriv.PublicKey, rsaPriv)
 
 	tokenWithKid := func() *jwt.Token {
@@ -110,10 +114,10 @@ func TestGetPublicKey_X5c(t *testing.T) {
 		return tok
 	}
 
-	// A: EC kty with an EC certificate yields the ECDSA key.
+	// A: EC kty with a matching-curve EC certificate yields the ECDSA key.
 	t.Run("ec kty with ec certificate", func(t *testing.T) {
 		key, err := getPublicKey(tokenWithKid(), &Jwks{Keys: []JSONWebKey{{
-			Kty: "EC", Kid: kid, X5c: []string{ecCert},
+			Kty: "EC", Kid: kid, Crv: p256, X5c: []string{ecCert},
 		}}})
 		require.NoError(t, err)
 
@@ -170,5 +174,15 @@ func TestGetPublicKey_X5c(t *testing.T) {
 		}}})
 		require.ErrorIs(t, err, errKeyNotFound)
 		assert.Nil(t, key)
+	})
+
+	// G: the certificate's curve must match the curve the JWK declares.
+	t.Run("ec certificate curve must match jwk crv", func(t *testing.T) {
+		key, err := getPublicKey(tokenWithKid(), &Jwks{Keys: []JSONWebKey{{
+			Kty: "EC", Kid: kid, Crv: p256, X5c: []string{ec384Cert},
+		}}})
+		require.Error(t, err)
+		assert.Nil(t, key)
+		assert.ErrorContains(t, err, "does not match JWK curve")
 	})
 }

--- a/shared/auth/jwt/validator_x5c_test.go
+++ b/shared/auth/jwt/validator_x5c_test.go
@@ -167,13 +167,16 @@ func TestGetPublicKey_X5c(t *testing.T) {
 		assert.ErrorContains(t, err, "RSA public key")
 	})
 
-	// F: a kty the non-x5c path does not support stays unsupported with x5c too.
+	// F: a kty neither RSA nor EC stays unsupported, and reports why rather than
+	// looking like a missing key (which would trigger a pointless JWKS refresh).
 	t.Run("unsupported kty stays unsupported", func(t *testing.T) {
 		key, err := getPublicKey(tokenWithKid(), &Jwks{Keys: []JSONWebKey{{
 			Kty: "OKP", Kid: kid, X5c: []string{ecCert},
 		}}})
-		require.ErrorIs(t, err, errKeyNotFound)
+		require.Error(t, err)
 		assert.Nil(t, key)
+		assert.NotErrorIs(t, err, errKeyNotFound)
+		assert.ErrorContains(t, err, "unsupported JWK key type")
 	})
 
 	// G: the certificate's curve must match the curve the JWK declares.

--- a/shared/auth/jwt/validator_x5c_test.go
+++ b/shared/auth/jwt/validator_x5c_test.go
@@ -1,0 +1,174 @@
+package jwt
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// x5cCertificate builds a self-signed certificate for the given public key and
+// returns it base64-encoded as it would appear in a JWKS "x5c" entry (RFC 7517
+// §4.7: standard base64 of the DER certificate).
+func x5cCertificate(t *testing.T, pub crypto.PublicKey, signer crypto.Signer) string {
+	t.Helper()
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "netbird-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, pub, signer)
+	require.NoError(t, err)
+
+	return base64.StdEncoding.EncodeToString(der)
+}
+
+// TestValidateAndParse_ECDSA_X5c reproduces #5302: an EC/ES256 signing key whose
+// JWKS entry carries an x5c certificate must still validate tokens end to end.
+func TestValidateAndParse_ECDSA_X5c(t *testing.T) {
+	const (
+		kid      = "es256-x5c-kid"
+		issuer   = "https://issuer.example.com/"
+		audience = "netbird"
+	)
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	key := ecdsaJWK(t, kid, &priv.PublicKey, p256, 32)
+	key.X5c = []string{x5cCertificate(t, &priv.PublicKey, priv)}
+
+	jwks, err := json.Marshal(Jwks{Keys: []JSONWebKey{key}})
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwks)
+	}))
+	defer srv.Close()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+		"iss": issuer,
+		"aud": audience,
+		"sub": "user-1",
+		"iat": time.Now().Add(-time.Minute).Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	token.Header["kid"] = kid
+
+	signed, err := token.SignedString(priv)
+	require.NoError(t, err)
+
+	v := NewValidator(issuer, []string{audience}, srv.URL, false)
+
+	parsed, err := v.ValidateAndParse(context.Background(), signed)
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	assert.Equal(t, "user-1", claims["sub"])
+}
+
+// TestGetPublicKey_X5c covers the certificate-backed key paths. The certificate's
+// key type must match the JWK kty, x5c supports only the same key types as the
+// non-x5c path (RSA and EC), and mismatched or unsupported entries fail rather
+// than silently broadening the accepted key types.
+func TestGetPublicKey_X5c(t *testing.T) {
+	const kid = "x5c-kid"
+
+	ecPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	rsaPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	ecCert := x5cCertificate(t, &ecPriv.PublicKey, ecPriv)
+	rsaCert := x5cCertificate(t, &rsaPriv.PublicKey, rsaPriv)
+
+	tokenWithKid := func() *jwt.Token {
+		tok := jwt.New(jwt.SigningMethodES256)
+		tok.Header["kid"] = kid
+		return tok
+	}
+
+	// A: EC kty with an EC certificate yields the ECDSA key.
+	t.Run("ec kty with ec certificate", func(t *testing.T) {
+		key, err := getPublicKey(tokenWithKid(), &Jwks{Keys: []JSONWebKey{{
+			Kty: "EC", Kid: kid, X5c: []string{ecCert},
+		}}})
+		require.NoError(t, err)
+
+		got, ok := key.(*ecdsa.PublicKey)
+		require.True(t, ok, "expected *ecdsa.PublicKey, got %T", key)
+		assert.True(t, ecPriv.PublicKey.Equal(got))
+	})
+
+	// B: RSA kty with an RSA certificate yields the RSA key.
+	t.Run("rsa kty with rsa certificate", func(t *testing.T) {
+		key, err := getPublicKey(tokenWithKid(), &Jwks{Keys: []JSONWebKey{{
+			Kty: "RSA", Kid: kid, X5c: []string{rsaCert},
+		}}})
+		require.NoError(t, err)
+
+		got, ok := key.(*rsa.PublicKey)
+		require.True(t, ok, "expected *rsa.PublicKey, got %T", key)
+		assert.True(t, rsaPriv.PublicKey.Equal(got))
+	})
+
+	// C: a malformed certificate fails cleanly.
+	t.Run("malformed x5c", func(t *testing.T) {
+		key, err := getPublicKey(tokenWithKid(), &Jwks{Keys: []JSONWebKey{{
+			Kty: "EC", Kid: kid, X5c: []string{"not-a-valid-certificate"},
+		}}})
+		require.Error(t, err)
+		assert.Nil(t, key)
+	})
+
+	// D: EC kty with an RSA certificate is rejected.
+	t.Run("ec kty with rsa certificate", func(t *testing.T) {
+		key, err := getPublicKey(tokenWithKid(), &Jwks{Keys: []JSONWebKey{{
+			Kty: "EC", Kid: kid, X5c: []string{rsaCert},
+		}}})
+		require.Error(t, err)
+		assert.Nil(t, key)
+		assert.ErrorContains(t, err, "ECDSA public key")
+	})
+
+	// E: RSA kty with an EC certificate is rejected.
+	t.Run("rsa kty with ec certificate", func(t *testing.T) {
+		key, err := getPublicKey(tokenWithKid(), &Jwks{Keys: []JSONWebKey{{
+			Kty: "RSA", Kid: kid, X5c: []string{ecCert},
+		}}})
+		require.Error(t, err)
+		assert.Nil(t, key)
+		assert.ErrorContains(t, err, "RSA public key")
+	})
+
+	// F: a kty the non-x5c path does not support stays unsupported with x5c too.
+	t.Run("unsupported kty stays unsupported", func(t *testing.T) {
+		key, err := getPublicKey(tokenWithKid(), &Jwks{Keys: []JSONWebKey{{
+			Kty: "OKP", Kid: kid, X5c: []string{ecCert},
+		}}})
+		require.ErrorIs(t, err, errKeyNotFound)
+		assert.Nil(t, key)
+	})
+}


### PR DESCRIPTION
## Describe your changes

JWKS entries that include an `x5c` certificate were always parsed as an RSA public key, regardless of the key's type. Providers that sign with an EC/ES256 key and populate `x5c` (for example Authentik with an EC P-256 key) failed authentication with `key is not a valid RSA public key`, even though EC keys *without* `x5c` already validated.

The `x5c` entry is now decoded and parsed generically with `crypto/x509`, and the public key it contains is used — but only for the key types the non-`x5c` path already supports:

- Only `RSA` and `EC` JWK key types are accepted; any other `kty` stays unsupported (returns the existing "unable to find appropriate key" result), so `x5c` does not widen the set of accepted algorithms.
- The certificate's public-key type must match the JWK `kty`: an `RSA` key must come from a certificate carrying an RSA key, and an `EC` key from one carrying an ECDSA key. Mismatches are rejected.
- RSA + `x5c` behavior is unchanged.
- EC/ES256 + `x5c` now validates.
- Malformed certificates, and certificates whose key type does not match `kty`, are rejected.

## Issue ticket number and link

Fixes #5302

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This corrects internal JWKS key parsing in the JWT validator. There is no change to configuration, the public API, gRPC protocols, CLI/service flags, or any documented behavior — EC signing keys are already a supported configuration; they simply failed when the provider included `x5c`.

## Testing

Regression tests reproduce the original failure (they fail on `main` and pass with this change):

- `TestValidateAndParse_ECDSA_X5c` — end-to-end: an ES256 token verified through `ValidateAndParse` against a JWKS whose EC key carries an `x5c` certificate. On `main` this fails with `key is not a valid RSA public key`.
- `TestGetPublicKey_X5c` — EC `kty` + EC cert succeeds; RSA `kty` + RSA cert succeeds; malformed `x5c` fails; EC `kty` + RSA cert and RSA `kty` + EC cert are rejected; an unsupported `kty` stays unsupported.

Commands run locally:

```
go test -race ./shared/auth/jwt/
go test ./shared/auth/... ./management/server/auth/...
go build ./shared/auth/... ./management/server/auth/...
go vet ./shared/auth/jwt/
golangci-lint run ./shared/auth/jwt/...
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT validation for certificates containing RSA and elliptic-curve public keys.
  * Added validation for supported elliptic curves and certificate/JWK curve consistency.
  * Improved handling of malformed certificates, unsupported key types, and certificate/key-type mismatches with clearer errors.

* **Tests**
  * Added coverage for certificate-backed JWT validation using EC and RSA certificates, including malformed certificates and expected validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->