### PR TITLE
[client] Report a missing OS user in the SSH login error message

### DIFF
--- a/client/ssh/server/session_handlers.go
+++ b/client/ssh/server/session_handlers.go
@@ -119,8 +119,12 @@ func (s *Server) handlePrivError(logger *log.Entry, session ssh.Session, err err
 // buildUserLookupErrorMessage creates appropriate user-facing error messages based on error type
 func (s *Server) buildUserLookupErrorMessage(err error) string {
 	var privilegedErr *PrivilegedUserError
+	var notFoundErr *UserNotFoundError
 
 	switch {
+	case errors.As(err, &notFoundErr):
+		return fmt.Sprintf("user %q does not exist on this host\n", notFoundErr.Username)
+
 	case errors.As(err, &privilegedErr):
 		if privilegedErr.Username == "root" {
 			return "root login is disabled on this SSH server\n"


### PR DESCRIPTION
## Describe your changes

The session handler mapped a failed user lookup to the generic "User authentication failed", which reads as a rejected SSO login even though the JWT was accepted. Name the missing user instead.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH authentication error messages when the specified user does not exist on the host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->