### PR TITLE
[client] Add a release-wired rootless UBI image variant

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -289,6 +289,43 @@ dockers_v2:
        "org.opencontainers.image.revision": "{{.FullCommit}}"
        "org.opencontainers.image.source": "{{.GitURL}}"
        "maintainer": "dev@netbird.io"
+   - id: netbird-rootless-ubi
+     disable: "{{ .Env.SKIP_DOCKER_PUSH }}"
+     ids:
+       - netbird
+     images:
+       - netbirdio/netbird
+       - ghcr.io/netbirdio/netbird
+     tags:
+       - "{{ .Version }}-rootless-ubi"
+       - "{{ if eq .Env.SKIP_PUBLISH \"false\" }}rootless-ubi-latest{{ end }}"
+     dockerfile: client/Dockerfile-rootless.ubi
+     extra_files:
+       - client/netbird-entrypoint.sh
+     platforms:
+       - linux/amd64
+     build_args:
+       VERSION: "{{ .Version }}"
+       RELEASE: "{{ .Timestamp }}"
+     hooks:
+       pre:
+         - cmd: 'sh client/collect-licenses.sh "{{ .ContextDir }}/licenses"'
+           env:
+             - GOOS=linux
+             - GOARCH=amd64
+             - CGO_ENABLED=0
+     labels:
+       "org.opencontainers.image.created": "{{.Date}}"
+       "org.opencontainers.image.version": "{{.Version}}"
+       "org.opencontainers.image.revision": "{{.FullCommit}}"
+       "org.opencontainers.image.source": "{{.GitURL}}"
+     annotations:
+       "org.opencontainers.image.created": "{{.Date}}"
+       "org.opencontainers.image.title": "{{.ProjectName}}"
+       "org.opencontainers.image.version": "{{.Version}}"
+       "org.opencontainers.image.revision": "{{.FullCommit}}"
+       "org.opencontainers.image.source": "{{.GitURL}}"
+       "maintainer": "dev@netbird.io"
    - id: relay
      disable: "{{ .Env.SKIP_DOCKER_PUSH }}"
      ids:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -304,15 +304,15 @@ dockers_v2:
        - client/netbird-entrypoint.sh
      platforms:
        - linux/amd64
+       - linux/arm64
      build_args:
        VERSION: "{{ .Version }}"
        RELEASE: "{{ .Timestamp }}"
      hooks:
        pre:
-         - cmd: 'sh client/collect-licenses.sh "{{ .ContextDir }}/licenses"'
+         - cmd: 'sh client/collect-licenses.sh "{{ .ContextDir }}/licenses" amd64 arm64'
            env:
              - GOOS=linux
-             - GOARCH=amd64
              - CGO_ENABLED=0
      labels:
        "org.opencontainers.image.created": "{{.Date}}"

--- a/client/Dockerfile-rootless.ubi
+++ b/client/Dockerfile-rootless.ubi
@@ -1,0 +1,45 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7fbeae18dc9476399f565e68255f602a3374ea8614ba3d14843565131a13ff93
+
+ARG TARGETPLATFORM
+ARG NETBIRD_BINARY=$TARGETPLATFORM/netbird
+ARG VERSION=dev
+ARG RELEASE=1
+
+LABEL name="netbird-rootless" \
+      maintainer="NetBird <dev@netbird.io>" \
+      vendor="NetBird GmbH" \
+      version="${VERSION}" \
+      release="${RELEASE}" \
+      summary="NetBird Rootless Client" \
+      description="NetBird connects devices through an encrypted overlay using userspace networking without a TUN device or network administration capabilities."
+
+RUN microdnf install -y bash ca-certificates && microdnf clean all
+
+COPY --chmod=0555 client/netbird-entrypoint.sh /usr/local/bin/netbird-entrypoint.sh
+COPY --chmod=0555 ${NETBIRD_BINARY} /usr/local/bin/netbird
+COPY licenses/ /licenses/
+# Only application storage is group-writable for arbitrary non-root UIDs.
+# Runtime-created credentials keep the client's restrictive file modes.
+RUN mkdir -p /var/lib/netbird && \
+    chown 1000:0 /var/lib/netbird && \
+    chmod 0770 /var/lib/netbird && \
+    chmod -R a+rX /licenses
+
+WORKDIR /var/lib/netbird
+USER 1000:0
+
+ENV \
+    HOME="/var/lib/netbird" \
+    NETBIRD_BIN="/usr/local/bin/netbird" \
+    NB_USE_NETSTACK_MODE="true" \
+    NB_ENABLE_NETSTACK_LOCAL_FORWARDING="true" \
+    NB_CONFIG="/var/lib/netbird/config.json" \
+    NB_STATE_DIR="/var/lib/netbird" \
+    NB_DAEMON_ADDR="unix:///var/lib/netbird/netbird.sock" \
+    NB_LOG_FILE="console,/var/lib/netbird/client.log" \
+    NB_DISABLE_DNS="true" \
+    NB_ENABLE_CAPTURE="false" \
+    NB_ENTRYPOINT_SERVICE_TIMEOUT="30"
+
+STOPSIGNAL SIGTERM
+ENTRYPOINT ["/usr/local/bin/netbird-entrypoint.sh"]

--- a/client/collect-licenses.sh
+++ b/client/collect-licenses.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+	printf '%s\n' "usage: $0 OUTPUT_DIRECTORY" >&2
+	exit 2
+fi
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+output_name=$(basename "$1")
+case "$output_name" in
+	"" | . | .. | /)
+		printf '%s\n' "OUTPUT_DIRECTORY must name a directory" >&2
+		exit 2
+		;;
+esac
+output_parent=$(CDPATH= cd -- "$(dirname "$1")" && pwd)
+output="$output_parent/$output_name"
+modules=$(mktemp "${TMPDIR:-/tmp}/netbird-client-licenses.modules.XXXXXX")
+sorted_modules=$(mktemp "${TMPDIR:-/tmp}/netbird-client-licenses.sorted.XXXXXX")
+trap 'rm -f "$modules" "$sorted_modules"' EXIT HUP INT TERM
+
+if [ -e "$output" ] || [ -L "$output" ]; then
+	printf 'output directory already exists: %s\n' "$output" >&2
+	exit 1
+fi
+mkdir "$output"
+mkdir "$output/third_party"
+
+cp "$repo_root/LICENSE" "$output/BSD-3-Clause.txt"
+
+cd "$repo_root"
+GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64} CGO_ENABLED=${CGO_ENABLED:-0} \
+	go list -deps -f '{{with .Module}}{{if .Replace}}{{.Replace.Path}}{{"\t"}}{{.Replace.Version}}{{"\t"}}{{.Replace.Dir}}{{else}}{{.Path}}{{"\t"}}{{.Version}}{{"\t"}}{{.Dir}}{{end}}{{end}}' -tags load_wgnt_from_rsrc ./client >"$modules"
+LC_ALL=C sort -u "$modules" >"$sorted_modules"
+
+goroot=$(go env GOROOT)
+for term in LICENSE PATENTS; do
+	if [ ! -f "$goroot/$term" ]; then
+		printf 'missing Go standard-library term: %s\n' "$goroot/$term" >&2
+		exit 1
+	fi
+	cp "$goroot/$term" "$output/Go-$term"
+done
+
+while IFS='	' read -r module version module_dir; do
+	[ -n "$module" ] || continue
+	[ "$module" = "github.com/netbirdio/netbird" ] && continue
+
+	if [ -z "$version" ] || [ ! -d "$module_dir" ]; then
+		printf 'cannot collect terms for module %s at version %s\n' "$module" "$version" >&2
+		exit 1
+	fi
+
+	destination="$output/third_party/$module/$version"
+	mkdir -p "$destination"
+	printf 'module: %s\nversion: %s\n' "$module" "$version" >"$destination/MODULE"
+
+	found=false
+	for term in \
+		"$module_dir"/LICENSE* "$module_dir"/License* "$module_dir"/license* \
+		"$module_dir"/LICENCE* "$module_dir"/Licence* "$module_dir"/licence* \
+		"$module_dir"/COPYING* "$module_dir"/Copying* "$module_dir"/copying* \
+		"$module_dir"/NOTICE* "$module_dir"/Notice* "$module_dir"/notice* \
+		"$module_dir"/PATENTS* "$module_dir"/Patents* "$module_dir"/patents*; do
+		[ -f "$term" ] || continue
+		cp "$term" "$destination/"
+		found=true
+	done
+
+	if [ "$found" = false ]; then
+		printf 'no root license terms found for module %s at %s\n' "$module" "$module_dir" >&2
+		exit 1
+	fi
+done <"$sorted_modules"

--- a/client/collect-licenses.sh
+++ b/client/collect-licenses.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -eu
 
-if [ "$#" -ne 1 ]; then
-	printf '%s\n' "usage: $0 OUTPUT_DIRECTORY" >&2
+if [ "$#" -lt 2 ]; then
+	printf '%s\n' "usage: $0 OUTPUT_DIRECTORY GOARCH..." >&2
 	exit 2
 fi
 
@@ -16,6 +16,7 @@ case "$output_name" in
 esac
 output_parent=$(CDPATH= cd -- "$(dirname "$1")" && pwd)
 output="$output_parent/$output_name"
+shift
 modules=$(mktemp "${TMPDIR:-/tmp}/netbird-client-licenses.modules.XXXXXX")
 sorted_modules=$(mktemp "${TMPDIR:-/tmp}/netbird-client-licenses.sorted.XXXXXX")
 trap 'rm -f "$modules" "$sorted_modules"' EXIT HUP INT TERM
@@ -30,8 +31,10 @@ mkdir "$output/third_party"
 cp "$repo_root/LICENSE" "$output/BSD-3-Clause.txt"
 
 cd "$repo_root"
-GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64} CGO_ENABLED=${CGO_ENABLED:-0} \
-	go list -deps -f '{{with .Module}}{{if .Replace}}{{.Replace.Path}}{{"\t"}}{{.Replace.Version}}{{"\t"}}{{.Replace.Dir}}{{else}}{{.Path}}{{"\t"}}{{.Version}}{{"\t"}}{{.Dir}}{{end}}{{end}}' -tags load_wgnt_from_rsrc ./client >"$modules"
+for arch in "$@"; do
+	GOOS=${GOOS:-linux} GOARCH="$arch" CGO_ENABLED=${CGO_ENABLED:-0} \
+		go list -deps -f '{{with .Module}}{{if .Replace}}{{.Replace.Path}}{{"\t"}}{{.Replace.Version}}{{"\t"}}{{.Replace.Dir}}{{else}}{{.Path}}{{"\t"}}{{.Version}}{{"\t"}}{{.Dir}}{{end}}{{end}}' -tags load_wgnt_from_rsrc ./client >>"$modules"
+done
 LC_ALL=C sort -u "$modules" >"$sorted_modules"
 
 goroot=$(go env GOROOT)

--- a/client/collect-licenses.sh
+++ b/client/collect-licenses.sh
@@ -8,12 +8,11 @@ fi
 
 repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 output_name=$(basename "$1")
-case "$output_name" in
-	"" | . | .. | /)
-		printf '%s\n' "OUTPUT_DIRECTORY must name a directory" >&2
-		exit 2
-		;;
-esac
+if [ -z "$output_name" ] || [ "$output_name" = "." ] ||
+	[ "$output_name" = ".." ] || [ "$output_name" = "/" ]; then
+	printf '%s\n' "OUTPUT_DIRECTORY must name a directory" >&2
+	exit 2
+fi
 output_parent=$(CDPATH= cd -- "$(dirname "$1")" && pwd)
 output="$output_parent/$output_name"
 shift


### PR DESCRIPTION
## Describe your changes

Add a UBI-based rootless client image without changing the existing images. It retains netstack mode and includes an AMD64/ARM64 GoReleaser entry, image metadata and license terms.

## Issue ticket number and link

---

## Stack

<!-- branch-stack -->

Depends on #7440 for unmapped-UID identity handling. This upper layer adds only the UBI rootless image, license collection and release configuration.

Stack: #7440 → #7469.

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

UBI documentation is pending before review.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/___


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a rootless NetBird container image based on UBI9 Minimal.
  - Supports both `linux/amd64` and `linux/arm64` platforms.
  - Runs with non-root privileges and includes userspace networking configuration.
  - Provides graceful handling of container termination signals.

- **Documentation**
  - Container distributions now include third-party license and notice information for included dependencies.
  - License information covers NetBird, the Go standard library, and included module dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->