### PR TITLE
[client] Bump the wireguard-go fork to f6c41ca

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -331,7 +331,7 @@ replace github.com/kardianos/service => github.com/netbirdio/service v0.0.0-2024
 
 replace github.com/getlantern/systray => github.com/netbirdio/systray v0.0.0-20231030152038-ef1ed2a27949
 
-replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go v0.0.0-20260628102922-2834bebf6c1a
+replace golang.zx2c4.com/wireguard => github.com/netbirdio/wireguard-go v0.0.0-20260911073736-f6c41ca4d739
 
 replace github.com/cloudflare/circl => codeberg.org/cunicu/circl v0.0.0-20230801113412-fec58fc7b5f6
 

--- a/go.sum
+++ b/go.sum
@@ -492,8 +492,8 @@ github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470
 github.com/netbirdio/signal-dispatcher/dispatcher v0.0.0-20250805121659-6b4ac470ca45/go.mod h1:5/sjFmLb8O96B5737VCqhHyGRzNFIaN/Bu7ZodXc3qQ=
 github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260825085513-5f07a01f7a78 h1:B/jRv24jnFeoA+VccxoCx6K94PUgsqR9wnshpeu9M+8=
 github.com/netbirdio/wails/v3 v3.0.0-beta.3.0.20260825085513-5f07a01f7a78/go.mod h1:/6QR46/nhGCSADHbS++XtDb9dkTnenTHlGskTPRo9S0=
-github.com/netbirdio/wireguard-go v0.0.0-20260628102922-2834bebf6c1a h1:3CWK+yTvRKOcC0Q8VCTGy4l60TEb27CQVS7LkMxwjmw=
-github.com/netbirdio/wireguard-go v0.0.0-20260628102922-2834bebf6c1a/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
+github.com/netbirdio/wireguard-go v0.0.0-20260911073736-f6c41ca4d739 h1:6s4AupyM7XrVWxf8YsR/iskZTRdqmDTKUrCFhYmXvtA=
+github.com/netbirdio/wireguard-go v0.0.0-20260911073736-f6c41ca4d739/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=


### PR DESCRIPTION
## Describe your changes

Moves the wireguard-go fork pin from `2834beb` to `f6c41ca`, picking up the three
changes merged there since:

- [#18](https://github.com/netbirdio/wireguard-go/pull/18) disable gVisor TCP RACK loss detection on Windows
- [#19](https://github.com/netbirdio/wireguard-go/pull/19) make `netTun.Close` idempotent, so a second close no longer panics the whole process (NET-1609)
- [#20](https://github.com/netbirdio/wireguard-go/pull/20) stop an exhausted buffer pool from wedging peer removal

\#20 is the one that matters for the reverse proxy. With a capped pool
(`NB_PROXY_PREALLOCATED_BUFFERS`), packets staged for a peer that cannot handshake
drain the per-device pool; a keepalive then parks inside a timer callback holding
that timer's `runningLock`, so `Timer.DelSync` never returns and peer removal -
and with it `Device.Close` - can never complete. One unreachable peer takes down
every service of that account, and it does not recover.

After the bump a keepalive never blocks on the pool, and the data path no longer
clears `handshakeAttempts`, so `expiredRetransmitHandshake` reaches its limit after
~90s, flushes the staged queue and returns the buffers.

Validated on a local deployment, identical commands against both builds: before,
the account stayed down for 9 minutes after the traffic stopped, with a keepalive
parked in the pool; after, no keepalive ever parks, the device log shows the skips,
and the pool frees itself 107s into the stall while still under load.

Every non-proxy build runs with an unbounded pool and never reaches the blocking
path #20 removes.

## Issue ticket number and link

No public issue. Internal incident on the reverse proxy: accounts stop serving and
`netbird-proxy debug status <account>` times out. The client-side half of the fix
shipped as #7452; this bump brings in the wireguard-go half.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Dependency bump. No public API, configuration, CLI or documented behavior changes:
the fork's fix removes a blocking path inside WireGuard's own buffer pool, which is
not surfaced anywhere users can observe except as the proxy no longer wedging.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

N/A


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WireGuard component to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->