### PR TITLE
[client] Continue Kubernetes discovery after reverse-DNS failures

### DIFF
--- a/client/cmd/kubernetes.go
+++ b/client/cmd/kubernetes.go
@@ -119,6 +119,10 @@ type kubernetesCluster struct {
 	version string
 }
 
+type reverseResolver interface {
+	LookupAddr(context.Context, string) ([]string, error)
+}
+
 func getKubernetesClusters(ctx context.Context, peers []*proto.PeerState, nameFilter string) ([]kubernetesCluster, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tls.Config{
@@ -132,13 +136,23 @@ func getKubernetesClusters(ctx context.Context, peers []*proto.PeerState, nameFi
 		// https://github.com/golang/go/issues/17093
 		PreferGo: true,
 	}
+	return getKubernetesClustersWithResolver(ctx, peers, nameFilter, &resolver, httpClient)
+}
 
+func getKubernetesClustersWithResolver(
+	ctx context.Context,
+	peers []*proto.PeerState,
+	nameFilter string,
+	resolver reverseResolver,
+	httpClient *http.Client,
+) ([]kubernetesCluster, error) {
 	kcs := []kubernetesCluster{}
 	attempted := map[string]struct{}{}
 	for _, peer := range peers {
 		fqdns, err := resolver.LookupAddr(ctx, peer.IP)
 		if err != nil {
-			return nil, err
+			log.Debugf("could not reverse-resolve peer %s: %v", peer.IP, err)
+			continue
 		}
 		for _, fqdn := range fqdns {
 			if _, ok := attempted[fqdn]; ok {

--- a/client/cmd/kubernetes.go
+++ b/client/cmd/kubernetes.go
@@ -123,6 +123,7 @@ type reverseResolver interface {
 	LookupAddr(context.Context, string) ([]string, error)
 }
 
+// getKubernetesClusters discovers Kubernetes clusters from the supplied peer states.
 func getKubernetesClusters(ctx context.Context, peers []*proto.PeerState, nameFilter string) ([]kubernetesCluster, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tls.Config{
@@ -139,6 +140,7 @@ func getKubernetesClusters(ctx context.Context, peers []*proto.PeerState, nameFi
 	return getKubernetesClustersWithResolver(ctx, peers, nameFilter, &resolver, httpClient)
 }
 
+// getKubernetesClustersWithResolver discovers clusters using the provided dependencies.
 func getKubernetesClustersWithResolver(
 	ctx context.Context,
 	peers []*proto.PeerState,
@@ -149,10 +151,9 @@ func getKubernetesClustersWithResolver(
 	kcs := []kubernetesCluster{}
 	attempted := map[string]struct{}{}
 	for _, peer := range peers {
-		fqdns, err := resolver.LookupAddr(ctx, peer.IP)
+		fqdns, err := peerFQDNs(ctx, peer, resolver)
 		if err != nil {
-			log.Debugf("could not reverse-resolve peer %s: %v", peer.IP, err)
-			continue
+			return nil, err
 		}
 		for _, fqdn := range fqdns {
 			if _, ok := attempted[fqdn]; ok {
@@ -186,6 +187,24 @@ func getKubernetesClustersWithResolver(
 		}
 	}
 	return kcs, nil
+}
+
+// peerFQDNs returns the daemon-provided names before consulting reverse DNS.
+func peerFQDNs(ctx context.Context, peer *proto.PeerState, resolver reverseResolver) ([]string, error) {
+	if fqdn := peer.GetFqdn(); fqdn != "" {
+		return []string{fqdn}, nil
+	}
+
+	fqdns, err := resolver.LookupAddr(ctx, peer.GetIP())
+	if err == nil {
+		return fqdns, nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+
+	log.Debugf("could not reverse-resolve peer %s: %v", peer.GetIP(), err)
+	return nil, nil
 }
 
 func fingerprintClusters(ctx context.Context, httpClient *http.Client, fqdn string) (*url.URL, string, error) {

--- a/client/cmd/kubernetes_test.go
+++ b/client/cmd/kubernetes_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -10,7 +12,33 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/proto"
 )
+
+type reverseResolverFunc func(context.Context, string) ([]string, error)
+
+func (f reverseResolverFunc) LookupAddr(ctx context.Context, ip string) ([]string, error) {
+	return f(ctx, ip)
+}
+
+func TestGetKubernetesClustersSkipsReverseLookupFailures(t *testing.T) {
+	peers := []*proto.PeerState{
+		{IP: "100.64.0.10"},
+		{IP: "100.64.0.11"},
+	}
+	resolver := reverseResolverFunc(func(_ context.Context, ip string) ([]string, error) {
+		if ip == peers[0].IP {
+			return nil, errors.New("no PTR record")
+		}
+		return []string{"unrelated.example.com."}, nil
+	})
+
+	clusters, err := getKubernetesClustersWithResolver(
+		t.Context(), peers, "", resolver, http.DefaultClient)
+	require.NoError(t, err)
+	require.Empty(t, clusters, "an unrelated peer lookup failure must not abort discovery")
+}
 
 func TestFingerprintClusters(t *testing.T) {
 	t.Parallel()

--- a/client/cmd/kubernetes_test.go
+++ b/client/cmd/kubernetes_test.go
@@ -18,16 +18,20 @@ import (
 
 type reverseResolverFunc func(context.Context, string) ([]string, error)
 
+// LookupAddr resolves an IP address with the test resolver function.
 func (f reverseResolverFunc) LookupAddr(ctx context.Context, ip string) ([]string, error) {
 	return f(ctx, ip)
 }
 
+// TestGetKubernetesClustersSkipsReverseLookupFailures verifies discovery continues after a failed lookup.
 func TestGetKubernetesClustersSkipsReverseLookupFailures(t *testing.T) {
 	peers := []*proto.PeerState{
 		{IP: "100.64.0.10"},
 		{IP: "100.64.0.11"},
 	}
+	var lookupIPs []string
 	resolver := reverseResolverFunc(func(_ context.Context, ip string) ([]string, error) {
+		lookupIPs = append(lookupIPs, ip)
 		if ip == peers[0].IP {
 			return nil, errors.New("no PTR record")
 		}
@@ -37,7 +41,33 @@ func TestGetKubernetesClustersSkipsReverseLookupFailures(t *testing.T) {
 	clusters, err := getKubernetesClustersWithResolver(
 		t.Context(), peers, "", resolver, http.DefaultClient)
 	require.NoError(t, err)
+	require.Equal(t, []string{peers[0].IP, peers[1].IP}, lookupIPs,
+		"discovery must process every peer after a reverse lookup failure")
 	require.Empty(t, clusters, "an unrelated peer lookup failure must not abort discovery")
+}
+
+// TestPeerFQDNsUsesStoredFQDN verifies daemon-provided names avoid reverse DNS.
+func TestPeerFQDNsUsesStoredFQDN(t *testing.T) {
+	resolver := reverseResolverFunc(func(context.Context, string) ([]string, error) {
+		t.Fatal("reverse DNS should not be called when the peer FQDN is available")
+		return nil, nil
+	})
+
+	fqdns, err := peerFQDNs(t.Context(), &proto.PeerState{Fqdn: "cluster.netbird-kubeapi-proxy"}, resolver)
+	require.NoError(t, err)
+	require.Equal(t, []string{"cluster.netbird-kubeapi-proxy"}, fqdns)
+}
+
+// TestPeerFQDNsPreservesContextCancellation verifies cancellation is returned to the caller.
+func TestPeerFQDNsPreservesContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	resolver := reverseResolverFunc(func(ctx context.Context, _ string) ([]string, error) {
+		return nil, ctx.Err()
+	})
+
+	_, err := peerFQDNs(ctx, &proto.PeerState{IP: "100.64.0.10"}, resolver)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestFingerprintClusters(t *testing.T) {


### PR DESCRIPTION
## Describe your changes

netbird kubernetes list and write-kubeconfig currently abort when any peer has no PTR record. A single unrelated offline peer can therefore hide reachable Kubernetes clusters.

Reverse-DNS failures are now logged at debug level and skipped so discovery continues. A regression test covers the failure path.

Focused tests pass:
go test ./client/cmd -run 'Test(GetKubernetesClustersSkipsReverseLookupFailures|FingerprintClusters|WriteKubeconfig|ResolveKubeconfigPath)$'

The full client/cmd package run is currently affected by unrelated Unix-socket bind failures in the macOS sandbox.

## Issue ticket number and link

Closes #7437

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is it a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change: this only changes failure handling in an existing CLI discovery flow and adds no new user-facing option.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kubernetes cluster discovery now continues when reverse-DNS lookups fail, rather than stopping the entire discovery process.
  * Unresolvable or unrelated peer hostnames are skipped without preventing other discovery results from being processed.
  * Discovery now uses peer-provided fully qualified domain names when available and still respects canceled requests.

* **Tests**
  * Added coverage for reverse-DNS failures, stored peer hostnames, and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->