### PR TITLE
[client] Read MDM boolean keys delivered as JSON numbers

### DIFF
--- a/client/mdm/policy.go
+++ b/client/mdm/policy.go
@@ -235,6 +235,8 @@ func (p *Policy) GetBool(key string) (bool, bool) {
 		return t != 0, true
 	case int64:
 		return t != 0, true
+	case float64:
+		return t != 0, true
 	}
 	return false, false
 }

--- a/client/mdm/policy_test.go
+++ b/client/mdm/policy_test.go
@@ -96,7 +96,8 @@ func TestPolicy_GetBool(t *testing.T) {
 		{"int64 nonzero", int64(2), true, true},
 		{"int64 zero", int64(0), false, true},
 		{"string garbage", "maybe", false, false},
-		{"float unsupported", 1.0, false, false},
+		{"float nonzero", 1.0, true, true},
+		{"float zero", 0.0, false, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -154,6 +155,20 @@ func TestPolicy_GetStringSlice(t *testing.T) {
 		_, ok := p.GetStringSlice(KeySplitTunnelApps)
 		assert.False(t, ok)
 	})
+}
+
+// encoding/json decodes every JSON number into float64, so the mobile
+// loaders never see int.
+func TestJSONLoader_BoolFromNumber(t *testing.T) {
+	p := NewJSONLoader(func() string { return `{"blockInbound":1,"disableProfiles":0}` }).Load()
+
+	got, ok := p.GetBool(KeyBlockInbound)
+	assert.True(t, ok)
+	assert.True(t, got)
+
+	got, ok = p.GetBool(KeyDisableProfiles)
+	assert.True(t, ok)
+	assert.False(t, got)
 }
 
 func TestLoader_NilFetcherReturnsEmpty(t *testing.T) {


### PR DESCRIPTION
## Describe your changes

`encoding/json` decodes every JSON number into `float64`, so the policy values
produced by the mobile loaders never contain `int` or `int64`. [`Policy.GetBool`](https://github.com/netbirdio/netbird/blob/7a62d63a3/client/mdm/policy.go#L220)
accepted both of those but not `float64`, so a managed boolean pushed as `1` or
`0` — how some MDM consoles normalise flags — read as unreadable while the key
still counted as managed: the policy was not applied, and the conflict gate
rejected both values the user could pick for that field. `GetInt` already
accepts `float64`.

The rejected-float assertion in the test table predates the JSON channel; it
came with the registry and plist loaders, where a real number for a flag is a
configuration mistake.

## Issue ticket number and link

No public ticket. Found while reviewing the iOS MDM bridge: the JSON channel
added in #6435 ([`jsonloader.go:29`](https://github.com/netbirdio/netbird/blob/7a62d63a3/client/mdm/jsonloader.go#L29))
decodes into `map[string]any`, which `GetBool` was never taught to handle.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal type coercion in the MDM policy reader. No public API, configuration
key, or CLI surface changes: the set of recognised MDM keys and their meaning
is unchanged, only the value shapes accepted for the boolean ones.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean policy settings represented as numeric values are now interpreted correctly: non-zero values enable the setting, while zero values disable it.
  * JSON-loaded numeric policy values now work as expected when read as booleans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->