### PR TITLE
[client] Match peer routes by NetString in GetActiveClientRoutes

### DIFF
--- a/client/internal/routemanager/active_routes_test.go
+++ b/client/internal/routemanager/active_routes_test.go
@@ -1,0 +1,80 @@
+package routemanager
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/internal/peer"
+	"github.com/netbirdio/netbird/client/internal/routeselector"
+	"github.com/netbirdio/netbird/route"
+	"github.com/netbirdio/netbird/shared/management/domain"
+)
+
+// Recorder keys are spelled out here instead of being taken from NetString():
+// deriving them would pass even if reader and writer agreed on a key the
+// recorder never uses.
+func TestGetActiveClientRoutes(t *testing.T) {
+	const peerKey = "peerA"
+
+	// Network is the placeholder management sends for domain routes.
+	domainRoute := &route.Route{
+		ID:          "r1",
+		NetID:       "corp-domains",
+		Peer:        peerKey,
+		Network:     netip.MustParsePrefix("192.0.2.0/32"),
+		Domains:     domain.List{"gitlab.example.com"},
+		NetworkType: route.DomainNetwork,
+		Enabled:     true,
+	}
+	staticRoute := &route.Route{
+		ID:          "r2",
+		NetID:       "corp-net",
+		Peer:        peerKey,
+		Network:     netip.MustParsePrefix("10.0.0.0/24"),
+		NetworkType: route.IPv4Network,
+		Enabled:     true,
+	}
+
+	tests := []struct {
+		name string
+		rt   *route.Route
+		// key the status recorder holds for the peer, empty for none
+		recordedKey string
+		status      peer.ConnStatus
+		wantActive  bool
+	}{
+		{"domain route, connected peer, route recorded", domainRoute, "gitlab.example.com", peer.StatusConnected, true},
+		{"domain route, connected peer, no route recorded", domainRoute, "", peer.StatusConnected, false},
+		{"domain route, route recorded, peer not connected", domainRoute, "gitlab.example.com", peer.StatusIdle, false},
+		{"static route, connected peer, route recorded", staticRoute, "10.0.0.0/24", peer.StatusConnected, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := peer.NewRecorder("https://mgm")
+			require.NoError(t, recorder.AddPeer(peerKey, "vpn-me.netbird.cloud", "100.64.0.1", ""))
+			require.NoError(t, recorder.UpdatePeerState(peer.State{
+				PubKey:     peerKey,
+				ConnStatus: tc.status,
+			}))
+			if tc.recordedKey != "" {
+				require.NoError(t, recorder.AddPeerStateRoute(peerKey, tc.recordedKey, route.ResID("res1")))
+			}
+
+			mgr := &DefaultManager{
+				clientRoutes:   route.HAMap{tc.rt.GetHAUniqueID(): []*route.Route{tc.rt}},
+				statusRecorder: recorder,
+				routeSelector:  routeselector.NewRouteSelector(),
+			}
+
+			active := mgr.GetActiveClientRoutes()
+			if tc.wantActive {
+				require.Contains(t, active, tc.rt.GetHAUniqueID())
+				return
+			}
+			require.NotContains(t, active, tc.rt.GetHAUniqueID())
+		})
+	}
+}

--- a/client/internal/routemanager/manager.go
+++ b/client/internal/routemanager/manager.go
@@ -528,7 +528,11 @@ func (m *DefaultManager) GetActiveClientRoutes() route.HAMap {
 			if st.ConnStatus != peer.StatusConnected {
 				continue
 			}
-			if _, hasRoute := st.GetRoutes()[r.Network.String()]; !hasRoute {
+			// The recorder keys peer routes by handler.String(): the
+			// domain list for dynamic routes, the prefix for static
+			// ones. NetString() returns that; r.Network is a domain
+			// route placeholder and would never match.
+			if _, hasRoute := st.GetRoutes()[r.NetString()]; !hasRoute {
 				continue
 			}
 			out[id] = routes


### PR DESCRIPTION
## Describe your changes

`GetActiveClientRoutes` looks up a peer's routes by `r.Network.String()`, but the status recorder keys them by the route handler's `String()`:

```go
// client/internal/routemanager/client/client.go:297
w.statusRecorder.AddPeerStateRoute(route.Peer, w.handler.String(), route.GetResourceID())
```

For a dynamic (domain) route that handler returns the domain list (`dynamic.Route.String()` → `Domains.SafeString()`), while `Network` holds the `192.0.2.0/32` placeholder that management sends for domain routes. The two keys can never be equal, so a domain-based network is dropped from the "active" map even when its peer is connected and the route is installed. Static routes were never affected: their handler's `String()` is `Network.String()`.

`route.Route.NetString()` returns exactly what the handler reports — the domain list for a dynamic route with domains, the prefix otherwise — so the lookup uses it now. One-line change; the rest is the comment explaining which side owns the key.

The mismatch dates back to 9ed2e2a5 ("[client] Drop DNS probes for passive health projection", #5971, May 2026), which introduced the accessor.

**No user-visible change today.** The only consumer is the DNS server's nameserver-group health projection (`e.dnsServer.SetRouteSources(...)` in `client/internal/engine.go`), and the matcher it feeds skips dynamic routes when testing an upstream address:

```go
// client/internal/dns/upstream.go:878
if r.IsDynamic() { haveDynamic = true; continue }
```

So the extra entries do not move that verdict. This is a correctness fix to the accessor itself, so that it reports what its name and doc comment promise before anything else starts reading it.

**Verified locally.** The tests are a small table: a domain route with a connected peer and a recorded key, the same route with nothing recorded, the same route with the peer not connected, and a static route. Recorder keys are string literals rather than `NetString()`, so a reader and writer agreeing on a key the recorder never uses would still fail the test.

```
# on main, with the tests applied
--- FAIL: TestGetActiveClientRoutes/domain_route,_connected_peer,_route_recorded
    route.HAMap{} does not contain "corp-domains|gitlab.example.com"
# the other three cases pass there, including the static route: no regression to that path

# with the fix
ok  github.com/netbirdio/netbird/client/internal/routemanager
```

`make lint` and `make lint-all` report 0 issues. `go test -tags devcert ./client/internal/...` is green on darwin/arm64 except `TestMatchDomainBatching`, which fails the same way on a clean `main` here — it reads the host's DNS configuration.

## Issue ticket number and link

https://github.com/netbirdio/netbird/discussions/7491

Issues are maintainer-curated in this repository, so the report went to Issue Triage rather than to a new issue. The change is a one-line fix to an internal accessor with no behavior change for any current consumer; the discussion carries the reasoning if you would rather have the recorder key changed instead.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand.

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): the fix is internal to the client's route manager and changes no documented behavior, flag, or API.

### Docs PR URL (required if "docs added" is checked)

n/a


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected active route detection so dynamically resolved and static routes are recognized consistently.
  - Improved route status reporting when checking whether routes are currently active.

- **Tests**
  - Added coverage for active route reporting across connected and disconnected peers.
  - Verified behavior for both dynamic domain routes and static network routes, including recorded and unrecorded route states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->