### PR TITLE
[management] validate the domain for the flock in proxy

### DIFF
--- a/proxy/internal/acme/locker.go
+++ b/proxy/internal/acme/locker.go
@@ -2,12 +2,14 @@ package acme
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/netbirdio/netbird/proxy/internal/flock"
 	"github.com/netbirdio/netbird/proxy/internal/k8s"
+	"github.com/netbirdio/netbird/shared/management/domain"
 )
 
 // certLocker provides distributed mutual exclusion for certificate operations.
@@ -74,9 +76,15 @@ func newFlockLocker(certDir string, logger *log.Logger) *flockLocker {
 	return &flockLocker{certDir: certDir, logger: logger}
 }
 
-// Lock acquires an advisory file lock for the given domain.
-func (l *flockLocker) Lock(ctx context.Context, domain string) (func(), error) {
-	lockPath := filepath.Join(l.certDir, domain+".lock")
+// Lock acquires an advisory file lock for the given domain. The domain must
+// be a valid hostname so the lock file always resolves to a direct child of
+// certDir; anything else is rejected before touching the filesystem.
+func (l *flockLocker) Lock(ctx context.Context, name string) (func(), error) {
+	if !domain.IsValidDomainNoWildcard(name) {
+		return nil, fmt.Errorf("invalid domain %q for lock file", name)
+	}
+
+	lockPath := filepath.Join(l.certDir, name+".lock")
 	lockFile, err := flock.Lock(ctx, lockPath)
 	if err != nil {
 		return nil, err
@@ -89,7 +97,7 @@ func (l *flockLocker) Lock(ctx context.Context, domain string) (func(), error) {
 
 	return func() {
 		if err := flock.Unlock(lockFile); err != nil {
-			l.logger.Debugf("release cert lock for domain %q: %v", domain, err)
+			l.logger.Debugf("release cert lock for domain %q: %v", name, err)
 		}
 	}, nil
 }

--- a/proxy/internal/acme/locker_test.go
+++ b/proxy/internal/acme/locker_test.go
@@ -63,3 +63,33 @@ func TestNewCertLockerK8sFallsBackToFlock(t *testing.T) {
 	_, ok := locker.(*flockLocker)
 	assert.True(t, ok, "k8s-lease without SA should fall back to flockLocker")
 }
+
+func TestFlockLockerRejectsUnsafeDomain(t *testing.T) {
+	root := t.TempDir()
+	certDir := filepath.Join(root, "certs")
+	require.NoError(t, os.Mkdir(certDir, 0o700))
+	locker := newFlockLocker(certDir, nil)
+
+	for _, d := range []string{
+		"",
+		".",
+		"..",
+		"../escape",
+		"../../etc/cron.d/attacker",
+		"sub/dir.example.com",
+		`back\slash.example.com`,
+		"*.example.com",
+	} {
+		unlock, err := locker.Lock(context.Background(), d)
+		assert.Error(t, err, "domain %q", d)
+		assert.Nil(t, unlock, "domain %q", d)
+	}
+
+	assert.NoFileExists(t, filepath.Join(root, "escape.lock"))
+	certEntries, err := os.ReadDir(certDir)
+	require.NoError(t, err)
+	assert.Empty(t, certEntries)
+	rootEntries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	assert.Len(t, rootEntries, 1)
+}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lock requests with invalid or unsafe domain names are now rejected before any files are created.
  * Prevented lock paths from escaping the certificate directory.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->