### PR TITLE
[client, proxy] Make the buffer-pool retune reachable while a device is stalled

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -2134,11 +2134,14 @@ func (e *Engine) close() {
 	log.Debugf("removing Netbird interface %s", e.config.WgIfaceName)
 
 	if e.wgInterface != nil {
+		// Drop the handle before the close starts: a retune that loads it
+		// afterwards would touch a device on its way out and report success
+		// for an engine that is already gone.
+		e.wgDevice.Store(nil)
 		if err := e.wgInterface.Close(); err != nil {
 			log.Errorf("failed closing Netbird interface %s %v", e.config.WgIfaceName, err)
 		}
 		e.wgInterface = nil
-		e.wgDevice.Store(nil)
 		e.statusRecorder.SetWgIface(nil)
 	}
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -14,12 +14,14 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pion/ice/v4"
 	"github.com/pion/stun/v3"
 	log "github.com/sirupsen/logrus"
+	wgdevice "golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/tun/netstack"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
@@ -235,6 +237,12 @@ type Engine struct {
 	started bool
 
 	wgInterface WGIface
+
+	// wgDevice is a lock-free handle on the WireGuard device behind
+	// wgInterface. Reaching the device through wgInterface requires
+	// syncMsgMux, which handleSync holds while it adds and removes peers;
+	// SetPerformance must stay reachable exactly when that work is stuck.
+	wgDevice atomic.Pointer[wgdevice.Device]
 
 	udpMux *udpmux.UniversalUDPMuxDefault
 
@@ -649,6 +657,7 @@ func (e *Engine) Start(netbirdConfig *mgmProto.NetbirdConfig, mgmtURL *url.URL) 
 		log.Errorf("failed to pull up wgInterface [%s]: %s", e.wgInterface.Name(), err.Error())
 		return fmt.Errorf("up wg interface: %w", err)
 	}
+	e.wgDevice.Store(e.wgInterface.GetWGDevice())
 
 	// Set up notrack rules immediately after proxy is listening to prevent
 	// conntrack entries from being created before the rules are in place
@@ -2129,6 +2138,7 @@ func (e *Engine) close() {
 			log.Errorf("failed closing Netbird interface %s %v", e.config.WgIfaceName, err)
 		}
 		e.wgInterface = nil
+		e.wgDevice.Store(nil)
 		e.statusRecorder.SetWgIface(nil)
 	}
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -2294,15 +2294,16 @@ type Performance struct {
 }
 
 // SetPerformance applies the given tuning to this engine's live Device.
+//
+// It deliberately does not take syncMsgMux. Raising the buffer pool cap is the
+// recovery path for a device whose pool is exhausted, and an exhausted pool
+// blocks peer removal inside handleSync, which holds syncMsgMux for as long as
+// it stays blocked. Taking the lock here would make the retune unreachable in
+// the one situation that needs it.
 func (e *Engine) SetPerformance(t Performance) error {
-	e.syncMsgMux.Lock()
-	defer e.syncMsgMux.Unlock()
-	if e.wgInterface == nil {
-		return fmt.Errorf("wg interface not initialized")
-	}
-	dev := e.wgInterface.GetWGDevice()
+	dev := e.wgDevice.Load()
 	if dev == nil {
-		return fmt.Errorf("wg device not initialized")
+		return errors.New("wg device not initialized")
 	}
 	if t.PreallocatedBuffersPerPool != nil {
 		dev.SetPreallocatedBuffersPerPool(*t.PreallocatedBuffersPerPool)

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -729,17 +729,54 @@ func (h *Handler) handlePerf(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, resp)
 }
 
+// perfApplyTimeout bounds the whole apply, however many clients are registered.
+const perfApplyTimeout = 5 * time.Second
+
+type perfResult struct {
+	accountID types.AccountID
+	err       error
+}
+
 // applyBufferCap sets the WireGuard buffer pool cap on every registered client
 // and reports how many took it, plus a per-account error for those that did not.
+//
+// Clients are handled concurrently and the wait is bounded: SetPerformance goes
+// through the embedded client's lock, which Start holds for the whole of a slow
+// startup, and this endpoint is the recovery path for a fleet where some clients
+// are wedged. One stuck account must not keep the cap from reaching the others.
+// Goroutines left waiting on a stuck client finish on their own; the buffered
+// channel means they do not leak.
 func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string) {
+	clients := h.provider.ListClientsForStartup()
+	results := make(chan perfResult, len(clients))
+	for accountID, client := range clients {
+		go func() {
+			results <- perfResult{
+				accountID: accountID,
+				err:       client.SetPerformance(nbembed.Performance{PreallocatedBuffersPerPool: &capN}),
+			}
+		}()
+	}
+
+	pending := maps.Clone(clients)
 	applied := 0
 	failed := map[string]string{}
-	for accountID, client := range h.provider.ListClientsForStartup() {
-		if err := client.SetPerformance(nbembed.Performance{PreallocatedBuffersPerPool: &capN}); err != nil {
-			failed[string(accountID)] = err.Error()
-			continue
+	deadline := time.After(perfApplyTimeout)
+	for range clients {
+		select {
+		case res := <-results:
+			delete(pending, res.accountID)
+			if res.err != nil {
+				failed[string(res.accountID)] = res.err.Error()
+				continue
+			}
+			applied++
+		case <-deadline:
+			for accountID := range pending {
+				failed[string(accountID)] = fmt.Sprintf("timed out after %s waiting for the client", perfApplyTimeout)
+			}
+			return applied, failed
 		}
-		applied++
 	}
 	return applied, failed
 }

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -782,6 +782,28 @@ func collectBuffered(results <-chan perfResult, pending map[types.AccountID]*per
 	}
 }
 
+// resolvePending closes out the accounts still pending when the deadline fires.
+// A worker whose done channel is closed has finished, whatever the results
+// channel has managed to deliver, so its own error is the truth; the rest are
+// genuinely still running and are reported as timed out. Returns how many of
+// them had in fact succeeded.
+func resolvePending(pending map[types.AccountID]*perfWorker, failed map[string]string) int {
+	applied := 0
+	for accountID, w := range pending {
+		select {
+		case <-w.done:
+			if w.err != nil {
+				failed[string(accountID)] = w.err.Error()
+				continue
+			}
+			applied++
+		default:
+			failed[string(accountID)] = fmt.Sprintf("timed out after %s waiting for the client", perfApplyTimeout)
+		}
+	}
+	return applied
+}
+
 // startPerfWorker returns the in-flight retune for the account, starting one if
 // there is none. The bool reports whether this call started it.
 //
@@ -871,9 +893,7 @@ func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string, []string)
 			applied++
 		case <-deadline:
 			applied += collectBuffered(results, pending, failed)
-			for accountID := range pending {
-				failed[string(accountID)] = fmt.Sprintf("timed out after %s waiting for the client", perfApplyTimeout)
-			}
+			applied += resolvePending(pending, failed)
 			return applied, failed, inFlight
 		}
 	}

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -807,11 +807,14 @@ func (h *Handler) startPerfWorker(accountID types.AccountID, client *nbembed.Cli
 		w.err = err
 		close(w.done)
 
+		// Publish before touching the registry: perfMu is taken once per
+		// account by every caller walking the fleet, so a finishing worker
+		// can queue behind a long apply and miss its own deadline.
+		results <- perfResult{accountID: accountID, err: err}
+
 		h.perfMu.Lock()
 		delete(h.perfInflight, accountID)
 		h.perfMu.Unlock()
-
-		results <- perfResult{accountID: accountID, err: err}
 	}()
 
 	return w, true

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -782,6 +782,22 @@ func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string) {
 			}
 			applied++
 		case <-deadline:
+			// select picks at random among ready cases, so results already
+			// buffered when the deadline fires would otherwise be reported as
+			// timeouts. Take them first.
+			for drained := true; drained; {
+				select {
+				case res := <-results:
+					delete(pending, res.accountID)
+					if res.err != nil {
+						failed[string(res.accountID)] = res.err.Error()
+						continue
+					}
+					applied++
+				default:
+					drained = false
+				}
+			}
 			for accountID := range pending {
 				failed[string(accountID)] = fmt.Sprintf("timed out after %s waiting for the client", perfApplyTimeout)
 			}

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -761,6 +761,27 @@ func setClientPerformance(client *nbembed.Client, capN uint32) error {
 	return client.SetPerformance(nbembed.Performance{PreallocatedBuffersPerPool: &capN})
 }
 
+// collectBuffered takes every result already sitting in the channel, removing
+// those accounts from pending, and returns how many of them succeeded. It is
+// called when the deadline fires: select picks at random among ready cases, so
+// a result that landed in time would otherwise be reported as a timeout.
+func collectBuffered(results <-chan perfResult, pending map[types.AccountID]struct{}, failed map[string]string) int {
+	applied := 0
+	for {
+		select {
+		case res := <-results:
+			delete(pending, res.accountID)
+			if res.err != nil {
+				failed[string(res.accountID)] = res.err.Error()
+				continue
+			}
+			applied++
+		default:
+			return applied
+		}
+	}
+}
+
 // startPerfWorker returns the in-flight retune for the account, starting one if
 // there is none. The bool reports whether this call started it.
 //
@@ -846,22 +867,7 @@ func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string, []string)
 			}
 			applied++
 		case <-deadline:
-			// select picks at random among ready cases, so results already
-			// buffered when the deadline fires would otherwise be reported as
-			// timeouts. Take them first.
-			for drained := true; drained; {
-				select {
-				case res := <-results:
-					delete(pending, res.accountID)
-					if res.err != nil {
-						failed[string(res.accountID)] = res.err.Error()
-						continue
-					}
-					applied++
-				default:
-					drained = false
-				}
-			}
+			applied += collectBuffered(results, pending, failed)
 			for accountID := range pending {
 				failed[string(accountID)] = fmt.Sprintf("timed out after %s waiting for the client", perfApplyTimeout)
 			}

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -716,15 +716,7 @@ func (h *Handler) handlePerf(w http.ResponseWriter, r *http.Request) {
 	}
 
 	capN := uint32(n)
-	applied := 0
-	failed := map[string]string{}
-	for accountID, client := range h.provider.ListClientsForStartup() {
-		if err := client.SetPerformance(nbembed.Performance{PreallocatedBuffersPerPool: &capN}); err != nil {
-			failed[string(accountID)] = err.Error()
-			continue
-		}
-		applied++
-	}
+	applied, failed := h.applyBufferCap(capN)
 
 	resp := map[string]any{
 		"success": true,
@@ -735,6 +727,21 @@ func (h *Handler) handlePerf(w http.ResponseWriter, r *http.Request) {
 		resp["failed"] = failed
 	}
 	h.writeJSON(w, resp)
+}
+
+// applyBufferCap sets the WireGuard buffer pool cap on every registered client
+// and reports how many took it, plus a per-account error for those that did not.
+func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string) {
+	applied := 0
+	failed := map[string]string{}
+	for accountID, client := range h.provider.ListClientsForStartup() {
+		if err := client.SetPerformance(nbembed.Performance{PreallocatedBuffersPerPool: &capN}); err != nil {
+			failed[string(accountID)] = err.Error()
+			continue
+		}
+		applied++
+	}
+	return applied, failed
 }
 
 // handleRuntime returns cheap runtime and process stats. Safe to hit on a

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -105,6 +105,10 @@ type Handler struct {
 	startTime  time.Time
 	templates  *template.Template
 	templateMu sync.RWMutex
+
+	// setPerformance applies a buffer cap to one client. Held as a field so
+	// tests can drive applyBufferCap without a live embedded client.
+	setPerformance func(*nbembed.Client, uint32) error
 }
 
 // NewHandler creates a new debug handler.
@@ -113,10 +117,11 @@ func NewHandler(provider clientProvider, healthChecker healthChecker, logger *lo
 		logger = log.StandardLogger()
 	}
 	h := &Handler{
-		provider:  provider,
-		health:    healthChecker,
-		logger:    logger,
-		startTime: time.Now(),
+		provider:       provider,
+		health:         healthChecker,
+		logger:         logger,
+		startTime:      time.Now(),
+		setPerformance: setClientPerformance,
 	}
 	if err := h.loadTemplates(); err != nil {
 		logger.Errorf("failed to load embedded templates: %v", err)
@@ -737,6 +742,11 @@ type perfResult struct {
 	err       error
 }
 
+// setClientPerformance is the production implementation behind Handler.setPerformance.
+func setClientPerformance(client *nbembed.Client, capN uint32) error {
+	return client.SetPerformance(nbembed.Performance{PreallocatedBuffersPerPool: &capN})
+}
+
 // applyBufferCap sets the WireGuard buffer pool cap on every registered client
 // and reports how many took it, plus a per-account error for those that did not.
 //
@@ -753,7 +763,7 @@ func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string) {
 		go func() {
 			results <- perfResult{
 				accountID: accountID,
-				err:       client.SetPerformance(nbembed.Performance{PreallocatedBuffersPerPool: &capN}),
+				err:       h.setPerformance(client, capN),
 			}
 		}()
 	}

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -748,7 +748,8 @@ func (h *Handler) handlePerf(w http.ResponseWriter, r *http.Request) {
 }
 
 // perfApplyTimeout bounds the whole apply, however many clients are registered.
-const perfApplyTimeout = 5 * time.Second
+// A var, not a const, so tests can shorten the wait.
+var perfApplyTimeout = 5 * time.Second
 
 type perfResult struct {
 	accountID types.AccountID

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -765,7 +765,7 @@ func setClientPerformance(client *nbembed.Client, capN uint32) error {
 // those accounts from pending, and returns how many of them succeeded. It is
 // called when the deadline fires: select picks at random among ready cases, so
 // a result that landed in time would otherwise be reported as a timeout.
-func collectBuffered(results <-chan perfResult, pending map[types.AccountID]struct{}, failed map[string]string) int {
+func collectBuffered(results <-chan perfResult, pending map[types.AccountID]*perfWorker, failed map[string]string) int {
 	applied := 0
 	for {
 		select {
@@ -833,12 +833,12 @@ func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string, []string)
 	applied := 0
 	failed := map[string]string{}
 	var inFlight []string
-	pending := make(map[types.AccountID]struct{}, len(clients))
+	pending := make(map[types.AccountID]*perfWorker, len(clients))
 
 	for accountID, client := range clients {
 		w, started := h.startPerfWorker(accountID, client, capN, results)
 		if started {
-			pending[accountID] = struct{}{}
+			pending[accountID] = w
 			continue
 		}
 		// Another request owns this account's retune. Take its result if it

--- a/proxy/internal/debug/handler.go
+++ b/proxy/internal/debug/handler.go
@@ -109,6 +109,16 @@ type Handler struct {
 	// setPerformance applies a buffer cap to one client. Held as a field so
 	// tests can drive applyBufferCap without a live embedded client.
 	setPerformance func(*nbembed.Client, uint32) error
+
+	perfMu       sync.Mutex
+	perfInflight map[types.AccountID]*perfWorker
+}
+
+// perfWorker is the single in-flight retune for one account. err is valid once
+// done is closed.
+type perfWorker struct {
+	done chan struct{}
+	err  error
 }
 
 // NewHandler creates a new debug handler.
@@ -721,7 +731,7 @@ func (h *Handler) handlePerf(w http.ResponseWriter, r *http.Request) {
 	}
 
 	capN := uint32(n)
-	applied, failed := h.applyBufferCap(capN)
+	applied, failed, inFlight := h.applyBufferCap(capN)
 
 	resp := map[string]any{
 		"success": true,
@@ -730,6 +740,9 @@ func (h *Handler) handlePerf(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(failed) > 0 {
 		resp["failed"] = failed
+	}
+	if len(inFlight) > 0 {
+		resp["in_flight"] = inFlight
 	}
 	h.writeJSON(w, resp)
 }
@@ -747,32 +760,82 @@ func setClientPerformance(client *nbembed.Client, capN uint32) error {
 	return client.SetPerformance(nbembed.Performance{PreallocatedBuffersPerPool: &capN})
 }
 
-// applyBufferCap sets the WireGuard buffer pool cap on every registered client
-// and reports how many took it, plus a per-account error for those that did not.
+// startPerfWorker returns the in-flight retune for the account, starting one if
+// there is none. The bool reports whether this call started it.
 //
-// Clients are handled concurrently and the wait is bounded: SetPerformance goes
-// through the embedded client's lock, which Start holds for the whole of a slow
-// startup, and this endpoint is the recovery path for a fleet where some clients
-// are wedged. One stuck account must not keep the cap from reaching the others.
-// Goroutines left waiting on a stuck client finish on their own; the buffered
-// channel means they do not leak.
-func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string) {
-	clients := h.provider.ListClientsForStartup()
-	results := make(chan perfResult, len(clients))
-	for accountID, client := range clients {
-		go func() {
-			results <- perfResult{
-				accountID: accountID,
-				err:       h.setPerformance(client, capN),
-			}
-		}()
+// At most one retune runs per account at a time. A client wedged inside its own
+// lock never returns, so without this a caller could add one permanently blocked
+// goroutine per request just by retrying the endpoint.
+func (h *Handler) startPerfWorker(accountID types.AccountID, client *nbembed.Client, capN uint32, results chan<- perfResult) (*perfWorker, bool) {
+	h.perfMu.Lock()
+	defer h.perfMu.Unlock()
+
+	if w, ok := h.perfInflight[accountID]; ok {
+		return w, false
 	}
 
-	pending := maps.Clone(clients)
+	w := &perfWorker{done: make(chan struct{})}
+	if h.perfInflight == nil {
+		h.perfInflight = make(map[types.AccountID]*perfWorker)
+	}
+	h.perfInflight[accountID] = w
+
+	go func() {
+		err := h.setPerformance(client, capN)
+		w.err = err
+		close(w.done)
+
+		h.perfMu.Lock()
+		delete(h.perfInflight, accountID)
+		h.perfMu.Unlock()
+
+		results <- perfResult{accountID: accountID, err: err}
+	}()
+
+	return w, true
+}
+
+// applyBufferCap sets the WireGuard buffer pool cap on every registered client
+// and reports how many took it, a per-account error for those that did not, and
+// the accounts whose earlier retune has not come back yet.
+//
+// Clients are handled concurrently and the wait is bounded: SetPerformance goes
+// through the embedded client's lock, which Start and Stop hold for as long as
+// they take - and on a wedged client Stop never returns. This endpoint is the
+// recovery path for exactly that fleet, so one stuck account must neither delay
+// the others nor accumulate goroutines across retries.
+func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string, []string) {
+	clients := h.provider.ListClientsForStartup()
+	results := make(chan perfResult, len(clients))
+
 	applied := 0
 	failed := map[string]string{}
+	var inFlight []string
+	pending := make(map[types.AccountID]struct{}, len(clients))
+
+	for accountID, client := range clients {
+		w, started := h.startPerfWorker(accountID, client, capN, results)
+		if started {
+			pending[accountID] = struct{}{}
+			continue
+		}
+		// Another request owns this account's retune. Take its result if it
+		// has already landed, otherwise report it as still running instead of
+		// waiting on it again.
+		select {
+		case <-w.done:
+			if w.err != nil {
+				failed[string(accountID)] = w.err.Error()
+				continue
+			}
+			applied++
+		default:
+			inFlight = append(inFlight, string(accountID))
+		}
+	}
+
 	deadline := time.After(perfApplyTimeout)
-	for range clients {
+	for range len(pending) {
 		select {
 		case res := <-results:
 			delete(pending, res.accountID)
@@ -801,10 +864,10 @@ func (h *Handler) applyBufferCap(capN uint32) (int, map[string]string) {
 			for accountID := range pending {
 				failed[string(accountID)] = fmt.Sprintf("timed out after %s waiting for the client", perfApplyTimeout)
 			}
-			return applied, failed
+			return applied, failed, inFlight
 		}
 	}
-	return applied, failed
+	return applied, failed, inFlight
 }
 
 // handleRuntime returns cheap runtime and process stats. Safe to hit on a

--- a/proxy/internal/debug/perf_test.go
+++ b/proxy/internal/debug/perf_test.go
@@ -57,7 +57,11 @@ func TestCollectBufferedCountsResultsReadyAtTheDeadline(t *testing.T) {
 	results <- perfResult{accountID: "ok"}
 	results <- perfResult{accountID: "broken", err: errors.New("boom")}
 
-	pending := map[types.AccountID]struct{}{"ok": {}, "broken": {}, "wedged": {}}
+	pending := map[types.AccountID]*perfWorker{
+		"ok":     {done: make(chan struct{})},
+		"broken": {done: make(chan struct{})},
+		"wedged": {done: make(chan struct{})},
+	}
 	failed := map[string]string{}
 
 	applied := collectBuffered(results, pending, failed)

--- a/proxy/internal/debug/perf_test.go
+++ b/proxy/internal/debug/perf_test.go
@@ -1,0 +1,118 @@
+package debug
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	nbembed "github.com/netbirdio/netbird/client/embed"
+	"github.com/netbirdio/netbird/proxy/internal/health"
+	"github.com/netbirdio/netbird/proxy/internal/roundtrip"
+	"github.com/netbirdio/netbird/proxy/internal/types"
+)
+
+// perfProvider serves a fixed set of accounts. The clients are nil: the tests
+// drive Handler.setPerformance, which never dereferences them.
+type perfProvider struct {
+	accounts []types.AccountID
+}
+
+func (p *perfProvider) GetClient(types.AccountID) (*nbembed.Client, bool) { return nil, false }
+
+func (p *perfProvider) ListClientsForDebug() map[types.AccountID]roundtrip.ClientDebugInfo {
+	return nil
+}
+
+func (p *perfProvider) ListClientsForStartup() map[types.AccountID]*nbembed.Client {
+	out := make(map[types.AccountID]*nbembed.Client, len(p.accounts))
+	for _, id := range p.accounts {
+		out[id] = nil
+	}
+	return out
+}
+
+type stubHealth struct{}
+
+func (stubHealth) ReadinessProbe() bool              { return true }
+func (stubHealth) StartupProbe(context.Context) bool { return true }
+func (stubHealth) CheckClientsConnected(context.Context) (bool, map[types.AccountID]health.ClientHealth) {
+	return true, nil
+}
+
+func shortenPerfTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := perfApplyTimeout
+	perfApplyTimeout = d
+	t.Cleanup(func() { perfApplyTimeout = prev })
+}
+
+// TestCollectBufferedCountsResultsReadyAtTheDeadline covers the select-ordering
+// trap: when the deadline fires, results already buffered must be counted, not
+// reported as timeouts. Driving collectBuffered directly keeps it deterministic
+// - through applyBufferCap the two select cases race by construction.
+func TestCollectBufferedCountsResultsReadyAtTheDeadline(t *testing.T) {
+	results := make(chan perfResult, 3)
+	results <- perfResult{accountID: "ok"}
+	results <- perfResult{accountID: "broken", err: errors.New("boom")}
+
+	pending := map[types.AccountID]struct{}{"ok": {}, "broken": {}, "wedged": {}}
+	failed := map[string]string{}
+
+	applied := collectBuffered(results, pending, failed)
+
+	if applied != 1 {
+		t.Fatalf("applied = %d, want 1", applied)
+	}
+	if failed["broken"] != "boom" {
+		t.Fatalf("failed = %v, want the error recorded for \"broken\"", failed)
+	}
+	if _, ok := pending["wedged"]; !ok || len(pending) != 1 {
+		t.Fatalf("pending = %v, want only the account that never answered", pending)
+	}
+}
+
+// TestApplyBufferCapSingleFlightPerAccount covers the goroutine accumulation
+// reported on PR #7452: repeated calls against a client stuck in its own lock
+// must not start a second attempt for the same account.
+func TestApplyBufferCapSingleFlightPerAccount(t *testing.T) {
+	shortenPerfTimeout(t, 50*time.Millisecond)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	var calls atomic.Int32
+	h := &Handler{
+		provider: &perfProvider{accounts: []types.AccountID{"wedged"}},
+		health:   stubHealth{},
+		setPerformance: func(_ *nbembed.Client, _ uint32) error {
+			calls.Add(1)
+			<-release
+			return nil
+		},
+	}
+
+	for i := range 5 {
+		applied, failed, inFlight := h.applyBufferCap(4096)
+		if applied != 0 {
+			t.Fatalf("call %d: applied = %d, want 0", i, applied)
+		}
+		if i == 0 {
+			if len(failed) != 1 {
+				t.Fatalf("first call: failed = %v, want the account reported as timed out", failed)
+			}
+			continue
+		}
+		if len(inFlight) != 1 {
+			t.Fatalf("call %d: inFlight = %v, want the account reported as still running", i, inFlight)
+		}
+		if len(failed) != 0 {
+			t.Fatalf("call %d: failed = %v, want empty while the retune is in flight", i, failed)
+		}
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("setPerformance called %d times, want 1: each retry started another blocked worker", got)
+	}
+}

--- a/proxy/internal/debug/perf_test.go
+++ b/proxy/internal/debug/perf_test.go
@@ -120,3 +120,39 @@ func TestApplyBufferCapSingleFlightPerAccount(t *testing.T) {
 		t.Fatalf("setPerformance called %d times, want 1: each retry started another blocked worker", got)
 	}
 }
+
+// TestResolvePendingTrustsFinishedWorkers covers the reporting race cubic
+// flagged on PR #7452: a retune that finished just before the deadline must be
+// reported by its outcome, not as a timeout, whatever the results channel has
+// delivered so far.
+func TestResolvePendingTrustsFinishedWorkers(t *testing.T) {
+	ok := &perfWorker{done: make(chan struct{})}
+	close(ok.done)
+
+	broken := &perfWorker{done: make(chan struct{}), err: errors.New("boom")}
+	close(broken.done)
+
+	stillRunning := &perfWorker{done: make(chan struct{})}
+
+	pending := map[types.AccountID]*perfWorker{
+		"ok":      ok,
+		"broken":  broken,
+		"running": stillRunning,
+	}
+	failed := map[string]string{}
+
+	applied := resolvePending(pending, failed)
+
+	if applied != 1 {
+		t.Fatalf("applied = %d, want 1", applied)
+	}
+	if failed["broken"] != "boom" {
+		t.Fatalf("failed[broken] = %q, want the worker's own error", failed["broken"])
+	}
+	if _, ok := failed["ok"]; ok {
+		t.Fatalf("failed = %v, want no entry for the account that succeeded", failed)
+	}
+	if got := failed["running"]; got == "" || got == "boom" {
+		t.Fatalf("failed[running] = %q, want the timeout message", got)
+	}
+}


### PR DESCRIPTION
## Describe your changes

With `NB_PROXY_PREALLOCATED_BUFFERS` set, an exhausted per-device buffer pool
blocks peer removal: the keepalive timer callback parks in `WaitPool.Get` while
holding the timer's `runningLock`, so `Timer.DelSync` never returns and
`handleSync` keeps `syncMsgMux` for as long as it is stuck. Raising the pool cap
through `/debug/perf?value=` is the way out of that state, but it was
unreachable exactly then, because `Engine.SetPerformance` took `syncMsgMux`
before touching the device
([engine.go:2288](https://github.com/netbirdio/netbird/blob/0bdfa4277eb668ee599e8fe3a8b29fe5a7f51647/client/internal/engine.go#L2288)),
and `handlePerf` applied the new cap to clients one at a time, so a single
wedged account delayed every healthy one.

Four commits, two refactors and two behavior changes:

1. Publish the wg device on the engine through an `atomic.Pointer`, set once the
   interface is up and cleared on close. Nothing reads it yet.
2. `SetPerformance` loads that handle instead of taking `syncMsgMux`.
   `Device.SetPreallocatedBuffersPerPool` takes the pool's own lock and
   broadcasts, so blocked waiters wake up.
3. Extract the apply loop into `applyBufferCap` — pure move.
4. Apply to all clients concurrently under a 5s budget; accounts that do not
   answer in time are reported in `failed` instead of holding the response.

This is the recovery lever only. The root cause — a keepalive that blocks on the
pool, and a staged queue that is never given up on — is fixed in
`netbirdio/wireguard-go` and is independent of this PR.

Follow-up worth doing separately: move the atomic down into `client/iface`, so
`t.device` becomes an `atomic.Pointer` and `GetWGDevice()` does the load. That
makes the accessor race-free at the source for every caller and lets the engine
field added here go away. Kept out of this PR because it touches the tun
implementations of all platforms (netstack, usp, darwin, ios, windows, android)
to fix a hygiene issue no current caller violates.

## Issue ticket number and link

No public issue. Internal incident on the reverse proxy: accounts stop serving
and `netbird-proxy debug status <account>` times out, because
`Client.Status` → `RunHealthProbes` needs the same `syncMsgMux`. The pool-cap
retune at
[handler.go:706](https://github.com/netbirdio/netbird/blob/0bdfa4277eb668ee599e8fe3a8b29fe5a7f51647/proxy/internal/debug/handler.go#L706)
was added for this recovery path and could not be used.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [x] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal debug endpoint and engine locking. No public API, configuration, CLI or
client behavior change: the pool cap is still set by the same environment
variable, and the endpoint that retunes it already existed.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved responsiveness when adjusting performance settings, including while background synchronization is busy.
  - Performance updates for multiple clients continue to run concurrently with deadline handling.
  - Prevented duplicate performance updates for the same account while an earlier update is in progress.
  - Improved reporting for completed and timed-out performance updates at the deadline.
  - Performance configuration requests no longer block indefinitely; unavailable or unsuccessful updates are reported as failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->