### PR TITLE
[client] Locate the UDP header through the IHL field in the STUN filter

### DIFF
--- a/sharedsock/stun_filter_linux.go
+++ b/sharedsock/stun_filter_linux.go
@@ -16,27 +16,52 @@ func NewIncomingSTUNFilter() BPFFilter {
 
 // GetInstructions returns raw BPF instructions for ipv4 and ipv6 that filter out anything but STUN packets
 func (filter *IncomingSTUNFilter) GetInstructions(dstPort uint32) (raw4 []bpf.RawInstruction, raw6 []bpf.RawInstruction, err error) {
-	raw4, err = rawInstructions(22, 32, dstPort)
+	raw4, err = rawInstructions4(dstPort)
 	if err != nil {
 		return nil, nil, err
 	}
-	raw6, err = rawInstructions(2, 12, dstPort)
+	raw6, err = rawInstructions6(dstPort)
 	if err != nil {
 		return nil, nil, err
 	}
 	return raw4, raw6, nil
 }
 
-func rawInstructions(dstPortOff, cookieOff, dstPort uint32) ([]bpf.RawInstruction, error) {
-	// UDP raw socket for ipv4 receives the rcvdPacket with IP headers
-	// UDP raw socket for ipv6 receives the rcvdPacket with UDP headers
+// rawInstructions4 filters an ipv4 raw socket, which delivers the IP header along
+// with the packet. The IP header length varies, so the UDP header is located
+// through the IHL field rather than at a fixed offset. Reading the destination
+// port at a fixed 22 would miss every datagram carrying IP options.
+func rawInstructions4(dstPort uint32) ([]bpf.RawInstruction, error) {
 	instructions := []bpf.Instruction{
-		// Load the destination port from the UDP header (offset 22 for ipv4 and 2 for ipv6)
-		bpf.LoadAbsolute{Off: dstPortOff, Size: 2},
+		// Put the IP header length into X, so the UDP header starts at X.
+		bpf.LoadMemShift{Off: 0},
+		// Load the destination port from the UDP header.
+		bpf.LoadIndirect{Off: 2, Size: 2},
 		// Check if the destination port is equal to the specified `dstPort`. If not, skip the next 3 instructions.
 		bpf.JumpIf{Cond: bpf.JumpNotEqual, Val: dstPort, SkipTrue: 3},
-		// Load the 4-byte value (magic cookie) from the UDP payload (offset 32 for ipv4 and 12 for ipv6)
-		bpf.LoadAbsolute{Off: cookieOff, Size: 4},
+		// Load the 4-byte value (magic cookie) from the UDP payload.
+		bpf.LoadIndirect{Off: 12, Size: 4},
+		// Check if the loaded value is equal to the `magicCookie`. If not, skip the next instruction.
+		bpf.JumpIf{Cond: bpf.JumpNotEqual, Val: magicCookie, SkipTrue: 1},
+		// If both the dstPort and the magic cookie match, return a positive value (0xffffffff)
+		bpf.RetConstant{Val: 0xffffffff},
+		// If either the dstPort or the magic cookie doesn't match, return 0
+		bpf.RetConstant{Val: 0},
+	}
+
+	return bpf.Assemble(instructions)
+}
+
+// rawInstructions6 filters an ipv6 raw socket. The kernel strips the IPv6 header
+// and any extension headers, so the packet starts at the UDP header.
+func rawInstructions6(dstPort uint32) ([]bpf.RawInstruction, error) {
+	instructions := []bpf.Instruction{
+		// Load the destination port from the UDP header.
+		bpf.LoadAbsolute{Off: 2, Size: 2},
+		// Check if the destination port is equal to the specified `dstPort`. If not, skip the next 3 instructions.
+		bpf.JumpIf{Cond: bpf.JumpNotEqual, Val: dstPort, SkipTrue: 3},
+		// Load the 4-byte value (magic cookie) from the UDP payload.
+		bpf.LoadAbsolute{Off: 12, Size: 4},
 		// Check if the loaded value is equal to the `magicCookie`. If not, skip the next instruction.
 		bpf.JumpIf{Cond: bpf.JumpNotEqual, Val: magicCookie, SkipTrue: 1},
 		// If both the dstPort and the magic cookie match, return a positive value (0xffffffff)

--- a/sharedsock/stun_filter_linux_test.go
+++ b/sharedsock/stun_filter_linux_test.go
@@ -1,0 +1,112 @@
+//go:build linux && !android
+
+package sharedsock
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"golang.org/x/net/bpf"
+)
+
+const testPort = 51820
+
+// ipv4STUNPacket builds an IPv4 datagram carrying a STUN message, with the given
+// number of 4-byte IP option words. optionWords of 0 gives the usual 20-byte header.
+func ipv4STUNPacket(optionWords int, dstPort uint16, cookie uint32) []byte {
+	ihl := 5 + optionWords
+	hdr := make([]byte, ihl*4)
+	hdr[0] = 0x40 | byte(ihl)
+	hdr[9] = 17 // UDP
+
+	udp := make([]byte, 8)
+	binary.BigEndian.PutUint16(udp[0:2], 12345)
+	binary.BigEndian.PutUint16(udp[2:4], dstPort)
+
+	payload := make([]byte, 20)
+	binary.BigEndian.PutUint16(payload[0:2], 0x0001) // binding request
+	binary.BigEndian.PutUint32(payload[4:8], cookie)
+
+	return append(append(hdr, udp...), payload...)
+}
+
+// ipv6STUNPacket builds what an ipv6 raw socket delivers: the UDP header onward.
+func ipv6STUNPacket(dstPort uint16, cookie uint32) []byte {
+	udp := make([]byte, 8)
+	binary.BigEndian.PutUint16(udp[0:2], 12345)
+	binary.BigEndian.PutUint16(udp[2:4], dstPort)
+
+	payload := make([]byte, 20)
+	binary.BigEndian.PutUint16(payload[0:2], 0x0001)
+	binary.BigEndian.PutUint32(payload[4:8], cookie)
+
+	return append(udp, payload...)
+}
+
+func runFilter(t *testing.T, raw []bpf.RawInstruction, packet []byte) int {
+	t.Helper()
+
+	insts, ok := bpf.Disassemble(raw)
+	if !ok {
+		t.Fatal("disassemble produced unknown instructions")
+	}
+	vm, err := bpf.NewVM(insts)
+	if err != nil {
+		t.Fatalf("new vm: %v", err)
+	}
+	n, err := vm.Run(packet)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return n
+}
+
+func TestIncomingSTUNFilterIPv4(t *testing.T) {
+	raw4, _, err := NewIncomingSTUNFilter().GetInstructions(testPort)
+	if err != nil {
+		t.Fatalf("get instructions: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		optionWords int
+		dstPort     uint16
+		cookie      uint32
+		wantMatch   bool
+	}{
+		{"no options", 0, testPort, magicCookie, true},
+		{"one option word", 1, testPort, magicCookie, true},
+		{"three option words", 3, testPort, magicCookie, true},
+		{"wrong port", 0, testPort + 1, magicCookie, false},
+		{"wrong port with options", 2, testPort + 1, magicCookie, false},
+		{"not stun", 0, testPort, 0xdeadbeef, false},
+		{"not stun with options", 2, testPort, 0xdeadbeef, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			packet := ipv4STUNPacket(tc.optionWords, tc.dstPort, tc.cookie)
+			got := runFilter(t, raw4, packet) > 0
+			if got != tc.wantMatch {
+				t.Errorf("match = %v, want %v", got, tc.wantMatch)
+			}
+		})
+	}
+}
+
+func TestIncomingSTUNFilterIPv6(t *testing.T) {
+	_, raw6, err := NewIncomingSTUNFilter().GetInstructions(testPort)
+	if err != nil {
+		t.Fatalf("get instructions: %v", err)
+	}
+
+	if runFilter(t, raw6, ipv6STUNPacket(testPort, magicCookie)) == 0 {
+		t.Error("stun packet did not match")
+	}
+	if runFilter(t, raw6, ipv6STUNPacket(testPort+1, magicCookie)) > 0 {
+		t.Error("packet for another port matched")
+	}
+	if runFilter(t, raw6, ipv6STUNPacket(testPort, 0xdeadbeef)) > 0 {
+		t.Error("non-stun packet matched")
+	}
+}


### PR DESCRIPTION
## Describe your changes

`sharedsock` exists so STUN can share the WireGuard port. Its cBPF filter decides what the
raw socket delivers. The ipv4 socket is opened as `AF_INET, SOCK_RAW, IPPROTO_UDP`, so the
packet arrives with its IP header. The filter read the destination port at a fixed offset
22 and the magic cookie at 32. Both are correct only when IHL is 5.

A datagram carrying IP options has a longer header. The two loads then read the wrong
bytes, the cookie test fails, and the kernel drops the packet. `ReadFrom` never sees it.
The asymmetry is the part worth noting. `ReadFrom` parses with
`gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, …)`, which is IHL-aware. So the
filter discards exactly what the parser behind it was written to handle. The symptom is a
peer that never learns its server-reflexive candidate on the shared port. It falls back to
a relay.

IP options are rare, and middleboxes often strip them. This is not a common path. It is an
uncommon one, and those are what this code exists for.

The fix puts the header length into X with `LoadMemShift`. Both fields are then read
relative to it. The ipv6 path is unchanged in effect and now has its own function. The
kernel strips the IPv6 header and any extension headers there, so the fixed offsets 2 and
12 are right for it.

The test assembles the real filter and runs it in `bpf.NewVM`. It needs no privileges and
no socket. Against the previous filter:

```
--- FAIL: TestIncomingSTUNFilterIPv4/one_option_word
        match = false, want true
--- FAIL: TestIncomingSTUNFilterIPv4/three_option_words
        match = false, want true
```

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

Trivial fix: the filter is corrected to accept the packets the decoder behind it already
handles. No API, protocol, flag or behavior change beyond that.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why) — an internal packet
  filter offset fix with no user-visible surface: no setting, flag, or documented behavior
  changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

<!-- not applicable -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved STUN packet filtering for IPv4 packets with optional IP header fields.
  * Ensured valid IPv4 and IPv6 STUN traffic is recognized only on the configured port.
  * Prevented packets with incorrect ports or invalid STUN markers from matching the filter.

* **Tests**
  * Added coverage for IPv4 and IPv6 filtering, including optional IPv4 headers, incorrect ports, and invalid packets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
