### PR TITLE
[infrastructure] Preserve snapshot image variant tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,10 +287,15 @@ jobs:
           image_refs=()
 
           tag_and_push() {
-            local src="$1" img_name tag dst
+            local src="$1" img_name tag dst variant=""
             img_name="${src%%:*}"
+            # Client variants share a repository, so keep their tag suffixes.
+            case "$src" in
+              *-rootless-ubi-amd64) variant="-rootless-ubi" ;;
+              *-rootless-amd64) variant="-rootless" ;;
+            esac
             for tag in $(resolve_tags); do
-              dst="${img_name}:${tag}"
+              dst="${img_name}:${tag}${variant}"
               echo "Tagging ${src} -> ${dst}"
               docker tag "$src" "$dst"
               docker push "$dst"


### PR DESCRIPTION
## Describe your changes

Preserve `-rootless` and `-rootless-ubi` when tagging snapshot images for main, PRs, and release branches. These variants share the client image repository and previously overwrote the standard image tags.

## Issue ticket number and link

<!--
Required for anything that changes behavior. Link the issue (or the validated
discussion it came from) that the NetBird team already agreed on. See
https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second
-->

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [ ] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Only CI snapshot tagging changes; versioned release tags are unchanged.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Docker image tags for amd64 rootless and rootless UBI variants now retain their `-rootless` and `-rootless-ubi` suffixes.
  - Other image tags continue to follow the existing format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->