### PR TITLE
[client] Keep the updater silent until management decides the mode

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -274,6 +274,7 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 	stateManager.RegisterState(&sshconfig.ShutdownState{})
 
 	if c.updateManager != nil {
+		c.updateManager.ResetMode()
 		c.updateManager.CheckUpdateSuccess(c.ctx)
 	}
 

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -274,7 +274,6 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 	stateManager.RegisterState(&sshconfig.ShutdownState{})
 
 	if c.updateManager != nil {
-		c.updateManager.ResetMode()
 		c.updateManager.CheckUpdateSuccess(c.ctx)
 	}
 
@@ -291,6 +290,10 @@ func (c *ConnectClient) run(mobileDependency MobileDependency, runningChan chan 
 		// if context cancelled we not start new backoff cycle
 		if c.ctx.Err() != nil {
 			return nil
+		}
+
+		if c.updateManager != nil {
+			c.updateManager.ResetMode()
 		}
 
 		// suspend connection attempts while the OS reports no usable network

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -967,8 +967,14 @@ func (e *Engine) handleAutoUpdateVersion(autoUpdateSettings *mgmProto.AutoUpdate
 		return
 	}
 
-	if autoUpdateSettings == nil || autoUpdateSettings.Version == disableAutoUpdate {
-		log.Infof("auto-update is disabled")
+	if autoUpdateSettings == nil {
+		log.Infof("no auto-update settings received, defaulting to download-only")
+		e.updateManager.SetDownloadOnly()
+		return
+	}
+
+	if autoUpdateSettings.Version == disableAutoUpdate {
+		log.Infof("auto-update is disabled, switching to download-only")
 		e.updateManager.SetDownloadOnly()
 		return
 	}

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -455,10 +455,6 @@ func (e *Engine) stopLocked() {
 		e.sessionWatcher.Close()
 	}
 
-	if e.updateManager != nil {
-		e.updateManager.SetDownloadOnly()
-	}
-
 	log.Info("cleaning up status recorder states")
 	e.statusRecorder.ReplaceOfflinePeers([]peer.State{})
 	e.statusRecorder.UpdateDNSStates([]peer.NSGroupState{})
@@ -971,11 +967,7 @@ func (e *Engine) handleAutoUpdateVersion(autoUpdateSettings *mgmProto.AutoUpdate
 		return
 	}
 
-	if autoUpdateSettings == nil {
-		return
-	}
-
-	if autoUpdateSettings.Version == disableAutoUpdate {
+	if autoUpdateSettings == nil || autoUpdateSettings.Version == disableAutoUpdate {
 		log.Infof("auto-update is disabled")
 		e.updateManager.SetDownloadOnly()
 		return

--- a/client/internal/updater/manager.go
+++ b/client/internal/updater/manager.go
@@ -45,6 +45,7 @@ type Manager struct {
 	stateManager   *statemanager.Manager
 
 	mode        updateMode
+	modeGen     uint64
 	forceUpdate bool // true when management sets AlwaysUpdate; skips UI interaction and installs directly
 
 	lastTrigger    time.Time
@@ -62,7 +63,7 @@ type Manager struct {
 	pendingVersion *v.Version
 
 	// updateMutex protects update, expectedVersion, updateToLatestVersion,
-	// mode, forceUpdate, pendingVersion, and lastTrigger fields
+	// mode, modeGen, forceUpdate, pendingVersion, and lastTrigger fields
 	updateMutex sync.Mutex
 
 	// installMutex and installing guard against concurrent installation attempts
@@ -158,11 +159,7 @@ func (m *Manager) Start(ctx context.Context) {
 
 func (m *Manager) SetDownloadOnly() {
 	m.updateMutex.Lock()
-	m.mode = modeDownloadOnly
-	m.forceUpdate = false
-	m.expectedVersion = nil
-	m.updateToLatestVersion = false
-	m.lastTrigger = time.Time{}
+	m.setModeLocked(modeDownloadOnly)
 	m.updateMutex.Unlock()
 
 	select {
@@ -185,30 +182,26 @@ func (m *Manager) SetVersion(expectedVersion string, forceUpdate bool) {
 
 	if expectedVersion == "" {
 		log.Errorf("empty expected version provided")
-		m.expectedVersion = nil
-		m.updateToLatestVersion = false
-		m.mode = modeDownloadOnly
+		m.setModeLocked(modeDownloadOnly)
 		return
 	}
 
-	if expectedVersion == latestVersion {
-		m.updateToLatestVersion = true
-		m.expectedVersion = nil
-	} else {
-		expectedSemVer, err := v.NewVersion(expectedVersion)
+	var expectedSemVer *v.Version
+	if expectedVersion != latestVersion {
+		parsed, err := v.NewVersion(expectedVersion)
 		if err != nil {
 			log.Errorf("error parsing version: %v", err)
 			return
 		}
-		if m.expectedVersion != nil && m.expectedVersion.Equal(expectedSemVer) {
+		if m.mode == modeManaged && m.expectedVersion != nil && m.expectedVersion.Equal(parsed) {
 			return
 		}
-		m.expectedVersion = expectedSemVer
-		m.updateToLatestVersion = false
+		expectedSemVer = parsed
 	}
 
-	m.lastTrigger = time.Time{}
-	m.mode = modeManaged
+	m.setModeLocked(modeManaged)
+	m.expectedVersion = expectedSemVer
+	m.updateToLatestVersion = expectedSemVer == nil
 	m.forceUpdate = forceUpdate
 
 	select {
@@ -221,12 +214,7 @@ func (m *Manager) ResetMode() {
 	m.updateMutex.Lock()
 	defer m.updateMutex.Unlock()
 
-	m.mode = modeUndecided
-	m.forceUpdate = false
-	m.expectedVersion = nil
-	m.updateToLatestVersion = false
-	m.pendingVersion = nil
-	m.lastTrigger = time.Time{}
+	m.setModeLocked(modeUndecided)
 }
 
 // Install triggers the installation of the pending version. It is called when the user clicks the install button in the UI.
@@ -276,6 +264,7 @@ func (m *Manager) NotifyUI() {
 		return
 	}
 	mode := m.mode
+	gen := m.modeGen
 	pendingVersion := m.pendingVersion
 	latestVersion := m.update.LatestVersion()
 	m.updateMutex.Unlock()
@@ -292,6 +281,9 @@ func (m *Manager) NotifyUI() {
 		if err != nil || currentVersion.GreaterThanOrEqual(latestVersion) {
 			return
 		}
+		if m.modeChanged(gen) {
+			return
+		}
 		m.statusRecorder.PublishEvent(
 			cProto.SystemEvent_INFO,
 			cProto.SystemEvent_SYSTEM,
@@ -302,7 +294,7 @@ func (m *Manager) NotifyUI() {
 		return
 	}
 
-	if pendingVersion != nil {
+	if pendingVersion != nil && !m.modeChanged(gen) {
 		m.statusRecorder.PublishEvent(
 			cProto.SystemEvent_INFO,
 			cProto.SystemEvent_SYSTEM,
@@ -368,6 +360,7 @@ func (m *Manager) handleUpdate(ctx context.Context) {
 	}
 
 	mode := m.mode
+	gen := m.modeGen
 	forceUpdate := m.forceUpdate
 	curLatestVersion := m.update.LatestVersion()
 
@@ -407,6 +400,11 @@ func (m *Manager) handleUpdate(ctx context.Context) {
 	}
 	m.updateMutex.Unlock()
 
+	if m.modeChanged(gen) {
+		log.Debugf("auto-update mode changed while checking %s, discarding", updateVersion)
+		return
+	}
+
 	if mode == modeDownloadOnly {
 		m.statusRecorder.PublishEvent(
 			cProto.SystemEvent_INFO,
@@ -432,6 +430,23 @@ func (m *Manager) handleUpdate(ctx context.Context) {
 		"",
 		map[string]string{"new_version_available": updateVersion.String(), "enforced": "true"},
 	)
+}
+
+func (m *Manager) modeChanged(gen uint64) bool {
+	m.updateMutex.Lock()
+	defer m.updateMutex.Unlock()
+
+	return m.modeGen != gen
+}
+
+func (m *Manager) setModeLocked(mode updateMode) {
+	m.mode = mode
+	m.modeGen++
+	m.forceUpdate = false
+	m.expectedVersion = nil
+	m.updateToLatestVersion = false
+	m.pendingVersion = nil
+	m.lastTrigger = time.Time{}
 }
 
 func (m *Manager) install(ctx context.Context, pendingVersion *v.Version) error {

--- a/client/internal/updater/manager.go
+++ b/client/internal/updater/manager.go
@@ -21,7 +21,15 @@ const (
 	latestVersion = "latest"
 )
 
+const (
+	modeUndecided updateMode = iota
+	modeDownloadOnly
+	modeManaged
+)
+
 var errNoUpdateState = errors.New("no update state found")
+
+type updateMode int
 
 type UpdateState struct {
 	PreUpdateVersion string
@@ -36,8 +44,8 @@ type Manager struct {
 	statusRecorder *peer.Status
 	stateManager   *statemanager.Manager
 
-	downloadOnly bool // true when no enforcement from management; notifies UI to download latest
-	forceUpdate  bool // true when management sets AlwaysUpdate; skips UI interaction and installs directly
+	mode        updateMode
+	forceUpdate bool // true when management sets AlwaysUpdate; skips UI interaction and installs directly
 
 	lastTrigger    time.Time
 	mgmUpdateChan  chan struct{}
@@ -54,7 +62,7 @@ type Manager struct {
 	pendingVersion *v.Version
 
 	// updateMutex protects update, expectedVersion, updateToLatestVersion,
-	// downloadOnly, forceUpdate, pendingVersion, and lastTrigger fields
+	// mode, forceUpdate, pendingVersion, and lastTrigger fields
 	updateMutex sync.Mutex
 
 	// installMutex and installing guard against concurrent installation attempts
@@ -76,7 +84,6 @@ func NewManager(statusRecorder *peer.Status, stateManager *statemanager.Manager)
 		updateChannel:       make(chan struct{}, 1),
 		currentVersion:      version.NetbirdVersion(),
 		update:              version.NewUpdate("nb/client"),
-		downloadOnly:        true,
 		autoUpdateSupported: isAutoUpdateSupported,
 	}
 
@@ -151,7 +158,7 @@ func (m *Manager) Start(ctx context.Context) {
 
 func (m *Manager) SetDownloadOnly() {
 	m.updateMutex.Lock()
-	m.downloadOnly = true
+	m.mode = modeDownloadOnly
 	m.forceUpdate = false
 	m.expectedVersion = nil
 	m.updateToLatestVersion = false
@@ -169,6 +176,7 @@ func (m *Manager) SetVersion(expectedVersion string, forceUpdate bool) {
 
 	if !m.autoUpdateSupported() {
 		log.Warnf("auto-update not supported on this platform")
+		m.SetDownloadOnly()
 		return
 	}
 
@@ -179,7 +187,7 @@ func (m *Manager) SetVersion(expectedVersion string, forceUpdate bool) {
 		log.Errorf("empty expected version provided")
 		m.expectedVersion = nil
 		m.updateToLatestVersion = false
-		m.downloadOnly = true
+		m.mode = modeDownloadOnly
 		return
 	}
 
@@ -200,13 +208,25 @@ func (m *Manager) SetVersion(expectedVersion string, forceUpdate bool) {
 	}
 
 	m.lastTrigger = time.Time{}
-	m.downloadOnly = false
+	m.mode = modeManaged
 	m.forceUpdate = forceUpdate
 
 	select {
 	case m.mgmUpdateChan <- struct{}{}:
 	default:
 	}
+}
+
+func (m *Manager) ResetMode() {
+	m.updateMutex.Lock()
+	defer m.updateMutex.Unlock()
+
+	m.mode = modeUndecided
+	m.forceUpdate = false
+	m.expectedVersion = nil
+	m.updateToLatestVersion = false
+	m.pendingVersion = nil
+	m.lastTrigger = time.Time{}
 }
 
 // Install triggers the installation of the pending version. It is called when the user clicks the install button in the UI.
@@ -255,12 +275,16 @@ func (m *Manager) NotifyUI() {
 		m.updateMutex.Unlock()
 		return
 	}
-	downloadOnly := m.downloadOnly
+	mode := m.mode
 	pendingVersion := m.pendingVersion
 	latestVersion := m.update.LatestVersion()
 	m.updateMutex.Unlock()
 
-	if downloadOnly {
+	if mode == modeUndecided {
+		return
+	}
+
+	if mode == modeDownloadOnly {
 		if latestVersion == nil {
 			return
 		}
@@ -343,13 +367,17 @@ func (m *Manager) handleUpdate(ctx context.Context) {
 		return
 	}
 
-	downloadOnly := m.downloadOnly
+	mode := m.mode
 	forceUpdate := m.forceUpdate
 	curLatestVersion := m.update.LatestVersion()
 
 	switch {
+	case mode == modeUndecided:
+		log.Tracef("auto-update mode not decided yet")
+		m.updateMutex.Unlock()
+		return
 	// Download-only mode or resolve "latest" to actual version
-	case downloadOnly, m.updateToLatestVersion:
+	case mode == modeDownloadOnly, m.updateToLatestVersion:
 		if curLatestVersion == nil {
 			log.Tracef("latest version not fetched yet")
 			m.updateMutex.Unlock()
@@ -374,12 +402,12 @@ func (m *Manager) handleUpdate(ctx context.Context) {
 	m.lastTrigger = time.Now()
 	log.Infof("new version available: %s", updateVersion)
 
-	if !downloadOnly && !forceUpdate {
+	if mode == modeManaged && !forceUpdate {
 		m.pendingVersion = updateVersion
 	}
 	m.updateMutex.Unlock()
 
-	if downloadOnly {
+	if mode == modeDownloadOnly {
 		m.statusRecorder.PublishEvent(
 			cProto.SystemEvent_INFO,
 			cProto.SystemEvent_SYSTEM,

--- a/client/internal/updater/manager_linux_test.go
+++ b/client/internal/updater/manager_linux_test.go
@@ -96,14 +96,14 @@ func Test_SetVersion_FallsBackToDownloadOnly_Linux(t *testing.T) {
 	defer recorder.UnsubscribeFromEvents(sub)
 
 	m := NewManager(recorder, statemanager.New(tmpFile))
-	m.update = &versionUpdateMock{latestVersion: v.Must(v.NewSemver("1.0.1"))}
+	m.update = &versionUpdateMock{latestVersion: v.Must(v.NewSemver("1.0.5"))}
 	m.currentVersion = "1.0.0"
 	m.Start(context.Background())
 	m.SetVersion("1.0.1", false)
 
 	ver, enforced := waitForUpdateEvent(sub, 500*time.Millisecond)
-	if ver != "1.0.1" {
-		t.Fatalf("expected download-only event for 1.0.1, got %q", ver)
+	if ver != "1.0.5" {
+		t.Fatalf("expected download-only event for fetched 1.0.5, got %q", ver)
 	}
 	if enforced {
 		t.Error("Linux fallback must never have enforced metadata")

--- a/client/internal/updater/manager_linux_test.go
+++ b/client/internal/updater/manager_linux_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // On Linux, only Mode 1 (downloadOnly) is supported.
-// SetVersion is a no-op because auto-update installation is not supported.
+// SetVersion falls back to download-only because auto-update installation is not supported.
 
 func Test_LatestVersion_Linux(t *testing.T) {
 	testMatrix := []struct {
@@ -89,9 +89,8 @@ func Test_LatestVersion_Linux(t *testing.T) {
 	}
 }
 
-func Test_SetVersion_NoOp_Linux(t *testing.T) {
-	// On Linux, SetVersion should be a no-op — no events fired
-	tmpFile := path.Join(t.TempDir(), "update-test-noop.json")
+func Test_SetVersion_FallsBackToDownloadOnly_Linux(t *testing.T) {
+	tmpFile := path.Join(t.TempDir(), "update-test-fallback.json")
 	recorder := peer.NewRecorder("")
 	sub := recorder.SubscribeToEvents()
 	defer recorder.UnsubscribeFromEvents(sub)
@@ -102,9 +101,12 @@ func Test_SetVersion_NoOp_Linux(t *testing.T) {
 	m.Start(context.Background())
 	m.SetVersion("1.0.1", false)
 
-	ver, _ := waitForUpdateEvent(sub, 500*time.Millisecond)
-	if ver != "" {
-		t.Errorf("SetVersion should be a no-op on Linux, but got event with version %s", ver)
+	ver, enforced := waitForUpdateEvent(sub, 500*time.Millisecond)
+	if ver != "1.0.1" {
+		t.Fatalf("expected download-only event for 1.0.1, got %q", ver)
+	}
+	if enforced {
+		t.Error("Linux fallback must never have enforced metadata")
 	}
 
 	m.Stop()

--- a/client/internal/updater/manager_mode_test.go
+++ b/client/internal/updater/manager_mode_test.go
@@ -87,3 +87,31 @@ func Test_ResetMode_ReturnsToUndecided(t *testing.T) {
 		t.Fatalf("expected enforced event again after reset, got %q enforced=%v", ver, enforced)
 	}
 }
+
+func Test_SetDownloadOnly_ClearsPendingVersion(t *testing.T) {
+	tmpFile := path.Join(t.TempDir(), "update-test-pending.json")
+	recorder := peer.NewRecorder("")
+	sub := recorder.SubscribeToEvents()
+	defer recorder.UnsubscribeFromEvents(sub)
+
+	m := NewManager(recorder, statemanager.New(tmpFile))
+	m.update = &versionUpdateMock{latestVersion: v.Must(v.NewSemver("1.0.1"))}
+	m.currentVersion = "1.0.0"
+	m.autoUpdateSupported = func() bool { return true }
+	m.Start(context.Background())
+	defer m.Stop()
+
+	m.SetVersion("1.0.1", false)
+	if ver, enforced := waitForUpdateEvent(sub, 500*time.Millisecond); ver != "1.0.1" || !enforced {
+		t.Fatalf("expected enforced event for 1.0.1, got %q enforced=%v", ver, enforced)
+	}
+
+	m.SetDownloadOnly()
+	if ver, enforced := waitForUpdateEvent(sub, 500*time.Millisecond); ver != "1.0.1" || enforced {
+		t.Fatalf("expected download-only event for 1.0.1, got %q enforced=%v", ver, enforced)
+	}
+
+	if err := m.Install(context.Background()); err == nil {
+		t.Fatal("Install in download-only mode must not install the staged managed version")
+	}
+}

--- a/client/internal/updater/manager_mode_test.go
+++ b/client/internal/updater/manager_mode_test.go
@@ -1,0 +1,89 @@
+package updater
+
+import (
+	"context"
+	"path"
+	"testing"
+	"time"
+
+	v "github.com/hashicorp/go-version"
+
+	"github.com/netbirdio/netbird/client/internal/peer"
+	"github.com/netbirdio/netbird/client/internal/statemanager"
+)
+
+func Test_UndecidedMode_SuppressesNotification(t *testing.T) {
+	tmpFile := path.Join(t.TempDir(), "update-test-undecided.json")
+	recorder := peer.NewRecorder("")
+	sub := recorder.SubscribeToEvents()
+	defer recorder.UnsubscribeFromEvents(sub)
+
+	mockUpdate := &versionUpdateMock{latestVersion: v.Must(v.NewSemver("1.0.1"))}
+	m := NewManager(recorder, statemanager.New(tmpFile))
+	m.update = mockUpdate
+	m.currentVersion = "1.0.0"
+	m.Start(context.Background())
+	defer m.Stop()
+
+	mockUpdate.onUpdate()
+	if ver, _ := waitForUpdateEvent(sub, 300*time.Millisecond); ver != "" {
+		t.Fatalf("undecided mode must not publish, got %q", ver)
+	}
+
+	m.NotifyUI()
+	if ver, _ := waitForUpdateEvent(sub, 300*time.Millisecond); ver != "" {
+		t.Fatalf("NotifyUI in undecided mode must not publish, got %q", ver)
+	}
+
+	m.SetDownloadOnly()
+	ver, enforced := waitForUpdateEvent(sub, 500*time.Millisecond)
+	if ver != "1.0.1" {
+		t.Fatalf("expected download-only event for 1.0.1, got %q", ver)
+	}
+	if enforced {
+		t.Error("download-only event must not carry enforced metadata")
+	}
+}
+
+func Test_ResetMode_ReturnsToUndecided(t *testing.T) {
+	tmpFile := path.Join(t.TempDir(), "update-test-reset.json")
+	recorder := peer.NewRecorder("")
+	sub := recorder.SubscribeToEvents()
+	defer recorder.UnsubscribeFromEvents(sub)
+
+	mockUpdate := &versionUpdateMock{latestVersion: v.Must(v.NewSemver("1.0.1"))}
+	m := NewManager(recorder, statemanager.New(tmpFile))
+	m.update = mockUpdate
+	m.currentVersion = "1.0.0"
+	m.autoUpdateSupported = func() bool { return true }
+	m.Start(context.Background())
+	defer m.Stop()
+
+	m.SetVersion("1.0.1", false)
+	ver, enforced := waitForUpdateEvent(sub, 500*time.Millisecond)
+	if ver != "1.0.1" || !enforced {
+		t.Fatalf("expected enforced event for 1.0.1, got %q enforced=%v", ver, enforced)
+	}
+
+	m.ResetMode()
+
+	mockUpdate.onUpdate()
+	if ver, _ := waitForUpdateEvent(sub, 300*time.Millisecond); ver != "" {
+		t.Fatalf("reset mode must not publish on fetch, got %q", ver)
+	}
+
+	m.NotifyUI()
+	if ver, _ := waitForUpdateEvent(sub, 300*time.Millisecond); ver != "" {
+		t.Fatalf("NotifyUI after reset must not publish, got %q", ver)
+	}
+
+	if err := m.Install(context.Background()); err == nil {
+		t.Fatal("Install after reset must fail without a pending version")
+	}
+
+	m.SetVersion("1.0.1", false)
+	ver, enforced = waitForUpdateEvent(sub, 500*time.Millisecond)
+	if ver != "1.0.1" || !enforced {
+		t.Fatalf("expected enforced event again after reset, got %q enforced=%v", ver, enforced)
+	}
+}


### PR DESCRIPTION
## Describe your changes

Peers whose account enforces auto-update still saw a **New version available** item in the tray and installed the release by hand. Two paths in the update manager leaked the download-only notification onto managed peers:

1. **Every engine stop reset the mode.** `Engine.Stop` called `SetDownloadOnly()`, which not only flipped the manager back to download-only but also kicked the update loop. With the latest release already cached by the version fetcher, the loop published the notification at once. Any disconnect, session expiry or logout on a managed peer produced it.
2. **The startup window.** The manager defaulted to download-only, and the version fetcher started as soon as the tray subscribed to daemon events. A single HTTPS GET usually finishes before login and the first network map, so the notification went out before the daemon learned that the peer is managed. The tray then kept the stale item for the rest of the session, because nothing ever retracts it.

### How to reproduce (before this change)

Needs a Windows or macOS peer (auto-update is not supported elsewhere) running a release older than the latest one on `pkgs.netbird.io`, with the tray running.

1. In the dashboard, Settings → Auto-update: set the version to the release the test peer already runs (its current `netbird version`). Managed mode then has nothing to install, so the correct behaviour is complete silence.
2. Start the daemon and the tray, connect, wait for **Connected**. The tray shows no update item — correct so far.
3. Disconnect: `netbird down`, tray → Disconnect, `netbird logout`, or let the session expire.
4. Within a second the tray shows **New version available &lt;latest&gt;** and clicking it opens the download page. The daemon log has `new version available: <latest>` right after `cleaning up status recorder states`.

Startup variant: with the same account settings, stop the daemon, then start daemon and tray together (a reboot with autostart does this). When the version fetch wins the race against login — reliably when the network comes up a few seconds after the daemon, as on boot — the item appears at startup and stays visible for the whole session although the peer is managed.

### What changed

The `downloadOnly` boolean becomes a three-state mode: `undecided`, `downloadOnly`, `managed`.

- The manager starts **undecided** and publishes nothing — not from the fetcher, not from `NotifyUI` when a GUI connects — until the network map decides. Management is the only authority; without its verdict in the current connection the tray stays quiet.
- `Engine.Stop` no longer touches the mode. Disconnect, session expiry and logout keep the last decision.
- `ConnectClient.run` resets to undecided, so every new connection lifecycle (boot autoconnect, `up`, login, profile switch, MDM-triggered restart) waits for its own network map.
- A missing `AutoUpdateSettings` (older management server) now selects download-only instead of being a no-op.
- On platforms without an installer `SetVersion` falls back to download-only explicitly; they used to rely on the default, which no longer exists.

### How to verify

Repeat the steps above: no item after disconnect, none at startup until the first network map arrives. Then set the dashboard version to `disabled`: the download-only item appears on the next sync, confirming the live switch still works in both directions. A Linux peer keeps notifying.

Behaviour change to be aware of: a peer that has never logged in no longer gets the update notification until its first login.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update handling across connection retries, ensuring each attempt uses the current update mode.
  - Prevented outdated or invalid update actions after update settings change.
  - Auto-update now correctly falls back to download-only behavior when unavailable, disabled, or unsupported.
  - Stopping the application no longer unexpectedly changes update behavior.
  - On Linux, available updates can now be downloaded and shown without being automatically installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->