### PR TITLE
[misc] Pull the MinIO test image from quay.io

### DIFF
--- a/upload-server/server/s3_test.go
+++ b/upload-server/server/s3_test.go
@@ -29,7 +29,7 @@ func Test_S3HandlerGetUploadURL(t *testing.T) {
 	ctx := context.Background()
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "minio/minio:RELEASE.2025-04-22T22-12-26Z",
+			Image:        "quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z",
 			ExposedPorts: []string{"9000/tcp"},
 			Env: map[string]string{
 				"MINIO_ROOT_USER":     "minioadmin",


### PR DESCRIPTION
## Describe your changes

`minio/minio` is no longer on Docker Hub. The repository and the pinned tag both return 404, and an anonymous pull is refused, so `Test_S3HandlerGetUploadURL` now fails on every Linux CI run:

```
create container: Error response from daemon: pull access denied for minio/minio,
repository does not exist or may require 'docker login'
```

The test last passed yesterday at 17:21 UTC, and it has failed in every run since.

The same release is still published at `quay.io/minio/minio` with digest `sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e`, so this points the testcontainers request there and keeps the tag pinned. It is the only reference to that image in the tree.

## Issue ticket number and link

None — CI fix, no behavior change.

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] I ran and tested this change locally — I did not rely on CI to find out whether it works
- [x] This PR has a single purpose (not a fix + refactor + feature in one)
- [x] This change is a trivial fix, **OR** it links an issue the NetBird team agreed on beforehand. Changes to the public API, gRPC protocols, functionality behavior, CLI / service flags, or new features always need that agreement first. See [CONTRIBUTING.md](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTING.md#ticket-first-pr-second).

Ran locally against the host Docker daemon: the test fails on `main` with the pull error above and passes with this change.

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Test-only change: it swaps the registry a test image is pulled from and is invisible to users and operators.

### Docs PR URL (required if "docs added" is checked)

N/A


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/netbirdio/netbird/pull/7516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the S3 integration test environment to use the MinIO image from its Quay registry, with no changes to test behavior or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->