### PR TITLE
[management] Let embedding binaries extend the command tree

### DIFF
--- a/management/cmd/root.go
+++ b/management/cmd/root.go
@@ -54,6 +54,15 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
+// Customize hands the fully built root command to fn so an embedding binary
+// can extend or adjust the command tree — most commonly attaching its own
+// subcommands next to (or under) the built-in ones — before calling Execute.
+// The root command is constructed in this package's init, so Customize may be
+// called from the embedding binary's main at any point before Execute.
+func Customize(fn func(root *cobra.Command)) {
+	fn(rootCmd)
+}
+
 func init() {
 	mgmtCmd.Flags().IntVar(&mgmtPort, "port", 80, "server port to listen on (defaults to 443 if TLS is enabled, 80 otherwise")
 	mgmtCmd.Flags().BoolVar(&disableLegacyManagementPort, "disable-legacy-port", false, "disabling the old legacy port (33073)")

--- a/management/cmd/root_test.go
+++ b/management/cmd/root_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestCustomize verifies an embedding binary can extend the command tree: a
+// top-level command attached through the hook, and a subcommand attached under
+// the built-in admin group, are both resolvable exactly as Execute would
+// resolve them.
+func TestCustomize(t *testing.T) {
+	topLevel := &cobra.Command{Use: "some-extra", RunE: func(*cobra.Command, []string) error { return nil }}
+	nested := &cobra.Command{Use: "cluster", RunE: func(*cobra.Command, []string) error { return nil }}
+
+	Customize(func(root *cobra.Command) {
+		root.AddCommand(topLevel)
+		for _, c := range root.Commands() {
+			if c.Name() == "admin" {
+				c.AddCommand(nested)
+				return
+			}
+		}
+		t.Fatal("admin command not found in the root tree")
+	})
+	t.Cleanup(func() {
+		rootCmd.RemoveCommand(topLevel)
+		for _, c := range rootCmd.Commands() {
+			if c.Name() == "admin" {
+				c.RemoveCommand(nested)
+			}
+		}
+	})
+
+	if found, _, err := rootCmd.Find([]string{"some-extra"}); err != nil || found != topLevel {
+		t.Fatalf("top-level command not resolvable: found=%v err=%v", found, err)
+	}
+	if found, _, err := rootCmd.Find([]string{"admin", "cluster"}); err != nil || found != nested {
+		t.Fatalf("nested admin subcommand not resolvable: found=%v err=%v", found, err)
+	}
+}


### PR DESCRIPTION
## Describe your changes

The management binary is embedded by downstream builds that override server construction via SetNewServer, but the cobra command tree itself was closed: rootCmd is unexported and fully assembled in init, with no way to attach additional subcommands. Customize hands the built root command to a caller-supplied function before Execute, so an embedding binary can add its own commands next to — or under — the built-in ones, such as extra administrative helpers beneath the existing admin group.

## Issue ticket number and link

N/A

## Stack

N/A

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change — Small internal plumbing seam.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a customization hook that allows embedded applications to extend or adjust the command-line command tree before execution.
  - Custom commands can be added at the top level or under existing command groups.

- **Tests**
  - Added coverage verifying that customized commands are registered and discoverable as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->