### PR TITLE
[management] fix delete of owner user

### DIFF
--- a/management/server/user.go
+++ b/management/server/user.go
@@ -1337,6 +1337,10 @@ func (am *DefaultAccountManager) deleteRegularUser(ctx context.Context, accountI
 			return fmt.Errorf("failed to get user to delete: %w", err)
 		}
 
+		if targetUser.Role == types.UserRoleOwner && targetUser.Id != initiatorUserID {
+			return status.NewOwnerDeletePermissionError()
+		}
+
 		settings, err = transaction.GetAccountSettings(ctx, store.LockingStrengthNone, accountID)
 		if err != nil {
 			return fmt.Errorf("failed to get account settings: %w", err)

--- a/management/server/user_test.go
+++ b/management/server/user_test.go
@@ -942,6 +942,49 @@ func TestUser_DeleteUser_regularUser(t *testing.T) {
 
 }
 
+func TestUser_deleteRegularUser_RejectsOwner(t *testing.T) {
+	s, cleanup, err := store.NewTestStoreFromSQL(context.Background(), "", t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	account := newAccountWithId(context.Background(), mockAccountID, mockUserID, "", "", "", false)
+	account.Users[mockTargetUserId] = &types.User{
+		Id:     mockTargetUserId,
+		Issued: types.UserIssuedAPI,
+		Role:   types.UserRoleOwner,
+	}
+	require.NoError(t, s.SaveAccount(context.Background(), account))
+
+	am := DefaultAccountManager{Store: s}
+
+	_, err = am.deleteRegularUser(context.Background(), mockAccountID, mockUserID, &types.UserInfo{ID: mockTargetUserId})
+	assert.EqualError(t, err, status.NewOwnerDeletePermissionError().Error())
+}
+
+func TestUser_deleteRegularUser_InitiatorOwnerDeletesThemself(t *testing.T) {
+	s, cleanup, err := store.NewTestStoreFromSQL(context.Background(), "", t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	account := newAccountWithId(context.Background(), mockAccountID, mockUserID, "", "", "", false)
+	require.NoError(t, s.SaveAccount(context.Background(), account))
+
+	networkMapControllerMock := network_map.NewMockController(gomock.NewController(t))
+	networkMapControllerMock.EXPECT().OnPeersDeleted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	am := DefaultAccountManager{
+		Store:                s,
+		eventStore:           &activity.InMemoryEventStore{},
+		networkMapController: networkMapControllerMock,
+	}
+
+	_, err = am.deleteRegularUser(context.Background(), mockAccountID, mockUserID, &types.UserInfo{ID: mockUserID})
+	require.NoError(t, err)
+
+	_, err = s.GetUserByUserID(context.Background(), store.LockingStrengthNone, mockUserID)
+	assert.Equal(t, status.NewUserNotFoundError(mockUserID), err)
+}
+
 func TestUser_DeleteUser_RegularUsers(t *testing.T) {
 	store, cleanup, err := store.NewTestStoreFromSQL(context.Background(), "", t.TempDir())
 	if err != nil {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented owners from deleting a different owner account.
  * Preserved the ability for an owner to delete their own account.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->