### PR TITLE
[client] Pass the resolver port to systemd-resolved through SetDNSEx

### DIFF
--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -4,6 +4,7 @@ package dns
 
 import (
 	"context"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"net"
@@ -39,6 +40,11 @@ const (
 	systemdDbusResolvConfModeForeign       = "foreign"
 
 	dbusErrorUnknownObject = "org.freedesktop.DBus.Error.UnknownObject"
+	dbusIntrospectMethod   = "org.freedesktop.DBus.Introspectable.Introspect"
+
+	// dbusCallTimeout bounds a single method call, so an unresponsive resolved
+	// cannot stall the caller.
+	dbusCallTimeout = 5 * time.Second
 
 	dnsSecDisabled = "no"
 )
@@ -257,8 +263,8 @@ func (s *systemdDbusConfigurator) supportCustomPort() bool {
 }
 
 // hasDNSExMethod reports whether resolved exposes SetDNSEx on the link
-// interface. It was added in systemd 240; before that, resolved has no way to
-// accept a resolver port.
+// interface. Older versions carry only SetDNS, which has no way to accept a
+// resolver port.
 func (s *systemdDbusConfigurator) hasDNSExMethod() bool {
 	obj, closeConn, err := getDbusObject(systemdResolvedDest, s.dbusLinkObject)
 	if err != nil {
@@ -267,9 +273,18 @@ func (s *systemdDbusConfigurator) hasDNSExMethod() bool {
 	}
 	defer closeConn()
 
-	node, err := introspect.Call(obj)
-	if err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), dbusCallTimeout)
+	defer cancel()
+
+	var data string
+	if err := obj.CallWithContext(ctx, dbusIntrospectMethod, dbusDefaultFlag).Store(&data); err != nil {
 		log.Debugf("failed to introspect systemd-resolved link: %v", err)
+		return false
+	}
+
+	var node introspect.Node
+	if err := xml.Unmarshal([]byte(data), &node); err != nil {
+		log.Debugf("failed to parse systemd-resolved link introspection: %v", err)
 		return false
 	}
 
@@ -442,7 +457,7 @@ func (s *systemdDbusConfigurator) callLinkMethod(method string, value any) error
 	}
 	defer closeConn()
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), dbusCallTimeout)
 	defer cancel()
 
 	if value != nil {

--- a/client/internal/dns/systemd_linux.go
+++ b/client/internal/dns/systemd_linux.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
@@ -29,6 +30,8 @@ const (
 	systemdDbusLinkInterface               = "org.freedesktop.resolve1.Link"
 	systemdDbusRevertMethodSuffix          = systemdDbusLinkInterface + ".Revert"
 	systemdDbusSetDNSMethodSuffix          = systemdDbusLinkInterface + ".SetDNS"
+	setDNSExMethodName                     = "SetDNSEx"
+	systemdDbusSetDNSExMethodSuffix        = systemdDbusLinkInterface + "." + setDNSExMethodName
 	systemdDbusSetDefaultRouteMethodSuffix = systemdDbusLinkInterface + ".SetDefaultRoute"
 	systemdDbusSetDomainsMethodSuffix      = systemdDbusLinkInterface + ".SetDomains"
 	systemdDbusSetDNSSECMethodSuffix       = systemdDbusLinkInterface + ".SetDNSSEC"
@@ -41,9 +44,13 @@ const (
 )
 
 type systemdDbusConfigurator struct {
-	dbusLinkObject  dbus.ObjectPath
-	ifaceName       string
-	wgIndex         int
+	dbusLinkObject dbus.ObjectPath
+	ifaceName      string
+	wgIndex        int
+	// supportsDNSEx reports whether resolved exposes SetDNSEx on the link, which
+	// is the only way to hand it a resolver port. SetDNS carries the address
+	// alone, so on older resolved a resolver off port 53 cannot be advertised.
+	supportsDNSEx   bool
 	origNameservers []netip.Addr
 }
 
@@ -59,6 +66,17 @@ const (
 type systemdDbusDNSInput struct {
 	Family  int32
 	Address []byte
+}
+
+// systemdDbusDNSInputEx maps to a (iayqs) dbus input for the SetDNSEx method,
+// which takes a port and a server name on top of the address SetDNS accepts. A
+// zero port means the default, and an empty name means no name is pinned for
+// DNS-over-TLS validation.
+type systemdDbusDNSInputEx struct {
+	Family  int32
+	Address []byte
+	Port    uint16
+	Name    string
 }
 
 // systemdDbusLinkDomainsInput maps to a (sb) dbus input for SetDomains method
@@ -91,6 +109,12 @@ func newSystemdDbusConfigurator(wgInterface string) (*systemdDbusConfigurator, e
 		dbusLinkObject: dbus.ObjectPath(s),
 		ifaceName:      wgInterface,
 		wgIndex:        iface.Index,
+	}
+
+	c.supportsDNSEx = c.hasDNSExMethod()
+	if !c.supportsDNSEx {
+		log.Infof("systemd-resolved does not expose %s; a DNS resolver on a port other than %d cannot be advertised to it",
+			setDNSExMethodName, DefaultPort)
 	}
 
 	origNameservers, err := c.captureOriginalNameservers()
@@ -229,19 +253,65 @@ func (s *systemdDbusConfigurator) getOriginalNameservers() []netip.Addr {
 }
 
 func (s *systemdDbusConfigurator) supportCustomPort() bool {
-	return true
+	return s.supportsDNSEx
 }
 
-func (s *systemdDbusConfigurator) applyDNSConfig(config HostDNSConfig, stateManager *statemanager.Manager) error {
+// hasDNSExMethod reports whether resolved exposes SetDNSEx on the link
+// interface. It was added in systemd 240; before that, resolved has no way to
+// accept a resolver port.
+func (s *systemdDbusConfigurator) hasDNSExMethod() bool {
+	obj, closeConn, err := getDbusObject(systemdResolvedDest, s.dbusLinkObject)
+	if err != nil {
+		log.Debugf("failed to get dbus link object for introspection: %v", err)
+		return false
+	}
+	defer closeConn()
+
+	node, err := introspect.Call(obj)
+	if err != nil {
+		log.Debugf("failed to introspect systemd-resolved link: %v", err)
+		return false
+	}
+
+	for _, iface := range node.Interfaces {
+		if iface.Name != systemdDbusLinkInterface {
+			continue
+		}
+		return slices.ContainsFunc(iface.Methods, func(m introspect.Method) bool {
+			return m.Name == setDNSExMethodName
+		})
+	}
+
+	return false
+}
+
+// dnsServerMethod picks the resolved method that can carry the resolver's
+// address and port, and builds its input. SetDNS takes the address alone, so a
+// resolver on a port other than 53 needs SetDNSEx; the caller is expected to
+// have checked supportCustomPort before asking for one.
+func (s *systemdDbusConfigurator) dnsServerMethod(config HostDNSConfig) (string, any) {
 	family := int32(unix.AF_INET)
 	if config.ServerIP.Is6() {
 		family = unix.AF_INET6
 	}
-	defaultLinkInput := systemdDbusDNSInput{
+
+	if config.ServerPort == DefaultPort || !s.supportsDNSEx {
+		return systemdDbusSetDNSMethodSuffix, []systemdDbusDNSInput{{
+			Family:  family,
+			Address: config.ServerIP.AsSlice(),
+		}}
+	}
+
+	return systemdDbusSetDNSExMethodSuffix, []systemdDbusDNSInputEx{{
 		Family:  family,
 		Address: config.ServerIP.AsSlice(),
-	}
-	if err := s.callLinkMethod(systemdDbusSetDNSMethodSuffix, []systemdDbusDNSInput{defaultLinkInput}); err != nil {
+		Port:    uint16(config.ServerPort),
+	}}
+}
+
+func (s *systemdDbusConfigurator) applyDNSConfig(config HostDNSConfig, stateManager *statemanager.Manager) error {
+	method, input := s.dnsServerMethod(config)
+	if err := s.callLinkMethod(method, input); err != nil {
 		return fmt.Errorf("set interface DNS server %s:%d: %w", config.ServerIP, config.ServerPort, err)
 	}
 

--- a/client/internal/dns/systemd_linux_test.go
+++ b/client/internal/dns/systemd_linux_test.go
@@ -1,0 +1,77 @@
+//go:build !android
+
+package dns
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// The dbus signatures are the contract with resolved: SetDNS has no port field,
+// so a resolver on a fallback port can only be advertised through SetDNSEx.
+func TestSystemdDNSInputSignatures(t *testing.T) {
+	assert.Equal(t, "(iay)", dbus.SignatureOf(systemdDbusDNSInput{}).String())
+	assert.Equal(t, "(iayqs)", dbus.SignatureOf(systemdDbusDNSInputEx{}).String())
+}
+
+func TestSystemdDNSServerMethod(t *testing.T) {
+	serverIP := netip.MustParseAddr("100.66.100.1")
+	serverIPv6 := netip.MustParseAddr("fd00::1")
+
+	t.Run("default port uses SetDNS", func(t *testing.T) {
+		c := &systemdDbusConfigurator{supportsDNSEx: true}
+
+		method, input := c.dnsServerMethod(HostDNSConfig{ServerIP: serverIP, ServerPort: DefaultPort})
+
+		assert.Equal(t, systemdDbusSetDNSMethodSuffix, method)
+		in, ok := input.([]systemdDbusDNSInput)
+		require.True(t, ok, "input type %T", input)
+		require.Len(t, in, 1)
+		assert.Equal(t, int32(unix.AF_INET), in[0].Family)
+		assert.Equal(t, serverIP.AsSlice(), in[0].Address)
+	})
+
+	t.Run("fallback port carries the port through SetDNSEx", func(t *testing.T) {
+		c := &systemdDbusConfigurator{supportsDNSEx: true}
+
+		method, input := c.dnsServerMethod(HostDNSConfig{ServerIP: serverIP, ServerPort: 5053})
+
+		assert.Equal(t, systemdDbusSetDNSExMethodSuffix, method)
+		in, ok := input.([]systemdDbusDNSInputEx)
+		require.True(t, ok, "input type %T", input)
+		require.Len(t, in, 1)
+		assert.Equal(t, int32(unix.AF_INET), in[0].Family)
+		assert.Equal(t, serverIP.AsSlice(), in[0].Address)
+		assert.Equal(t, uint16(5053), in[0].Port)
+		assert.Empty(t, in[0].Name)
+	})
+
+	t.Run("v6 resolver reports the v6 family", func(t *testing.T) {
+		c := &systemdDbusConfigurator{supportsDNSEx: true}
+
+		_, input := c.dnsServerMethod(HostDNSConfig{ServerIP: serverIPv6, ServerPort: 5053})
+
+		in, ok := input.([]systemdDbusDNSInputEx)
+		require.True(t, ok, "input type %T", input)
+		require.Len(t, in, 1)
+		assert.Equal(t, int32(unix.AF_INET6), in[0].Family)
+	})
+
+	// Without SetDNSEx there is nothing to fall back to but the portless call.
+	// supportCustomPort reports false so the caller keeps primary DNS off the
+	// link instead of pointing it at a port resolved will not use.
+	t.Run("no SetDNSEx support falls back to SetDNS", func(t *testing.T) {
+		c := &systemdDbusConfigurator{supportsDNSEx: false}
+
+		method, input := c.dnsServerMethod(HostDNSConfig{ServerIP: serverIP, ServerPort: 5053})
+
+		assert.Equal(t, systemdDbusSetDNSMethodSuffix, method)
+		assert.IsType(t, []systemdDbusDNSInput{}, input)
+		assert.False(t, c.supportCustomPort())
+	})
+}


### PR DESCRIPTION
## Describe your changes

When the local resolver cannot bind port 53 it falls back to another port, and the client reported that it supported a custom port to systemd-resolved. It did not: the resolver was configured through the `SetDNS` method, whose input carries the address alone, so the port was dropped and resolved kept querying port 53. The peer then had its DNS pointed at a resolver it could never reach, with nothing in the log to say so.

- Configure the resolver through `SetDNSEx`, which takes a port, whenever it runs on a port other than 53
- Report custom-port support based on whether resolved actually exposes `SetDNSEx`, so on older versions the client leaves primary DNS alone instead of advertising a port that will be ignored

`SetDNSEx` arrived in a later systemd than the client's minimum, so its absence is detected once per link and logged.

## Issue ticket number and link

Found alongside https://github.com/netbirdio/netbird/pull/7439

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why) — the resolver port and its fallback are internal to the client; no documented setting or behaviour changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Custom DNS server ports are now applied correctly when supported by the system’s DNS resolver.
  - Systems without extended DNS configuration support continue using standard DNS setup without errors.
  - DNS configuration now correctly handles both IPv4 and IPv6 resolver addresses.
- **Tests**
  - Added coverage for standard and custom-port DNS configuration scenarios, including compatibility fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->