### PR TITLE
[client] Compare MDM-managed URLs as endpoints, not as strings

### DIFF
--- a/client/mdm/conflicts.go
+++ b/client/mdm/conflicts.go
@@ -1,6 +1,10 @@
 package mdm
 
-import "net/url"
+import (
+	"net/url"
+
+	"github.com/netbirdio/netbird/util"
+)
 
 // PreSharedKeyRedactedSentinel is the redaction mask returned in place of a
 // real pre-shared key; an incoming value equal to it is a round-trip echo,
@@ -44,8 +48,9 @@ func ConflictStringPtr(key string, p *string) ConflictCheck {
 	}
 }
 
-// ConflictURL builds a ConflictCheck for a URL-typed MDM key; both sides are
-// normalized via CanonicalURL before comparison.
+// ConflictURL builds a ConflictCheck for a URL-typed MDM key. The two sides are
+// compared as the endpoints they address, not as strings: see
+// util.SameServiceURL.
 func ConflictURL(key, got string) ConflictCheck {
 	return ConflictCheck{
 		Key: key,
@@ -54,7 +59,7 @@ func ConflictURL(key, got string) ConflictCheck {
 				return true
 			}
 			want, ok := pol.GetString(key)
-			return ok && CanonicalURL(want) == CanonicalURL(got)
+			return ok && util.SameServiceURLStrings(want, got)
 		},
 	}
 }

--- a/client/mdm/conflicts_test.go
+++ b/client/mdm/conflicts_test.go
@@ -1,0 +1,40 @@
+package mdm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The same spellings, through the conflict check that decides whether a request
+// is refused. An enforced URL restated in another spelling addresses the very
+// server the policy names, so it must not be reported as a conflict.
+func TestConflictURLComparesEndpoints(t *testing.T) {
+	policy := NewPolicy(map[string]any{KeyManagementURL: "https://mgmt.example.com"})
+	require.True(t, policy.HasKey(KeyManagementURL))
+
+	for _, restated := range []string{
+		"https://mgmt.example.com",
+		"https://mgmt.example.com:443",
+		"https://mgmt.example.com/",
+		"https://MGMT.example.com",
+		"https://mgmt.example.com:0443",
+	} {
+		conflicts := ResolveConflicts(policy, []ConflictCheck{ConflictURL(KeyManagementURL, restated)})
+		assert.Empty(t, conflicts, "%q is the enforced endpoint written differently", restated)
+	}
+
+	for _, diverging := range []string{
+		"https://other.example.com",
+		"http://mgmt.example.com",
+		"https://mgmt.example.com:8443",
+		"https://mgmt.example.com/other",
+	} {
+		conflicts := ResolveConflicts(policy, []ConflictCheck{ConflictURL(KeyManagementURL, diverging)})
+		assert.Equal(t, []string{KeyManagementURL}, conflicts, "%q addresses another endpoint", diverging)
+	}
+
+	// An unset field is not a request to change anything.
+	assert.Empty(t, ResolveConflicts(policy, []ConflictCheck{ConflictURL(KeyManagementURL, "")}))
+}

--- a/util/serviceurl.go
+++ b/util/serviceurl.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// SameServiceURL reports whether two service URLs address the same endpoint.
+// One endpoint can be written several ways, and every spelling below reaches
+// the same server, so none of them is a divergence from another:
+//
+//	an implicit default port    https://mgmt.example.com   :443
+//	a zero-padded port          https://mgmt.example.com:0443
+//	a different host case       https://MGMT.example.com
+//	a trailing slash            https://mgmt.example.com/
+//
+// A path is otherwise part of the identity: https://mgmt.example.com and
+// https://mgmt.example.com/other are two endpoints.
+//
+// It lives here rather than next to any one caller because several of them
+// compare the same kind of URL — an MDM-enforced management URL against a
+// requested one, a stored profile URL against a command-line one — and every
+// copy of these rules that drifts turns an equivalent URL into a refused
+// request.
+func SameServiceURL(a, b *url.URL) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	return strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		ServiceURLPort(a) == ServiceURLPort(b) &&
+		strings.TrimSuffix(a.Path, "/") == strings.TrimSuffix(b.Path, "/")
+}
+
+// SameServiceURLStrings is SameServiceURL for unparsed input. Input that does
+// not parse falls back to string equality, which is the strictest thing left
+// to do with it.
+func SameServiceURLStrings(a, b string) bool {
+	ua, errA := url.ParseRequestURI(a)
+	ub, errB := url.ParseRequestURI(b)
+	if errA != nil || errB != nil {
+		return a == b
+	}
+
+	return SameServiceURL(ua, ub)
+}
+
+// ServiceURLPort is the port a URL addresses: the one it carries, normalized
+// numerically so ":0443" and ":443" are one port, or the scheme's default.
+func ServiceURLPort(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		switch strings.ToLower(u.Scheme) {
+		case "https":
+			return "443"
+		case "http":
+			return "80"
+		default:
+			return ""
+		}
+	}
+
+	if n, err := strconv.Atoi(port); err == nil {
+		return strconv.Itoa(n)
+	}
+	return port
+}

--- a/util/serviceurl_test.go
+++ b/util/serviceurl_test.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSameServiceURLSpellings(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		// One endpoint, written several ways.
+		{a: "https://mgmt.example.com", b: "https://mgmt.example.com:443", want: true},
+		{a: "https://mgmt.example.com", b: "https://mgmt.example.com/", want: true},
+		{a: "https://mgmt.example.com/", b: "https://mgmt.example.com:443/", want: true},
+		{a: "https://MGMT.example.com", b: "https://mgmt.example.com", want: true},
+		{a: "https://mgmt.example.com:0443", b: "https://mgmt.example.com:443", want: true},
+		{a: "http://mgmt.example.com", b: "http://mgmt.example.com:80", want: true},
+		{a: "HTTPS://mgmt.example.com", b: "https://mgmt.example.com", want: true},
+
+		// Different endpoints.
+		{a: "https://mgmt.example.com", b: "http://mgmt.example.com", want: false},
+		{a: "https://mgmt.example.com", b: "https://mgmt.example.com:8443", want: false},
+		{a: "https://mgmt.example.com", b: "https://other.example.com", want: false},
+		{a: "https://mgmt.example.com", b: "https://mgmt.example.com/other", want: false},
+
+		// Unparseable input falls back to string equality.
+		{a: "mgmt.example.com", b: "mgmt.example.com", want: true},
+		{a: "mgmt.example.com", b: "https://mgmt.example.com", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+" vs "+tt.b, func(t *testing.T) {
+			assert.Equal(t, tt.want, SameServiceURLStrings(tt.a, tt.b))
+			assert.Equal(t, tt.want, SameServiceURLStrings(tt.b, tt.a), "the comparison must be symmetric")
+		})
+	}
+}
+
+// The parsed form is the primitive the string form delegates to, so it must
+// answer the same for a spelling that only the parser can tell apart.
+func TestSameServiceURLParsed(t *testing.T) {
+	parse := func(raw string) *url.URL {
+		t.Helper()
+		u, err := url.ParseRequestURI(raw)
+		require.NoError(t, err)
+		return u
+	}
+
+	assert.True(t, SameServiceURL(parse("https://mgmt.example.com:0443/"), parse("https://MGMT.example.com")))
+	assert.False(t, SameServiceURL(parse("https://mgmt.example.com"), parse("https://mgmt.example.com:8443")))
+
+	assert.True(t, SameServiceURL(nil, nil), "two absent URLs are the same absence")
+	assert.False(t, SameServiceURL(nil, parse("https://mgmt.example.com")))
+}
+
+func TestServiceURLPort(t *testing.T) {
+	parse := func(raw string) *url.URL {
+		t.Helper()
+		u, err := url.ParseRequestURI(raw)
+		require.NoError(t, err)
+		return u
+	}
+
+	assert.Equal(t, "443", ServiceURLPort(parse("https://mgmt.example.com")))
+	assert.Equal(t, "80", ServiceURLPort(parse("http://mgmt.example.com")))
+	assert.Equal(t, "443", ServiceURLPort(parse("https://mgmt.example.com:0443")))
+	assert.Equal(t, "8443", ServiceURLPort(parse("https://mgmt.example.com:8443")))
+}


### PR DESCRIPTION
## Describe your changes

An MDM policy that enforces a management URL refuses any `SetConfig` or `Login`
whose URL differs from it, but the comparison
([`conflicts.go:57`](https://github.com/netbirdio/netbird/blob/7a62d63a360624de9bf07d44217a4c7f2aa2160f/client/mdm/conflicts.go#L57))
normalized only the default port, so three ways of writing the very endpoint the
policy names were reported as conflicts:

```
policy https://mgmt.example.com  vs  https://mgmt.example.com/     refused
                                     https://MGMT.example.com      refused
                                     https://mgmt.example.com:0443 refused
```

For a managed deployment whose stored or command-line URL is spelled differently
from the policy's value, every settings update is then refused with an
`MDMManagedFieldsViolation` naming a field the caller did not change;
`netbird up --management-url https://MGMT.example.com` is enough to reproduce it.
The rules now live in `util.SameServiceURL` and `ConflictURL` delegates: scheme
and host compared case-insensitively, effective port normalized numerically, a
trailing slash ignored, a path otherwise still part of the identity. `util`
rather than either caller because more than one place compares this kind of URL
(here, plus `profilemanager` and the SSH gate), and each copy that drifts turns
an equivalent URL into a refused request. `CanonicalURL` is untouched: it is
also the canonical value handed to `mdm.Restrictions` and the Android/iOS
`Preferences` getters.

## Issue ticket number and link

No public issue. Found while merging `main` into #7398, which had unified the
same comparison before the MDM conflict machinery moved into `client/mdm`.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal comparison fix. No CLI flag, configuration key, MDM key or public API
changes: a policy still enforces the same URL and still refuses a divergent one
— it just stops refusing the same endpoint written another way.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved management URL conflict detection to recognize equivalent endpoint spellings, including differences in capitalization, trailing slashes, default ports, and leading zeros in port numbers.
  * Prevented empty URL values from being incorrectly reported as conflicts.
  * Conflicts are still reported when the scheme, host, port, or path identifies a genuinely different endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->