### PR TITLE
[client] Report the remote jobs key in the MDM UI snapshot

### DIFF
--- a/client/mdm/restrictions.go
+++ b/client/mdm/restrictions.go
@@ -20,6 +20,7 @@ type Fields struct {
 	DisableMetricsCollection bool   `json:"disableMetricsCollection"`
 	SplitTunnelMode          bool   `json:"splitTunnelMode"`
 	SplitTunnelApps          bool   `json:"splitTunnelApps"`
+	RemoteJobsAllowed        bool   `json:"remoteJobsAllowed"`
 	DisableAdvancedView      *bool  `json:"disableAdvancedView"`
 }
 
@@ -60,6 +61,7 @@ func BuildRestrictions(policy *Policy) Restrictions {
 	r.MDM.DisableMetricsCollection = policy.HasKey(KeyDisableMetricsCollection)
 	r.MDM.SplitTunnelMode = policy.HasKey(KeySplitTunnelMode)
 	r.MDM.SplitTunnelApps = policy.HasKey(KeySplitTunnelApps)
+	r.MDM.RemoteJobsAllowed = policy.HasKey(KeyRemoteJobsAllowed)
 	if v, ok := policy.GetBool(KeyAllowServerSSH); ok {
 		r.MDM.AllowServerSSH = &v
 	}

--- a/client/mdm/restrictions.go
+++ b/client/mdm/restrictions.go
@@ -20,7 +20,7 @@ type Fields struct {
 	DisableMetricsCollection bool   `json:"disableMetricsCollection"`
 	SplitTunnelMode          bool   `json:"splitTunnelMode"`
 	SplitTunnelApps          bool   `json:"splitTunnelApps"`
-	RemoteJobsAllowed        bool   `json:"remoteJobsAllowed"`
+	RemoteJobsAllowed        bool   `json:"allowRemoteJobs"`
 	DisableAdvancedView      *bool  `json:"disableAdvancedView"`
 }
 


### PR DESCRIPTION
## Describe your changes

The `allowRemoteJobs` policy key was already enforced end to end: `GetRemoteJobsAllowed` returns the managed value over the local one, and `Commit` rejects a divergent write through `CheckMDMConflicts`. What was missing is the UI-facing half. `BuildRestrictions` never reported the key, so `mdm.remoteJobsAllowed` was absent from the snapshot every frontend reads.

A client that cannot see the key cannot lock the control. On mobile the result is a toggle that looks editable, flips, fails to save, and silently snaps back with no explanation. Desktop is affected too: its `MDMFields` is a type alias for this same `mdm.Fields` (`client/ui/services/settings.go`), and `applyMDMRestrictions` fills it by matching the `mDMManagedFields` keys from `GetConfigResponse` against the struct's JSON tags.

This adds the missing field to `mdm.Fields` and sets it from `policy.HasKey(KeyRemoteJobsAllowed)`, matching every other managed boolean in the builder. No enforcement behavior changes; this only lets a UI render what the policy already enforces.

That exposed a second, related defect. The field's JSON tag was `remoteJobsAllowed` while the policy key is `allowRemoteJobs`. Since `mDMManagedFields` reports the raw policy keys and the desktop matches them against JSON tags, the field would never have turned true. Every other field in `mdm.Fields` already uses its policy key verbatim as the JSON tag, so this was the only divergence; the second commit aligns it.

The field is additive and mirrors the existing convention, so a frontend that does not know the key keeps decoding the snapshot unchanged. The iOS client consumes it in a companion change.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reporting whether remote jobs are allowed through device management restrictions.
  - Included the remote jobs setting in serialized restriction data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
