### PR TITLE
[management] do not hard-code tmp dir path in ws_conn_adapter_test

### DIFF
--- a/util/wsproxy/server/ws_conn_adapter_test.go
+++ b/util/wsproxy/server/ws_conn_adapter_test.go
@@ -22,6 +22,9 @@ import (
 )
 
 func TestAdapterHandlingConnectionClosures(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "tmp-socket")
+	assert.NoError(t, err)
+
 	var cases = []struct {
 		description string
 		casenum     int
@@ -34,7 +37,7 @@ func TestAdapterHandlingConnectionClosures(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			serversock := filepath.Join("/tmp", "http-server-"+strconv.FormatInt(rand.Int64(), 10)+".sock")
+			serversock := filepath.Join(tmpdir, "http-server-"+strconv.FormatInt(rand.Int64(), 10)+".sock")
 			t.Cleanup(func() { os.Remove(serversock) })
 
 			l, err := net.Listen("unix", serversock)
@@ -111,7 +114,10 @@ func TestAdapterHandlingConnectionClosures(t *testing.T) {
 func TestAdapterHandlingHttpConnection_NoHeadersSent(t *testing.T) {
 	t.Skip("currently disabled as it requires idle timeout to be set")
 
-	serversock := filepath.Join("/tmp", "http-server-"+strconv.FormatInt(rand.Int64(), 10)+".sock")
+	tmpdir, err := os.MkdirTemp("", "tmp-socket")
+	assert.NoError(t, err)
+
+	serversock := filepath.Join(tmpdir, "http-server-"+strconv.FormatInt(rand.Int64(), 10)+".sock")
 	defer os.Remove(serversock)
 
 	l, err := net.Listen("unix", serversock)

--- a/util/wsproxy/server/ws_conn_adapter_test.go
+++ b/util/wsproxy/server/ws_conn_adapter_test.go
@@ -22,9 +22,6 @@ import (
 )
 
 func TestAdapterHandlingConnectionClosures(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "tmp-socket")
-	assert.NoError(t, err)
-
 	var cases = []struct {
 		description string
 		casenum     int
@@ -37,7 +34,7 @@ func TestAdapterHandlingConnectionClosures(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			serversock := filepath.Join(tmpdir, "http-server-"+strconv.FormatInt(rand.Int64(), 10)+".sock")
+			serversock := filepath.Join(os.TempDir(), "http-server-"+strconv.FormatInt(rand.Int64(), 10)+".sock")
 			t.Cleanup(func() { os.Remove(serversock) })
 
 			l, err := net.Listen("unix", serversock)
@@ -114,10 +111,7 @@ func TestAdapterHandlingConnectionClosures(t *testing.T) {
 func TestAdapterHandlingHttpConnection_NoHeadersSent(t *testing.T) {
 	t.Skip("currently disabled as it requires idle timeout to be set")
 
-	tmpdir, err := os.MkdirTemp("", "tmp-socket")
-	assert.NoError(t, err)
-
-	serversock := filepath.Join(tmpdir, "http-server-"+strconv.FormatInt(rand.Int64(), 10)+".sock")
+	serversock := filepath.Join(os.TempDir(), "http-server-"+strconv.FormatInt(rand.Int64(), 10)+".sock")
 	defer os.Remove(serversock)
 
 	l, err := net.Listen("unix", serversock)


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [ ] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated connection-handling tests to construct Unix socket paths directly within the system temporary directory.
  * Simplified temporary path setup for connection closure and no-header scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->