### PR TITLE
[management] Restrict embedded IdP to the minimal set of OAuth2 grants

### DIFF
--- a/idp/dex/config.go
+++ b/idp/dex/config.go
@@ -7,16 +7,16 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
-	"golang.org/x/crypto/bcrypt"
-	"gopkg.in/yaml.v3"
-
 	"github.com/dexidp/dex/server"
 	"github.com/dexidp/dex/storage"
 	"github.com/dexidp/dex/storage/sql"
+	"golang.org/x/crypto/bcrypt"
+	"gopkg.in/yaml.v3"
 
 	"github.com/netbirdio/netbird/idp/dex/web"
 )
@@ -226,10 +226,11 @@ func (p *Password) UnmarshalYAML(node *yaml.Node) error {
 
 // Connector is a connector configuration that can unmarshal YAML dynamically.
 type Connector struct {
-	Type   string                 `yaml:"type" json:"type"`
-	Name   string                 `yaml:"name" json:"name"`
-	ID     string                 `yaml:"id" json:"id"`
-	Config map[string]interface{} `yaml:"config" json:"config"`
+	Type       string                 `yaml:"type" json:"type"`
+	Name       string                 `yaml:"name" json:"name"`
+	ID         string                 `yaml:"id" json:"id"`
+	Config     map[string]interface{} `yaml:"config" json:"config"`
+	GrantTypes []string               `yaml:"grantTypes" json:"grantTypes"`
 }
 
 // ToStorageConnector converts a Connector to storage.Connector type.
@@ -243,11 +244,17 @@ func (c *Connector) ToStorageConnector() (storage.Connector, error) {
 		return storage.Connector{}, fmt.Errorf("failed to marshal connector config: %v", err)
 	}
 
+	grantTypes := c.GrantTypes
+	if len(grantTypes) == 0 {
+		grantTypes = slices.Clone(DefaultGrantTypes)
+	}
+
 	return storage.Connector{
-		ID:     c.ID,
-		Type:   dexType,
-		Name:   c.Name,
-		Config: data,
+		ID:         c.ID,
+		Type:       dexType,
+		Name:       c.Name,
+		Config:     data,
+		GrantTypes: grantTypes,
 	}, nil
 }
 

--- a/idp/dex/connector.go
+++ b/idp/dex/connector.go
@@ -119,12 +119,17 @@ func (p *Provider) UpdateConnector(ctx context.Context, cfg *ConnectorConfig) er
 			name = old.Name
 		}
 
+		grantTypes := old.GrantTypes
+		if len(grantTypes) == 0 {
+			grantTypes = slices.Clone(DefaultGrantTypes)
+		}
+
 		return storage.Connector{
 			ID:         cfg.ID,
 			Type:       old.Type,
 			Name:       name,
 			Config:     configData,
-			GrantTypes: old.GrantTypes,
+			GrantTypes: grantTypes,
 		}, nil
 	}); err != nil {
 		return fmt.Errorf("failed to update connector: %w", err)

--- a/idp/dex/connector.go
+++ b/idp/dex/connector.go
@@ -6,10 +6,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/dexidp/dex/storage"
 )
+
+// DefaultGrantTypes is the minimal set of OAuth2 grants in use. Dex enables every
+// grant it supports when the list is empty.
+var DefaultGrantTypes = []string{
+	"authorization_code", // dashboard login
+	"refresh_token",      // session renewal
+	"urn:ietf:params:oauth:grant-type:device_code", // CLI login
+}
 
 // ConnectorConfig represents the configuration for an identity provider connector
 type ConnectorConfig struct {
@@ -111,10 +120,11 @@ func (p *Provider) UpdateConnector(ctx context.Context, cfg *ConnectorConfig) er
 		}
 
 		return storage.Connector{
-			ID:     cfg.ID,
-			Type:   old.Type,
-			Name:   name,
-			Config: configData,
+			ID:         cfg.ID,
+			Type:       old.Type,
+			Name:       name,
+			Config:     configData,
+			GrantTypes: old.GrantTypes,
 		}, nil
 	}); err != nil {
 		return fmt.Errorf("failed to update connector: %w", err)
@@ -200,7 +210,13 @@ func (p *Provider) buildStorageConnector(cfg *ConnectorConfig) (storage.Connecto
 		return storage.Connector{}, err
 	}
 
-	return storage.Connector{ID: cfg.ID, Type: dexType, Name: cfg.Name, Config: configData}, nil
+	return storage.Connector{
+		ID:         cfg.ID,
+		Type:       dexType,
+		Name:       cfg.Name,
+		Config:     configData,
+		GrantTypes: slices.Clone(DefaultGrantTypes),
+	}, nil
 }
 
 // resolveRedirectURI returns the redirect URI, using a default if not provided
@@ -423,10 +439,36 @@ func ensureStaticConnectors(ctx context.Context, stor storage.Storage, connector
 		if err := stor.UpdateConnector(ctx, conn.ID, func(old storage.Connector) (storage.Connector, error) {
 			old.Name = storConn.Name
 			old.Config = storConn.Config
+			old.GrantTypes = storConn.GrantTypes
 			return old, nil
 		}); err != nil {
 			return fmt.Errorf("failed to update connector %s: %w", conn.ID, err)
 		}
 	}
+	return nil
+}
+
+// ensureConnectorGrantTypes backfills DefaultGrantTypes onto stored connectors
+// that have no grants set. An explicit allowlist is left untouched.
+func ensureConnectorGrantTypes(ctx context.Context, stor storage.Storage) error {
+	connectors, err := stor.ListConnectors(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list connectors: %w", err)
+	}
+
+	for _, conn := range connectors {
+		if len(conn.GrantTypes) > 0 {
+			continue
+		}
+		if err := stor.UpdateConnector(ctx, conn.ID, func(old storage.Connector) (storage.Connector, error) {
+			if len(old.GrantTypes) == 0 {
+				old.GrantTypes = slices.Clone(DefaultGrantTypes)
+			}
+			return old, nil
+		}); err != nil {
+			return fmt.Errorf("failed to set grant types on connector %s: %w", conn.ID, err)
+		}
+	}
+
 	return nil
 }

--- a/idp/dex/connector_test.go
+++ b/idp/dex/connector_test.go
@@ -252,6 +252,28 @@ func TestConnectorGrantTypes(t *testing.T) {
 			"an empty list would re-enable token exchange for this connector")
 	})
 
+	t.Run("updating a connector stored without an allowlist sets the default", func(t *testing.T) {
+		p, cleanup := newTestProvider(t)
+		defer cleanup()
+
+		// Mimic a connector written by an older release.
+		require.NoError(t, p.storage.CreateConnector(ctx, storage.Connector{
+			ID:     "legacy-oidc",
+			Type:   "oidc",
+			Name:   "Legacy",
+			Config: []byte(`{"issuer":"https://accounts.example.com","clientID":"client-id"}`),
+		}))
+
+		require.NoError(t, p.UpdateConnector(ctx, &ConnectorConfig{
+			ID:           "legacy-oidc",
+			ClientSecret: "new-secret",
+		}))
+
+		conn, err := p.storage.GetConnector(ctx, "legacy-oidc")
+		require.NoError(t, err)
+		assert.Equal(t, DefaultGrantTypes, conn.GrantTypes)
+	})
+
 	t.Run("backfills connectors stored without an allowlist", func(t *testing.T) {
 		p, cleanup := newTestProvider(t)
 		defer cleanup()

--- a/idp/dex/connector_test.go
+++ b/idp/dex/connector_test.go
@@ -203,3 +203,94 @@ func TestUpdateConnector_AllowsSameTypeUpdate(t *testing.T) {
 	require.NoError(t, json.Unmarshal(conn.Config, &m))
 	assert.Equal(t, "https://login.microsoftonline.com/new/v2.0", m["issuer"])
 }
+
+func TestConnectorGrantTypes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("created connectors get the default allowlist", func(t *testing.T) {
+		p, cleanup := newTestProvider(t)
+		defer cleanup()
+
+		_, err := p.CreateConnector(ctx, &ConnectorConfig{
+			ID:       "entra-test",
+			Name:     "Entra",
+			Type:     "entra",
+			Issuer:   "https://login.microsoftonline.com/tid/v2.0",
+			ClientID: "client-id",
+		})
+		require.NoError(t, err)
+
+		conn, err := p.storage.GetConnector(ctx, "entra-test")
+		require.NoError(t, err)
+		assert.Equal(t, DefaultGrantTypes, conn.GrantTypes)
+		assert.NotContains(t, conn.GrantTypes, "urn:ietf:params:oauth:grant-type:token-exchange")
+	})
+
+	t.Run("updates do not reset the allowlist", func(t *testing.T) {
+		p, cleanup := newTestProvider(t)
+		defer cleanup()
+
+		_, err := p.CreateConnector(ctx, &ConnectorConfig{
+			ID:           "entra-test",
+			Name:         "Entra",
+			Type:         "entra",
+			Issuer:       "https://login.microsoftonline.com/tid/v2.0",
+			ClientID:     "client-id",
+			ClientSecret: "old-secret",
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, p.UpdateConnector(ctx, &ConnectorConfig{
+			ID:           "entra-test",
+			Type:         "entra",
+			ClientSecret: "new-secret",
+		}))
+
+		conn, err := p.storage.GetConnector(ctx, "entra-test")
+		require.NoError(t, err)
+		assert.Equal(t, DefaultGrantTypes, conn.GrantTypes,
+			"an empty list would re-enable token exchange for this connector")
+	})
+
+	t.Run("backfills connectors stored without an allowlist", func(t *testing.T) {
+		p, cleanup := newTestProvider(t)
+		defer cleanup()
+
+		// Mimic a connector written by an older release.
+		require.NoError(t, p.storage.CreateConnector(ctx, storage.Connector{
+			ID:     "legacy-oidc",
+			Type:   "oidc",
+			Name:   "Legacy",
+			Config: []byte(`{"issuer":"https://accounts.example.com"}`),
+		}))
+		require.NoError(t, p.storage.CreateConnector(ctx, storage.Connector{
+			ID:         "opted-in",
+			Type:       "oidc",
+			Name:       "Opted In",
+			Config:     []byte(`{"issuer":"https://accounts.example.com"}`),
+			GrantTypes: []string{"urn:ietf:params:oauth:grant-type:token-exchange"},
+		}))
+
+		require.NoError(t, ensureConnectorGrantTypes(ctx, p.storage))
+
+		legacy, err := p.storage.GetConnector(ctx, "legacy-oidc")
+		require.NoError(t, err)
+		assert.Equal(t, DefaultGrantTypes, legacy.GrantTypes)
+
+		optedIn, err := p.storage.GetConnector(ctx, "opted-in")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"urn:ietf:params:oauth:grant-type:token-exchange"}, optedIn.GrantTypes,
+			"an explicit operator allowlist must not be overwritten")
+	})
+
+	t.Run("static connectors default and honour an explicit allowlist", func(t *testing.T) {
+		conn, err := (&Connector{ID: "static-oidc", Type: "oidc", Name: "Static"}).ToStorageConnector()
+		require.NoError(t, err)
+		assert.Equal(t, DefaultGrantTypes, conn.GrantTypes)
+
+		explicit := []string{"authorization_code", "urn:ietf:params:oauth:grant-type:token-exchange"}
+		conn, err = (&Connector{ID: "static-oidc", Type: "oidc", Name: "Static", GrantTypes: explicit}).ToStorageConnector()
+		require.NoError(t, err)
+		assert.Equal(t, explicit, conn.GrantTypes)
+	})
+}

--- a/idp/dex/provider.go
+++ b/idp/dex/provider.go
@@ -240,7 +240,10 @@ func initializeStorage(ctx context.Context, stor storage.Storage, cfg *YAMLConfi
 	if err := ensureStaticClients(ctx, stor, cfg.StaticClients); err != nil {
 		return err
 	}
-	return ensureStaticConnectors(ctx, stor, cfg.StaticConnectors)
+	if err := ensureStaticConnectors(ctx, stor, cfg.StaticConnectors); err != nil {
+		return err
+	}
+	return ensureConnectorGrantTypes(ctx, stor)
 }
 
 // ensureStaticPasswords creates or updates static passwords in storage

--- a/idp/dex/provider.go
+++ b/idp/dex/provider.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -123,7 +124,7 @@ func NewProvider(ctx context.Context, config *Config) (*Provider, error) {
 		Storage:                    stor,
 		SkipApprovalScreen:         true,
 		SupportedResponseTypes:     []string{"code"},
-		AllowedGrantTypes:          DefaultGrantTypes,
+		AllowedGrantTypes:          slices.Clone(DefaultGrantTypes),
 		ContinueOnConnectorFailure: true,
 		Logger:                     logger,
 		PrometheusRegistry:         prometheus.NewRegistry(),

--- a/idp/dex/provider.go
+++ b/idp/dex/provider.go
@@ -90,6 +90,11 @@ func NewProvider(ctx context.Context, config *Config) (*Provider, error) {
 		return nil, fmt.Errorf("failed to ensure local connector: %w", err)
 	}
 
+	if err := ensureConnectorGrantTypes(ctx, stor); err != nil {
+		stor.Close()
+		return nil, fmt.Errorf("failed to ensure connector grant types: %w", err)
+	}
+
 	// Ensure issuer ends with /oauth2 for proper path mounting
 	issuer := strings.TrimSuffix(config.Issuer, "/")
 	if !strings.HasSuffix(issuer, "/oauth2") {
@@ -118,6 +123,7 @@ func NewProvider(ctx context.Context, config *Config) (*Provider, error) {
 		Storage:                    stor,
 		SkipApprovalScreen:         true,
 		SupportedResponseTypes:     []string{"code"},
+		AllowedGrantTypes:          DefaultGrantTypes,
 		ContinueOnConnectorFailure: true,
 		Logger:                     logger,
 		PrometheusRegistry:         prometheus.NewRegistry(),

--- a/idp/dex/provider_test.go
+++ b/idp/dex/provider_test.go
@@ -245,7 +245,7 @@ web:
 enablePasswordDB: true
 `
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	err = os.WriteFile(configPath, []byte(yamlContent), 0644)
+	err = os.WriteFile(configPath, []byte(yamlContent), 0o644)
 	require.NoError(t, err)
 
 	// Load config and create provider
@@ -317,7 +317,7 @@ connectors:
     redirectURI: http://localhost:5556/dex/callback
 `
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	err = os.WriteFile(configPath, []byte(yamlContent), 0644)
+	err = os.WriteFile(configPath, []byte(yamlContent), 0o644)
 	require.NoError(t, err)
 
 	yamlConfig, err := LoadConfig(configPath)
@@ -375,7 +375,7 @@ connectors:
     clientSecret: original-secret
 `
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	err = os.WriteFile(configPath, []byte(yamlContent1), 0644)
+	err = os.WriteFile(configPath, []byte(yamlContent1), 0o644)
 	require.NoError(t, err)
 
 	yamlConfig1, err := LoadConfig(configPath)
@@ -417,7 +417,7 @@ connectors:
     clientID: updated-client-id
     clientSecret: updated-secret
 `
-	err = os.WriteFile(configPath, []byte(yamlContent2), 0644)
+	err = os.WriteFile(configPath, []byte(yamlContent2), 0o644)
 	require.NoError(t, err)
 
 	yamlConfig2, err := LoadConfig(configPath)
@@ -483,7 +483,7 @@ connectors:
     clientSecret: google-secret
 `
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	err = os.WriteFile(configPath, []byte(yamlContent), 0644)
+	err = os.WriteFile(configPath, []byte(yamlContent), 0o644)
 	require.NoError(t, err)
 
 	yamlConfig, err := LoadConfig(configPath)
@@ -549,7 +549,7 @@ web:
 enablePasswordDB: true
 `
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	err = os.WriteFile(configPath, []byte(yamlContent), 0644)
+	err = os.WriteFile(configPath, []byte(yamlContent), 0o644)
 	require.NoError(t, err)
 
 	yamlConfig, err := LoadConfig(configPath)
@@ -610,7 +610,7 @@ web:
 enablePasswordDB: true
 `
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	err = os.WriteFile(configPath, []byte(yamlContent), 0644)
+	err = os.WriteFile(configPath, []byte(yamlContent), 0o644)
 	require.NoError(t, err)
 
 	yamlConfig, err := LoadConfig(configPath)
@@ -668,7 +668,7 @@ enablePasswordDB: true
 ` + grantTypesYAML
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0644))
+	require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0o644))
 
 	yamlConfig, err := LoadConfig(configPath)
 	require.NoError(t, err)
@@ -716,4 +716,43 @@ func TestHandler_AllowsDeviceEndpointsWhenGrantsDefault(t *testing.T) {
 	rec := httptest.NewRecorder()
 	provider.Handler().ServeHTTP(rec, req)
 	assert.NotEqual(t, http.StatusNotFound, rec.Code)
+}
+
+func TestInitializeStorage_SetsConnectorGrantTypes(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	yamlContent := `
+issuer: http://localhost:5556/dex
+storage:
+  type: sqlite3
+  config:
+    file: ` + filepath.Join(tmpDir, "dex.db") + `
+web:
+  http: 127.0.0.1:5556
+enablePasswordDB: true
+connectors:
+- type: oidc
+  id: my-oidc
+  name: My OIDC Provider
+  config:
+    issuer: https://accounts.example.com
+    clientID: test-client-id
+`
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0o644))
+
+	yamlConfig, err := LoadConfig(configPath)
+	require.NoError(t, err)
+
+	stor := openTestStorage(t, tmpDir)
+	defer stor.Close()
+	require.NoError(t, initializeStorage(ctx, stor, yamlConfig))
+
+	connectors, err := stor.ListConnectors(ctx)
+	require.NoError(t, err)
+	require.Len(t, connectors, 2)
+	for _, conn := range connectors {
+		assert.Equal(t, DefaultGrantTypes, conn.GrantTypes, "connector %s", conn.ID)
+	}
 }

--- a/idp/dex/provider_test.go
+++ b/idp/dex/provider_test.go
@@ -756,3 +756,30 @@ connectors:
 		assert.Equal(t, DefaultGrantTypes, conn.GrantTypes, "connector %s", conn.ID)
 	}
 }
+
+func TestNewProvider_SetsGrantTypes(t *testing.T) {
+	ctx := context.Background()
+
+	provider, err := NewProvider(ctx, &Config{
+		Issuer:  "https://example.com/oauth2",
+		Port:    5556,
+		DataDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer func() { _ = provider.Stop(ctx) }()
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/.well-known/openid-configuration", nil)
+	rec := httptest.NewRecorder()
+	provider.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var discovery struct {
+		GrantTypes []string `json:"grant_types_supported"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &discovery))
+	assert.ElementsMatch(t, DefaultGrantTypes, discovery.GrantTypes)
+
+	local, err := provider.storage.GetConnector(ctx, "local")
+	require.NoError(t, err)
+	assert.Equal(t, DefaultGrantTypes, local.GrantTypes)
+}

--- a/idp/dex/provider_test.go
+++ b/idp/dex/provider_test.go
@@ -766,7 +766,7 @@ func TestNewProvider_SetsGrantTypes(t *testing.T) {
 		DataDir: t.TempDir(),
 	})
 	require.NoError(t, err)
-	defer func() { _ = provider.Stop(ctx) }()
+	defer func() { _ = provider.storage.Close() }()
 
 	req := httptest.NewRequest(http.MethodGet, "/oauth2/.well-known/openid-configuration", nil)
 	rec := httptest.NewRecorder()

--- a/management/server/idp/embedded.go
+++ b/management/server/idp/embedded.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/dexidp/dex/storage"
@@ -173,7 +174,7 @@ func (c *EmbeddedIdPConfig) ToYAMLConfig() (*dex.YAMLConfig, error) {
 	// the minimal set instead. Operators can still opt in to more by setting it.
 	grantTypes := c.GrantTypes
 	if len(grantTypes) == 0 {
-		grantTypes = dex.DefaultGrantTypes
+		grantTypes = slices.Clone(dex.DefaultGrantTypes)
 	}
 
 	cfg := &dex.YAMLConfig{

--- a/management/server/idp/embedded.go
+++ b/management/server/idp/embedded.go
@@ -79,7 +79,7 @@ type EmbeddedIdPConfig struct {
 	DashboardPostLogoutRedirectURIs []string
 	// StaticConnectors are additional connectors to seed during initialization
 	StaticConnectors []dex.Connector
-	// GrantTypes restricts allowed OAuth2 grants; empty means all (Dex default). Omit the
+	// GrantTypes restricts allowed OAuth2 grants; empty means dex.DefaultGrantTypes. Omit the
 	// device_code grant to disable the device flow; keep authorization_code and refresh_token.
 	GrantTypes []string
 }
@@ -169,6 +169,13 @@ func (c *EmbeddedIdPConfig) ToYAMLConfig() (*dex.YAMLConfig, error) {
 	redirectURIs = append(redirectURIs, cliRedirectURIs...)
 	redirectURIs = append(redirectURIs, dashboardRedirectURIs...)
 
+	// An empty grant list makes Dex enable every supported grant, so fall back to
+	// the minimal set instead. Operators can still opt in to more by setting it.
+	grantTypes := c.GrantTypes
+	if len(grantTypes) == 0 {
+		grantTypes = dex.DefaultGrantTypes
+	}
+
 	cfg := &dex.YAMLConfig{
 		Issuer: c.Issuer,
 		Storage: dex.Storage{
@@ -181,7 +188,7 @@ func (c *EmbeddedIdPConfig) ToYAMLConfig() (*dex.YAMLConfig, error) {
 		},
 		OAuth2: dex.OAuth2{
 			SkipApprovalScreen: true,
-			GrantTypes:         c.GrantTypes,
+			GrantTypes:         grantTypes,
 		},
 		Frontend: dex.Frontend{
 			Issuer: "NetBird",

--- a/management/server/idp/embedded_test.go
+++ b/management/server/idp/embedded_test.go
@@ -3,8 +3,13 @@ package idp
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -694,5 +699,97 @@ func TestEmbeddedIdPManager_LocalAuthDisabled(t *testing.T) {
 		_, err = manager2.CreateUserWithPassword(ctx, "newuser@example.com", "SecurePass123!", "New User")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "local user creation is disabled")
+	})
+}
+
+func TestEmbeddedIdPConfig_ToYAMLConfig_GrantTypes(t *testing.T) {
+	newConfig := func(grantTypes []string) *EmbeddedIdPConfig {
+		return &EmbeddedIdPConfig{
+			Enabled:    true,
+			Issuer:     "https://example.com/oauth2",
+			GrantTypes: grantTypes,
+			Storage: EmbeddedStorageConfig{
+				Type: "sqlite3",
+				Config: EmbeddedStorageTypeConfig{
+					File: filepath.Join(t.TempDir(), "dex.db"),
+				},
+			},
+		}
+	}
+
+	t.Run("defaults to the minimal allowlist without token exchange", func(t *testing.T) {
+		yamlConfig, err := newConfig(nil).ToYAMLConfig()
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{
+			"authorization_code",
+			"refresh_token",
+			"urn:ietf:params:oauth:grant-type:device_code",
+		}, yamlConfig.OAuth2.GrantTypes)
+		assert.NotContains(t, yamlConfig.OAuth2.GrantTypes, "urn:ietf:params:oauth:grant-type:token-exchange")
+	})
+
+	t.Run("empty slice also falls back to the default", func(t *testing.T) {
+		yamlConfig, err := newConfig([]string{}).ToYAMLConfig()
+		require.NoError(t, err)
+		assert.Equal(t, dex.DefaultGrantTypes, yamlConfig.OAuth2.GrantTypes)
+	})
+
+	t.Run("explicit operator allowlist is preserved", func(t *testing.T) {
+		grantTypes := []string{"authorization_code", "refresh_token"}
+		yamlConfig, err := newConfig(grantTypes).ToYAMLConfig()
+		require.NoError(t, err)
+		assert.Equal(t, grantTypes, yamlConfig.OAuth2.GrantTypes)
+	})
+}
+
+func TestEmbeddedIdPManager_TokenExchangeGrantDisabledByDefault(t *testing.T) {
+	ctx := context.Background()
+
+	manager, err := NewEmbeddedIdPManager(ctx, &EmbeddedIdPConfig{
+		Enabled: true,
+		Issuer:  "http://localhost:5556/oauth2",
+		Storage: EmbeddedStorageConfig{
+			Type: "sqlite3",
+			Config: EmbeddedStorageTypeConfig{
+				File: filepath.Join(t.TempDir(), "dex.db"),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	defer func() { _ = manager.Stop(ctx) }()
+
+	t.Run("token endpoint rejects the token-exchange grant", func(t *testing.T) {
+		form := url.Values{
+			"grant_type":           {"urn:ietf:params:oauth:grant-type:token-exchange"},
+			"client_id":            {StaticClientDashboard},
+			"connector_id":         {"external-oidc"},
+			"scope":                {"openid profile email"},
+			"subject_token":        {"not-a-real-token"},
+			"subject_token_type":   {"urn:ietf:params:oauth:token-type:id_token"},
+			"requested_token_type": {"urn:ietf:params:oauth:token-type:id_token"},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/oauth2/token", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		manager.Handler().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "unsupported_grant_type")
+	})
+
+	t.Run("discovery does not advertise the token-exchange grant", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/oauth2/.well-known/openid-configuration", nil)
+		rec := httptest.NewRecorder()
+		manager.Handler().ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var discovery struct {
+			GrantTypes []string `json:"grant_types_supported"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &discovery))
+
+		assert.NotContains(t, discovery.GrantTypes, "urn:ietf:params:oauth:grant-type:token-exchange")
+		assert.ElementsMatch(t, dex.DefaultGrantTypes, discovery.GrantTypes)
 	})
 }

--- a/management/server/idp/embedded_test.go
+++ b/management/server/idp/embedded_test.go
@@ -748,7 +748,7 @@ func TestEmbeddedIdPManager_TokenExchangeGrantDisabledByDefault(t *testing.T) {
 
 	manager, err := NewEmbeddedIdPManager(ctx, &EmbeddedIdPConfig{
 		Enabled: true,
-		Issuer:  "http://localhost:5556/oauth2",
+		Issuer:  "https://example.com/oauth2",
 		Storage: EmbeddedStorageConfig{
 			Type: "sqlite3",
 			Config: EmbeddedStorageTypeConfig{


### PR DESCRIPTION
## Describe your changes

The embedded IdP relied on Dex's default grant handling, which enables every grant Dex supports when no list is configured. This narrows both the server and the connector configuration down to the grants we actually use.

`DefaultGrantTypes` in `idp/dex/connector.go` is the single source of truth for that set: `authorization_code` for the dashboard, the device flow for the CLI, and `refresh_token` for session renewal.

`EmbeddedIdPConfig.ToYAMLConfig()` falls back to that set when `server.auth.grantTypes` is unset; an explicit list still wins, so the device-flow opt-out is unchanged (#6809)

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable OAuth grant-type allowlists for identity provider connectors.
  * New connectors default to authorization code, refresh token, and device code grants.
  * Existing connectors without an explicit allowlist receive these secure defaults.
  * Explicitly configured grant lists are preserved during updates and synchronization.

* **Bug Fixes**
  * Token exchange is disabled by default and omitted from OpenID discovery unless explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->