### PR TITLE
[relay] Add a release-wired UBI image variant

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -311,6 +311,41 @@ dockers_v2:
        "org.opencontainers.image.revision": "{{.FullCommit}}"
        "org.opencontainers.image.source": "{{.GitURL}}"
        "maintainer": "dev@netbird.io"
+   - id: relay-ubi
+     disable: "{{ .Env.SKIP_DOCKER_PUSH }}"
+     ids:
+       - netbird-relay
+     images:
+       - netbirdio/relay
+       - ghcr.io/netbirdio/relay
+     tags:
+       - "{{ .Version }}-ubi"
+       - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}ubi-latest{{ end }}"
+     dockerfile: relay/Dockerfile.ubi
+     platforms:
+       - linux/amd64
+     build_args:
+       VERSION: "{{ .Version }}"
+       RELEASE: "{{ .Timestamp }}"
+     hooks:
+       pre:
+         - cmd: 'sh relay/collect-licenses.sh "{{ .ContextDir }}/licenses"'
+           env:
+             - GOOS=linux
+             - GOARCH=amd64
+             - CGO_ENABLED=0
+     labels:
+       "org.opencontainers.image.created": "{{.Date}}"
+       "org.opencontainers.image.version": "{{.Version}}"
+       "org.opencontainers.image.revision": "{{.FullCommit}}"
+       "org.opencontainers.image.source": "{{.GitURL}}"
+     annotations:
+       "org.opencontainers.image.created": "{{.Date}}"
+       "org.opencontainers.image.title": "{{.ProjectName}}"
+       "org.opencontainers.image.version": "{{.Version}}"
+       "org.opencontainers.image.revision": "{{.FullCommit}}"
+       "org.opencontainers.image.source": "{{.GitURL}}"
+       "maintainer": "dev@netbird.io"
    - id: signal
      disable: "{{ .Env.SKIP_DOCKER_PUSH }}"
      ids:

--- a/relay/Dockerfile.ubi
+++ b/relay/Dockerfile.ubi
@@ -1,0 +1,23 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7fbeae18dc9476399f565e68255f602a3374ea8614ba3d14843565131a13ff93
+
+ARG TARGETPLATFORM
+ARG VERSION=dev
+ARG RELEASE=1
+
+LABEL name="netbird-relay" \
+      maintainer="NetBird <dev@netbird.io>" \
+      vendor="NetBird GmbH" \
+      version="${VERSION}" \
+      release="${RELEASE}" \
+      summary="NetBird Relay server" \
+      description="NetBird Relay carries traffic when a direct peer connection is unavailable."
+
+COPY --chmod=0555 ${TARGETPLATFORM}/netbird-relay /go/bin/netbird-relay
+COPY licenses/AGPL-3.0.txt licenses/BSD-3-Clause.txt licenses/Go-LICENSE licenses/Go-PATENTS /licenses/
+COPY licenses/third_party/ /licenses/third_party/
+RUN chmod -R a+rX /licenses
+
+USER 65532
+STOPSIGNAL SIGTERM
+ENTRYPOINT [ "/go/bin/netbird-relay" ]
+ENV NB_LOG_FILE=console

--- a/relay/collect-licenses.sh
+++ b/relay/collect-licenses.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+	printf '%s\n' "usage: $0 OUTPUT_DIRECTORY" >&2
+	exit 2
+fi
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+output_name=$(basename "$1")
+case "$output_name" in
+	"" | . | .. | /)
+		printf '%s\n' "OUTPUT_DIRECTORY must name a directory" >&2
+		exit 2
+		;;
+esac
+output_parent=$(CDPATH= cd -- "$(dirname "$1")" && pwd)
+output="$output_parent/$output_name"
+modules=$(mktemp "${TMPDIR:-/tmp}/netbird-relay-licenses.modules.XXXXXX")
+sorted_modules=$(mktemp "${TMPDIR:-/tmp}/netbird-relay-licenses.sorted.XXXXXX")
+trap 'rm -f "$modules" "$sorted_modules"' EXIT HUP INT TERM
+
+if [ -e "$output" ] || [ -L "$output" ]; then
+	printf 'output directory already exists: %s\n' "$output" >&2
+	exit 1
+fi
+mkdir "$output"
+mkdir "$output/third_party"
+
+cp "$repo_root/relay/LICENSE" "$output/AGPL-3.0.txt"
+cp "$repo_root/LICENSE" "$output/BSD-3-Clause.txt"
+
+cd "$repo_root"
+GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64} CGO_ENABLED=${CGO_ENABLED:-0} \
+	go list -deps -f '{{with .Module}}{{if .Replace}}{{.Replace.Path}}{{"\t"}}{{.Replace.Version}}{{"\t"}}{{.Replace.Dir}}{{else}}{{.Path}}{{"\t"}}{{.Version}}{{"\t"}}{{.Dir}}{{end}}{{end}}' ./relay >"$modules"
+LC_ALL=C sort -u "$modules" >"$sorted_modules"
+
+goroot=$(go env GOROOT)
+for term in LICENSE PATENTS; do
+	if [ ! -f "$goroot/$term" ]; then
+		printf 'missing Go standard-library term: %s\n' "$goroot/$term" >&2
+		exit 1
+	fi
+	cp "$goroot/$term" "$output/Go-$term"
+done
+
+while IFS='	' read -r module version module_dir; do
+	[ -n "$module" ] || continue
+	[ "$module" = "github.com/netbirdio/netbird" ] && continue
+
+	if [ -z "$version" ] || [ ! -d "$module_dir" ]; then
+		printf 'cannot collect terms for module %s at version %s\n' "$module" "$version" >&2
+		exit 1
+	fi
+
+	destination="$output/third_party/$module/$version"
+	mkdir -p "$destination"
+	printf 'module: %s\nversion: %s\n' "$module" "$version" >"$destination/MODULE"
+
+	found=false
+	for term in \
+		"$module_dir"/LICENSE* "$module_dir"/License* "$module_dir"/license* \
+		"$module_dir"/LICENCE* "$module_dir"/Licence* "$module_dir"/licence* \
+		"$module_dir"/COPYING* "$module_dir"/Copying* "$module_dir"/copying* \
+		"$module_dir"/NOTICE* "$module_dir"/Notice* "$module_dir"/notice* \
+		"$module_dir"/PATENTS* "$module_dir"/Patents* "$module_dir"/patents*; do
+		[ -f "$term" ] || continue
+		cp "$term" "$destination/"
+		found=true
+	done
+
+	if [ "$found" = false ]; then
+		printf 'no root license terms found for module %s at %s\n' "$module" "$module_dir" >&2
+		exit 1
+	fi
+done <"$sorted_modules"


### PR DESCRIPTION
## Describe your changes

Add an explicit UBI-based relay image for the internal Red Hat certification-readiness requirement without changing the existing relay images or deployment defaults. The variant uses a pinned UBI base, a non-root user, applicable license files and required image metadata, with its own AMD64 GoReleaser build entry and distinct UBI tags.

## Issue ticket number and link

---

## Stack

<!-- branch-stack -->

Second layer: relay. Base: jnfrati/ubi-signal. The signal layer targets main.

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

Documentation for the new UBI image variant remains pending before review. Neither option is checked because no docs PR has been opened and this user-facing variant does need documentation. The documentation acknowledgement gate may therefore remain red while this PR is a draft.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/___


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

